### PR TITLE
Add noexample comment of Numeric#denominator

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -892,7 +892,9 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 
 @return 分母を返します。
 
-@see [[m:Numeric#numerator]]
+#@#noexample Integer、Float、Rational、Complex 各クラスに実装されているため
+
+@see [[m:Numeric#numerator]]、[[m:Integer#denominator]]、[[m:Float#denominator]]、[[m:Rational#denominator]]、[[m:Complex#denominator]]
 
 --- imag      -> 0
 --- imaginary -> 0


### PR DESCRIPTION
`Numeric#denominator`に noexample コメントを追加します。
https://docs.ruby-lang.org/ja/latest/method/Numeric/i/denominator.html

                           Numeric    Integer     Float     Rational   Complex
             denominator |     o          o          o          o          o

``` ruby
> 1.method(:denominator)
=> #<Method: Integer#denominator>
> 0.1.method(:denominator)
=> #<Method: Float#denominator>
> Rational(2).method(:denominator)
=> #<Method: Rational#denominator>
> (1+3i).method(:denominator)
=> #<Method: Complex#denominator>
```

各子クラスにメソッドが実装されています。