### PR TITLE
add explaination difference between Range#include? and Range#cover?

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -93,8 +93,31 @@ include? が、[[m:Enumerable#include?]],[[m:Enumerable#member?]]
 obj が範囲内に含まれている時に真を返します。
 
 [[m:Range#include?]] と異なり <=> メソッドによる演算により範囲内かどうかを判定します。
+[[m:Range#include?]] は原則として離散値を扱い、
+Range#cover? は連続値を扱います。
+（数値については、例外として [[m:Range#include?]] も連続的に扱います。）
 
 @param obj 比較対象のオブジェクトを指定します。
+
+  # 数値は連続的に扱われているため、 include? / cover? が同じ結果を返却
+  (1.1..2.3).include?(1.0)                                                                                         # => false
+  (1.1..2.3).include?(1.1)                                                                                         # => true
+  (1.1..2.3).include?(1.555)                                                                                       # => true
+  (1.1..2.3).cover?(1.0)                                                                                           # => false
+  (1.1..2.3).cover?(1.1)                                                                                           # => true
+  (1.1..2.3).cover?(1.555)                                                                                         # => true
+  
+  # String の例
+  ('b'..'d').include?('d')                                                                                         # => true
+  ('b'..'d').include?('ba')                                                                                        # => false
+  ('b'..'d').cover?('d')                                                                                           # => true
+  ('b'..'d').cover?('ba')                                                                                          # => true
+  
+  # Date, DateTime の例
+  (Date.new(2014,1,3)..Date.new(2014,1,5)).include?(Date.new(2014,1,5))                                            # => true
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))                                   # => "can't iterate from Time"
+  (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))                                              # => true
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))                                     # => true
 
 @see [[m:Range#include?]]
 #@end

--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -100,24 +100,24 @@ Range#cover? は連続値を扱います。
 @param obj 比較対象のオブジェクトを指定します。
 
   # 数値は連続的に扱われているため、 include? / cover? が同じ結果を返却
-  (1.1..2.3).include?(1.0)                                                                                         # => false
-  (1.1..2.3).include?(1.1)                                                                                         # => true
-  (1.1..2.3).include?(1.555)                                                                                       # => true
-  (1.1..2.3).cover?(1.0)                                                                                           # => false
-  (1.1..2.3).cover?(1.1)                                                                                           # => true
-  (1.1..2.3).cover?(1.555)                                                                                         # => true
+  (1.1..2.3).include?(1.0)    # => false
+  (1.1..2.3).include?(1.1)    # => true
+  (1.1..2.3).include?(1.555)  # => true
+  (1.1..2.3).cover?(1.0)      # => false
+  (1.1..2.3).cover?(1.1)      # => true
+  (1.1..2.3).cover?(1.555)    # => true
   
   # String の例
-  ('b'..'d').include?('d')                                                                                         # => true
-  ('b'..'d').include?('ba')                                                                                        # => false
-  ('b'..'d').cover?('d')                                                                                           # => true
-  ('b'..'d').cover?('ba')                                                                                          # => true
+  ('b'..'d').include?('d')    # => true
+  ('b'..'d').include?('ba')   # => false
+  ('b'..'d').cover?('d')      # => true
+  ('b'..'d').cover?('ba')     # => true
   
   # Date, DateTime の例
-  (Date.new(2014,1,3)..Date.new(2014,1,5)).include?(Date.new(2014,1,5))                                            # => true
-  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))                                   # => "can't iterate from Time"
-  (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))                                              # => true
-  (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))                                     # => true
+  (Date.new(2014,1,3)..Date.new(2014,1,5)).include?(Date.new(2014,1,5))           # => true
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))  # => "can't iterate from Time"
+  (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))             # => true
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))    # => true
 
 @see [[m:Range#include?]]
 #@end


### PR DESCRIPTION
# Range#include? と Range#cover? の差異を追記
## プルリクエスト作成の理由
現状の記載だと、 Range#cover? の目的・用途が分かりにくいため、
Rubyメーリングリストや、Matz にっきの Matz さんの発言をもとに
目的・用途に関する記載とサンプルコードを追加した方が良いと感じました。

## 参考資料
* [Ruby メーリングリスト Rangeクラスに関する質問に対する Matz さんの回答 21 Apr 2014](http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/49799)
* [Matzにっき 2005-12-10 名前重要](http://www.rubyist.net/~matz/20051210.html)
