### PR TITLE
Fix the documentation for OptionParser#order (without bang)

### DIFF
--- a/refm/api/src/optparse/OptionParser
+++ b/refm/api/src/optparse/OptionParser
@@ -521,12 +521,12 @@ argv からオプションを取り除いたものを返します。
   opt.on('-a [VAL]') {|v| p :a }
   opt.on('-b') {|v| p :b }
 
-  opt.order!(ARGV)
+  opt.order(ARGV)
   p ARGV
 
   $ ruby opt2.rb -a foo somefile -b
   :a
-  ["somefile", "-b"]
+  ["-a", "foo", "somefile", "-b"]
 
 --- order!(argv = self.default_argv)             -> [String]
 --- order!(argv = self.default_argv) {|s| ...}   -> [String]


### PR DESCRIPTION
`OptionParser#order`(bang なし)にコード例がありますが、`OptionParser#order!`(bang あり)と完全に同一のコードになっていました。
そのため、`OptionParser#order`のコード例をbangがないものに書き換えました。