### PR TITLE
Add Array#{max, min}

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2325,9 +2325,9 @@ a == b のとき 0、a < b のとき負の整数を、期待しています。
   [].max {|a, b| a <=> b }    #=> nil
   [].max(1) {|a, b| a <=> b } #=> []
 
-  a = %w(albatross dog horse)
-  a.max {|a, b| a.length <=> b.length }    #=> "albatross"
-  a.max(2) {|a, b| a.length <=> b.length } #=> ["albatross", "horse"]
+  ary = %w(albatross dog horse)
+  ary.max {|a, b| a.length <=> b.length }    #=> "albatross"
+  ary.max(2) {|a, b| a.length <=> b.length } #=> ["albatross", "horse"]
 
 @param n 取得する要素数。
 
@@ -2369,9 +2369,9 @@ a < b のとき負の整数を、期待しています。
   [].min {|a, b| a <=> b }    #=> nil
   [].min(1) {|a, b| a <=> b } #=> []
 
-  a = %w(albatross dog horse)
-  a.min {|a, b| a.length <=> b.length }    #=> "dog"
-  a.min(2) {|a, b| a.length <=> b.length } #=> ["dog", "horse"]
+  ary = %w(albatross dog horse)
+  ary.min {|a, b| a.length <=> b.length }    #=> "dog"
+  ary.min(2) {|a, b| a.length <=> b.length } #=> ["dog", "horse"]
 
 @param n 取得する要素数。
 

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2291,6 +2291,94 @@ find-any モードは [[man:bsearch(3)]] のように動作します。ブロッ
 #@end
 
 #@since 2.4.0
+--- max    -> object | nil
+--- max(n) -> Array
+
+最大の要素、もしくは最大の n 要素を返します。
+全要素が互いに <=> メソッドで比較できることを仮定しています。
+
+引数を指定しない形式では要素が存在しなければ nil を返します。
+引数を指定する形式では、空の配列を返します。
+
+例:
+  [].max           #=> nil
+  [].max(1)        #=> []
+  [2, 5, 3].max    #=> 5
+  [2, 5, 3].max(2) #=> [5, 3]
+
+@param n 取得する要素数。
+
+@see [[m:Enumerable#max]]
+
+--- max {|a, b| ... }    -> object | nil
+--- max(n) {|a, b| ... } -> Array
+
+ブロックの評価結果で各要素の大小判定を行い、最大の要素、もしくは最小の
+n 要素を返します。
+引数を指定しない形式では要素が存在しなければ nil を返します。
+引数を指定する形式では、空の配列を返します。
+
+ブロックの値は、a > b のとき正、
+a == b のとき 0、a < b のとき負の整数を、期待しています。
+
+例:
+  [].max {|a, b| a <=> b }    #=> nil
+  [].max(1) {|a, b| a <=> b } #=> []
+
+  a = %w(albatross dog horse)
+  a.max {|a, b| a.length <=> b.length }    #=> "albatross"
+  a.max(2) {|a, b| a.length <=> b.length } #=> ["albatross", "horse"]
+
+@param n 取得する要素数。
+
+@see [[m:Enumerable#max]]
+#@end
+
+#@since 2.4.0
+--- min    -> object | nil
+--- min(n) -> Array
+
+最小の要素、もしくは最小の n 要素を返します。
+全要素が互いに <=> メソッドで比較できることを仮定しています。
+
+引数を指定しない形式では要素が存在しなければ nil を返します。
+引数を指定する形式では、空の配列を返します。
+
+例:
+  [].min           #=> nil
+  [].min(1)        #=> []
+  [2, 5, 3].max    #=> 2
+  [2, 5, 3].min(2) #=> [2, 3]
+
+@param n 取得する要素数。
+
+@see [[m:Enumerable#min]]
+
+--- min {|a, b| ... }    -> object | nil
+--- min(n) {|a, b| ... } -> Array
+
+ブロックの評価結果で各要素の大小判定を行い、最小の要素、もしくは最小の
+n 要素を返します。
+引数を指定しない形式では要素が存在しなければ nil を返します。
+引数を指定する形式では、空の配列を返します。
+
+ブロックの値は、a > b のとき正、a == b のとき 0、
+a < b のとき負の整数を、期待しています。
+
+例:
+  [].min {|a, b| a <=> b }    #=> nil
+  [].min(1) {|a, b| a <=> b } #=> []
+
+  a = %w(albatross dog horse)
+  a.min {|a, b| a.length <=> b.length }    #=> "dog"
+  a.min(2) {|a, b| a.length <=> b.length } #=> ["dog", "horse"]
+
+@param n 取得する要素数。
+
+@see [[m:Enumerable#min]]
+#@end
+
+#@since 2.4.0
 --- sum(init=0)                    -> number
 --- sum(init=0) {|e| expr }        -> number
 


### PR DESCRIPTION
Ruby 2.4.0 で Array に max と min メソッドが直接実装されたので、リファレンスを追加します。