### PR TITLE
Move methods return Method class

### DIFF
--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -1,6 +1,6 @@
 = class Method < Object
 
-[[m:Object#method]] によりオブジェクト化され
+[[m:Kernel.#method]] によりオブジェクト化され
 たメソッドオブジェクトのクラスです。
 
 メソッドの実体（名前でなく）とレシーバの組を封入します。
@@ -78,7 +78,7 @@
   p Foo.new.send(methods[2])      # => "bar"
   p Foo.new.send(methods[3])      # => "baz"
 
-@see [[m:Object#method]]
+@see [[m:Kernel.#method]]
 
 == Instance Methods
 

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -804,7 +804,7 @@ self の public インスタンスメソッド name をオブジェクト化し�
   Kernel.public_instance_method(:object_id) #=> #<UnboundMethod: Kernel#object_id>
   Kernel.public_instance_method(:p)         #   method `p' for module `Kernel' is private (NameError)
 
-@see [[m:Module#instance_method]],[[m:Object#public_method]]
+@see [[m:Module#instance_method]],[[m:Kernel.#public_method]]
 #@end
 
 #@since 1.9.1

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -605,7 +605,7 @@ self のインスタンスメソッド name をオブジェクト化した [[c:U
 
 @raise NameError self に存在しないメソッドを指定した場合に発生します。
 
-@see [[m:Module#public_instance_method]], [[m:Object#method]]
+@see [[m:Module#public_instance_method]], [[m:Kernel.#method]]
 
 --- method_defined?(name) -> bool
 

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1391,35 +1391,6 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
 
 @see [[m:Object#freeze]]
 
-#@since 2.1.0
---- singleton_method(name) -> Method
-
-オブジェクトの特異メソッド name をオブジェクト化した [[c:Method]] オブ
-ジェクトを返します。
-
-@param name メソッド名を[[c:Symbol]] または[[c:String]]で指定します。
-@raise NameError 定義されていないメソッド名を引数として与えると発生します。
-
-   class Demo
-     def initialize(n)
-       @iv = n
-     end
-     def hello()
-       "Hello, @iv = #{@iv}"
-     end
-   end
-
-   k = Demo.new(99)
-   def k.hi
-     "Hi, @iv = #{@iv}"
-   end
-   m = k.singleton_method(:hi)    # => #<Method: #<Demo:0xf8b0c3c4 @iv=99>.hi>
-   m.call   #=> "Hi, @iv = 99"
-   m = k.singleton_method(:hello) # => NameError
-
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Kernel.#method]]
-#@end
-
 #@since 2.0.0
 --- respond_to?(name, include_all = false) -> bool
 #@else

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -191,22 +191,6 @@ other が self 自身の時、真を返します。
 @see [[m:Module#instance_methods]],[[m:Object#singleton_methods]]
 
 #@since 1.9.1
---- public_method(name) -> Method
-
-オブジェクトの public メソッド name をオブジェクト化した
-[[c:Method]] オブジェクトを返します。
-
-@param name メソッド名を [[c:Symbol]] または [[c:String]] で指定します。
-@raise NameError 定義されていないメソッド名や、
-       protected メソッド名、 private メソッド名を引数として与えると発生します。
-
-  1.public_method(:to_int) #=> #<Method: Fixnum(Integer)#to_int>
-  1.public_method(:p)      #   method `p' for class `Fixnum' is private (NameError)
-
-@see [[m:Kernel.#method]],[[m:Object#public_send]],[[m:Module#public_instance_method]]
-#@end
-
-#@since 1.9.1
 --- public_methods(include_inherited = true) -> [Symbol]
 #@else
 #@since 1.8.0

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -203,7 +203,7 @@ other が self 自身の時、真を返します。
   1.public_method(:to_int) #=> #<Method: Fixnum(Integer)#to_int>
   1.public_method(:p)      #   method `p' for class `Fixnum' is private (NameError)
 
-@see [[m:Object#method]],[[m:Object#public_send]],[[m:Module#public_instance_method]]
+@see [[m:Kernel.#method]],[[m:Object#public_send]],[[m:Module#public_instance_method]]
 #@end
 
 #@since 1.9.1
@@ -1107,7 +1107,7 @@ send, __send__ は、メソッドの呼び出し制限
   p Foo.new.send(methods[2])      # => "bar"
   p Foo.new.send(methods[3])      # => "baz"
 
-@see [[m:Object#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
+@see [[m:Kernel.#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
 
 #@since 1.9.1
 --- public_send(name, *args) -> object
@@ -1391,24 +1391,6 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
 
 @see [[m:Object#freeze]]
 
---- method(name) -> Method
-
-オブジェクトのメソッド name をオブジェクト化した
-[[c:Method]] オブジェクトを返します。
-
-@param name メソッド名を[[c:Symbol]] または[[c:String]]で指定します。
-@raise NameError 定義されていないメソッド名を引数として与えると発生します。
-
-  me = -365.method(:abs)
-  p me #=> #<Method: Fixnum#abs>
-  p me.call #=> 365
-
-#@since 2.1.0
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#singleton_method]]
-#@else
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]]
-#@end
-
 #@since 2.1.0
 --- singleton_method(name) -> Method
 
@@ -1435,7 +1417,7 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
    m.call   #=> "Hi, @iv = 99"
    m = k.singleton_method(:hello) # => NameError
 
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#method]]
+@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Kernel.#method]]
 #@end
 
 #@since 2.0.0

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1697,9 +1697,38 @@ to_s メソッドにより文字列に変換してから出力します。
   p me.call #=> 365
 
 #@since 2.1.0
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#singleton_method]]
+@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Kernel.#singleton_method]]
 #@else
 @see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]]
+#@end
+
+#@since 2.1.0
+--- singleton_method(name) -> Method
+
+オブジェクトの特異メソッド name をオブジェクト化した [[c:Method]] オブ
+ジェクトを返します。
+
+@param name メソッド名を[[c:Symbol]] または[[c:String]]で指定します。
+@raise NameError 定義されていないメソッド名を引数として与えると発生します。
+
+   class Demo
+     def initialize(n)
+       @iv = n
+     end
+     def hello()
+       "Hello, @iv = #{@iv}"
+     end
+   end
+
+   k = Demo.new(99)
+   def k.hi
+     "Hi, @iv = #{@iv}"
+   end
+   m = k.singleton_method(:hi)    # => #<Method: #<Demo:0xf8b0c3c4 @iv=99>.hi>
+   m.call   #=> "Hi, @iv = 99"
+   m = k.singleton_method(:hello) # => NameError
+
+@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Kernel.#method]]
 #@end
 
 --- Array(arg) -> Array

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1684,6 +1684,24 @@ to_s メソッドにより文字列に変換してから出力します。
 @see [[m:$stderr]],[[m:$VERBOSE]]
 #@end
 
+--- method(name) -> Method
+
+オブジェクトのメソッド name をオブジェクト化した
+[[c:Method]] オブジェクトを返します。
+
+@param name メソッド名を[[c:Symbol]] または[[c:String]]で指定します。
+@raise NameError 定義されていないメソッド名を引数として与えると発生します。
+
+  me = -365.method(:abs)
+  p me #=> #<Method: Fixnum#abs>
+  p me.call #=> 365
+
+#@since 2.1.0
+@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#singleton_method]]
+#@else
+@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]]
+#@end
+
 --- Array(arg) -> Array
 
 引数を配列([[c:Array]])に変換した結果を返します。
@@ -2679,9 +2697,9 @@ bind によらずに特定のオブジェクトのコンテキストで expr を
   #       from ..:9
 
 #@since 1.9.1
-@see [[m:Kernel.#binding]],[[m:Module#module_eval]],[[m:BasicObject#instance_eval]],[[m:Object#method]],[[m:Object#send]]
+@see [[m:Kernel.#binding]],[[m:Module#module_eval]],[[m:BasicObject#instance_eval]],[[m:Kernel.#method]],[[m:Object#send]]
 #@else
-@see [[m:Kernel.#binding]],[[m:Module#module_eval]],[[m:Object#instance_eval]],[[m:Object#method]],[[m:Object#send]]
+@see [[m:Kernel.#binding]],[[m:Module#module_eval]],[[m:Object#instance_eval]],[[m:Kernel.#method]],[[m:Object#send]]
 #@end
 
 #@#==== リフレクション

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1702,6 +1702,22 @@ to_s メソッドにより文字列に変換してから出力します。
 @see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]]
 #@end
 
+#@since 1.9.1
+--- public_method(name) -> Method
+
+オブジェクトの public メソッド name をオブジェクト化した
+[[c:Method]] オブジェクトを返します。
+
+@param name メソッド名を [[c:Symbol]] または [[c:String]] で指定します。
+@raise NameError 定義されていないメソッド名や、
+       protected メソッド名、 private メソッド名を引数として与えると発生します。
+
+  1.public_method(:to_int) #=> #<Method: Fixnum(Integer)#to_int>
+  1.public_method(:p)      #   method `p' for class `Fixnum' is private (NameError)
+
+@see [[m:Kernel.#method]],[[m:Object#public_send]],[[m:Module#public_instance_method]]
+#@end
+
 #@since 2.1.0
 --- singleton_method(name) -> Method
 


### PR DESCRIPTION
`method`, `public_method`, `singleton_method`が定義されているのは、ObjectではなくKernelだと思います。(バージョンに関係なく)

```ruby
method(:method).owner #=> Kernel
method(:public_method).owner #=> Kernel
method(:singleton_method).owner #=> Kernel
```

3つのメソッド説明記述の移動と、リンクの修正を行いました。