### PR TITLE
Fix method scope of `Module#include'

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -563,6 +563,10 @@ inherit に真を指定すると
 
 @see [[m:Object#freeze]]
 
+#@since 2.1.0
+#@include(Module.include)
+#@end
+
 #@since 1.8.0
 --- include?(mod) -> bool
 
@@ -1235,69 +1239,8 @@ self が他のオブジェクト に [[m:Object#extend]] されたときに
 
 #@end
 
---- include(*mod) -> self
-
-モジュール mod をインクルードします。
-
-@param mod [[c:Module]] のインスタンス( [[c:Enumerable]] など)を指定します。
-
-@raise ArgumentError 継承関係が循環してしまうような include を行った場合に発生します。
-
-  module M
-  end
-  module M2
-    include M
-  end
-  module M
-    include M2
-  end
-
-実行結果:
-
-  -:3:in `append_features': cyclic include detected (ArgumentError)
-          from -:3:in `include'
-          from -:3
-
-
-インクルードとは、指定されたモジュールの定義
-#@since 1.9.1
-(メソッド、定数) を引き継ぐことです。
-#@else
-(メソッド、定数、クラス変数) を引き継ぐことです。
-#@end
-インクルードは多重継承の代わりに用いられており、 mix-in とも呼びます。
-
-  class C
-    include FileTest
-    include Math
-  end
-
-  p C.ancestors
-
-  # => [C, Math, FileTest, Object, Kernel]
-
-モジュールの機能追加は、クラスの継承関係の間にそのモジュールが挿入
-されることで実現されています。従って、メソッドの探索などは
-スーパークラスよりもインクルードされたモジュールのほうが
-先に行われます
-(上の例の [[m:Module#ancestors]] の結果がメソッド探索の順序です)。
-
-同じモジュールを二回以上 include すると二回目以降は無視されます。
-
-  module M
-  end
-  class C1
-    include M
-  end
-  class C2 < C1
-    include M   # この include は無視される
-  end
-
-  p C2.ancestors  # => [C2, C1, M, Object, Kernel]
-
-#@since 1.8.0
-引数に複数のモジュールを指定した場合、
-最後の引数から順にインクルードします。
+#@until 2.1.0
+#@include(Module.include)
 #@end
 
 #@since 1.8.0

--- a/refm/api/src/_builtin/Module.include
+++ b/refm/api/src/_builtin/Module.include
@@ -1,0 +1,64 @@
+--- include(*mod) -> self
+
+モジュール mod をインクルードします。
+
+@param mod [[c:Module]] のインスタンス( [[c:Enumerable]] など)を指定します。
+
+@raise ArgumentError 継承関係が循環してしまうような include を行った場合に発生します。
+
+  module M
+  end
+  module M2
+    include M
+  end
+  module M
+    include M2
+  end
+
+実行結果:
+
+  -:3:in `append_features': cyclic include detected (ArgumentError)
+          from -:3:in `include'
+          from -:3
+
+
+インクルードとは、指定されたモジュールの定義
+#@since 1.9.1
+(メソッド、定数) を引き継ぐことです。
+#@else
+(メソッド、定数、クラス変数) を引き継ぐことです。
+#@end
+インクルードは多重継承の代わりに用いられており、 mix-in とも呼びます。
+
+  class C
+    include FileTest
+    include Math
+  end
+
+  p C.ancestors
+
+  # => [C, Math, FileTest, Object, Kernel]
+
+モジュールの機能追加は、クラスの継承関係の間にそのモジュールが挿入
+されることで実現されています。従って、メソッドの探索などは
+スーパークラスよりもインクルードされたモジュールのほうが
+先に行われます
+(上の例の [[m:Module#ancestors]] の結果がメソッド探索の順序です)。
+
+同じモジュールを二回以上 include すると二回目以降は無視されます。
+
+  module M
+  end
+  class C1
+    include M
+  end
+  class C2 < C1
+    include M   # この include は無視される
+  end
+
+  p C2.ancestors  # => [C2, C1, M, Object, Kernel]
+
+#@since 1.8.0
+引数に複数のモジュールを指定した場合、
+最後の引数から順にインクルードします。
+#@end


### PR DESCRIPTION
ISSUE https://github.com/rurema/doctree/issues/269 への対応をしてみました。

`Module#include` のテキストが public instance method と private instance method のスコープに重複して存在する対応をしております。バージョンによって可視性が変わる対応方法として、このような形で良いか分かっていないのですが如何でしょうか？