### PR TITLE
Add sample code of UnboundMethod#clone

### DIFF
--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -155,6 +155,13 @@ true を返します。そうでない場合に false を返します。
 
 自身を複製した [[c:UnboundMethod]] オブジェクトを作成して返します。
 
+#@samplecode 例
+a = String.instance_method(:size)
+b = a.clone
+
+a == b       # => true
+#@end
+
 --- inspect -> String
 --- to_s    -> String
 

--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -151,7 +151,7 @@ true を返します。そうでない場合に false を返します。
   c = Array.instance_method(:size)
   p a == c                            #=> false
 
---- clone -> Method
+--- clone -> UnboundMethod
 
 自身を複製した [[c:UnboundMethod]] オブジェクトを作成して返します。
 


### PR DESCRIPTION
`UnboundMethod#clone`にサンプルコードを追加します。

https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/clone.html
https://docs.ruby-lang.org/en/2.4.0/UnboundMethod.html#method-i-clone

rdocのサンプルは`Method#clone`のものでしたので、違うものを追加しています。