### PR TITLE
Add sample code of File.readlink

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -404,6 +404,12 @@ path が整数の場合はファイルディスクリプタとして扱い、そ
 
 @raise Errno::EXXX 指定された path がシンボリックリンクでない場合や、リンクの読み取りに失敗した場合に発生します。
 
+#@samplecode 例:
+IO.write("testfile", "test")
+File.symlink("testfile", "testlink")   # => 0
+File.readlink("testlink")              # => "testfile"
+#@end
+
 #@since 1.9.2
 --- realpath(pathname, basedir = nil) -> String
 


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/File/s/readlink.html
* https://docs.ruby-lang.org/en/2.4.0/File.html#method-c-readlink

基本は rdoc のままですが、 https://github.com/rurema/doctree/pull/894 に合わせてファイル名を testlink にしました

