### PR TITLE
Marshal フォーマット解説ページのコード片が認識されていないのを修正

### DIFF
--- a/refm/doc/marshal-format.rd
+++ b/refm/doc/marshal-format.rd
@@ -613,7 +613,7 @@ p Marshal.dump(ary).unpack("x2 acac")
 : <= 1.6.1
     * Range が終端を含むかどうかのフラグがダンプ時に保存されない
 
-以下は、テストスクリプトです(要 [[c:RAA:RubyUnit]])
+以下は、テストスクリプトです(要 RubyUnit)
 
     # test for Marshal for ruby version 1.6
     require 'rubyunit'


### PR DESCRIPTION
インデントが認識されずにコード部分がpreで囲われずにコードとして見えていなかったので、printf-formatを参考に `//emlist{}` で囲みました。またRubyUnitが既に存在しないため、リンクを解除しました。
