### PR TITLE
Add sample code of Enumerable::Lazy#drop_while

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -192,6 +192,13 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 [[m:Enumerable#drop_while]] と同じですが、配列ではなくEnumerator::Lazy を返します。
 
+例:
+  (1..Float::INFINITY).lazy.drop_while { |i| i < 42 }
+  # => #<Enumerator::Lazy: #<Enumerator::Lazy: 1..Infinity>:drop_while>
+
+  (1..Float::INFINITY).lazy.drop_while { |i| i < 42 }.take(10).force
+  # => [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+
 @see [[m:Enumerable#drop_while]]
 
 --- lazy -> self

--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -187,7 +187,6 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 @see [[m:Enumerable#drop]]
 
---- drop_while -> Enumerator::Lazy
 --- drop_while {|item| ... } -> Enumerator::Lazy
 
 [[m:Enumerable#drop_while]] と同じですが、配列ではなくEnumerator::Lazy を返します。


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/2.4.0/method/Enumerator=3a=3aLazy/i/drop_while.html
* https://docs.ruby-lang.org/en/2.4.0/Enumerator/Lazy.html#method-i-drop_while

## 補足
リファレンスでは `drop_while -> Enumerator::Lazy` の記載がありますが、
ブロックを指定しないと

```
t.rb:1:in `drop_while': tried to call lazy drop_while without a block (ArgumentError)
	from t.rb:1:in `<main>'
```

という感じでエラーになります。
実際に ruby 本家のテストコードを確認しましたが、仕様としてはブロックは必須というのが正しそうです。

https://github.com/ruby/ruby/blob/trunk/spec/ruby/core/enumerator/lazy/drop_while_spec.rb#L42-L44

この認識が正しければ、別途該当のシグニチャを消すプルリクエスをと送ります。
（ここで追加コミットしたほうがよければ、そちらでもいいです）
