### PR TITLE
Add noexample of Struct#equal?

### DIFF
--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -325,6 +325,8 @@ true を返します。そうでない場合に false を返します。
 
 #@include(Struct.attention)
 
+#@#noexample Object#equal? のデフォルトの動作と変わらないため
+
 @see [[m:Struct#eql?]], [[m:Struct#==]]
 
 --- hash    -> Integer


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/2.4.0/method/Struct/i/equal=3f.html

`Object#equal?` のデフォルトの動作と同じためサンプルなしにしました