### PR TITLE
Add description to Object#respond_to? about NotImplementedError case(nat...

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1453,7 +1453,9 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
 Windows での [[m:Process.fork]] や GNU/Linux での [[m:File.lchmod]] の
 ような [[c:NotImplementedError]] が発生する場合は false を返します。
 
-※ NotImplementedError が発生する場合に false を返すのはネイティブのメソッドのみです。
+※ NotImplementedError が発生する場合に false を返すのは
+Rubyの組み込みライブラリや標準ライブラリなど、C言語で実装されているメソッドのみです。
+Rubyで実装されたメソッドで NotImplementedError が発生する場合は true を返します。
 
 メソッドが定義されていない場合は、[[m:Object#respond_to_missing?]] を呼
 び出してその結果を返します。
@@ -1526,9 +1528,9 @@ Windows での [[m:Process.fork]] や GNU/Linux での [[m:File.lchmod]] の
   end
 
   puts ImplTemplateMethod.new.respond_to?(:template_method) # => true
-  # NotImplementedError を返却しているが、非ネイティブのため真を返却
+  # NotImplementedError が発生しているが、Rubyによる実装部のため true を返却
   puts NotImplTemplateMethod.new.respond_to?(:template_method) # => true
-  # GNU/Linux で実行
+  # GNU/Linux で実行。C言語による実装部のため false を返却
   puts File.respond_to?(:lchmod)         # => false
 
 @see [[m:Module#method_defined?]]


### PR DESCRIPTION
## respond_to? の NotImplementedError に対する挙動の詳細を追記

respond_to? が NotImplementedError を返却するメソッドに対して偽を返却する、という記述についてですが、
ネイティブ・非ネイティブに関する記述がないため経緯を知らないとネイティブ限定で利用可能であることが
判断出来ない記述になっていると思います。  
### 経緯を確認した場所

http://comments.gmane.org/gmane.comp.lang.ruby.devel/12261
### るりまの記述

```
Windows での Process.fork や GNU/Linux での File.lchmod の ような NotImplementedError が発生する場合は false を返します。
メソッドが定義されていない場合は、Object#respond_to_missing? を呼 び出してその結果を返します。
```
### 対応

Object#respond_to? に、ネイティブ・非ネイティブに関する記述を追加し、
サンプルコードを追加しました。

サンプルコードの動作確認結果も添付致します。

http://ideone.com/pC21JZ
