### PR TITLE
Add sample code of Thread#wakeup

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -696,6 +696,14 @@ safe_level は、[[m:$SAFE]] と同じです。
 
 @raise ThreadError 死んでいるスレッドに対して実行すると発生します。
 
+#@samplecode 例
+c = Thread.new { Thread.stop; puts "hey!" }
+sleep 0.1 while c.status!='sleep'
+c.wakeup
+c.join
+# => "hey!"
+#@end
+
 --- inspect -> String
 #@since 2.5.0
 --- to_s -> String


### PR DESCRIPTION
`Thread#wakeup`にサンプルコードを追加します。
rdocにあったものをそのまま持ってきています。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/wakeup.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-wakeup