### PR TITLE
Fix docs for String#tr!

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2377,10 +2377,11 @@ pattern の形式は [[man:tr(1)]] と同じです。
 指定文字以外が置換の対象になります。
 
 replace に対しても `-' による範囲指定が可能です。
-例えば、[[m:String#upcase]] を tr で書くと、
+例えば、[[m:String#upcase]] を tr! で書くと、
 
-  p "foo".tr('a-z', 'A-Z')
-  => "FOO"
+  str = "foo"
+  p str.tr!('a-z', 'A-Z') #=> "FOO"
+  p str                   #=> "FOO"
 
 となります。
 


### PR DESCRIPTION
`String#tr!`の説明文の一部が破壊的でなかったので修正しました。
コード例が破壊的でなかったので修正しました。