### PR TITLE
Fix example that trace method is called outside block

### DIFF
--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -120,7 +120,7 @@
   TracePoint.trace(:line) do |tp|
     $tp = tp
   end
-  $tp.line # => access from outside (RuntimeError)
+  $tp.lineno # => access from outside (RuntimeError)
 
 他のスレッドから参照する事も禁じられています。
 


### PR DESCRIPTION
see https://github.com/ruby/ruby/pull/1731