### PR TITLE
Add cross-references between Kernel.#print and IO#print

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1230,6 +1230,8 @@ IO に対してシステムコール ioctl を実行し、その結果を返し�
 
 @raise Errno::EXXX 出力に失敗した場合に発生します。
 
+@see [[m:Kernel.#print]]
+
 --- printf(format, *arg)    -> nil
 
 C 言語の printf と同じように、format に従い引数

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1392,7 +1392,7 @@ to_s メソッドにより文字列に変換してから出力します。
   #=> input<end>
   #=> AA<and>BB<end>
 
-@see [[m:Kernel.#puts]],[[m:Kernel.#p]]
+@see [[m:Kernel.#puts]],[[m:Kernel.#p]],[[m:IO#print]]
 
 --- puts(*arg) -> nil
 


### PR DESCRIPTION
IO#print does not mention `$,` and `$\`.