### PR TITLE
Add sample code of Hash#to_h

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -299,6 +299,18 @@ self を返します。
 
 self を返します。[[c:Hash]] クラスのサブクラスから呼び出した場合は
 self を [[c:Hash]] オブジェクトに変換します。
+
+例:
+  hash = {}
+  p hash.to_h      # => {}
+  p hash.to_h == hash # => true
+
+  class MyHash < Hash;end
+  my_hash = MyHash.new
+  p my_hash.to_h        # => {}
+  p my_hash.class       # => MyHash
+  p my_hash.to_h.class  # => Hash
+
 #@end
 
 #@since 2.3.0


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Hash/i/to_h.html
* https://docs.ruby-lang.org/en/2.4.0/Hash.html#method-i-to_h

※ `==` 利用時に `ruby -w` で実行すると警告がでるので `p` 付きにしている