### PR TITLE
Fix a typo

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -47,7 +47,7 @@ Time オブジェクトを生成する各メソッドで、それぞれの環境
 
 [[lib:time]] ライブラリによって、[[m:Time.parse]], [[m:Time.rfc2822]], [[m:Time.httpdate]], [[m:Time.iso8601]] 等が拡張されます。
 
-[[man:localtime(3)]] も参照しください。
+[[man:localtime(3)]] も参照してください。
 
 === C 言語との違いに注意
 


### PR DESCRIPTION
`参照しください`を`参照してください`
に修正しました。

https://docs.ruby-lang.org/ja/latest/class/Time.html