### PR TITLE
Remove unnecessary regexp encoding option

### DIFF
--- a/refm/api/src/webrick/httpproxy/HTTPProxyServer
+++ b/refm/api/src/webrick/httpproxy/HTTPProxyServer
@@ -51,8 +51,8 @@
   nil を指定した場合なにもしません。デフォルトは nil です。
 //emlist{
  handler = proc{|req, res|
-   res.body.gsub!(/です。/e, 'でんがな。')
-   res.body.gsub!(/ます。/e, 'まんがな。')
+   res.body.gsub!(/です。/, 'でんがな。')
+   res.body.gsub!(/ます。/, 'まんがな。')
  }
  s = WEBrick::HTTPProxyServer.new( { :ProxyContentHandler => handler } )
 //}


### PR DESCRIPTION
It will raise following error if source encoding is UTF-8

> regexp encoding option 'e' differs from source encoding 'UTF-8'