### PR TITLE
Add noexample comment of UnboundMethod#parameters

### DIFF
--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -231,6 +231,9 @@ UnboundMethod オブジェクトの引数の情報を返します。
 
 詳しくは [[m:Method#parameters]] を参照してください。
 
+#@#noexample Method#parametersを参照
+
+
 @see [[m:Proc#parameters]], [[m:Method#parameters]]
 #@end
 


### PR DESCRIPTION
`UnboundMethod#parameters`に noexample コメントを追加します。

https://docs.ruby-lang.org/ja/latest/method/UnboundMethod/i/parameters.html

説明文に`詳しくは Method#parameters を参照してください。 `とあり、`Method#parameters`にサンプルコードがあります。