### PR TITLE
Add noexample comment of Module#protected_instance_methods

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -871,6 +871,8 @@ self の public インスタンスメソッド name をオブジェクト化し�
 
 @param inherited_too false を指定するとそのモジュールで定義されているメソッドのみ返します。
 
+#@#noexample 参照先のModule#instance_methodsにサンプルが書かれているため
+
 @see [[m:Object#protected_methods]], [[m:Module#instance_methods]]
 
 --- private_class_method(*name) -> self


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Module/i/protected_instance_methods.html
* https://docs.ruby-lang.org/en/2.4.0/Module.html#method-i-protected_instance_methods

参照先のModule#instance_methodsでModule#protected_instance_methodsのサンプルがあったので、サンプルを追加していない旨コメントに残しました。