### PR TITLE
print関数の出力例を修正

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1578,8 +1578,8 @@ to_s メソッドにより文字列に変換してから出力します。
   $\ = "<end>\n"
   print
   print "AA","BB"
-  #=> input<and><end>
-  #=> AA<and>BB<and><end>
+  #=> input<end>
+  #=> AA<and>BB<end>
 #@else
   print "Hello, world!"
   print "Regexp is",/ant/


### PR DESCRIPTION
http://docs.ruby-lang.org/ja/2.2.0/class/Kernel.html#M_PRINT

の出力例の間違い（修正漏れ）を修正しました。
