### PR TITLE
Update sample of Kernel.#Float

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1721,7 +1721,8 @@ arg に to_ary, to_a のいずれのメソッドもない場合は
     p Float("-Inf")       # invalid value (ArgumentError)
     p Float(("10" * 1000)) #=> Infinity
     p Float("0xa.a")      # invalid value (ArgumentError)
-    p Float(" \n10\s \t") #=> 10.0 # 空白類は無視される
+    p Float(" \n10\s \t") #=> 10.0 # 先頭と末尾の空白類は無視される
+    p Float("1\n0")       # invalid value (ArgumentError)
     p Float("")           # invalid value (ArgumentError)
 
 @see [[m:String#to_f]],[[c:Float]]


### PR DESCRIPTION
#81 のInteger()と同じ理由で、Float()の方も空白類についての文言とサンプルを追加してみました。

http://docs.ruby-lang.org/ja/2.1.0/method/Kernel/m/Float.html
