### PR TITLE
Add sample code of File.symlink

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -509,6 +509,9 @@ old への new という名前のシンボリックリンクを生成します�
 
 @raise Errno::EXXX 失敗した場合に発生します。
 
+例:
+  File.symlink("testfile", "testlink")   # => 0
+
 --- truncate(path, length)    -> 0
 
 path で指定されたファイルのサイズを最大 length バイト


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/File/s/symlink.html
* https://docs.ruby-lang.org/en/2.4.0/File.html#method-c-symlink

基本は rdoc のままですが、 https://github.com/rurema/doctree/pull/894 に合わせてファイル名を testlink にしました

