### PR TITLE
Add sample code of IO#each_byte

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -852,6 +852,17 @@ IO の現在位置から 1 バイトずつ読み込み、それを整数とし�
 
 @raise IOError 自身が読み込み用にオープンされていなければ発生します。
 
+#@samplecode 例
+IO.write("testfile", "aあ")
+File.open("testfile") do |io|
+  io.each_byte { |x| p x }
+  # => 97
+  # 227
+  # 129
+  # 130
+end
+#@end
+
 --- bytes {|ch| ... }        -> self
 --- bytes                    -> Enumerator
 


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/i/each_byte.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-each_byte

rdoc のサンプルだと、中身の各byteを確認する形になっていなかったので別にしてみました。
