### PR TITLE
$ERROR_INFO has nil when exception does not occur

### DIFF
--- a/refm/api/src/English.rd
+++ b/refm/api/src/English.rd
@@ -14,7 +14,7 @@
 
 == Special Variables
 
---- $ERROR_INFO -> Exception
+--- $ERROR_INFO -> Exception  | nil
 
 [[m:$!]] の別名
 


### PR DESCRIPTION
例外が発生してない場合、$ERROR_INFOはnilであるため戻り値に追記しました。