### PR TITLE
Fix syntax error in example of ENV#values_at

### DIFF
--- a/refm/api/src/_builtin/ENV
+++ b/refm/api/src/_builtin/ENV
@@ -293,7 +293,7 @@ self を返します。
 
 例:
 
-  ENV.update({'FOO','foo', 'BAR','bar'})
+  ENV.update({'FOO' => 'foo', 'BAR' => 'bar'})
   p ENV.values_at(*%w(FOO BAR BAZ))   # => ["foo", "bar", nil]
 
 @param key 環境変数名を指定します。文字列で指定します。文字列で指定しま


### PR DESCRIPTION
This should fix following syntax error in example of ENV#values_at.

```
irb(main):001:0> ENV.update({'FOO','foo', 'BAR','bar'})
SyntaxError: (irb):1: syntax error, unexpected ',', expecting =>
ENV.update({'FOO','foo', 'BAR','bar'})
                  ^
```