### PR TITLE
Update sample of OpenStruct.new

### DIFF
--- a/refm/api/src/ostruct.rd
+++ b/refm/api/src/ostruct.rd
@@ -83,7 +83,9 @@ OpenStruct オブジェクトを生成します。
 
   require 'ostruct'
   some1 = OpenStruct.new({:a =>"a",:b =>"b"}) # => #<OpenStruct b="b", a="a">
+#@until 2.0.0
   some2 = OpenStruct.new([[:a,"a"],[:b,"b"]]) # => #<OpenStruct b="b", a="a">
+#@end
 
 == Instance Methods
 


### PR DESCRIPTION
サンプル例で、引数に「配列の配列」を取る実装が残っていたため修正しました。