### PR TITLE
Fix http status code by exception class

### DIFF
--- a/refm/api/src/net/Net__HTTPExceptions
+++ b/refm/api/src/net/Net__HTTPExceptions
@@ -36,7 +36,7 @@ HTTP ステータスコード 3xx を受け取ったという例外です。
 = class Net::HTTPServerException < Net::ProtoServerError
 include Net::HTTPExceptions
 
-HTTP ステータスコード 5xx を受け取ったという例外です。
+HTTP ステータスコード 4xx を受け取ったという例外です。
 
 クライアントのリクエストに誤りがあるか、サーバにリクエストを拒否さ
 れた(認証が必要、リソースが存在しないなどで)ことを示します。
@@ -44,7 +44,7 @@ HTTP ステータスコード 5xx を受け取ったという例外です。
 = class Net::HTTPFatalError < Net::ProtoFatalError
 include Net::HTTPExceptions
 
-HTTP ステータスコード 4xx を受け取ったという例外です。
+HTTP ステータスコード 5xx を受け取ったという例外です。
 
 クライアントのリクエストに誤りがあるか、サーバにリクエストを拒否さ
 れた(認証が必要、リソースが存在しないなどで)ことを示します。


### PR DESCRIPTION
例外クラスに対するhttp status codeが間違っていたので修正します。

Net::HTTPServerExceptionはNet::HTTPClientError(4xx)と
Net::HTTPFatalErrorはNet::HTTPServerError(5xx)と
それぞれ関連するはずです。

参考: https://github.com/ruby/ruby/blob/3e972a116fb063fc0c1dda7292ff386d6d2ae737/lib/net/http/responses.rb#L18-L25