### PR TITLE
draft-coar-cgi-v11-03.txtへのリンクを修正した

### DIFF
--- a/refm/api/src/cgi.rd
+++ b/refm/api/src/cgi.rd
@@ -11,7 +11,7 @@ CGI プログラムの支援ライブラリです。
 
 CGI プロトコルの詳細については以下の文書を参照してください。
 
-  * [[url:http://Web.Golux.Com/coar/cgi/draft-coar-cgi-v11-03.txt]]
+  * [[url:https://tools.ietf.org/html/draft-coar-cgi-v11-03]]
   * [[RFC:3875]]: The Common Gateway Interface (CGI) Version 1.1
   * [[url:http://www.w3.org/CGI/]]
 


### PR DESCRIPTION
`draft-coar-cgi-v11-03.txt`へのリンクが切れていたため、修正しました。