### PR TITLE
Add sample code of GC.start

### DIFF
--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -236,6 +236,12 @@ nil を返します。
 トしていない場合はキーワード引数を指定しても無視される可能性があります。
 #@end
 
+#@samplecode 例
+GC.count  # => 3
+GC.start  # => nil
+GC.count  # => 4
+#@end
+
 #@since 1.8.7
 --- stress -> bool
 --- stress=(value)


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/GC/s/start.html
* https://docs.ruby-lang.org/en/2.5.0/GC.html#method-c-start

>注意: これらのキーワード引数は Ruby の実装やバージョンによって異なりま す。将来のバージョンとの互換性も保証されません。また、Ruby の実装がサポー トしていない場合はキーワード引数を指定しても無視される可能性があります。

という記載があるので、引数付きの例は無しにしてみました
