### PR TITLE
add sample code of NameError#to_s

### DIFF
--- a/refm/api/src/_builtin/NameError
+++ b/refm/api/src/_builtin/NameError
@@ -43,6 +43,11 @@
 
 例外オブジェクトを文字列に変換して返します。
 
+例:
+
+  err = NameError.new("message", "foo")
+  p err.to_s  # => "message"
+
 #@since 2.3.0
 --- receiver -> object
 

--- a/refm/api/src/_builtin/NameError
+++ b/refm/api/src/_builtin/NameError
@@ -45,8 +45,12 @@
 
 例:
 
-  err = NameError.new("message", "foo")
-  p err.to_s  # => "message"
+  begin
+    foobar
+  rescue NameError => err
+    p err       # => #<NameError: undefined local variable or method `foobar' for main:Object>
+    p err.to_s  # => "undefined local variable or method `foobar' for main:Object"
+  end
 
 #@since 2.3.0
 --- receiver -> object


### PR DESCRIPTION
#433 
NameError#to_sのサンブルコードと追加しました。
https://docs.ruby-lang.org/ja/latest/method/NameError/i/to_s.html
