### PR TITLE
Fix ObjectSpace.define_finalizer sample code syntax error

### DIFF
--- a/refm/api/src/_builtin/ObjectSpace
+++ b/refm/api/src/_builtin/ObjectSpace
@@ -80,13 +80,13 @@ proc の呼び出しで発生した大域脱出(exitや例外)は無視されま
 
   class Baz
     def initialize
-      ObjectSpace.define_finalizer self, eval %q{
+      ObjectSpace.define_finalizer self, eval(%q{
         proc {
           raise "baz" rescue puts $!
           raise "baz2"
           puts "baz3"
         }
-      }, TOPLEVEL_BINDING
+      }, TOPLEVEL_BINDING)
     end
   end
   Baz.new


### PR DESCRIPTION
```
% ruby foo.rb
foo.rb:3: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '('
efine_finalizer self, eval %q{
                              ^
foo.rb:9: syntax error, unexpected ',', expecting keyword_end
      }, TOPLEVEL_BINDING
        ^
```