### PR TITLE
rakeタスク追加

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
 
-VERSIONS = ["1.8.7", "1.9.3", "2.0.0", "2.1.0", "2.2.0", "2.3.0", "2.4.0"]
+OLD_VERSIONS = %w[1.8.7 1.9.3 2.0.0 2.1.0]
+SUPPORTED_VERSIONS = %w[2.2.0 2.3.0 2.4.0]
+UNRELEASED_VERSIONS = %w[2.5.0]
+ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 
 def generate_database(version)
   puts version
@@ -19,18 +22,35 @@ end
 
 task :default => [:generate, :check_prev_commit_format]
 
-desc "Generate document database"
-task :generate do
-  VERSIONS.each do |version|
-    generate_database(version)
+namespace :generate do
+  ALL_VERSIONS.each do |version|
+    desc "Generate document database of #{version}"
+    task version do
+      generate_database(version)
+    end
   end
+
+  desc "Generate document database of all versions"
+  task :all => ALL_VERSIONS
+
+  desc "Generate document database for old versions"
+  task :old => OLD_VERSIONS
+
+  desc "Generate document database for supported versions"
+  task :supported => SUPPORTED_VERSIONS
+
+  desc "Generate document database for unreleased versions"
+  task :unreleased => UNRELEASED_VERSIONS
 end
+
+desc "Generate document database"
+task :generate => [*OLD_VERSIONS, *SUPPORTED_VERSIONS].map {|version| "generate:#{version}" }
 
 desc "Check previous commit format"
 task :check_prev_commit_format do
   change_files = `git diff HEAD^ HEAD --name-only --diff-filter=d`.split
   res = []
-  VERSIONS.each do |v|
+  ALL_VERSIONS.each do |v|
     change_files.each do |path|
       if %r!\Arefm/api/!.match(path)
         htmls = []

--- a/Rakefile
+++ b/Rakefile
@@ -34,8 +34,8 @@ def generate_statichtml(version)
                      "--fs-casesensitive",
                      "--canonical-base-url=http://localhost:9292/latest/")
   raise "Failed to generate static html" unless succeeded
-  require 'fileutils'
-  FileUtils.ln_sf(version, "/tmp/html/latest")
+  File.unlink("/tmp/html/latest") rescue nil
+  File.symlink(version, "/tmp/html/latest")
 end
 
 task :default => [:generate, :check_prev_commit_format]

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ UNRELEASED_VERSIONS = %w[2.5.0]
 ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 
 def generate_database(version)
-  puts version
+  puts "generate database of #{version}"
   db = "/tmp/db-#{version}"
   succeeded = system("bundle", "exec",
                      "bitclust", "--database=#{db}",
@@ -21,7 +21,7 @@ def generate_database(version)
 end
 
 def generate_statichtml(version)
-  puts version
+  puts "generate static html of #{version}"
   db = "/tmp/db-#{version}"
   outputdir = "/tmp/html/#{version}"
   bitclust_gem_path = File.expand_path('../..', `bundle exec gem which bitclust`)

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,1 @@
+run Rack::Directory.new('/tmp/html')


### PR DESCRIPTION
html を生成して確認するのに、[bc-setup-all](https://github.com/ruby/docs.ruby-lang.org/blob/a3d7253c03aaceafc4d60332d9319a91b31be4bc/system/bc-setup-all) と [bc-static-all](https://github.com/ruby/docs.ruby-lang.org/blob/a3d7253c03aaceafc4d60332d9319a91b31be4bc/system/bc-static-all) を参考にして生成しているのですが、共通の Rakefile に入っていた方が便利だと思ったのでよろしくお願いします。

データベースや HTML の生成は、バージョンごとの生成もできるように機能追加しています。
生成した HTML 確認用の config.ru も追加したので、

```
rake statichtml
rackup
```

の後、 `http://localhost:9292/latest/index.html` でみえるはずです。

デフォルトターゲットの挙動は変えていないつもりです。