### PR TITLE
Add sample code of Integer#to_i

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -147,6 +147,10 @@ self が正の整数でない場合は何もしません。
 
 self を返します。
 
+例:
+
+  10.to_i   # => 10
+
 #@since 2.4.0
 --- floor(ndigits = 0) -> Integer | Float
 


### PR DESCRIPTION
`Integer#to_i`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/2.4.0/method/Integer/i/to_i.html