### PR TITLE
Fix SizedQueue

### DIFF
--- a/refm/api/src/thread/SizedQueue
+++ b/refm/api/src/thread/SizedQueue
@@ -118,3 +118,13 @@ non_block が真でなければ、キューのサイズが [[m:Thread::SizedQueu
 
 @see [[m:Thread::Queue#close]]
 #@end
+#@since 2.5.0
+--- empty? -> bool
+
+キューが空の時、真を返します。
+
+--- length -> Integer
+--- size -> Integer
+
+キューの長さを返します。
+#@end

--- a/refm/api/src/thread/SizedQueue
+++ b/refm/api/src/thread/SizedQueue
@@ -1,10 +1,10 @@
 #@since 2.1.0
-= class Thread::SizedQueue < Object
+= class Thread::SizedQueue < Thread::Queue
 alias SizedQueue
 
 サイズの最大値を指定できる [[c:Thread::Queue]] です。
 #@else
-= class SizedQueue < Object
+= class SizedQueue < Queue
 
 サイズの最大値を指定できる [[c:Queue]] です。
 #@end


### PR DESCRIPTION
SizedQueue の親クラスが Queue ではなく Object になっていたのを修正します。
それから、 https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=58805&view=revision で `empty?,length,size` が Queue のものをそのまま使っていたのが、 SizedQueue で個別に定義されるようになったので追加です。