### PR TITLE
rssライブラリーのチュートリアルにAtom関連を追加

### DIFF
--- a/refm/api/src/rss.rd
+++ b/refm/api/src/rss.rd
@@ -10,6 +10,7 @@ RSS を扱うためのライブラリです。
   * RSS 0.91 [[url:http://backend.userland.com/rss091]]
   * RSS 1.0  [[url:http://purl.org/rss/1.0/spec]]  
   * RSS 2.0  [[url:http://www.rssboard.org/rss-specification]]
+  * Atom 1.0 [[url:http://www.ietf.org/rfc/rfc4287.txt]]
 #@include(rss/Tutorial)
 #@include(rss/0.9.rd)
 #@include(rss/1.0.rd)

--- a/refm/api/src/rss/Tutorial
+++ b/refm/api/src/rss/Tutorial
@@ -2,7 +2,7 @@
 
 === 注意
 
-RSS ParserはRSS 0.9x/1.0/2.0をサポートしていますが，RSS 0.90
+RSS ParserはRSS 0.9x/1.0/2.0, Atom 1.0 をサポートしていますが，RSS 0.90
 はサポートしてません．ごめんなさい．
 
 RSS のモジュールはそれぞれ、
@@ -21,11 +21,12 @@ RSS::Parser.parse は String の RSSを パースします(使用するXMLパー
 サによっては File や IO オブジェクトなどでもパース可能です)。
  * RSS 1.0をパースした場合は [[c:RSS::RDF]] オブジェクト
  * RSS 0.9x/2.0をパースした場合は [[c:RSS::Rss]] オブジェクト
+ * Atom をパースした場合は [[c:RSS::Atom::Feed]] オブジェクト
 をそれぞれ返します。パースした
 String が well formed な XML で無い場合は，
 例外 [[c:RSS::NotWellFormedError]] が発生します。well formed な
-XML だが，RSS 0.9x/1.0/2.0 のいずれでもない場合は，nil が返りま
-す．
+XML だが，RSS 0.9x/1.0/2.0, Atom のいずれでもない場合は，nil が
+返ります．
 
 例えば、RSS 1.0 をバリデーション付きでパースするには以下のよ
 うにします。ここで、変数 rss_source には RSS 1.0 形式の文
@@ -62,17 +63,18 @@ RSS::Parser.parse の第二引数は省略すると true が指定されたも�
 要素)を無視します。もし、知らない要素に遭遇した時に例外を発
 生させたければ，RSS::Parser.parse の第三引数に false を指定して
 ください。こうすると、パース中に知らない要素に遭遇した時に
-[[c:RSS::UnknownTagError]] 例外が発生します。
+[[c:RSS::UnknownTagError]] 例外が発生します。RSS::UnknownTagError
+クラスは [[c:RSS::InvalidError]] クラスのサブクラスです。
 
-以下のようにすると，より厳密にRSS 1.0をパースできます。
+以下のようにすると，より厳密にパースできます。
 
   RSS::Parser.parse(rss_source, true, false)
 
-=== パースされたRSS
+=== パースされたフィード
 
-RSS はパースされると [[c:String]] オブジェクトから [[c:RSS::RDF]],
-[[c:RSS::RDF::Channel]], [[c:RSS::Rss]] 等のオブジェクトになります。各オ
-ブジェクトで子要素オブジェクトにアクセスするために，要素名と
+フィードをパースすると  [[c:RSS::RDF]], [[c:RSS::RDF::Channel]],
+[[c:RSS::Rss]], [[c:RSS::Atom::Feed]] 等のオブジェクトになります。
+各オブジェクトで子要素オブジェクトにアクセスするために，要素名と
 同じ名前のアクセサがあります。
 
 ==== リーダ(reader)
@@ -145,17 +147,17 @@ Array#<<やArray#[]=などを用いて要素を設定します．
 
 === 出力
 
-RSS Parserといっているので誤解されがちですが，RSSを出力する
+RSS Parserといっているので誤解されがちですが，RSS/Atomを出力する
 こともできます．
 
 ==== 基本
 
-to_sするとRSS形式の文字列を返します．
+to_sするとRSSまたはAtom形式の文字列を返します．
 
-RSSを出力する流れは以下のようになります．
+RSS/Atomを出力する流れは以下のようになります．
 
-  * RSSオブジェクト（RSS::RDFとかRSS::Rssクラス
-    のオブジェクト）を作成する
+  * RSS/Atomオブジェクト（RSS::RDFとかRSS::Rssクラスとか
+    RSS::Atom::Feedのオブジェクト）を作成する
 
   * 出力エンコーディングを指定する(省略可)
 
@@ -166,9 +168,11 @@ RSSを出力する流れは以下のようになります．
 xml-stylesheetも出力することができます．
 
 RSSのルート要素（RSS::RDFまたはRSS::Rss）オブジェ
-クトはxml_stylesheetsという名前の配列を持っています．この配
-列にRSS::XMLStyleSheetオブジェクトを挿入することでRSS
-にxml-stylesheetを関連づけることができます．
+クトおよびAtomのルート要素（RSS::Atom::Feedまたは
+RSS::Atom::Entry）オブジェクトはxml_stylesheetsという
+名前の配列を持っています．この配列にRSS::XMLStyleSheet
+オブジェクトを挿入することでRSS/Atomにxml-stylesheetを
+関連づけることができます．
 
   rss.xml_stylesheets << RSS::XMLStyleSheet.new(...)
 
@@ -209,10 +213,10 @@ Hash:
 ろですが，拡張子が.xslまたは，.cssの場合は適当に推測してくれ
 るので省略可能です．
 
-==== RSSオブジェクトを作る
+==== RSS/Atomオブジェクトを作る
 
-既存のRSSをパースせずに，一から新しくRSSを作成するにはRSS
-Makerが便利です．
+既存のRSS/Atomをパースせずに，一から新しくRSS/Atomを作成するには
+RSS Makerが便利です．
 
 
 以下のように使います．
@@ -223,6 +227,8 @@ Makerが便利です．
     maker.XXX = YYY
     ...
   end
+
+===== シンプルなRSS
 
 例えば，
 
@@ -262,6 +268,8 @@ Makerが便利です．
     item.title = "Sample Article"
   end
 
+===== 更新時刻を追加
+
 もし，先のエントリが
 
   * 2004/11/1 10:10
@@ -276,10 +284,11 @@ Makerが便利です．
     maker.channel.description = "Example Site"
     maker.channel.link = "http://example.com/"
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
   end
 
 サンプル中の
@@ -293,6 +302,7 @@ Makerが便利です．
 でも構いません．#dc_date=は#date=の単なる別名で
 す．
 
+===== さらにエントリを追加
 
 さらに，
 
@@ -310,16 +320,20 @@ Makerが便利です．
     maker.channel.description = "Example Site"
     maker.channel.link = "http://example.com/"
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
   end
+
+===== エントリを並び替える
 
 もし，更新日が新しい順に並び替えたければ
 
@@ -337,16 +351,20 @@ Makerが便利です．
 
     maker.items.do_sort = true
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
   end
+
+===== ロゴの指定
 
 もし，サイトに
 
@@ -365,19 +383,23 @@ Makerが便利です．
 
     maker.items.do_sort = true
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
 
     maker.image.title = "Example Site"
     maker.image.url = "http://example.com/logo.png"
   end
+
+===== 検索ページの指定
 
 もし，
 
@@ -386,7 +408,7 @@ Makerが便利です．
   * Search Example Siteという名前で
   * Search Example Site's all textという説明付きの
 
-検索用CGIがあったら以下のようにします．
+検索用ページがあったら以下のようにします．
 
   require "rss"
 
@@ -398,15 +420,17 @@ Makerが便利です．
 
     maker.items.do_sort = true
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
 
     maker.image.title = "Example Site"
     maker.image.url = "http://example.com/logo.png"
@@ -416,6 +440,8 @@ Makerが便利です．
     maker.textinput.name = "keyword"
     maker.textinput.link = "http://example.com/search.cgi"
   end
+
+===== XMLスタイルシートの指定
 
 もし，
 
@@ -436,15 +462,17 @@ xml-stylesheetを追加したい場合は以下のようにします．
 
     maker.items.do_sort = true
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
 
     maker.image.title = "Example Site"
     maker.image.url = "http://example.com/logo.png"
@@ -454,6 +482,8 @@ xml-stylesheetを追加したい場合は以下のようにします．
     maker.textinput.name = "keyword"
     maker.textinput.link = "http://example.com/search.cgi"
   end
+
+===== RSS 2.0の生成
 
 もし，RSS 2.0を生成したい場合は以下のように，
 RSS::Maker.makeの第一引数を変更します．
@@ -471,15 +501,17 @@ RSS::Maker.makeの第一引数を変更します．
 
     maker.items.do_sort = true
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article.html"
-    item.title = "Sample Article"
-    item.date = Time.parse("2004/11/1 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
 
-    item = maker.items.new_item
-    item.link = "http://example.com/article2.html"
-    item.title = "Sample Article2"
-    item.date = Time.parse("2004/11/2 10:10")
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
 
     maker.image.title = "Example Site"
     maker.image.url = "http://example.com/logo.png"
@@ -490,8 +522,200 @@ RSS::Maker.makeの第一引数を変更します．
     maker.textinput.link = "http://example.com/search.cgi"
   end
 
+===== RSS 0.91の生成
+
 もし，RSS 0.91を生成したい場合は，RSS 2.0の場合と同様に
 RSS::Maker.make の第一引数を"0.91"に変更します．
+
+ただし、RSS 0.91では言語指定が必須なので、言語を指定する必要
+があります。ここでは日本語であると指定します。
+
+  rss = RSS::Maker.make("0.91") do |maker|
+    maker.channel.language = "ja"
+    ...
+  end
+
+RSS 1.0など、/rdf:RDF/channel/language要素がないフィードの場
+合でも、単に無視したりdc:languageとして扱ったりと適切に処理し
+ます。そのため、以下のように「バージョンが"0.91"のとき
+だけ言語を指定する」というように書く必要はありません。
+フィードのバージョンに関わらず言語を指定してください。
+
+  rss = RSS::Maker.make("0.91") do |maker|
+    maker.channel.language = "ja" if maker.feed_version == "0.91"
+    ...
+  end
+
+===== Atom 1.0の生成
+
+もし，Atom 1.0を生成したい場合は，RSS 0.91や2.0の場合と同様に
+RSS::Maker.makeの第一引数を"atom"に変更します．
+
+  rss = RSS::Maker.make("atom") do |maker|
+    ...
+  end
+
+ただし、これだけでは十分ではありません。これは、Atom 1.0では
+RSS 1.0/2.0/0.91では必須ではなかった以下の情報が必要となるか
+らです。
+
+  * このAtom 1.0の作者
+  * このAtom 1.0の更新日
+
+よって、これまでのスクリプトをAtom 1.0を出力するようにするた
+めには以下のように変更する必要があります。
+
+  * RSS::Maker.makeの第一引数を"atom"に変更
+  * maker.channel.authorを設定
+  * maker.channel.dateを設定
+
+もし、
+
+  * 作者がBobで
+  * たった今、作成された
+
+Atom 1.0なら以下のようになります。
+
+  require "rss"
+
+  atom = RSS::Maker.make("atom") do |maker|
+    xss = maker.xml_stylesheets.new_xml_stylesheet
+    xss.href = "http://example.com/index.xsl"
+
+    maker.channel.about = "http://example.com/atom.xml"
+    maker.channel.title = "Example"
+    maker.channel.description = "Example Site"
+    maker.channel.link = "http://example.com/"
+
+    maker.channel.author = "Bob"
+    maker.channel.date = Time.now
+
+    maker.items.do_sort = true
+
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article.html"
+      item.title = "Sample Article"
+      item.date = Time.parse("2004/11/1 10:10")
+    end
+
+    maker.items.new_item do |item|
+      item.link = "http://example.com/article2.html"
+      item.title = "Sample Article2"
+      item.date = Time.parse("2004/11/2 10:10")
+    end
+
+    maker.image.title = "Example Site"
+    maker.image.url = "http://example.com/logo.png"
+
+    maker.textinput.title = "Search Example Site"
+    maker.textinput.description = "Search Example Site's all text"
+    maker.textinput.name = "keyword"
+    maker.textinput.link = "http://example.com/search.cgi"
+  end
+
+Atom 1.0用の情報を加えたこのスクリプトを最初のRSS 1.0を出
+力するスクリプトに戻す場合は、RSS::Maker.makeの第一引
+数を"1.0"に変えるだけです。Atom 1.0用に追加した情報を
+削除する必要はありません。それらは単に無視されます。
+
+==== RSS/Atomオブジェクトを変換する
+
+フィードの種類がRSS 1.0/2.0でもAtomでもパースするためのAPIは
+以下のように共通です。
+
+  feed = RSS::Parser.parse(feed_xml)
+
+しかし、返ってくるオブジェクトはRSS 1.0オブジェクト
+（RSS::RDF）かもしれませんし、Atomオブジェクト
+（RSS::Atom::Feed）かもしれません。このため、パースした結果
+を使う場合はフィードの種類を意識しなくてはならず、
+使いづらくなります。
+
+RSS Parserが提供する解決方法はユーザに好みのフィードの種類を
+選んでもらうというものです。例えば、以下のようにしてRSS 1.0
+をRSS 2.0に変換することができます。
+
+  require 'rss'
+  rss10 = RSS::Parser.parse(rss10_xml)
+  rss20 = rss10.to_feed("rss2.0")
+
+種類がわからない複数のフィードを扱う場合は以下のようにし、す
+べてのフィードをRSS 2.0のように扱うことができます。
+
+  feeds.each do |xml|
+    rss20 = RSS::Parser.parse(xml).to_feed("rss2.0")
+    ...
+  end
+
+また、to_feedは以下のように書くことも出来ます。
+
+  feed.to_rss("1.0") # == feed.to_feed("rss1.0")
+  feed.to_rss("2.0") # == feed.to_feed("rss2.0")
+  feed.to_atom("1.0") # == feed.to_feed("atom1.0")
+
+形式を変換したときに問題になるのは、変換元のオブジェクトが変
+換後の形式に必須の情報を持っていない場合です。この場合は変換
+に失敗します（RSS::Errorのサブクラスの例外が発生します）。そ
+のため、適宜、必要な情報を補う必要があります。たとえば、RSS
+1.0では各item要素にタイトルが必須ですが、RSS 2.0では省略可能
+です。そのような場合に対応するために、以下のようにブロックを
+使用することが出来ます。
+
+  rss10 = feed.to_rss("1.0") do |maker|
+    maker.items.each do |item|
+      item.title.content ||= "No title"
+    end
+  end
+
+to_feedのブロック内で出来ることを理解するためには、to_feedが
+どのように動作するかを理解するとよいです。パース結果のオブジェ
+クトはフィードの種類に関わらずsetup_makerというメソッドを持っ
+ています。これは、自分が持っている情報をRSS Makerに与えるメソッ
+ドです。to_feedはRSS::Maker.makeで作ったRSS Makerに対して
+setup_makerを行い、他の形式に変換しようとします。ブロックには
+setup_makerを行った後のRSS Makerが渡されます。つまり、
+to_feedのブロック内で出来ることはRSS Makerに対して出来ること
+と同じです。
+
+==== フィードの形式を変換する
+
+上記の方法でパース済みのオブジェクトを変換できるので、フィー
+ドを異なる形式のXMLへ変換することは簡単です。
+
+  feed = RSS::Parser.parse(feed_xml)
+  new_feed_xml = feed.to_feed("atom1.0").to_s
+
+これを行うための便利なメソッドto_xmlがあります。to_xmlを使う
+と以下のように書き直すことができます。
+
+  feed = RSS::Parser.parse(feed_xml)
+  new_feed_xml = feed.to_xml("atom1.0")
+
+。。。あまり変わりませんね。to_feedを用いた場合と同じように
+ブロックを指定してRSS Makerを操作することも出来ます。ますま
+す変わりませんね。
+
+to_feed().to_sではなく、to_xmlを使うことには一長一短がありま
+す。to_xmlは変換元のフィードの種類と変換後のフィードの種類が
+同じ場合は単にto_sを呼び出すだけです。これにより、同じ形式に
+変換する場合の速度があがります（RSS Makerを作って変換、という
+ことを省略するので当然です）。しかし、ブロックを指定して変換
+後の結果を調整することができません。例えば、以下のようにRSS
+1.0からRSS 2.0に変換する場合はブロックが呼ばれます。
+
+  rss10.to_xml("rss2.0") do |maker|
+    # makerを操作できる
+  end
+
+しかし、以下のようにRSS 1.0からRSS 1.0に変換しようとした場合
+はブロックは呼び出されません。
+
+  rss10.to_xml("rss1.0") do |maker|
+    # ブロックが呼び出されないのでmakerを操作できない。
+  end
+
+このAPIに関しては、どうしたらよいのかまだ悩んでいます。もし、
+なにかアイディアがあれば教えてください。
 
 === サンプル
 
@@ -500,70 +724,96 @@ RSS Parser のサンプルスクリプトをいくつか紹介します．これ
 
 ==== サンプル1 - 項目一覧
 
-それでは、複数のRSSをパースしてitem要素を表示するスクリプト
+それでは、複数のフィードをパースしてitem要素を表示するスクリプト
 を書いてみましょう。
 
-まず、RSS 0.9x/1.0/2.0をパースできるように以下のようにrequireします。
+まず、RSS 0.9x/1.0/2.0, Atom 1.0をパースできるように以下のようにrequireします。
 
   require 'rss'
 
-パースするRSSはファイルに保存されていて引数で与えられるものとします。
+パースするフィードはファイルに保存されていて引数で与えられるものとします。
 
   ARGV.each do |fname|
-    rss_source = nil
-    File.open(fname) do |f|
-      rss_source = f.read
-    end
-
-    rss = nil
+    feed = nil
     begin
-      rss = RSS::Parser.parse(rss_source, false)
+      feed = RSS::Parser.parse(File.read(fname), false)
     rescue RSS::Error
     end
 
-    if rss.nil?
-      puts "#{fname}はRSS 0.9x/1.0/2.0のいずれでもありません。"
+    if feed.nil?
+      puts "#{fname}はRSS 0.9x/1.0/2.0, Atom 1.0のいずれでもありません。"
     else
-      print_items(rss)
+      print_items(feed)
     end
   end
 
 あとはprint_itemsというメソッドを定義するだけです。
 
-RSS::RDFとRSS::Rssには便利のためにitemsというメソッドとimage
-というメソッドが定義されています。
+RSS::RDF/RSS::Rss/RSS::Atom::Feed/RSS::Atom::Entryには便利の
+ためにitemsというメソッドとimageというメソッドが定義されています。
 
-itemsはRSS::RDFの場合は全ての/rdf:RDF/item要素を配列で返しま
-す。RSS::Rssの場合は全ての/rss/channel/item要素を配列で返し
-ます。
+itemsはそれぞれ以下を返します。
 
-imageはRSS::RDFの場合は/rdf:RDF/image要素を返します。
-RSS::Rssの場合は/rss/channel/image要素を返します。
+  * RSS::RDF: 全ての/rdf:RDF/item要素の配列
+  * RSS::Rss: 全ての/rss/channel/item要素の配列
+  * RSS::Atom::Feed: 全ての/atom:feed/atom:entry要素の配列
+  * RSS::Atom::Entry: /atom:entry要素のみが含まれる配列
 
-  def print_items(rss)
-    rss.items.each do |item|
+imageはそれぞれ以下を返します。
+
+  * RSS::RDF: /rdf:RDF/image要素
+  * RSS::Rss: /rss/channel/image要素
+
+ここでは、itemsを使って各項目を表示します。
+
+  def print_items(feed)
+    feed.items.each do |item|
       puts "#{item.title} : #{item.description}"
     end
   end
 
-出力する文字コードを変更するにはRSS::RDF#output_encoding=ま
-たはRSS::Rss#output_encoding=が使えます。もし、変換できない
-エンコーディングを指定された場合は
+これは、RSSフィードに対してはうまく動きますが、Atomフィードに
+対してはうまく動きません。それはAtomフィードにはdescription要
+素がないからです。そこで、AtomフィードもRSSフィードに変えて
+扱うことにします。
+
+  def print_items(feed)
+    convert_to_rss10(feed).items.each do |item|
+      puts "#{item.title} : #{item.description}"
+    end
+  end
+
+convert_to_rss10は以下のようになります。
+
+  def convert_to_rss10(feed)
+    feed.to_rss("1.0") do |maker|
+      maker.channel.about ||= maker.channel.link
+      maker.channel.description.content ||= "No description"
+      maker.items.each do |item|
+        item.title.content ||= "No title"
+        item.link ||= "UNKNOWN"
+      end
+    end
+  end
+
+未設定の可能性がある要素にデフォルト値を設定しています。
+
+出力する文字コードを変更するにはoutput_encoding=が使えます。
+もし、変換できないエンコーディングを指定された場合は
 RSS::UnknownConversionMethodError例外が発生します。
 
 先程のprint_itemsをEUC-JPで出力するように書き換えてみましょう。
 
-  def print_items(rss)
+  def print_items(feed)
+    rss10 = convert_to_rss10(feed)
     begin
-      rss.output_encoding = "EUC-JP"
+      rss10.output_encoding = "EUC-JP"
     rescue RSS::UnknownConversionMethodError
     end
-    rss.items.each do |item|
+    rss10.items.each do |item|
       puts "#{item.title} : #{item.description}"
     end
   end
-
-
 
 ==== サンプル2 - 更新順表示
 
@@ -572,8 +822,8 @@ RSS::UnknownConversionMethodError例外が発生します。
 
 最初に現れたDublin Coreモジュールの要素にアクセスするには
 「dc_要素名」というアクセサが用意されています。全ての要素の
-配列にアクセスするには「dc_要素の複数形」とします．
-(rights の場合は dc_rightses とする必要があります)
+配列にアクセスするには「dc_要素の複数形」（dc_rightsは
+dc_rights_listになります）とします．
 
 複数形でアクセスした場合は「要素の内容を表す文字列」ではなく，
 「要素を表すオブジェクト」の配列が返ります．「要素を表すオブ
@@ -608,6 +858,7 @@ content=メソッドやその別名であるvalue=メソッドを
 サンプル1と同じようにパースするRSSはファイルに保存されていて
 引数で与えられるものとします。
 
+  require 'rss'
   items = []
   ARGV.each do |fname|
     rss_source = nil
@@ -652,3 +903,7 @@ itemsにはdc_dateがnilではないものしか含まれていないは
 #@# ==== サンプル3 - 複数のRSSをブレンド
 #@#
 #@# TODO: sample/blend.rbを元にしたサンプルを書く．
+
+#@# ==== サンプル4 - フィードを変換する
+#@#
+#@# TODO: sample/convert.rbを元にしたサンプルを書く．


### PR DESCRIPTION
こんにちは。

@kou さんにお願いして、rssライブラリーの最新のチュートリアルをGitHubに上げてもらいました：
https://github.com/kou/cozmixng-rwiki/blob/master/RSS%2520Parser%253A%253ATutorial%252Eja.rd

これをBitClust用に少し修正したので、プルリクエストを送ります。
主な変更点は、Atom関連の操作についての追記です。
その他についても僕の任意で取捨選択しました。

ご検討よろしくお願いします。