### PR TITLE
Add sample code of File.truncate

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -523,6 +523,11 @@ path で指定されたファイルのサイズを最大 length バイト
 
 @raise Errno::EXXX 失敗した場合に発生します。
 
+例
+  IO.write("testfile", "1234567890")
+  File.truncate("testfile", 5)   # => 0
+  File.size("testfile")          # => 5
+
 --- umask           -> Integer
 
 現在の umask の値を返します。


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/File/s/truncate.html
* https://docs.ruby-lang.org/en/2.4.0/File.html#method-c-truncate

別のサンプルを作成した際に IO.write のほうがシンプルで良いというアドバイスをいただいたので
rdoc のサンプルのファイル作成部分を置き換えてあります。

