### PR TITLE
Add sample code of Hash#default_proc=

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -705,6 +705,32 @@ nil を指定した場合は現在の [[m:Hash#default_proc]] をクリアしま
 #@end
 
 @param pr デフォルト値を返す手続きオブジェクト
+
+例:
+  h = {}
+  h.default_proc = proc do |hash, key|
+    hash[key] = case
+                       when (key % 15).zero?
+                         "FizzBuzz"
+                       when (key % 5).zero?
+                          "Buzz"
+                       when (key % 3).zero?
+                          "Fizz"
+                       else
+                          key
+                       end
+  end
+  p h[1]  # => 1
+  p h[2]  # => 2
+  p h[3]  # => "Fizz"
+  p h[5]  # => "Buzz"
+  p h[15] # => "FizzBuzz"
+
+  h.default_proc = nil
+  p h[16] # => nil
+  # default_proc が nil になったので `16=>16 が追加されていない`
+  p h     # => {1=>1, 2=>2, 3=>"Fizz", 5=>"Buzz", 15=>"FizzBuzz"}
+
 @see [[m:Hash#default_proc]], [[m:Hash#default]]
 
 #@end


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Hash/i/default_proc=3d.html
* https://docs.ruby-lang.org/en/2.4.0/Hash.html#method-i-default_proc-3D

ruby 2.0 以下向けの分岐は不要という判断でサンプルコードをバージョンで分岐しませんでした。
