### PR TITLE
Fix a result of sample code of include method.

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -105,7 +105,7 @@ Range#cover? は連続値を扱います。
   
   # Date, DateTime の例
   (Date.new(2014,1,3)..Date.new(2014,1,5)).include?(Date.new(2014,1,5))           # => true
-  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))  # => "can't iterate from Time"
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))  # => true
   (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))             # => true
   (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))    # => true
 


### PR DESCRIPTION
Timeクラスでinclude?が使用できるようになっていたので
サンプルコードを修正しました。

(すみません、最初coverとincludeを勘違いしてしまってブランチ名とコミットメッセージが間違っています😖)