### PR TITLE
Hide net/telnet since 2.3.0

### DIFF
--- a/refm/api/src/LIBRARIES
+++ b/refm/api/src/LIBRARIES
@@ -233,7 +233,9 @@ net/imap
 net/pop
 net/protocol
 net/smtp
+#@until 2.3.0
 net/telnet
+#@end
 #@until 1.9.1
 net/telnets
 #@end

--- a/refm/api/src/net/telnet.rd
+++ b/refm/api/src/net/telnet.rd
@@ -8,6 +8,13 @@ Telnet に関する RFC は数多く存在します。
 [[RFC:859]], [[RFC:860]], [[RFC:861]], でプロトコルの
 基本が定義されています。
 
+=== 注意
+
+このライブラリは 2.3.0 で gem ライブラリとして切り離されました。2.3.0
+以降ではそちらを利用してください。
+
+ * [[url:https://rubygems.org/gems/net-telnet]]
+
 = class Net::Telnet < SimpleDelegator
 
 このクラスは telnet のクライアント機能を提供します。


### PR DESCRIPTION
Ruby 2.3.0 で `Net::Telnet` が標準添付ライブラリから外されて、RubyGems の net-telnet を使うようになったことに対応する PR です。

https://github.com/rurema/doctree/blob/68a3024a65105cdd1f6a206b800314bc23d06fd1/refm/doc/news/2_3_0.rd#L298-L300

ドキュメント変更については、Ruby 2.4.0 で tk が標準添付ライブラリから外されたコミットを参考にしています。

https://github.com/rurema/doctree/commit/286344782cd07866398174676358b469aad41eef
