### PR TITLE
Add noexample comment of Numeric#numerator

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -916,7 +916,9 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 
 @return 分子を返します。
 
-@see [[m:Numeric#denominator]]
+#@#noexample Integer、Float、Rational、Complex 各クラスに実装されているため
+
+@see [[m:Numeric#denominator]]、[[m:Integer#numerator]]、[[m:Float#numerator]]、[[m:Rational#numerator]]、[[m:Complex#numerator]]
 
 --- polar -> [Numeric, Numeric]
 


### PR DESCRIPTION
`Numeric#numerator`に noexample コメントを追加し、各子クラスにリンクを追加します。

                           Numeric    Integer     Float     Rational   Complex
               numerator |     o          o          o          o          o

``` ruby
> 1.method(:numerator)
=> #<Method: Integer#numerator>
> 0.1.method(:numerator)
=> #<Method: Float#numerator>
> Rational(3).method(:numerator)
=> #<Method: Rational#numerator>
> (3+2i).method(:numerator)
=> #<Method: Complex#numerator>
```