### PR TITLE
Range#include? support Time range

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -105,7 +105,7 @@ Range#cover? は連続値を扱います。
   
   # Date, DateTime の例
   (Date.new(2014,1,3)..Date.new(2014,1,5)).include?(Date.new(2014,1,5))           # => true
-  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))  # => "can't iterate from Time"
+  (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))  # => true
   (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))             # => true
   (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))    # => true
 


### PR DESCRIPTION
`Range#include?` support Time object since 2.2.3.

```
$ rbenv shell 2.2.2
$ ruby -e 'puts (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))'
-e:1:in `each': can't iterate from Time (TypeError)
        from -e:1:in `include?'
        from -e:1:in `include?'
        from -e:1:in `<main>'
$ rbenv shell 2.2.3
$ ruby -e 'puts (Time.new(2014,1,3)..Time.new(2014,1,5)).include?(Time.new(2014,1,4,10,10,10))'
true
```

This commit changes above behavior.
https://github.com/ruby/ruby/commit/b0616346f8098d0f2063c48ee61c09eb2ddc851e