### PR TITLE
Add sample code of Enumerator::Lazy#slice_after

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -233,6 +233,13 @@ self を返します。
 
 [[m:Enumerable#slice_after]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
+例:
+  (1..Float::INFINITY).lazy.slice_after { |e| e % 3 == 0 }
+  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x007fd73980e6f8>:each>>
+
+  (1..Float::INFINITY).lazy.slice_after { |e| e % 3 == 0 }.take(5).force
+  # => [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]
+
 @see [[m:Enumerable#slice_after]]
 
 --- slice_when {|elt_before, elt_after| bool } -> Enumerator::Lazy


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Enumerator=3a=3aLazy/i/slice_after.html
* https://docs.ruby-lang.org/en/2.4.0/Enumerator/Lazy.html#method-i-slice_after
