### PR TITLE
Add sample code of Numeric#positive?

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -653,6 +653,12 @@ modulo はメソッド % の呼び出しとして定義されています。
 
 self が 0 より大きい場合に true を返します。そうでない場合に false を返します。
 
+例:
+
+  1.positive?    # => true
+  0.positive?    # => false
+  -1.positive?   # => false
+
 @see [[m:Numeric#negative?]]
 
 --- negative? -> bool


### PR DESCRIPTION
`Numeric#positive?`にサンプルコードを追加します。
https://docs.ruby-lang.org/ja/latest/method/Numeric/i/positive=3f.html

                           Numeric    Integer     Float     Rational   Complex
               positive? |     o          -          o          o          -

``` ruby
> 1.method(:positive?)
=> #<Method: Integer(Numeric)#positive?>
> (1+0i).method(:positive?)
NameError: undefined method `positive?' for class `Complex'
```