### PR TITLE
Add information to Float

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1712,6 +1712,9 @@ arg に to_ary, to_a のいずれのメソッドもない場合は
     p Float("10e2")       #=> 1000.0
     p Float("1e-2")       #=> 0.01
     p Float(".1")         #=> 0.1
+#@since 1.9.2
+    p Float("0xa")        #=> 10.0
+#@end
 
     p Float("nan")        # invalid value (ArgumentError)
     p Float("INF")        # invalid value (ArgumentError)


### PR DESCRIPTION
The current reference manual does not clearly say that Float() can take a hexadecimal number as an argument.
According to https://github.com/ruby/ruby/tree/v1_9_2_381, Float() has supported hexadecimal floating point format since Ruby 1.9.2.
