### PR TITLE
Add sample code of Integer#integer?

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -277,6 +277,11 @@ self > max であれば何もしません。
 
 常に真を返します。
 
+例:
+
+  1.integer?     # => true
+  1.0.integer?   # => false
+
 #@since 1.8.7
 --- even? -> bool
 


### PR DESCRIPTION
`Integer#integer?`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/2.4.0/method/Integer/i/integer=3f.html
rdocを確認しましたが、サンプルコードが見つからなかったためtrunkを元にしています。
https://github.com/ruby/ruby/blob/fb38cfb90fcd467e398cbfc13aa99cf38c569311/numeric.c#L739,L747