### PR TITLE
Add sample code of IO.binread

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -540,6 +540,13 @@ length を省略するとファイルの末尾まで読み込みます。
 
 ファイルを開くときの mode は "rb:ASCII-8BIT" です。
 
+#@samplecode 例
+IO.write("testfile", "This is line one\nThis is line two\nThis is line three\nAnd so on...\n")
+IO.binread("testfile")           # => "This is line one\nThis is line two\nThis is line three\nAnd so on...\n"
+IO.binread("testfile", 20)       # => "This is line one\nThi"
+IO.binread("testfile", 20, 10)   # => "ne one\nThis is line "
+#@end
+
 @see [[m:IO.read]]
 
 #@since 2.4.0


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/s/binread.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-c-binread

rdoc のサンプルをベースにファイルの作成処理を追加しました