### PR TITLE
Add sample code of Integer#*

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -468,6 +468,11 @@ self の符号を反転させたものを返します。
 @param other 二項演算の右側の引数(対象)
 @return 計算結果
 
+例:
+
+  # 積
+  2 * 3   # => 6
+
 --- /(other) -> Numeric
 --- div(other) -> Numeric
 


### PR DESCRIPTION
`Integer#*`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/2.4.0/method/Integer/i/=2a.html

rdocにサンプルコードがなかったため、`Float#*`を元にしています。
https://docs.ruby-lang.org/ja/2.4.0/method/Float/i/=2a.html