### PR TITLE
Add noexample comment of IO#binmode?

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1803,6 +1803,10 @@ self は読み込み用にオープンされていなければなりません。
 
 自身がバイナリモードなら true を返します。そうでない場合、false を返します。
 
+#@#noexample binmode を参照
+
+@see [[m:IO#binmode]]
+
 --- close_on_exec=(bool)
 自身に close-on-exec フラグを設定します。
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/IO/i/binmode=3f.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-binmode

`IO#binmode` ( #1064 ) と同じ内容になってます。ちょっとその他のアイデアがでてきませんでした。

