### PR TITLE
Add sample code of Dir#read

### DIFF
--- a/refm/api/src/_builtin/Dir
+++ b/refm/api/src/_builtin/Dir
@@ -392,6 +392,21 @@ pos は [[m:Dir#tell]] で与えられた値でなければなりま
 
 @raise IOError 既に自身が close している場合に発生します。
 
+例:
+  require 'tmpdir'
+
+  Dir.mktmpdir do |tmpdir|
+    File.open("#{tmpdir}/test1.txt", "w") { |f| f.puts("test1") }
+    File.open("#{tmpdir}/test2.txt", "w") { |f| f.puts("test2") }
+    Dir.open(tmpdir) do |d|
+      p d.read   # => "."
+      p d.read   # => ".."
+      p d.read   # => "test1.txt"
+      p d.read   # => "test2.txt"
+      p d.read   # => nil
+    end
+  end
+
 --- rewind    -> self
 
 ディレクトリストリームの読み込み位置を先頭に移動させます。


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/class/Dir.html#I_READ
* https://ruby-doc.org/core-2.4.0/Dir.html#method-i-read

rdoc のサンプルは任意のディレクトリのファイルが有ることが前提になっているので、
そういった前提が不要になるように一時ディレクトリを作成して、その中にファイルを作成する
部分までサンプルに含めました。