### PR TITLE
Fix String case-converter

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -859,7 +859,9 @@ rangeで指定したインデックスの範囲に含まれる部分文字列を
 
   $KCODE = 'NONE'
   # 文字列は Shift JIS エンコーディングで記述されている
-  puts "帰".capitalize   # => 蟻
+  str = "帰"
+  str.capitalize!
+  puts str   # => 蟻
 
 また、$KCODE を設定しても、
 マルチバイト文字のいわゆる全角アルファベットは処理しません。


### PR DESCRIPTION
例のコードを含めどれも少しずつ表現が変わっているようで、どれに合わせるべきかの判断がつけきれませんでした（なんとなく、upcase周りの記述が一番しっかりしている印象は受けましたが・・・）
ひとまず、「seeリンク」「破壊的メソッドの例が破壊的じゃないメソッドの例になっている」の修正に重点を置いてパッチを書いてみました。
