### PR TITLE
Fix return values of `String#casecmp`

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -717,7 +717,7 @@ rangeで指定したインデックスの範囲に含まれる部分文字列を
 @see [[m:String#capitalize]], [[m:String#upcase!]],
      [[m:String#downcase!]], [[m:String#swapcase!]]
 
---- casecmp(other) -> Integer | nil
+--- casecmp(other) -> -1 | 0 | 1
 
 [[m:String#<=>]] と同様に文字列の順序を比較しますが、
 アルファベットの大文字小文字の違いを無視します。


### PR DESCRIPTION
see https://bugs.ruby-lang.org/issues/12835

調べられる範囲で調べてみたところ、1.8.6 でも `TypeError` でした。
`String#+` などでも `StringValue` による `@raise TypeError` はいちいち書いていないので、返り値だけ変更しています。
`-1`, `0`, `1` 以外を返すことはなさそうだったので、`Integer` も `Symbol#casecmp` と同じく `-1 | 0 | 1` に変更しました。

```
% rbenv each ruby -ve '"a".casecmp 1'
ruby 1.8.6 (2007-03-13 patchlevel 0) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1
ruby 1.8.6 (2010-09-02 patchlevel 420) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1
ruby 1.8.7 (2008-05-31 patchlevel 0) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1
ruby 1.8.7 (2013-12-22 patchlevel 375) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1
ruby 1.9.0 (2007-12-25 revision 14709) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.0 (2008-10-04 revision 19669) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.1p0 (2009-01-30 revision 21907) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.1p431 (2011-02-18 revision 30908) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.2p0 (2010-08-18 revision 29036) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.2p330 (2014-08-07 revision 47094) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.3p0 (2011-10-30 revision 33570) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
-e:1:in `casecmp': can't convert Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.2.5p319 (2016-04-26 revision 54774) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]
-e:1:in `casecmp': no implicit conversion of Fixnum into String (TypeError)
        from -e:1:in `<main>'
```
