### PR TITLE
Add main usage of Regexp#===

### DIFF
--- a/refm/api/src/_builtin/Regexp
+++ b/refm/api/src/_builtin/Regexp
@@ -285,6 +285,8 @@ string が文字列でない場合には false を返します。
 string が文字列でもシンボルでもない場合には false を返します。
 #@end
 
+このメソッドは主にcase文での比較に用いられます。
+
 @param string マッチ対象文字列
 
 --- ~ -> Fixnum | nil


### PR DESCRIPTION
Regexp#=== の主な用途について追記しました