### PR TITLE
Add references from obsoleted URI.unescape

### DIFF
--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -177,6 +177,12 @@ URI 文字列をデコードした文字列を返します。
 
 #@since 1.9.2
 このメソッドは obsolete です。
+
+代わりに
+[[m:CGI.unescape]],
+[[m:URI.decode_www_form]],
+[[m:URI.decode_www_form_component]]
+などの使用を検討してください。
 #@end
 
 例:


### PR DESCRIPTION
see https://github.com/ruby/ruby/pull/1630
and https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=58899&view=revision