### PR TITLE
Update environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
+language: ruby
+dist: trusty
 rvm:
-  - 2.4.0
+  - 2.4.1
 notifications:
   email:
     recipients:


### PR DESCRIPTION
- rvm で指定している ruby のバージョンを 2.4.0 から 2.4.1 にあげるのがメインです。
- ついでに `dist: trusty` でベースの ubuntu のバージョンもあげています。
- それから language が指定されていなかったので `language: ruby` にしてみました。