### PR TITLE
add sample code of NameError#local_variables

### DIFF
--- a/refm/api/src/_builtin/NameError
+++ b/refm/api/src/_builtin/NameError
@@ -53,4 +53,20 @@ self が発生した時のレシーバオブジェクトを返します。
 self が発生した時に定義されていたローカル変数名の一覧を返します。
 
 内部での使用に限ります。
+
+例:
+
+  def foo
+    begin
+      b = "bar"
+      c = 123
+      d
+    rescue NameError => err
+      p err.local_variables #=> [:b, :c, :err]
+    end
+  end
+
+  a = "buz"
+  foo
+
 #@end


### PR DESCRIPTION
#433 

https://docs.ruby-lang.org/ja/latest/method/NameError/i/local_variables.html

NameError#local_variablesのサンプルコードを書きました。