### PR TITLE
Fix link type

### DIFF
--- a/refm/api/src/socket/Socket
+++ b/refm/api/src/socket/Socket
@@ -28,8 +28,8 @@ Perl のソケットに対するアクセスと同レベルの機能を
   * UNIX socket のクライアントソケット [[m:Socket.unix]] [[m:UNIXSocket.open]]
   * UNIX socket のサーバソケット [[m:Socket.unix_server_loop]], 
     [[m:Socket.unix_server_socket]], [[m:UNIXServer.open]]
-また、クライアントソケットは [[c:Addrinfo#connect]] で、
-サーバソケットを [[c:Addrinfo#bind]] や [[c:Addrinfo#listen]] で
+また、クライアントソケットは [[m:Addrinfo#connect]] で、
+サーバソケットを [[m:Addrinfo#bind]] や [[m:Addrinfo#listen]] で
 作ることもできます。
 
 #@end


### PR DESCRIPTION
`Socket` でリンク切れがあったのですが、`c:` ではなく `m:` ではないでしょうか。