### PR TITLE
Fix typo at String.try_convert

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -199,7 +199,7 @@ obj を String に変換しようと試みます。変換には [[m:Object#to_st
 @param obj   変換する任意のオブジェクト
 @return      変換後の文字列または nil
 
-   String.try_convert("str")     # => str
+   String.try_convert("str")     # => "str"
    String.try_convert(/re/)      # => nil
 
 #@end


### PR DESCRIPTION
[rdoc](http://docs.ruby-lang.org/en/2.2.0/String.html#method-c-try_convert)に下記のように記載されていたので修正しました。

>String.try_convert("str")     #=> "str"
>String.try_convert(/re/)      #=> nil
