### PR TITLE
Add sample code of Numeric#finite?

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -726,6 +726,14 @@ self を other で割った余り r を返します。
 
 self の絶対値が有限値の場合に true を、そうでない場合に false を返します。
 
+例:
+
+  10.finite?                      # => true
+  Rational(3).finite?             # => true
+
+  Float::INFINITY.finite?         # => false
+  Float::INFINITY.is_a?(Numeric)  # => true
+
 @see [[m:Numeric#infinite?]]
 
 --- infinite? -> -1 | 1 | nil


### PR DESCRIPTION
`Numeric#finite?`にサンプルコードを追加します。
https://docs.ruby-lang.org/ja/latest/method/Numeric/i/finite=3f.html

                            Numeric    Integer     Float     Rational   Complex
                 finite? |     o          -          o          -          o

``` ruby
> 10.method(:finite?)
=> #<Method: Integer(Numeric)#finite?>
> Rational(3).method(:finite?)
=> #<Method: Rational(Numeric)#finite?>

> 0.1.method(:finite?)
=> #<Method: Float#finite?>
> (1+3i).method(:finite?)
=> #<Method: Complex#finite?>
```

結果が false にならないため、説明文を変更し、 [Float#finite?](https://docs.ruby-lang.org/ja/latest/method/Float/i/finite=3f.html) と [Complex#finite?](https://docs.ruby-lang.org/ja/latest/method/Complex/i/finite=3f.html) へのリンクを追加します。