### PR TITLE
Add sample code of main#include

### DIFF
--- a/refm/api/src/_builtin/main
+++ b/refm/api/src/_builtin/main
@@ -55,6 +55,12 @@ main では参照できない事に注意してください。トップレベル
 @raise ArgumentError 継承関係が循環してしまうような include を行った場
                      合に発生します。
 
+#@samplecode 例:
+include Math
+
+hypot(3, 4)  # => 5.0
+#@end
+
 @see [[m:Module#include]]
 
 --- define_method(name, method) -> Symbol


### PR DESCRIPTION
#433 

https://docs.ruby-lang.org/ja/2.4.0/method/main/s/include.html

`Module#include` のケースを参考にArgumentErrorが発生するケースを考えてみたのですが
main のケースでは思い浮かばなかったためサンプルに含めていません。

https://docs.ruby-lang.org/ja/latest/method/Module/i/include.html

## 別件
https://docs.ruby-lang.org/ja/2.4.0/method/main/s/include.html

の説明文にある

>引数 modules で指定したモジュールを後ろから順番をインクルードします。

これは

引数 modules で指定したモジュールを後ろから順番にインクルードします。

でしょうか？
それでよければ別途prします
（ここのprに含めたほうがよければここに含めます）
