### PR TITLE
Array#slice!

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -1488,14 +1488,6 @@ reverse! は self を返します。
 指定した部分配列を自身から取り除き、取り除いた部分配列を返します。取り除く要素がなければ nil
 を返します。
 
-以下のコードと同値です。
-
-     def slice!(*args)
-        result = self[*args]
-        self[*args] = nil
-        result
-     end
-
 @param start 削除したい部分配列の先頭のインデックスを整数で指定します。[[m:Array#[] ]] と同じです。
 
 @param len 削除したい部分配列の長さを整数で指定します。[[m:Array#[] ]] と同じです。


### PR DESCRIPTION
下記コードが少なくとも1.8系以降で再現しませんでした。

``` ruby
a = [ "a", "b", "c" ]
p a.slice!(5, 1)       #=> nil
p a                    #=> ["a", "b", "c", nil, nil]
```

よって下記コードも挙動が異なります。

``` ruby
def slice!(*args)
  result = self[*args]
  self[*args] = nil
  result
end
```

2007年に書かれた箇所なので1.6系以前の動作なのでは。
