### PR TITLE
Add `NoMethodError#private_call?` since 2.4.0

### DIFF
--- a/refm/api/src/_builtin/NoMethodError
+++ b/refm/api/src/_builtin/NoMethodError
@@ -24,7 +24,11 @@
 
 == Class Methods
 
+#@since 2.4.0
+--- new(error_message = "", name = nil, args = nil, priv = false) -> NoMethodError
+#@else
 --- new(error_message = "", name = nil, args = nil) -> NoMethodError
+#@end
 
 例外オブジェクトを生成して返します。
 
@@ -33,6 +37,10 @@
 @param name 未定義だったシンボルです
 
 @param args メソッド呼び出しに使われた引数です
+
+#@since 2.4.0
+@param priv private なメソッドを呼び出せる形式 (関数形式(レシーバを省略した形式)) で呼ばれたかどうかを指定します
+#@end
 
 
 例:
@@ -65,4 +73,9 @@
        [1, 2, 3]
 
 #@end
+#@since 2.4.0
+--- private_call? -> bool
 
+メソッド呼び出しが private なメソッドを呼び出せる形式
+(関数形式(レシーバを省略した形式)) で呼ばれたかどうかを返します。
+#@end


### PR DESCRIPTION
see https://bugs.ruby-lang.org/issues/12043
https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=62055&view=revision
https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=62056&view=revision

「private なメソッドを呼び出せる形式 (関数形式(レシーバを省略した形式))」 is from https://docs.ruby-lang.org/ja/2.5.0/doc/spec=2fcall.html