### PR TITLE
Add sample code of Numeric#negative?

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -659,6 +659,12 @@ self が 0 より大きい場合に true を返します。そうでない場合
 
 self が 0 未満の場合に true を返します。そうでない場合に false を返します。
 
+例:
+
+  -1.negative?   # => true
+  0.negative?    # => false
+  1.negative?    # => false
+
 @see [[m:Numeric#positive?]]
 #@end
 


### PR DESCRIPTION
`Numric#negative?`にサンプルコードを追加します。
https://docs.ruby-lang.org/ja/latest/method/Numeric/i/negative=3f.html

```
                      Numeric    Integer     Float     Rational   Complex
 --------------------------------------------------------------------------------
         negative? |     o          -          o          o          -
```

``` ruby
> -1.method(:negative?)
=> #<Method: Integer(Numeric)#negative?>
> (1+0i).method(:negative?)
NoMethodError: undefined method `negative?' for (1+0i):Complex
```