### PR TITLE
Add String#match? and Symbol#match?

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1477,6 +1477,16 @@ regexp.match(self, pos) と同じです。
 regexp が文字列の場合は、正規表現にコンパイルします。
 詳しくは [[m:Regexp#match]] を参照してください。
 
+#@since 2.4.0
+--- match?(regexp, pos = 0) -> bool
+
+regexp.match?(self, pos) と同じです。
+regexp が文字列の場合は、正規表現にコンパイルします。
+詳しくは [[m:Regexp#match?]] を参照してください。
+
+@see [[m:Regexp#match?]], [[m:Symbol#match?]]
+#@end
+
 --- succ -> String
 --- next -> String
 

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1477,6 +1477,8 @@ regexp.match(self, pos) と同じです。
 regexp が文字列の場合は、正規表現にコンパイルします。
 詳しくは [[m:Regexp#match]] を参照してください。
 
+@see [[m:Regexp#match]], [[m:Symbol#match]]
+
 #@since 2.4.0
 --- match?(regexp, pos = 0) -> bool
 

--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -253,6 +253,16 @@ nil は文字列のエンコーディングが非互換の時に返されます�
 
 @see [[m:String#=~]], [[m:String#match]]
 
+#@since 2.4.0
+--- match?(regexp, pos = 0) -> bool
+
+regexp.match?(self, pos) と同じです。
+regexp が文字列の場合は、正規表現にコンパイルします。
+詳しくは [[m:Regexp#match?]] を参照してください。
+
+@see [[m:Regexp#match?]], [[m:String#match?]]
+#@end
+
 --- [](nth) -> String | nil
 --- slice(nth) -> String | nil
 


### PR DESCRIPTION
2.4.0で`Regexp#match?`が追加されましたが、`String#match?`と`Symbol#match?`も使いやすさのために追加されているようです。

https://bugs.ruby-lang.org/issues/12898
https://github.com/ruby/ruby/commit/6dd5ee752ae1d6268619b96dec7d31e993cc59d9