### PR TITLE
Fix invalid hex escape error in String#encode sample code

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2863,7 +2863,7 @@ self を指定したエンコーディングに変換した文字列を作成し
   # 存在しないのでそのまま変換しようとすると Encoding::UndefinedConversionError が発生する
   str = "\u00b7\u2014"
   str.encode("Windows-31J", fallback: { "\u00b7" => "\xA5".force_encoding("Windows-31J"),
-                                        "\u2014" => "\x{815C}".force_encoding("Windows-31J") })
+                                        "\u2014" => "\x81\x5C".force_encoding("Windows-31J") })
 
 @see [[m:String#encode!]]
 


### PR DESCRIPTION
```
% ruby -ve '"\x{815C}"'
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
-e:1: invalid hex escape
"\x{815C}"
   ^
-e:1: warning: possibly useless use of a literal in void context
```