### PR TITLE
Add reference manual of Set#select!

### DIFF
--- a/refm/api/src/set.rd
+++ b/refm/api/src/set.rd
@@ -537,9 +537,13 @@ o1 と o2 は同じ分割に属します。
 
 #@since 1.9.2
 --- keep_if {|o| ... } -> self
-
+--- select! {|o| ... } -> self | nil
 集合の各要素に対してブロックを実行し、その結果が偽であるようなすべての要素を削除します。 
 
+keep_if は常に self を返します。
+
+select! は、要素が 1 つ以上削除されれば self を、1 つも削除されなければ
+nil を返します。
 #@end
 
 = class SortedSet < Set


### PR DESCRIPTION
According to https://github.com/ruby/ruby/tree/v1_9_2_381, this method was added as a new method to Ruby 1.9.2.
The reference manual of Ruby 1.9.2 and later versions will show the method with this change.
