### PR TITLE
Add sample code of Thread#safe_level

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -661,6 +661,12 @@ safe_level は、[[m:$SAFE]] と同じです。
 
 セーフレベルについては[[d:spec/safelevel]]を参照してください。
 
+#@samplecode 例
+thr = Thread.new { $SAFE = 1; sleep }
+Thread.current.safe_level   # => 0
+thr.safe_level              # => 1
+#@end
+
 --- status    -> String | false | nil
 
 生きているスレッドの状態を文字列 "run"、"sleep", "aborting" のいず


### PR DESCRIPTION
`Thread#safe_level`にサンプルコードを追加します。
rdocにあったものをそのまま持ってきています。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/safe_level.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-safe_level