### PR TITLE
`$LAST_MATCH_INFO` may be nil

### DIFF
--- a/refm/api/src/English.rd
+++ b/refm/api/src/English.rd
@@ -211,7 +211,7 @@
   end
 
 
---- $LAST_MATCH_INFO -> MatchData
+--- $LAST_MATCH_INFO -> MatchData | nil
 
 [[m:$~]] の別名
 


### PR DESCRIPTION
`$LAST_MATCH_INFO` は `nil` になることもあります。
参照先の `$~` は正しく `nil` がついています。