### PR TITLE
Removed lib/ubygems.rb

### DIFF
--- a/refm/api/src/LIBRARIES
+++ b/refm/api/src/LIBRARIES
@@ -805,7 +805,7 @@ tmpdir
 tracer
 #@since 1.8.0
 tsort
-#@since 1.9.1
+#@if("1.9.1" <= version and version < "2.5.0")
 ubygems
 #@end
 un


### PR DESCRIPTION
at https://github.com/ruby/ruby/commit/e5e1f904d584bb8afd6f97f868c1fe896a572356 (r60008)