### PR TITLE
Add reference manual of Set.keep_if()

### DIFF
--- a/refm/api/src/set.rd
+++ b/refm/api/src/set.rd
@@ -535,6 +535,12 @@ o1 と o2 は同じ分割に属します。
   puts Set.new(['element1', 'element2']).inspect
   #=> #<Set: {"element1", "element2"}>
 
+#@since 1.9.2
+--- keep_if {|o| ... } -> self
+
+集合の各要素に対してブロックを実行し、その結果が偽であるようなすべての要素を削除します。 
+
+#@end
 
 = class SortedSet < Set
 


### PR DESCRIPTION
The reference manual of Set.keep_if() is no currently available.
According to https://github.com/ruby/ruby/tree/v1_9_2_381, this method was added as a new method to Ruby 1.9.2.
The reference manual of Ruby 1.9.2 and later versions will show the method with this change.
