### PR TITLE
Add sample code of Enumerator::Lazy#slice_before

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -225,6 +225,13 @@ self を返します。
 
 [[m:Enumerable#slice_before]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
+例:
+  (1..Float::INFINITY).lazy.slice_before { |e| e.even? }
+  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x00007f9f31844ce8>:each>>
+
+  (1..Float::INFINITY).lazy.slice_before { |e| e % 3 == 0 }.take(5).force
+  # => [[1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14]]
+
 @see [[m:Enumerable#slice_before]]
 
 #@since 2.2.0


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Enumerator=3a=3aLazy/i/slice_before.html
* https://docs.ruby-lang.org/en/2.4.0/Enumerator/Lazy.html#method-i-slice_before