### PR TITLE
Fix Issue #306.

### DIFF
--- a/refm/api/src/tempfile.rd
+++ b/refm/api/src/tempfile.rd
@@ -23,6 +23,11 @@ require delegate
 
 == Class Methods
 
+#@since 2.3.0
+--- new(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
+--- open(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
+--- open(basename = '', tempdir = nil, mode: 0, **options){|fp| ...} -> object
+#@else
 #@since 2.2.0
 --- new(basename, tempdir = nil, mode: 0, **options) -> Tempfile
 --- open(basename, tempdir = nil, mode: 0, **options) -> Tempfile
@@ -34,6 +39,7 @@ require delegate
 --- open(basename, tempdir = Dir::tmpdir){|fp| ...} -> object
 #@else
 --- open(basename, tempdir = Dir::tmpdir){|fp| ...} -> nil
+#@end
 #@end
 #@end
 


### PR DESCRIPTION
Fix Issue #306.
`Tempfile#new` provide default basename parameter since 2.3

Issue #306 の対応をしてみました。 `Tempfile#new`の第一引数にデフォルト値をつけました。