### PR TITLE
Fix dead link to OpenSSL version number

### DIFF
--- a/refm/api/src/openssl.rd
+++ b/refm/api/src/openssl.rd
@@ -116,7 +116,7 @@ Ruby/OpenSSL のバージョンです。
 --- OPENSSL_VERSION_NUMBER -> Integer
 
 システムにインストールされている OpenSSL 本体のバージョンを表した数です。
-[[url:http://www.openssl.org/docs/crypto/OPENSSL_VERSION_NUMBER.html]]
+[[url:https://www.openssl.org/docs/manmaster/man3/OPENSSL_VERSION_NUMBER.html]]
 も参照してください。
 
 #@since 2.0.0


### PR DESCRIPTION
OpenSSL 公式サイトの docs 配下の OPENSSL_VERSION_NUMBER.html への URL が変わっていたため、リンク切れになっていたのを修正しました。

`OpenSSL::OPENSSL_VERSION_NUMBER` は、システムインストールされている OpenSSL 本体のバージョンを表した数ということで、外部ドキュメントへの依存を強くしない意図で master (開発版) のマニュアルの URL を指しています。

とはいえ実際のところ master を使っているユーザーは極少数だと思うため、安定版へのリンクを指した方が良いということであればリンク先を最新の安定版である 1.1.0 向けに修正しようと考えています。安定版 URL は以下となります (参考までに 1.0.2 の URL も記載しています) 。

- https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_VERSION_NUMBER.html
- https://www.openssl.org/docs/man1.0.2/crypto/OPENSSL_VERSION_NUMBER.html

いかがでしょうか。