### PR TITLE
Update Ruby version on test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.0.0
+  - 2.2.2
 notifications:
   recipients:
     - okkez000@gmail.com


### PR DESCRIPTION
Rack 2.0.1 requires Ruby >= 2.2.2, so we should update
ruby version if no constraint on Rack version.

If doctree would be run on Ruby < 2.2.2, I will constraint on Rack version instead.