### PR TITLE
Keep a reference to Tempfile object

### DIFF
--- a/refm/api/src/tempfile.rd
+++ b/refm/api/src/tempfile.rd
@@ -84,13 +84,13 @@ new にブロックを指定した場合は無視されます。
 例：ブロックを与えた場合
   require 'tempfile'
 
-  path = Tempfile.open("temp"){|fp|
+  tf = Tempfile.open("temp"){|fp|
     fp.puts "hoge"
-    fp.path
+    fp
   }
   # テンポラリファイルへのパスを表示
-  p path 
-  p File.read(path) #=> "hoge\n"
+  p tf.path
+  p File.read(tf.path) #=> "hoge\n"
 
 #@else
 例：ブロックを与えた場合


### PR DESCRIPTION
Tempfile への参照がなくなると GC されてファイルが消え得るので参照を保持するようにしました。
このコード例以外で参照が切れている箇所はなさそうに見えます。