### PR TITLE
Add `Integer.sqrt` since 2.5.0

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -812,3 +812,31 @@ self を表すのに必要なビット数を返します。
    (2**12+1).bit_length      # => 13
 
 #@end
+#@since 2.5.0
+--- sqrt(n) -> Integer
+
+非負整数 n の整数の平方根を返します。すなわち n の平方根以下の
+最大の非負整数を返します。
+
+@param n 非負整数。Integer ではない場合は、最初に Integer に変換されます。
+@raise Math::DomainError n が負の整数の時に発生します。
+
+#@samplecode
+Integer.sqrt(0)        # => 0
+Integer.sqrt(1)        # => 1
+Integer.sqrt(24)       # => 4
+Integer.sqrt(25)       # => 5
+Integer.sqrt(10**400) == 10**200 # => true
+#@end
+
+Math.sqrt(n).floor と同等ですが、後者は浮動小数点数の制度の限界によって
+真の値とは違う結果になることがあります。
+
+#@samplecode
+Integer.sqrt(10**46)     #=> 100000000000000000000000
+Math.sqrt(10**46).floor  #=>  99999999999999991611392 (!)
+#@end
+
+
+@see [[m:Math.sqrt]]
+#@end

--- a/refm/api/src/_builtin/Math
+++ b/refm/api/src/_builtin/Math
@@ -414,6 +414,10 @@ x の平方根を返します。
 @raise Errno::EDOM  引数が負の値である場合に発生します。
 #@end
 
+#@since 2.5.0
+@see [[m:Integer.sqrt]]
+#@end
+
 #@since 1.9.1
 --- cbrt(x) -> Float
 


### PR DESCRIPTION
closes #956
https://bugs.ruby-lang.org/issues/13219