### PR TITLE
Encoding.find() does not accept Symbol

### DIFF
--- a/refm/api/src/_builtin/Encoding
+++ b/refm/api/src/_builtin/Encoding
@@ -45,7 +45,7 @@
 --- find(name) -> Encoding
 指定された name という名前を持つ Encoding オブジェクトを返します。
 
-@param name エンコーディング名を表す [[c:String]] か [[c:Symbol]] を指定します。
+@param name エンコーディング名を表す [[c:String]] を指定します。
 @return 発見された Encoding オブジェクトを返します。
 @raise ArgumentError 指定した名前のエンコーディングが発見できないと発生します。
 
@@ -56,7 +56,6 @@
 #@end
 
 例:
- p Encoding.find(:Shift_JIS)    #=> #<Encoding:Shift_JIS>
  p Encoding.find("utf-8")       #=> #<Encoding:UTF-8>
 
 


### PR DESCRIPTION
Encding.find()にはStringかSymbolを指定できるとあります(ruby本体にrdocにもそうあります)が、
CRubyの実装はそのようになっていません。

ruby-devに問い合わせてみたところ、rdocの説明がまちがっていたようです。
- https://bugs.ruby-lang.org/issues/9966
- https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/46481/diff/encoding.c

r46481でrdocの訂正がされたようで、るりまも同様にSymbolの説明を消してしまってよいのではと思います。
