### PR TITLE
Add sample code of IO#close_write

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -786,6 +786,13 @@ self がパイプでプロセスにつながっていれば、そのプロセス
 
 @raise Errno::EXXX close に失敗した場合に発生します。
 
+#@samplecode 例
+f = IO.popen("/bin/sh","r+") do |f|
+  f.close_write
+  # f.print "nowhere" # => IOError: not opened for writing
+end
+#@end
+
 --- closed?    -> bool
 
 ポートがクローズされている時に真を返します。


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/i/close_write.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-close_write

rdoc ベースで例外の行だけコメントアウトにしました

