### PR TITLE
Add sample code of Thread#stop?

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -675,6 +675,13 @@ safe_level は、[[m:$SAFE]] と同じです。
 
 スレッドが終了(dead)あるいは停止(stop)している時、true を返します。
 
+#@samplecode 例
+a = Thread.new { Thread.stop }
+b = Thread.current
+a.stop?   # => true
+b.stop?   # => false
+#@end
+
 --- value    -> object 
 
 スレッド self が終了するまで待ち([[m:Thread#join]] と同じ)、


### PR DESCRIPTION
`Thread#stop?`にサンプルコードを追加します。
rdocにあったものをそのまま持ってきています。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/stop=3f.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-stop-3F