### PR TITLE
Add sample code of Numeric#infinite?

### DIFF
--- a/refm/api/src/_builtin/Numeric
+++ b/refm/api/src/_builtin/Numeric
@@ -732,11 +732,17 @@ self の絶対値が有限値の場合に true を、そうでない場合に fa
 
 @see [[m:Numeric#infinite?]]
 
---- infinite? -> -1 | 1 | nil
+--- infinite? -> nil
 
-self の絶対値が負の無限大の場合に-1を、正の無限大の場合に1を、有限値の場合に nil を返します。
+常に nil を返します。
+自身が [[c:Float]] か[[c:Complex]]、もしくはそのサブクラスのインスタンスの場合は、self の絶対値が負の無限大の場合に-1を、正の無限大の場合に1を、有限値の場合に nil を返します。
 
-@see [[m:Numeric#finite?]]
+例:
+
+  10.infinite?     # => nil
+  (3r).infinite?   # => nil
+
+@see [[m:Numeric#finite?]]、[[m:Float#infinite?]]、[[m:Complex#infinite?]]
 #@end
 
 --- to_int    -> Integer


### PR DESCRIPTION
`Numeric#infinite?`にサンプルコードを追加します。
https://docs.ruby-lang.org/ja/latest/method/Numeric/i/infinite=3f.html

                           Numeric    Integer     Float     Rational   Complex
               infinite? |     o          -          o          -          o

``` ruby
> 2.method(:infinite?)
=> #<Method: Integer(Numeric)#infinite?>
> Rational(3).method(:infinite?)
=> #<Method: Rational(Numeric)#infinite?>

> 0.2.method(:infinite?)
=> #<Method: Float#infinite?>
> (1+3i).method(:infinite?)
=> #<Method: Complex#infinite?>
```

 [Float#infinite?](https://docs.ruby-lang.org/ja/latest/method/Float/i/infinite=3f.html) と [Complex#infinite?](https://docs.ruby-lang.org/ja/latest/method/Complex/i/infinite=3f.html) へのリンクを追加します。

``` c
/*
 *  call-seq:
 *     num.infinite?  ->  -1, 1, or nil
 *
 *  Returns +nil+, -1, or 1 depending on whether the value is
 *  finite, <code>-Infinity</code>, or <code>+Infinity</code>.
 */
static VALUE
num_infinite_p(VALUE num)
{
    return Qnil;
}
```

実装が nil のみを返すため、説明文を変更します。