### PR TITLE
Tempfile.new がブロックをとる記述を削除

### DIFF
--- a/refm/api/src/tempfile.rd
+++ b/refm/api/src/tempfile.rd
@@ -24,11 +24,6 @@ require tmpdir
 
 --- new(basename, tempdir = Dir::tmpdir) -> Tempfile
 --- open(basename, tempdir = Dir::tmpdir) -> Tempfile
-#@since 1.9.1
---- open(basename, tempdir = Dir::tmpdir){|fp| ...} -> object
-#@else
---- open(basename, tempdir = Dir::tmpdir){|fp| ...} -> nil
-#@end
 
 #@since 1.8.7
 テンポラリファイルを作成し、それを表す Tempfile オブジェクトを生成して返します。
@@ -37,12 +32,6 @@ require tmpdir
 #@else
 "basename.pid.n" というファイル名で
 テンポラリファイルを作成し、インスタンスを返します。
-#@end
-ブロックを指定して呼び出した場合は、Tempfile オブジェクトを引数として ブロックを実行します。ブロックの実行が終了すると、ファイルは自動的に クローズされ、
-#@since 1.9.1
-ブロックの値をかえします。
-#@else
-nilをかえします。
 #@end
 
 @param basename ファイル名のプレフィクスを文字列で指定します。
@@ -62,31 +51,6 @@ nilをかえします。
    p t.path                            #=> "/tmp/hoge20080518-6961-5fnk19-0bar"
    t2 = Tempfile.open(['t', '.xml'])
    p t2.path                           #=> "/tmp/t20080518-6961-xy2wvx-0.xml"
-#@end
-
-#@since 1.9.1
-例：ブロックを与えた場合
-  require 'tempfile'
-
-  path = Tempfile.open("temp"){|fp|
-    fp.puts "hoge"
-    fp.path
-  }
-  # テンポラリファイルへのパスを表示
-  p path 
-  p File.read(path) #=> "hoge\n"
-
-#@else
-例：ブロックを与えた場合
-  require 'tempfile'
-
-  path = nil
-  Tempfile.open("temp"){|fp|
-    fp.puts "hoge"
-    path = fp.path
-  }
-
-  system("cat #{path}")
 #@end
 
 


### PR DESCRIPTION
Tempfile.new に、ブロックを渡すと実行されるという記述がありましたが、下記の状態だったため削除しました。
- 1.8.7, 1.9.3, 2.0.0, 2.1.0 で動作しない
- 上記バージョンの rdoc に記述がない
- 2.0.0, 2.1.0 では警告が表示される
