### PR TITLE
Use https instead of http for documentation of PEP 278

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -793,7 +793,7 @@ mode は以下の三つのうちのいずれかです。
 
 #@since 1.9.1
 ==== Universal Newline
-改行をLFに揃えます。一言で言えばPEP:278 [[url:http://www.python.org/dev/peps/pep-0278/]]のことです。
+改行をLFに揃えます。一言で言えばPEP:278 [[url:https://www.python.org/dev/peps/pep-0278/]]のことです。
 
 : "rt"
     CR、LF、CRLFのいずれをもLFとして読み込む。


### PR DESCRIPTION
`https`へのリンクがあったので、書き換えました。