### PR TITLE
Add sample code of ARGF.class#gets

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -369,6 +369,35 @@ ARGFの現在位置から一行ずつ文字列として読み込みます。EOF 
 
 @param limit 最大の読み込みバイト数
 
+例:
+  # $ echo "line1\nline2\nline3\n\nline4\n" > test.txt
+  # $ ruby test.rb test.txt
+
+  # test.rb
+  ARGF.gets                  # => "line1\n"
+
+例:
+  # $ echo "line1\nline2\nline3\n\nline4\n" > test.txt
+  # $ ruby test.rb test.txt
+
+  # test.rb
+  ARGF.gets(2)                  # => "li"
+
+例:
+  # $ echo "line1\nline2\nline3\n\nline4\n" > test.txt
+  # $ ruby test.rb test.txt
+
+  # test.rb
+  ARGF.gets("e")                  # => "line"
+
+
+例:
+  # $ echo "line1\nline2\nline3\n\nline4\n" > test.txt
+  # $ ruby test.rb test.txt
+
+  # test.rb
+  ARGF.gets("")                  # => "line1\nline2\nline3\n\n"
+
 @see [[m:Kernel.#gets]], [[m:IO#gets]], [[m:ARGF.class#getbyte]], [[m:ARGF.class#getc]]
 
 --- pos  -> Integer


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/2.4.0/method/ARGF=2eclass/i/gets.html

`rs` が `nil` のパターンや `rs` と `limit` を組み合わせたパターンは省略してます
