### PR TITLE
Add sample code of Hash#to_hash

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -289,6 +289,12 @@ ifnoneを省略した Hash.new は {} と同じです。
 self を返します。
 
 #@since 2.0.0
+
+例:
+  hash = {}
+  p hash.to_hash         # => {}
+  p hash.to_hash == hash # => true
+
 @see [[m:Object#to_hash]], [[m:Hash#to_h]]
 #@else
 @see [[m:Object#to_hash]]


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Hash/i/to_hash.html
* https://docs.ruby-lang.org/en/2.4.0/Hash.html#method-i-to_hash

`p hash.to_h == hash # => true` に `p` をつけないと `ruby -w` で警告が出るのでつけています。
一つだけついていると不自然そうなので全部につけました。

