### PR TITLE
Fix String#ord exception class

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3151,10 +3151,10 @@ self がセパレータを含まないときは、
 
 文字列の最初の文字の文字コードを整数で返します。
 
-self が空文字列のときは例外 TypeError を発生します。
+self が空文字列のときは例外を発生します。
 
-@return             文字コードを表す整数
-@raise TypeError    self の長さが 0 のとき発生
+@return                 文字コードを表す整数
+@raise ArgumentError    self の長さが 0 のとき発生
 
 例:
     p "a".ord   # => 97


### PR DESCRIPTION
個人的にはTypeErrorの方が自然に感じるので、空文字列時の記述を削った方がいいのか迷いました。
本パッチでは、あくまで例外クラスの修正のみに止めています。
