### PR TITLE
Add sample code of Thread#key?

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -590,6 +590,13 @@ true を返します。
 
 @param name 文字列か [[c:Symbol]] で指定します。
 
+#@samplecode 例
+me = Thread.current
+me[:oliver] = "a"
+me.key?(:oliver)    # => true
+me.key?(:stanley)   # => false
+#@end
+
 --- keys    -> [Symbol]
 
 スレッド固有データに関連づけられたキーの配列を返します。キーは


### PR DESCRIPTION
`Thread#key?`にサンプルコードを追加します。
rdocにあったものをそのまま持ってきています。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/key=3f.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-key-3F

