### PR TITLE
Consider non ASCII code in String#concat

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -336,12 +336,11 @@ other == self の結果を返します。(ただし、 other.to_str は実行さ
 --- concat(other) -> self
 
 self に文字列 other を破壊的に連結します。
-other が 0 から 255 のまでの整数である場合は
-その 1 バイトを末尾に追加します (つまり、整数が示す ASCII コードの文字が追加されます)。
+other が 整数である場合は other.chr(self.encoding) 相当の文字を末尾に追加します。
 
 self を返します。
 
-@param other    文字列もしくは 0 から 255 までの範囲の整数
+@param other    文字列もしくは 0 以上の整数
 
 例:
 


### PR DESCRIPTION
Command
```shell
ruby --version; ruby -e 'p("s" << 9996)'
```

Output
```
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]
"s✌"
```

---

正確に日本語で表現しようとするのが難しく感じた為、若干コードで逃げた感じになってしまったかもしれません・・・ 🙇 