### PR TITLE
Add sample code of File.stat

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -483,6 +483,10 @@ filename の情報を含む [[c:File::Stat]] オブジェクトを生成し
 
 @raise Errno::EXXX 情報の取得に失敗した場合に発生します。
 
+例:
+  File.stat("testfile").class   # => File::Stat
+  File.stat("testfile").mtime   # => 2017-12-10 01:13:56 +0900
+
 @see [[m:IO#stat]], [[m:File#lstat]]
 
 --- lstat(filename)   -> File::Stat


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/File/s/stat.html
* https://docs.ruby-lang.org/en/2.4.0/File.html#method-c-stat

rdoc のサンプルをベースに出力結果を日本ロケールのものに変更しました。
出力結果のクラスの確認も追加しています。