### PR TITLE
Add sample code of Symbol#match?

### DIFF
--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -275,6 +275,15 @@ regexp.match?(self, pos) と同じです。
 regexp が文字列の場合は、正規表現にコンパイルします。
 詳しくは [[m:Regexp#match?]] を参照してください。
 
+例:
+
+  :Ruby.match?(/R.../)    # => true
+  :Ruby.match?('Ruby')    # => true
+  :Ruby.match?('Ruby',1)  # => false
+  :Ruby.match?('uby',1)   # => true
+  :Ruby.match?(/P.../)    # => false
+  $&                      # => nil
+
 @see [[m:Regexp#match?]], [[m:String#match?]]
 #@end
 


### PR DESCRIPTION
`Symbol#match?`にサンプルコードを追加しました。
https://docs.ruby-lang.org/ja/latest/method/Symbol/i/match=3f.html