### PR TITLE
Add sample code of UncaughtThrowError#tag

### DIFF
--- a/refm/api/src/_builtin/UncaughtThrowError
+++ b/refm/api/src/_builtin/UncaughtThrowError
@@ -12,6 +12,18 @@
 
 [[m:Kernel.#throw]] に指定した tag を返します。
 
+#@samplecode 例:
+def do_complicated_things
+  throw :uncaught_label
+end
+
+begin
+  do_complicated_things
+rescue UncaughtThrowError => ex
+  p ex.tag # => ":uncaught_label"
+end
+#@end
+
 --- value -> object
 
 [[m:Kernel.#throw]] に指定した value を返します。


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/2.4.0/method/UncaughtThrowError/i/tag.html
* https://docs.ruby-lang.org/en/2.4.0/UncaughtThrowError.html#method-i-tag

UncaughtThrowError は throw - catch を利用した大域脱出時に発生するもので
これが発生するのは、コーディングミスのケースかな、という予想のもとサンプルを作りました。
想定は違うかもしれません。

## 参考資料
* https://docs.ruby-lang.org/ja/latest/method/Kernel/m/throw.html
* https://qiita.com/harvath/items/e716179538bc1da30f88
