### PR TITLE
Data is deprecated from Ruby 2.5

### DIFF
--- a/refm/api/src/_builtin/Data
+++ b/refm/api/src/_builtin/Data
@@ -1,5 +1,9 @@
 = class Data < Object
 
+#@since 2.5.0
+このクラスは deprecated です。
+#@end
+
 拡張ライブラリを書く時に new が定義されているとまずい場合が
 あるため、[[c:Object]] から new と allocate を undef したクラスです。
 Ruby スクリプトレベルでは気にする必要は全くありません。


### PR DESCRIPTION
Data クラスは Ruby 2.5 から deprecated になりました。
https://bugs.ruby-lang.org/issues/3072

使った場合は以下の warning が表示されます。

```console
% ruby -ve 'Data.to_s'
ruby 2.5.0dev (2017-12-07 trunk 61059) [x86_64-darwin13]
-e:1: warning: constant ::Data is deprecated
```