### PR TITLE
Fix typo

### DIFF
--- a/refm/api/src/shell/builtincommands
+++ b/refm/api/src/shell/builtincommands
@@ -619,7 +619,7 @@ command を実行する.
 
 @param to 文字列か [[c:IO]] を指定します。
 
-@param filter [[c:Shell::Filter]] のインスタンスをしています。
+@param filter [[c:Shell::Filter]] のインスタンスを指定します。
 
 --- tee(file) -> Shell::Filter
 

--- a/refm/api/src/zlib/Error
+++ b/refm/api/src/zlib/Error
@@ -19,7 +19,7 @@
 
 = class Zlib::NeedDict < Zlib::Error
 
-展開に用いる辞書がしていされていない場合に発生します。
+展開に用いる辞書が指定されていない場合に発生します。
 
 = class Zlib::DataError < Zlib::Error
 


### PR DESCRIPTION
refm/api/src/zlib/Error で「してい」がひらがなになっていたので、漢字にしました。

また、他に「してい」に関する typo みたいなものがないか検索したら refm/api/src/shell/builtincommands に typo をみつけたので修正しています。