### PR TITLE
Add sample code of ARGF.class#internal_encoding

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -597,6 +597,19 @@ ARGF から読み込んだ文字列の内部エンコーディングを返しま
 
 [[m:ARGF.class#set_encoding]] で設定します。
 
+
+例:
+  # $ ruby -Eutf-8 test.rb
+
+  # test.rb
+  ARGF.internal_encoding            # => #<Encoding:UTF-8>
+  ARGF.set_encoding('utf-8','ascii')
+  ARGF.internal_encoding            # => #<Encoding:US-ASCII>
+
+例:
+  ARGF.binmode
+  ARGF.internal_encoding            # => nil
+
 @see [[c:IO]], [[m:ARGF.class#external_encoding]]
 
 --- set_encoding(ext_enc)                        -> self


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/2.4.0/method/ARGF=2eclass/i/internal_encoding.html
* https://docs.ruby-lang.org/en/2.4.0/ARGF.html#method-i-internal_encoding