### PR TITLE
Ignore .bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Gemfile.lock
+/.bundle


### PR DESCRIPTION
rake タスクが `bundle exec` しているので、 `.bundle` が存在することになると思うのですが、 `.gitignore` に入っていなくて間違えてコミットしてしまいそうになるので、 `.gitignore` に追加します。