### PR TITLE
`nil[1]` raise NoMethodError on all version

### DIFF
--- a/refm/api/src/_builtin/Regexp
+++ b/refm/api/src/_builtin/Regexp
@@ -129,7 +129,7 @@ string の中で正規表現において特別な意味を持つ文字の直前�
 
 正規表現全体がマッチしなかった場合、引数なしの
 Regexp.last_match はnil を返すため、
-last_match[1] の形式では例外 [[c:NameError]] が発生します。
+last_match[1] の形式では例外 [[c:NoMethodError]] が発生します。
 対して、last_match(1) は nil を返します。
 
   str = "This is Regexp"


### PR DESCRIPTION
`nil[1]`は、少なくとも1.8以降はNameErrorではなくNoMethodErrorが発生するようです。

```ruby
$ irb
irb(main):001:0> RUBY_VERSION
=> "1.8.7"
irb(main):002:0> nil[1]
NoMethodError: undefined method `[]' for nil:NilClass
	from (irb):2
```