### PR TITLE
Add sample code of Integer#next

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -85,6 +85,13 @@ self < min であれば何もしません。
 
 self の次の整数を返します。
 
+例:
+
+  1.next      #=> 2
+  (-1).next   #=> 0
+  1.succ      #=> 2
+  (-1).succ   #=> 0
+
 --- times {|n| ... } -> self
 #@since 1.8.7
 #@since 1.9.1


### PR DESCRIPTION
`Integer#next`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/2.4.0/method/Integer/i/next.html

サンプルコードはrdocを元にしました。
https://ruby-doc.org/core-2.4.1/Integer.html#method-i-succ