### PR TITLE
Fix exception class of TracePoint#new without a block since 2.5.0

### DIFF
--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -124,7 +124,11 @@
 
 他のスレッドから参照する事も禁じられています。
 
+#@since 2.5.0
+@raise ArgumentError ブロックを指定しなかった場合に発生します。
+#@else
 @raise ThreadError ブロックを指定しなかった場合に発生します。
+#@end
 
 --- trace(*events) {|obj| ... } -> TracePoint
 


### PR DESCRIPTION
see https://bugs.ruby-lang.org/issues/14074