### PR TITLE
NotImplementedError is raised if birthtime is unavailable

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -44,11 +44,11 @@ include File::Constants
 
 作成された時刻を返します。
 
-Windows のような birthtime のない環境では ctime の値を返します。
-
 @param filename ファイル名を表す文字列か IO オブジェクトを指定します。
 
 @raise Errno::EXXX ファイルの時刻の取得に失敗した場合に発生します。
+
+@raise NotImplementedError  Windows のような birthtime のない環境で発生します。
 
   File.birthtime("testfile")   #=> Wed Apr 09 08:53:13 CDT 2003
 #@end
@@ -757,11 +757,11 @@ path が全てのユーザから書き込めるならば、そのファイルの
 
 作成された時刻を Time オブジェクトとして返します。
 
-Windows のような birthtime のない環境では ctime の値を返します。
-
 @raise IOError 自身が close されている場合に発生します。
 
 @raise Errno::EXXX ファイルの時刻の取得に失敗した場合に発生します。
+
+@raise NotImplementedError  Windows のような birthtime のない環境で発生します。
 
   File.new("testfile").birthtime   #=> Wed Apr 09 08:53:14 CDT 2003
 

--- a/refm/api/src/_builtin/File__Stat
+++ b/refm/api/src/_builtin/File__Stat
@@ -262,7 +262,7 @@ rdev の minor 番号部を返します。
 
 作成された時刻を返します。
 
-Windows のような birthtime のない環境では ctime の値を返します。
+@raise NotImplementedError  Windows のような birthtime のない環境で発生します。
 
   File.write("testfile", "foo")
   sleep 10


### PR DESCRIPTION
Ruby本体のdocが間違っていたようなのですが、`birthtime`が無い環境では、`ctime`が返らず、`NotImplementedError`が発生します。

Ruby本体の方は[このコミット](https://github.com/ruby/ruby/commit/857756ac6e07e6c2793c62ecd570fe2fc63c3aa1)で修正済みです。