### PR TITLE
Add sample code of Class#superclass

### DIFF
--- a/refm/api/src/_builtin/Class
+++ b/refm/api/src/_builtin/Class
@@ -114,11 +114,18 @@ new は [[m:Class#allocate]] でインスタンスを生成し、
 
 自身のスーパークラスを返します。
 
-#@since 1.9.1
+例:
+  File.superclass          #=> IO
+  IO.superclass            #=> Object
+  class Foo; end
+  class Bar < Foo; end
+  Bar.superclass           #=> Foo
+  Object.superclass        #=> BasicObject
+
 ただし [[c:BasicObject]].superclass は nil を返します。
-#@else
-ただし [[c:Object]].superclass は nil を返します。
-#@end
+
+例:
+  BasicObject.superclass   #=> nil
 
 --- _load(str)    -> Class
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/2.4.0/method/Class/i/superclass.html
* https://docs.ruby-lang.org/en/2.4.0/Class.html#method-i-superclass

基本的に rdoc のままです。
ruby 1.8 系と 1.9 以降の部分だけObject, BasicObjectの違いを加味した内容にしてあります。