### PR TITLE
Update Thread::MUTEX_FOR_THREAD_EXCLUSIVE

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -213,7 +213,11 @@ new メソッドと違い initialize メソッドを呼びません。
 VM グローバルの Mutex をロックし、ブロックを実行します。
 
 このクラスメソッドの挙動は 1.8 以前とは違います。
+#@since 2.6.0
+Thread.exclusive は VM グローバルの Mutex の
+#@else
 Thread.exclusive は VM グローバルの [[m:Thread::MUTEX_FOR_THREAD_EXCLUSIVE]] の
+#@end
 synchronize を呼び出しているだけで、Thread.exclusive していないスレッドは動きます。
 #@since 2.3.0
 [[c:Thread::Mutex]] や [[c:Monitor]] などの他の排他制御の方法を検討してください。
@@ -877,8 +881,11 @@ self の名前を name に設定します。
 
 == Constants
 
-#@since 1.9.1
+#@if("1.9.1" <= version and version < "2.6.0")
 --- MUTEX_FOR_THREAD_EXCLUSIVE -> Mutex
 
 [[m:Thread.exclusive]]用の[[c:Mutex]]オブジェクトです。
+#@since 2.4.0
+(private constant です。)
+#@end
 #@end


### PR DESCRIPTION
- private constant since 2.4.0
- removed since 2.6.0 (use local variable instead)