### PR TITLE
Fiddle::Function.newのパラメータptrの説明を修正

### DIFF
--- a/refm/api/src/fiddle/2.0/Fiddle__Function
+++ b/refm/api/src/fiddle/2.0/Fiddle__Function
@@ -6,7 +6,7 @@ C の関数を表すクラスです。
 ptr (関数ポインタ)から Fiddle::Function オブジェクトを
 生成します。
 
-ptr には [[c:Fiddle::Handle]] から [[m:Fiddle::Handle#ptr]] などで取りだした
+ptr には [[c:Fiddle::Handle]] から [[m:Fiddle::Handle#sym]] などで取りだした
 関数ポインタ(を表す整数)、もしくは関数を指している
 [[c:Fiddle::Pointer]] を渡します。
 


### PR DESCRIPTION
[[m:Fiddle::Handle#ptr]]に該当するメソッドがありません。
実行例は正しく動作するようですので、ptrでなくsymではないでしょうか。
