### PR TITLE
Fix sample code to executable for protected method

### DIFF
--- a/refm/doc/spec/def.rd
+++ b/refm/doc/spec/def.rd
@@ -671,7 +671,7 @@ protected よりは private が使われることの方が多いようです。
 
         class Foo
           def _val
-            @val
+            'val'
           end
           protected :_val
 


### PR DESCRIPTION
`protected`なメソッドのサンプルコードがコピペで動作しなかったので修正してみました。
この説明でインスタンス変数を使う必要もないのでこちらの方がいいかなと....
