### PR TITLE
Add Comparable#clamp

### DIFF
--- a/refm/api/src/_builtin/Comparable
+++ b/refm/api/src/_builtin/Comparable
@@ -150,3 +150,26 @@ self が min と max の範囲内(min, max
   6.between?(1, 5)               #=> false
   'cat'.between?('ant', 'dog')   #=> true
   'gnu'.between?('ant', 'dog')   #=> false
+
+#@since 2.4.0
+--- clamp(min, max)    -> object
+
+self が min と max の範囲内 (min, maxを含みます) のときにself を返します。
+範囲外の場合、self が min よりも小さい場合には min を返し、max よりも
+大きい場合には max を返します。
+
+@param min 範囲の下端を表すオブジェクトを指定します。
+
+@param max 範囲の上端を表すオブジェクトを指定します。
+
+@raise ArgumentError min が max より大きい値の場合に発生します。
+
+例:
+  12.clamp(0, 100)         #=> 12
+  523.clamp(0, 100)        #=> 100
+  -3.123.clamp(0, 100)     #=> 0
+  
+  'd'.clamp('a', 'f')      #=> 'd'
+  'z'.clamp('a', 'f')      #=> 'f'
+
+#@end


### PR DESCRIPTION
Ruby 2.4.0 から追加された Comparable#clamp の説明を追加します。