### PR TITLE
Add sample code of IO.readlines

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -583,6 +583,19 @@ opts でファイルを開くときのオプションを指定します。エン
 
 @raise Errno::EXXX path のオープン、ファイルの読み込みに失敗した場合に発生します。
 
+#@samplecode 例
+IO.write("testfile", "line1\nline2,\nline3\n")
+IO.readlines("testfile")             # => ["line1\n", "line2,\n", "line3\n"]
+IO.readlines("testfile", ",")        # => ["line1\nline2,", "\nline3\n"]
+#@end
+
+#@since 2.4.0
+#@samplecode 例: 各行の末尾から "\n", "\r", または "\r\n" を取り除く（chomp = true）
+IO.write("testfile", "line1\nline2,\nline3\n")
+IO.readlines("testfile", chomp: true)  # => ["line1", "line2,", "line3"]
+#@end
+#@end
+
 --- select(reads, writes = [], excepts = [], timeout = nil)    -> [[IO]] | nil
 
 [[man:select(2)]] を実行します。


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/IO/s/readlines.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-c-readlines

rs の例を追加するので、 rdoc と別のコードにしました

