### PR TITLE
Add OptionParser#parse, parse! method :into option since 2.4.0

### DIFF
--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -111,7 +111,7 @@ optparse を使う場合、基本的には
 明示的にコンテナへ格納する以外に、parse（及びparse!）メソッドの引数に
 :into オプションを指定することでハッシュへ自動的に値を格納することができます。
 この時ハッシュのキーとして利用される名前はロングオプションが定義されていれば
-ロングオプションの値を、ショートオプションのみの場合はショートオプションの値から
+ロングオプションの値を、ショートオプションのみの場合はショートオプションの値から、
 先頭の "-" を除いてシンボル化した値が使用されます。
 
         require 'optparse'
@@ -280,7 +280,7 @@ GNUの慣習にあわせて
 
         opt.parse!(ARGV)
         p ARGV
-        
+
         ruby ./sample.rb --help
         # => Usage: sample [options]
                 -a                               description of -a
@@ -315,13 +315,13 @@ GNUの慣習にあわせて
 
     #! /usr/bin/ruby
     # contributed by Minero Aoki.
-    
+
     require 'optparse'
-    
+
     parser = OptionParser.new
     parser.on('-i') { puts "-i" }
     parser.on('-o') { puts '-o' }
-    
+
     subparsers = Hash.new {|h,k|
       $stderr.puts "no such subcommand: #{k}"
       exit 1
@@ -329,7 +329,7 @@ GNUの慣習にあわせて
     subparsers['add'] = OptionParser.new.on('-i') { puts "add -i" }
     subparsers['del'] = OptionParser.new.on('-i') { puts "del -i" }
     subparsers['list'] = OptionParser.new.on('-i') { puts "list -i" }
-    
+
     parser.order!(ARGV)
     subparsers[ARGV.shift].parse!(ARGV) unless ARGV.empty?
 
@@ -338,7 +338,7 @@ GNUの慣習にあわせて
     $ ruby subcom.rb -i add -i
     -i
     add -i
-    
+
     $ ruby subcom.rb list -i
     list -i
 

--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -106,6 +106,32 @@ optparse を使う場合、基本的には
         # => ["foo", "bar", "baz"]
              {:a=>true, :b=>true}
 
+#@since 2.4.0
+
+明示的にコンテナへ格納する以外に、parse（及びparse!）メソッドの引数に
+:into オプションを指定することでハッシュへ自動的に値を格納することができます。
+この時ハッシュのキーとして利用される名前はロングオプションが定義されていれば
+ロングオプションの値を、ショートオプションのみの場合はショートオプションの値から
+先頭の "-" を除いてシンボル化した値が使用されます。
+
+        require 'optparse'
+        opt = OptionParser.new
+
+        OPTS = {}
+
+        opt.on('-a') {|v| v }
+        opt.on('-b', '--bbb') {|v| v }
+
+        opt.parse!(ARGV, into: OPTS) # intoオプションにハッシュを渡す
+        p ARGV
+        p OPTS
+
+        ruby sample.rb -a foo bar -b baz
+        # => ["foo", "bar", "baz"]
+             {:a=>true, :bbb=>true}
+
+#@end
+
 ====[a:optionarg] オプションの引数
 
 [[m:OptionParser#on]] メソッドのオプション定義で末尾に何かを書くと、そ

--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -93,14 +93,14 @@ optparse を使う場合、基本的には
         require 'optparse'
         opt = OptionParser.new
 
-        OPTS = {}
+        opts = {}
 
-        opt.on('-a') {|v| OPTS[:a] = v }
-        opt.on('-b') {|v| OPTS[:b] = v }
+        opt.on('-a') {|v| opts[:a] = v }
+        opt.on('-b') {|v| opts[:b] = v }
 
         opt.parse!(ARGV)
         p ARGV
-        p OPTS
+        p opts
 
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]
@@ -117,14 +117,14 @@ optparse を使う場合、基本的には
         require 'optparse'
         opt = OptionParser.new
 
-        OPTS = {}
+        opts = {}
 
         opt.on('-a') {|v| v }
         opt.on('-b', '--bbb') {|v| v }
 
-        opt.parse!(ARGV, into: OPTS) # intoオプションにハッシュを渡す
+        opt.parse!(ARGV, into: opts) # intoオプションにハッシュを渡す
         p ARGV
-        p OPTS
+        p opts
 
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]


### PR DESCRIPTION
Ruby 2.4でOptionParser#parse 及び parse! メソッドに追加された `:into` オプションについて記述しました

http://ruby-doc.org/stdlib-2.4.2/libdoc/optparse/rdoc/OptionParser.html#method-i-parse