### PR TITLE
Signal.signame may return nil since 2.3.0

### DIFF
--- a/refm/api/src/_builtin/Signal
+++ b/refm/api/src/_builtin/Signal
@@ -85,9 +85,16 @@ ruby の仕組みの外でシグナルハンドラが登録された場合
 @see [[d:spec/terminate]]
 
 #@since 2.0.0
+#@since 2.3.0
+--- signame(signo) -> String | nil
+#@else
 --- signame(signo) -> String
+#@end
 
 引数で指定されたシグナル番号をシグナル名に変換して返します。
+#@since 2.3.0
+対応するシグナル番号が存在しない場合は nil を返します。
+#@end
 
   Signal.trap("INT") { |signo| puts Signal.signame(signo) }
   Process.kill("INT", 0)


### PR DESCRIPTION
see https://github.com/ruby/ruby/commit/6c8fc79f95a109dc6eff3be02d98154a3c6323db