### PR TITLE
Add `Matrix#antisymmetric?` and `Matrix#reflexive?` since 2.6.0

### DIFF
--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1257,6 +1257,11 @@ Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4], 
 行列が反対称行列 (交代行列、歪〔わい〕対称行列とも) ならば真を返します。
 
 @raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
+
+--- reflexive? -> bool
+行列が反射的ならば真を返します。
+
+@raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
 #@end
 
 #@since 1.9.3

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1258,10 +1258,30 @@ Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4], 
 
 @raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
 
+#@samplecode
+require 'matrix'
+
+Matrix[[0, -2, Complex(1, 3)], [2, 0, 5], [-Complex(1, 3), -5, 0]].antisymmetric? # => true
+Matrix.empty.antisymmetric? # => true
+
+Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]].antisymmetric? # => false
+# 対角要素が違う
+Matrix[[1, -2, 3], [2, 0, 6], [-3, -6, 0]].antisymmetric? # => false
+# 負号が違う
+Matrix[[0, 2, -3], [2, 0, 6], [-3, 6, 0]].antisymmetric? # => false
+#@end
+
 --- reflexive? -> bool
 行列が反射的ならば真を返します。
 
 @raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
+
+#@samplecode
+require 'matrix'
+
+Matrix[[1, 2, 3], [4, 1, 3], [5, 3, 1]].reflexive? # => true
+Matrix.empty.reflexive? # => true
+#@end
 #@end
 
 #@since 1.9.3

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1271,17 +1271,6 @@ Matrix[[1, -2, 3], [2, 0, 6], [-3, -6, 0]].antisymmetric? # => false
 Matrix[[0, 2, -3], [2, 0, 6], [-3, 6, 0]].antisymmetric? # => false
 #@end
 
---- reflexive? -> bool
-行列が反射的ならば真を返します。
-
-@raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
-
-#@samplecode
-require 'matrix'
-
-Matrix[[1, 2, 3], [4, 1, 3], [5, 3, 1]].reflexive? # => true
-Matrix.empty.reflexive? # => true
-#@end
 #@end
 
 #@since 1.9.3

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1254,7 +1254,7 @@ Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4], 
 #@end
 #@since 2.6.0
 --- antisymmetric? -> bool
-行列が反対称行列ならば真を返します。
+行列が反対称行列 (交代行列、歪〔わい〕対称行列とも) ならば真を返します。
 
 @raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
 #@end

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1254,6 +1254,8 @@ Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4], 
 #@end
 #@since 2.6.0
 --- antisymmetric? -> bool
+--- skew_symmetric? -> bool
+
 行列が反対称行列 (交代行列、歪〔わい〕対称行列とも) ならば真を返します。
 
 @raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1252,6 +1252,12 @@ require 'matrix'
 Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4], [9, 8]]
 #@end
 #@end
+#@since 2.6.0
+--- antisymmetric? -> bool
+行列が反対称行列ならば真を返します。
+
+@raise ExceptionForMatrix::ErrDimensionMismatch 行列が正方行列でない場合に発生します
+#@end
 
 #@since 1.9.3
 = class Matrix::EigenvalueDecomposition


### PR DESCRIPTION
反対称行列 という訳語は
 https://ja.wikipedia.org/wiki/%E4%BA%A4%E4%BB%A3%E8%A1%8C%E5%88%97 を参考にしました。