### PR TITLE
Update DateTime._strptime

### DIFF
--- a/refm/api/src/date/DateTime
+++ b/refm/api/src/date/DateTime
@@ -211,7 +211,7 @@ complete が真で、年が "00" から "99" の範囲であれば、
 例:
 
   DateTime._strptime('2001-02-03T12:13:14Z')
-  # => {:sec=>14, :zone=>"Z", :year=>2001, :hour=>12, :mday=>3, :min=>13, :offset=>0, :mon=>2}
+  # => {:year=>2001, :mon=>2, :mday=>3, :hour=>12, :min=>13, :sec=>14, :zone=>"Z", :offset=>0}
 
 [[m:DateTime.strptime]] の内部で使用されています。
 


### PR DESCRIPTION
`DateTime._strptime('2001-02-03T12:13:14Z')`の挙動を1.8.7から2.2.0までの各バージョンで調査しました。結果は下記の通りです。

Rubyのバージョン|結果
-------|-----
1.9.1から2.2.0 | {:year=>2001, :mon=>2, :mday=>3, :hour=>12, :min=>13, :sec=>14, :zone=>"Z", :offset=>0}
1.8.7 | {:offset=>0, :mon=>2, :sec=>14, :zone=>"Z", :year=>2001, :min=>13, :hour=>12, :mday=>3}
元の記述|{:sec=>14, :zone=>"Z", :year=>2001, :hour=>12, :mday=>3, :min=>13, :offset=>0, :mon=>2}

元の記述は1.8.7より古いバージョンみたいです。

[各バージョンの対応方針](https://github.com/rurema/doctree/wiki/ProjectGoal)には、
>1.8.0から1.8.6は「対応してもよい」けど「消してもよい」
>1.8.7, 1.9.1, 1.9.2は「メンテを放棄してもよい」けど「残す」
>1.9.3, 2.0.0 以降は「対応しなければならない」

と記載されていましたので、「このPRは1.9.3以降のみ対応する」という前提で作成しています。