### PR TITLE
Add noexample comment of IO#chars

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1781,6 +1781,8 @@ self は読み込み用にオープンされていなければなりません。
 
 @raise IOError self が読み込み用にオープンされていない場合に発生します。
 
+#@#noexample obsolete
+
 @see [[m:IO#each_char]]
 
 --- ungetbyte(c) -> nil


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/i/chars.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-chars

obsolete なので noexample にしました

