### PR TITLE
OptionParser sample change to more readable name

### DIFF
--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -93,14 +93,14 @@ optparse を使う場合、基本的には
         require 'optparse'
         opt = OptionParser.new
 
-        opts = {}
+        params = {}
 
-        opt.on('-a') {|v| opts[:a] = v }
-        opt.on('-b') {|v| opts[:b] = v }
+        opt.on('-a') {|v| params[:a] = v }
+        opt.on('-b') {|v| params[:b] = v }
 
         opt.parse!(ARGV)
         p ARGV
-        p opts
+        p params
 
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]
@@ -117,14 +117,14 @@ optparse を使う場合、基本的には
         require 'optparse'
         opt = OptionParser.new
 
-        opts = {}
+        params = {}
 
         opt.on('-a') {|v| v }
         opt.on('-b', '--bbb') {|v| v }
 
-        opt.parse!(ARGV, into: opts) # intoオプションにハッシュを渡す
+        opt.parse!(ARGV, into: params) # intoオプションにハッシュを渡す
         p ARGV
-        p opts
+        p params
 
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]


### PR DESCRIPTION
see #670

OptionParserのインスタンス名とオプションの値を格納するオブジェクト名がまぎわらしい問題の対応です。

変更した名前は `params` にしています。
これは以前のPRでのやりとりと、同ページ（ https://docs.ruby-lang.org/ja/2.4.0/library/optparse.html ）の`getopts` の例からも `params` にしておくのが良いかなと思っためです。