### PR TITLE
Add `uplevel:` to `Kernel.#warn` since 2.5.0

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1426,25 +1426,51 @@ to_s メソッドにより文字列に変換してから出力します。
 
 @see [[m:Kernel.#print]], [[m:Kernel.#p]], [[m:IO#puts]]
 
+#@since 2.5.0
+--- warn(*message, uplevel: nil) -> nil
+#@else
 --- warn(*message) -> nil
+#@end
 
-message を 標準エラー出力 [[m:$stderr]] に出力します。 [[m:$VERBOSE]] 
+message を 標準エラー出力 [[m:$stderr]] に出力します。 [[m:$VERBOSE]]
 フラグ が nil のときは何も出力しません。
 
 文字列以外のオブジェクトが引数として与えられた場合には、
 to_s メソッドにより文字列に変換してから出力します。
 
+#@since 2.5.0
+uplevel を指定しない場合は、
+#@end
 このメソッドは以下と同じです。
-  $stderr.puts(*message) if !$VERBOSE.nil? && !message.empty?
-  nil
+
+#@samplecode
+$stderr.puts(*message) if !$VERBOSE.nil? && !message.empty?
+nil
+#@end
 
 @param message 出力するオブジェクトを任意個指定します。
+#@since 2.5.0
+@param uplevel いくつ前の呼び出し元のファイル名と行番号を表示するかを0以上の数値で指定します。 nil の場合は表示しません。
+#@end
 @raise IOError 標準エラー出力が書き込み用にオープンされていなければ発生します。
 @raise Errno::EXXX 出力に失敗した場合に発生します。
 
-  warn "caution!" #=> caution!
-  $VERBOSE = nil
-  warn "caution!" # 何もしない
+#@samplecode 例
+warn "caution!" #=> caution!
+$VERBOSE = nil
+warn "caution!" # 何もしない
+#@end
+
+#@since 2.5.0
+#@samplecode uplevel の例
+def foo
+  warn("test message", uplevel: 0) # => test.rb:2: warning: test message
+  warn("test message", uplevel: 1) # => test.rb:6: warning: test message
+  warn("test message", uplevel: 2) # => test message
+end
+foo
+#@end
+#@end
 
 @see [[m:$stderr]],[[m:$VERBOSE]]
 


### PR DESCRIPTION
closes #958
https://bugs.ruby-lang.org/issues/12882