### PR TITLE
Add sample code of Integer#to_f

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -423,6 +423,11 @@ self を浮動小数点数([[c:Float]])に変換します。
 
 self が [[c:Float]] の範囲に収まらない場合、[[m:Float::INFINITY]] を返します。
 
+例:
+
+  1.to_f                       # => 1.0
+  (Float::MAX.to_i * 2).to_f   # => Infinity
+
 --- <=>(other) -> -1 | 0 | 1 | nil
 
 self と other を比較して、self が大きい時に1、等しい時に 0、小さい時


### PR DESCRIPTION
`Integer#to_f`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/2.4.0/method/Integer/i/to_f.html