### PR TITLE
Add UnboundMethod#super_method

### DIFF
--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -352,4 +352,6 @@ self を元にカリー化した [[c:Proc]] を返します。
 
 self 内で super を実行した際に実行されるメソッドを [[c:Method]] オブジェ
 クトにして返します。
+
+@see [[m:UnboundMethod#super_method]]
 #@end

--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -221,3 +221,12 @@ UnboundMethod オブジェクトの引数の情報を返します。
 
 @see [[m:Proc#parameters]], [[m:Method#parameters]]
 #@end
+
+#@since 2.2.0
+--- super_method -> UnboundMethod | nil
+
+self 内で super を実行した際に実行されるメソッドを [[c:UnboundMethod]] オブジェ
+クトにして返します。
+
+@see [[m:Method#super_method]]
+#@end


### PR DESCRIPTION
2.2.0でMethod#super_methodとともに追加されたUnboundMethod#super_methodの記述がなかったので追加しました。

https://github.com/ruby/ruby/commit/b4981594dd8ac975d76ad1654a419bd6263c3c69
http://docs.ruby-lang.org/en/2.2.0/UnboundMethod.html#method-i-super_method

また、それにともないMethod#super_methodのsee項目にUnboundMethod#super_methodへのリンクを追加しました。