### PR TITLE
Add noexample comment of Thread#name

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -882,6 +882,8 @@ self の非同期例外のキューが空かどうかを返します。
 
 self の名前を返します。
 
+#@#noexample Thread#name=を参照
+
 @see [[m:Thread#name=]]
 
 --- name=(name) -> String


### PR DESCRIPTION
`Thread#name`に noexample コメントを追加します。
参照先の`#name=`にサンプルがあります。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/name.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-name