### PR TITLE
Add Time#hash

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -716,6 +716,14 @@ yday は 1 から数えます。
 #@end
 #@end
 
+--- hash -> Integer
+
+自身のハッシュ値を返します。
+
+@return ハッシュ値を返します。
+
+@see [[m:Object#hash]]
+
 --- usec         -> Integer
 --- tv_usec      -> Integer
 


### PR DESCRIPTION
リファレンスに書かれていなかった Time#hash メソッド
( https://github.com/ruby/ruby/blob/202fbe3046a6c37c6b9c7ce183d4e11aa34bb025/time.c#L3302-L3318 ) を追加します。