### PR TITLE
Fix sample code of Rational#quo

### DIFF
--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -137,12 +137,8 @@ other に [[c:Float]] を指定した場合は、計算結果を [[c:Float]] で
 
   r = Rational(3, 4)
   r / 2                # => (3/8)
-#@since 1.9.3
-  r / 2.0              # => (3/8)
-  r / 0.5              # => 1.5
-#@else
   r / 2.0              # => 0.375
-#@end
+  r / 0.5              # => 1.5
   r / Rational(1, 2)   # => (3/2)
   r / 0                # => ZeroDivisionError
 


### PR DESCRIPTION
`Rational#quo`内のサンプルコードを修正しました。
https://docs.ruby-lang.org/ja/latest/method/Rational/i/=2f.html

```ruby
> r = Rational(3, 4)
=> (3/4)
> r / 2.0
=> "0.375"
```