### PR TITLE
Fix OpenSSL::SSL::SSLContext#verify_mode= default value

### DIFF
--- a/refm/api/src/net/https.rd
+++ b/refm/api/src/net/https.rd
@@ -195,7 +195,7 @@ SSL/TLS が有効でなかったり、接続前である場合には nil
 [[m:OpenSSL::SSL::VERIFY_NONE]] か [[m:OpenSSL::SSL::VERIFY_PEER]]
 のいずれかを用います。
 
-デフォルトは nil で、VERIFY_NONE を意味します。
+デフォルトは nil で、VERIFY_PEER を意味します。
 
 --- verify_callback -> Proc
 自身に設定されている検証をフィルタするコールバックを


### PR DESCRIPTION
ソースコードを見る限り、nil の場合は VERIFY_PEER ではないかなと思います。

https://github.com/ruby/ruby/blob/trunk/lib/net/http.rb#L576

VERIFY_NONE じゃなくなったのはこのあたり（https://github.com/ruby/ruby/commit/c6920177f3e561f779f54534e511f0c9f0de6edd ）ですね。
2007年…