### PR TITLE
Fix documentation about exception of Array#dig

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -1093,7 +1093,7 @@ self 以下のネストしたオブジェクトを dig メソッドで再帰的�
 
   a.dig(0, 1, 1)                 # => 3
   a.dig(1, 2, 3)                 # => nil
-  a.dig(0, 0, 0)                 # => NoMethodError, undefined method `dig' for 1:Fixnum
+  a.dig(0, 0, 0)                 # => TypeError: Fixnum does not have #dig method
   [42, {foo: :bar}].dig(1, :foo) # => :bar
 
 @see [[m:Hash#dig]], [[m:Struct#dig]], [[m:OpenStruct#dig]]


### PR DESCRIPTION
Array#dig で起きる例外について、実際の動きに合わせて[修正されたRuby-Docの内容](https://github.com/ruby/ruby/commit/4df168074c9e80822b4326a4539600ae7dbe0adb#diff-24411fb2a634ee46e29925b04767d15e)を反映しました。