### PR TITLE
Some `#write` accept multiple arguments since 2.5.0

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1566,7 +1566,11 @@ self を返します。
   f.ungetc(c)                # => nil
   f.getc                     # => "い"
 
+#@since 2.5.0
+--- write(*str)     -> Integer
+#@else
 --- write(str)     -> Integer
+#@end
 
 IOポートに対して str を出力します。str が文字列でなけ
 れば to_s による文字列化を試みます。

--- a/refm/api/src/stringio.rd
+++ b/refm/api/src/stringio.rd
@@ -661,7 +661,11 @@ nil を返します。
       p s.pos        #=> 7
 #@end
 
+#@since 2.5.0
+--- write(*obj)    -> Integer
+#@else
 --- write(obj)    -> Integer
+#@end
 
 自身に obj を書き込みます。obj が文字列でなければ to_s による文字列化を試みます。
 書き込まれた文字列の長さを返します。

--- a/refm/api/src/zlib/GzipWriter
+++ b/refm/api/src/zlib/GzipWriter
@@ -291,7 +291,11 @@ C 言語の printf と同じように、format に従い引数
 
 @see [[m:IO#printf]], [[m:Kernel.#printf]]
 
+#@since 2.5.0
+--- write(*str) -> Integer
+#@else
 --- write(str) -> Integer
+#@end
 
 自身に str を出力します。str が文字列でなけ
 れば to_s による文字列化を試みます。


### PR DESCRIPTION
closes #953
https://bugs.ruby-lang.org/issues/9323