### PR TITLE
Add `String#delete_{prefix,suffix}{,!}` since 2.5.0

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2929,6 +2929,9 @@ self の先頭が strs のいずれかであるとき true を返します。
 #@end
 
 @see [[m:String#end_with?]]
+#@since 2.5.0
+@see [[m:String#delete_prefix]], [[m:String#delete_prefix!]]
+#@end
 
 --- end_with?(*strs) -> bool
 
@@ -2943,6 +2946,9 @@ self の末尾が strs のいずれかであるとき true を返します。
 #@end
 
 @see [[m:String#start_with?]]
+#@since 2.5.0
+@see [[m:String#delete_suffix]], [[m:String#delete_suffix!]]
+#@end
 
 --- partition(sep) -> [String, String, String]
 
@@ -3509,4 +3515,61 @@ unpackは配列を返しますがunpack1は配列の1つ目の要素のみを返
 #@end
 
 @see [[m:String#unpack]], [[m:Array#pack]]
+#@end
+#@since 2.5.0
+--- delete_prefix(prefix) -> String
+文字列の先頭から prefix を削除した文字列のコピーを返します。
+
+@return 文字列の先頭から prefix を削除した文字列のコピー
+
+#@samplecode
+"hello".delete_prefix("hel") # => "lo"
+"hello".delete_prefix("llo") # => "hello"
+#@end
+
+@see [[m:String#delete_prefix!]]
+@see [[m:String#delete_suffix]]
+@see [[m:String#start_with?]]
+
+--- delete_prefix!(prefix) -> self | nil
+self の先頭から破壊的に prefix を削除します。
+
+@return 削除した場合は self、変化しなかった場合は nil
+
+#@samplecode
+"hello".delete_prefix!("hel") # => "lo"
+"hello".delete_prefix!("llo") # => nil
+#@end
+
+@see [[m:String#delete_prefix]]
+@see [[m:String#delete_suffix!]]
+@see [[m:String#start_with?]]
+
+--- delete_suffix(suffix) -> String
+文字列の末尾から suffix を削除した文字列のコピーを返します。
+
+@return 文字列の末尾から suffix を削除した文字列のコピー
+
+#@samplecode
+"hello".delete_suffix("llo") # => "he"
+"hello".delete_suffix("hel") # => "hello"
+#@end
+
+@see [[m:String#delete_prefix]]
+@see [[m:String#delete_suffix!]]
+@see [[m:String#end_with?]]
+
+--- delete_suffix!(suffix) -> self | nil
+self の末尾から破壊的に suffix を削除します。
+
+@return 削除した場合は self、変化しなかった場合は nil
+
+#@samplecode
+"hello".delete_suffix!("llo") # => "he"
+"hello".delete_suffix!("hel") # => nil
+#@end
+
+@see [[m:String#delete_prefix!]]
+@see [[m:String#delete_suffix]]
+@see [[m:String#end_with?]]
 #@end

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3540,6 +3540,8 @@ unpackは配列を返しますがunpack1は配列の1つ目の要素のみを返
 --- delete_prefix(prefix) -> String
 文字列の先頭から prefix を削除した文字列のコピーを返します。
 
+@param prefix 先頭から削除する文字列を指定します。
+
 @return 文字列の先頭から prefix を削除した文字列のコピー
 
 #@samplecode
@@ -3554,6 +3556,8 @@ unpackは配列を返しますがunpack1は配列の1つ目の要素のみを返
 --- delete_prefix!(prefix) -> self | nil
 self の先頭から破壊的に prefix を削除します。
 
+@param prefix 先頭から削除する文字列を指定します。
+
 @return 削除した場合は self、変化しなかった場合は nil
 
 #@samplecode
@@ -3567,6 +3571,8 @@ self の先頭から破壊的に prefix を削除します。
 
 --- delete_suffix(suffix) -> String
 文字列の末尾から suffix を削除した文字列のコピーを返します。
+
+@param suffix 末尾から削除する文字列を指定します。
 
 @return 文字列の末尾から suffix を削除した文字列のコピー
 
@@ -3583,6 +3589,8 @@ self の先頭から破壊的に prefix を削除します。
 
 --- delete_suffix!(suffix) -> self | nil
 self の末尾から破壊的に suffix を削除します。
+
+@param suffix 末尾から削除する文字列を指定します。
 
 @return 削除した場合は self、変化しなかった場合は nil
 

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -950,6 +950,12 @@ p "foo\n".chomp    # => "foo"
 p "foo\n\r".chomp  # => "foo\n"
 #@end
 
+@see [[m:String#chomp!]]
+@see [[m:String#chop]]
+#@since 2.5.0
+@see [[m:String#delete_suffix]]
+#@end
+
 --- chomp!(rs = $/) -> self | nil
 
 self の末尾から rs で指定する改行コードを取り除きます。
@@ -975,6 +981,12 @@ p "foo\n".chomp!    # => "foo"
 p "foo\n\r".chomp!  # => "foo\n"
 #@end
 
+@see [[m:String#chomp]]
+@see [[m:String#chop!]]
+#@since 2.5.0
+@see [[m:String#delete_suffix!]]
+#@end
+
 --- chop -> String
 
 文字列の最後の文字を取り除いた新しい文字列を生成して返します。
@@ -988,7 +1000,11 @@ p "strin".chop       # => "stri"
 p "".chop            # => ""
 #@end
 
+@see [[m:String#chomp]]
 @see [[m:String#chop!]]
+#@since 2.5.0
+@see [[m:String#delete_suffix]]
+#@end
 
 --- chop! -> self | nil
 
@@ -1006,7 +1022,11 @@ p "".chop            # => ""
   "".chop!             # => nil
 #@end
 
+@see [[m:String#chomp!]]
 @see [[m:String#chop]]
+#@since 2.5.0
+@see [[m:String#delete_suffix!]]
+#@end
 
 --- clear -> self
 
@@ -3555,6 +3575,8 @@ self の先頭から破壊的に prefix を削除します。
 "hello".delete_suffix("hel") # => "hello"
 #@end
 
+@see [[m:String#chomp]]
+@see [[m:String#chop]]
 @see [[m:String#delete_prefix]]
 @see [[m:String#delete_suffix!]]
 @see [[m:String#end_with?]]
@@ -3569,6 +3591,8 @@ self の末尾から破壊的に suffix を削除します。
 "hello".delete_suffix!("hel") # => nil
 #@end
 
+@see [[m:String#chomp!]]
+@see [[m:String#chop!]]
 @see [[m:String#delete_prefix!]]
 @see [[m:String#delete_suffix]]
 @see [[m:String#end_with?]]


### PR DESCRIPTION
closes #960
https://bugs.ruby-lang.org/issues/12694
https://bugs.ruby-lang.org/issues/13665