### PR TITLE
Fix sample code of Rational#to_s

### DIFF
--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -596,7 +596,7 @@ precision を指定した場合は指定した桁数で切り捨てた整数か
 例:
 
   Rational(3, 4).to_s  # => "3/4"
-  Rational(8).to_s     # => "8"
+  Rational(8).to_s     # => "8/1"
   Rational(-8, 6).to_s # => "-4/3"
   Rational(0.5).to_s   # => "1/2"
 


### PR DESCRIPTION
`Rational#to_s`内のサンプルコードを修正しました。
https://docs.ruby-lang.org/ja/latest/method/Rational/i/to_s.html

```ruby
> Rational(8).to_s
=> "8/1"
```