### PR TITLE
Add noexample comment of Thread.exit

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -87,6 +87,8 @@ Thread を使うことで並行プログラミングが可能になります。
 
 カレントスレッドに対して [[m:Thread#exit]] を呼びます。
 
+#@#noexample Thread#exitを参照
+
 --- kill(thread)    -> Thread
 
 指定したスレッド thread に対して [[m:Thread#exit]] を呼びます。終了したスレッドを返します。


### PR DESCRIPTION
`Thread.exit`に noexample コメントを追加します。
参照先の`Thread#exit`にサンプルコードがあります。

https://docs.ruby-lang.org/ja/latest/method/Thread/s/exit.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-c-exit