### PR TITLE
Add sample code of IO.write

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -674,6 +674,16 @@ offset を指定しないと、書き込みの末尾でファイルを
 @param offset 書き込み開始位置
 @param opt ファイルを開くときのオプション引数
 
+#@samplecode 例
+text = "This is line one\nThis is line two\nThis is line three\nAnd so on...\n"
+IO.write("testfile", text)              # => 66
+IO.write("testfile", "0123456789", 20)  #=> 10
+IO.read("testfile")
+# => "This is line one\nTh0123456789 two\nThis is line three\nAnd so on...\n"
+IO.write("testfile", "0123456789")      #=> 10
+IO.read("testfile")                     # => "0123456789"
+#@end
+
 @see [[m:IO.binwrite]]
 
 --- binwrite(path, string, offset=nil) -> Integer


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/s/write.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-c-write

rdoc をベースに、ファイルの作成処理を追加し、
ファイル内容の確認のため `IO.read` を追加した。 