### PR TITLE
Add OpenSSL::OPENSSL_LIBRARY_VERSION

### DIFF
--- a/refm/api/src/openssl.rd
+++ b/refm/api/src/openssl.rd
@@ -107,7 +107,11 @@ Ruby/OpenSSL のバージョンです。
 
 --- OPENSSL_VERSION -> String
 
-システムにインストールされている OpenSSL 本体のバージョンを表した文字列です。
+ビルド時に使われた OpenSSL 本体のバージョンを表した文字列です。
+
+--- OPENSSL_LIBRARY_VERSION -> String
+
+実行時に使われている OpenSSL 本体のバージョンを表した文字列です。
 
 --- OPENSSL_VERSION_NUMBER -> Integer
 


### PR DESCRIPTION
2.0.0 と 2.1.x の途中で入ったようなので、微妙な感じですが、バージョン分岐が書きにくいこともあって、バージョン分岐なしで追加しました。
`OpenSSL::OPENSSL_VERSION` の方も rdoc を参考にして違いがわかりやすいように変えました。

```
% rbenv each -v ruby -vr openssl -e 'p OpenSSL::OPENSSL_LIBRARY_VERSION'
(略)
===[2.0.0-p0]===========================================================
ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-linux]
-e:1:in `<main>': uninitialized constant OpenSSL::OPENSSL_LIBRARY_VERSION (NameError)

===[2.0.0-p648]=========================================================
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-linux]
"OpenSSL 0.9.8zh 3 Dec 2015"

===[2.1.0]==============================================================
ruby 2.1.0p0 (2013-12-25 revision 44422) [x86_64-linux]
-e:1:in `<main>': uninitialized constant OpenSSL::OPENSSL_LIBRARY_VERSION (NameError)

===[2.1.10]=============================================================
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-linux]
"OpenSSL 1.0.2g  1 Mar 2016"
(略)
```
