### PR TITLE
Fix subclasses of ScriptError

### DIFF
--- a/refm/api/src/_builtin/ScriptError
+++ b/refm/api/src/_builtin/ScriptError
@@ -6,10 +6,6 @@
 
 #@# list child classes automatically
   * [[c:LoadError]]
-#@since 1.9.1
-  * [[c:NameError]]
-  * [[c:NoMethodError]]
-#@end
   * [[c:NotImplementedError]]
   * [[c:SyntaxError]]
 


### PR DESCRIPTION
明らかに意図された記述だとは思うのですが、 1.8.7, 1.9.3, 2.0.0 いずれでも ScriptErrorのサブクラスでは無いと思います。
こうなっていた時期があったのでしょうか？
