### PR TITLE
Add sample code of GC.latest_gc_info

### DIFF
--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -365,6 +365,18 @@ GC 内部の統計情報を [[c:Hash]] で返します。
 
 @param key 得られる情報から特定の情報を取得したい場合にキーを
            [[c:Symbol]] で指定します。
+
+#@samplecode 例
+latest = GC.latest_gc_info
+latest # => {:major_by=>nil, :gc_by=>:newobj, :have_finalizer=>false, :immediate_sweep=>false, :state=>:sweeping}
+
+stat = GC.stat
+merged = GC.latest_gc_info(stat)
+merged == latest.merge(stat) # => true
+
+GC.latest_gc_info(:gc_by)    # => :newobj
+#@end
+
 #@end
 
 == Instance Methods


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/GC/s/latest_gc_info.html
* https://docs.ruby-lang.org/en/2.5.0/GC.html#method-c-latest_gc_info

Hash を引数に渡すバージョンの狙いがわからなかったので、
予想で `GC.stat` を渡してみました。