### PR TITLE
Called method is write instead of print in display

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -861,7 +861,7 @@ self#=~(obj) を反転した結果と同じ結果を返します。
 
   class Object
     def display(out = $stdout)
-      out.print self.to_s
+      out.write self
       nil
     end
   end


### PR DESCRIPTION
```
% ruby -e 'port=Object.new;def port.write(o);p [:write,o];end;1.display(port)'
[:write, 1]
% ruby -e 'port=Object.new;def port.print(o);p [:print,o];end;1.display(port)'
-e:1:in `display': undefined method `write' for #<Object:0x000000017c9880> (NoMethodError)
        from -e:1:in `<main>'
```

see also https://github.com/ruby/ruby/commit/9fff0f9459f018479075b1f8d60a7c45ac657a1a
