### PR TITLE
Fix wrong exception calss name

### DIFF
--- a/refm/api/src/net/Net__HTTPResponse
+++ b/refm/api/src/net/Net__HTTPResponse
@@ -53,8 +53,8 @@ msg は obsolete です。使わないでください。
 @raise HTTPError レスポンスが 1xx であるか、 net/http が知らない
                  種類のレスポンスである場合に発生します。
 @raise HTTPRetriableError レスポンスが 3xx である場合に発生します。
-@raise HTTPFatalError レスポンスが 4xx である場合に発生します。
-@raise HTTPServerError レスポンスが 5xx である場合に発生します。
+@raise HTTPServerException レスポンスが 4xx である場合に発生します。
+@raise HTTPFatalError レスポンスが 5xx である場合に発生します。
 
 
 --- response -> self


### PR DESCRIPTION
Net::HTTPResponse#valueの例外の説明が、実際の挙動と違っていたので修正しました。

参考: https://github.com/ruby/ruby/blob/3e972a116fb063fc0c1dda7292ff386d6d2ae737/lib/net/http/responses.rb#L18-L25