### PR TITLE
Add sample code of Array#sort_by=21

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -1625,6 +1625,12 @@ sort_by の破壊的バージョンです。
 ブロックを省略した場合は返り値によって配列を破壊的に
 ソートする [[c:Enumerator]] を返します。
 
+#@samplecode
+fruits = %w{apple pear fig}
+fruits.sort_by! { |word| word.length }
+fruits # => ["fig", "pear", "apple"]
+#@end
+
 @see [[m:Enumerable#sort_by]]
 #@end
 


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Array/i/sort_by=21.html
* https://docs.ruby-lang.org/en/2.4.0/Array.html#method-i-sort_by-21

`Enumerable#sort_by` の rdoc のサンプルを参考にしました

https://docs.ruby-lang.org/en/2.4.0/Enumerable.html#method-i-sort_by