### PR TITLE
fix openssl url

### DIFF
--- a/refm/api/src/net/imap.rd
+++ b/refm/api/src/net/imap.rd
@@ -179,7 +179,7 @@ untagged な応答はコマンドの送信とは非同期的にサーバから�
     Myers, J., "IMAP4 ACL extension", RFC 2086, January 1997.
 
   * [OSSL]
-    [[url:http://www.openssl.org]]
+    [[url:https://www.openssl.org/]]
 
   * [RSSL]
     [[url:http://savannah.gnu.org/projects/rubypki]]

--- a/refm/api/src/openssl.rd
+++ b/refm/api/src/openssl.rd
@@ -1,6 +1,6 @@
 category Network
 
-OpenSSL([[url:http://www.openssl.org]])
+OpenSSL([[url:https://www.openssl.org/]])
 を Ruby から扱うためのライブラリです。
 
 このドキュメントでは SSL/TLS の一般的事項については


### PR DESCRIPTION
fix openssl url

`http://www.openssl.org` is now redirect to `https://www.openssl.org`