### PR TITLE
Update sample of Kernel.#Integer

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1792,7 +1792,8 @@ arg に to_ary, to_a のいずれのメソッドもない場合は
     p Integer("010")      #=> 8
     p Integer("0x10")     #=> 16
     p Integer("0b10")     #=> 2
-    p Integer(" \n10\t ") #=> 10 # 空白類は無視される
+    p Integer(" \n10\t ") #=> 10 # 先頭と末尾の空白類は無視される
+    p Integer("1\n0")     # `Integer': invalid value for Integer: "1\n0" (ArgumentError)
     p Integer("hoge")     # `Integer': invalid value for Integer: "hoge" (ArgumentError)
     p Integer("")         # `Integer': invalid value for Integer: "" (ArgumentError)
 #@end


### PR DESCRIPTION
Kernel.#Integerの説明として「空白類は無視される」と書かれていますが、
数字の途中の空白類は無視されずにエラーとなるので、文言とサンプルを追加してみました。

http://docs.ruby-lang.org/ja/2.1.0/method/Kernel/m/Integer.html

よさそうであれば、Kernel.#Floatにも同様の記述があるので、そちらも対応したいです。

http://docs.ruby-lang.org/ja/2.1.0/method/Kernel/m/Float.html
