### PR TITLE
Follow rubyist magazine URL changing.

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2319,10 +2319,10 @@ find-any モードは [[man:bsearch(3)]] のように動作します。ブロッ
 
 #@end
 #@if("2.0.0" <= version and version < "2.3.0")
-@see [[m:Range#bsearch]], [[url:http://magazine.rubyist.net/?0041-200Special-note#l15]]
+@see [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#arraybsearch-%E3%81%AE%E8%BF%BD%E5%8A%A0]]
 #@end
 #@since 2.3.0
-@see [[m:Array#bsearch_index]], [[m:Range#bsearch]], [[url:http://magazine.rubyist.net/?0041-200Special-note#l15]]
+@see [[m:Array#bsearch_index]], [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#arraybsearch-%E3%81%AE%E8%BF%BD%E5%8A%A0]]
 
 --- bsearch_index { |x| ... } -> Integer | nil
 --- bsearch_index             -> Enumerator

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2319,10 +2319,10 @@ find-any モードは [[man:bsearch(3)]] のように動作します。ブロッ
 
 #@end
 #@if("2.0.0" <= version and version < "2.3.0")
-@see [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#arraybsearch-%E3%81%AE%E8%BF%BD%E5%8A%A0]]
+@see [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html]]
 #@end
 #@since 2.3.0
-@see [[m:Array#bsearch_index]], [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#arraybsearch-%E3%81%AE%E8%BF%BD%E5%8A%A0]]
+@see [[m:Array#bsearch_index]], [[m:Range#bsearch]], [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html]]
 
 --- bsearch_index { |x| ... } -> Integer | nil
 --- bsearch_index             -> Enumerator

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -1621,7 +1621,7 @@ deprecate に設定した定数を参照すると警告メッセージが表示�
 
 refinements 機能の詳細については以下を参照してください。
 
- * [[url:http://magazine.rubyist.net/?0041-200Special-refinement]]
+ * [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-refinement.html]]
 #@since 2.1.0
  * [[url:https://docs.ruby-lang.org/en/trunk/syntax/refinements_rdoc.html]]
 #@else

--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -903,7 +903,7 @@ nil を渡すとトレースを解除します。
 
 @see [[m:Thread#thread_variable_set]], [[m:Thread#[] ]]
 
-@see [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#fiber-%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%81%A7%E3%81%AF%E3%81%AA%E3%81%84%E3%82%B9%E3%83%AC%E3%83%83%E3%83%89%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E5%A4%89%E6%95%B0%E3%81%AE%E6%A9%9F%E8%83%BD%E3%81%AE%E8%BF%BD%E5%8A%A0]]
+@see [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html]]
 
 --- thread_variable_set(key, value)
 

--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -903,7 +903,7 @@ nil を渡すとトレースを解除します。
 
 @see [[m:Thread#thread_variable_set]], [[m:Thread#[] ]]
 
-@see [[url:http://magazine.rubyist.net/?0041-200Special-note#l16]]
+@see [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-note.html#fiber-%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E3%81%A7%E3%81%AF%E3%81%AA%E3%81%84%E3%82%B9%E3%83%AC%E3%83%83%E3%83%89%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E5%A4%89%E6%95%B0%E3%81%AE%E6%A9%9F%E8%83%BD%E3%81%AE%E8%BF%BD%E5%8A%A0]]
 
 --- thread_variable_set(key, value)
 

--- a/refm/api/src/delegate.rd
+++ b/refm/api/src/delegate.rd
@@ -17,7 +17,7 @@ category DesignPattern
 
 === 参考
 
-  * Rubyist Magazine - 標準添付ライブラリ紹介【第 6 回】委譲 [[url:http://magazine.rubyist.net/?0012-BundledLibraries]]
+  * Rubyist Magazine - 標準添付ライブラリ紹介【第 6 回】委譲 [[url:https://magazine.rubyist.net/articles/0012/0012-BundledLibraries.html]]
 
 
 = reopen Kernel

--- a/refm/api/src/erb.rd
+++ b/refm/api/src/erb.rd
@@ -9,7 +9,7 @@ eRuby スクリプトを処理するクラス。
 従来 ERbLight と呼ばれていたもので、
 標準出力への印字が文字列の挿入とならない点が eruby と異なります。
 
- * [[url:http://magazine.rubyist.net/?0017-BundledLibraries]]
+ * [[url:https://magazine.rubyist.net/articles/0017/0017-BundledLibraries.html]]
 
 
 === 使い方

--- a/refm/api/src/forwardable.rd
+++ b/refm/api/src/forwardable.rd
@@ -11,7 +11,7 @@ category DesignPattern
 
 === 参考
 
-  * Rubyist Magazine 0012 号 標準添付ライブラリ紹介【第 6 回】委譲 ([[url:http://magazine.rubyist.net/?0012-BundledLibraries]])
+  * Rubyist Magazine 0012 号 標準添付ライブラリ紹介【第 6 回】委譲 ([[url:https://magazine.rubyist.net/articles/0012/0012-BundledLibraries.html]])
 
 = module Forwardable
 

--- a/refm/api/src/iconv.rd
+++ b/refm/api/src/iconv.rd
@@ -93,7 +93,7 @@ GNU libiconv で iconv ライブラリがビルドしてある場合、
 
 === 参考
 
-  * 標準添付ライブラリ紹介【第 3 回】 Kconv/NKF/Iconv ([[url:http://magazine.rubyist.net/?0009-BundledLibraries#l30]])
+  * 標準添付ライブラリ紹介【第 3 回】 Kconv/NKF/Iconv ([[url:https://magazine.rubyist.net/articles/0009/0009-BundledLibraries.html#iconv]])
 
 = class Iconv < Data
 iconv 関数のラッパークラスです。

--- a/refm/api/src/logger.rd
+++ b/refm/api/src/logger.rd
@@ -215,9 +215,9 @@ ERROR、FATALログのみが記録の対象になります。DEBUG、INFOログ�
 === 参考
 
 : Rubyist Magazine
-  [[url:http://magazine.rubyist.net/]]
+  [[url:https://magazine.rubyist.net/]]
 : 標準添付ライブラリ紹介【第 2 回】
-  [[url:http://magazine.rubyist.net/?0008-BundledLibraries]]
+  [[url:https://magazine.rubyist.net/articles/0008/0008-BundledLibraries.html]]
 
 = class Logger < Object
 include Logger::Severity

--- a/refm/api/src/nkf.rd
+++ b/refm/api/src/nkf.rd
@@ -157,7 +157,7 @@ Ruby から使うためのモジュールです。
 
 === 参考
 
-  * "標準添付ライブラリ紹介【第 3 回】 Kconv/NKF/Iconv" [[url:http://magazine.rubyist.net/?0009-BundledLibraries#l15]]
+  * "標準添付ライブラリ紹介【第 3 回】 Kconv/NKF/Iconv" [[url:https://magazine.rubyist.net/articles/0009/0009-BundledLibraries.html#nkf]]
 
 == Module Functions
 

--- a/refm/api/src/rubygems.rd
+++ b/refm/api/src/rubygems.rd
@@ -225,9 +225,9 @@ Proxy サーバ経由で Gem パッケージをインストールするには以
 
 === 参考
 : Rubyist Magazine - シリーズ パッケージマネジメント 【第 1 回】 RubyGems (1)
-  [[url:http://magazine.rubyist.net/?0006-PackageManagement]]
+  [[url:https://magazine.rubyist.net/articles/0006/0006-PackageManagement.html]]
 : Rubyist Magazine - シリーズ パッケージマネジメント 【第 2 回】 RubyGems (2)
-  [[url:http://magazine.rubyist.net/?0010-PackageManagement]]
+  [[url:https://magazine.rubyist.net/articles/0010/0010-PackageManagement.html]]
 
 
 = reopen Kernel

--- a/refm/api/src/tempfile.rd
+++ b/refm/api/src/tempfile.rd
@@ -6,7 +6,7 @@ require delegate
 テンポラリファイルを操作するためのクラスです
 
 === 参考
-標準添付ライブラリ紹介 【第 15 回】 tmpdir, tempfile  [[url:http://magazine.rubyist.net/?0029-BundledLibraries]]
+標準添付ライブラリ紹介 【第 15 回】 tmpdir, tempfile  [[url:https://magazine.rubyist.net/articles/0029/0029-BundledLibraries.html]]
 
 = class Tempfile < Delegator
 #@#= class Tempfile < DelegateClass(File)

--- a/refm/api/src/test/unit.rd
+++ b/refm/api/src/test/unit.rd
@@ -139,7 +139,7 @@ test_bar だけテストしたい場合は以下のようなオプションを�
 
 並列化の仕組みについては以下の記事をご覧ください。
 
- * Rubyist Magazine 0033 号 詳解! test-all 並列化: [[url:http://magazine.rubyist.net/?0033-ParallelizeTestAll]]
+ * Rubyist Magazine 0033 号 詳解! test-all 並列化: [[url:https://magazine.rubyist.net/articles/0033/0033-ParallelizeTestAll.html]]
 
 = module Test::Unit
 

--- a/refm/api/src/tk.rd
+++ b/refm/api/src/tk.rd
@@ -58,7 +58,7 @@ tkを用いてGUIアプリケーションを作成するためのライブラリ
 === 参考
 
  * [[unknown:RubyTkFAQ]]
- * "Rubyist Magazine - 0003-Ruby/Tk の動向"[[url:http://magazine.rubyist.net/?0003-RubyTkMovement]]
+ * "Rubyist Magazine - 0003-Ruby/Tk の動向"[[url:https://magazine.rubyist.net/articles/0003/0003-RubyTkMovement.html]]
 
 === 注意
 

--- a/refm/api/src/webrick/httpproxy/HTTPProxyServer
+++ b/refm/api/src/webrick/httpproxy/HTTPProxyServer
@@ -2,7 +2,7 @@
 
 プロクシの機能を提供するクラスです。CONNECT メソッドにも対応しています。
 
- * [[url:http://magazine.rubyist.net/?0002-WEBrickProxy]]
+ * [[url:https://magazine.rubyist.net/articles/0002/0002-WEBrickProxy.html]]
 
 以下は完全に動作するプロクシサーバの例です。
  

--- a/refm/api/src/win32ole.rd
+++ b/refm/api/src/win32ole.rd
@@ -6,14 +6,14 @@ Microsoft Windows で COM や ActiveX を扱うためのライブラリです。
   * [[url:http://suke.my.coocan.jp/ruby/win32ole/index.html]]
   * [[url:http://pub.cozmixng.org/~the-rwiki/rw-cgi.rb?cmd=view;name=Win32OLE]]
   * [[url:http://objectclub.jp/community/memorial/homepage3.nifty.com/masarl/article/ruby-win32ole.html]]
-  * Rubyist Magazine [[url:http://magazine.rubyist.net/]]
-    * Win32OLE 活用法【第 1 回】 Win32OLE ことはじめ [[url:http://magazine.rubyist.net/?0003-Win32OLE]]
-    * Win32OLE 活用法【第 2 回】 Excel [[url:http://magazine.rubyist.net/?0004-Win32OLE]]
-    * Win32OLE 活用法【第 3 回】 ADODB [[url:http://magazine.rubyist.net/?0005-Win32OLE]]
-    * Win32OLE 活用法【第 4 回】 Adobe Illustrator [[url:http://magazine.rubyist.net/?0006-Win32OLE]]
-    * Win32OLE 活用法【第 5 回】 Outlook [[url:http://magazine.rubyist.net/?0007-Win32OLE]]
-    * Win32OLE 活用法【第 6 回】 Web 自動巡回 [[url:http://magazine.rubyist.net/?0008-Win32OLE]]
-    * Win32OLE 活用法【第 7 回】ほかの言語での COM [[url:http://magazine.rubyist.net/?0009-Win32OLE]]
+  * Rubyist Magazine [[url:https://magazine.rubyist.net/]]
+    * Win32OLE 活用法【第 1 回】 Win32OLE ことはじめ [[url:https://magazine.rubyist.net/articles/0003/0003-Win32OLE.html]]
+    * Win32OLE 活用法【第 2 回】 Excel [[url:https://magazine.rubyist.net/articles/0004/0004-Win32OLE.html]]
+    * Win32OLE 活用法【第 3 回】 ADODB [[url:https://magazine.rubyist.net/articles/0005/0005-Win32OLE.html]]
+    * Win32OLE 活用法【第 4 回】 Adobe Illustrator [[url:https://magazine.rubyist.net/articles/0006/0006-Win32OLE.html]]
+    * Win32OLE 活用法【第 5 回】 Outlook [[url:https://magazine.rubyist.net/articles/0007/0007-Win32OLE.html]]
+    * Win32OLE 活用法【第 6 回】 Web 自動巡回 [[url:https://magazine.rubyist.net/articles/0008/0008-Win32OLE.html]]
+    * Win32OLE 活用法【第 7 回】ほかの言語での COM [[url:https://magazine.rubyist.net/articles/0009/0009-Win32OLE.html]]
 
 #@include(win32ole/WIN32OLE)
 #@include(win32ole/WIN32OLE_EVENT)

--- a/refm/api/src/xmlrpc.rd
+++ b/refm/api/src/xmlrpc.rd
@@ -123,7 +123,7 @@ You can change the XML-writer by calling method <i>set_writer</i>.
   * [[url:http://www.linux.or.jp/JF/JFdocs/XML-RPC-HOWTO/index.html]]
   * [[url:http://www.linux.or.jp/JF/JFdocs/XML-RPC-HOWTO/xmlrpc-howto-ruby.html]]
   * [XML-RPC] [[url:http://www.xmlrpc.com/spec]]
-  * [[url:http://magazine.rubyist.net/?0007-BundledLibraries]]
+  * [[url:https://magazine.rubyist.net/articles/0007/0007-BundledLibraries.html]]
 
 === 注意
 

--- a/refm/api/src/yaml.rd
+++ b/refm/api/src/yaml.rd
@@ -252,13 +252,13 @@ YAML4R
  * [[url:http://yaml4r.sourceforge.net/cookbook/]]([[url:http://yaml.org/YAML_for_ruby.html]])
  * [[url:http://yaml4r.sourceforge.net/doc/]]
 
-Rubyist Magazine: [[url:http://magazine.rubyist.net/]]
+Rubyist Magazine: [[url:https://magazine.rubyist.net/]]
 
- * プログラマーのための YAML 入門 (初級編): [[url:http://magazine.rubyist.net/?0009-YAML]]
- * プログラマーのための YAML 入門 (中級編): [[url:http://magazine.rubyist.net/?0010-YAML]]
- * プログラマーのための YAML 入門 (実践編): [[url:http://magazine.rubyist.net/?0011-YAML]]
- * プログラマーのための YAML 入門 (検証編): [[url:http://magazine.rubyist.net/?0012-YAML]]
- * プログラマーのための YAML 入門 (探索編): [[url:http://magazine.rubyist.net/?0013-YAML]]
+ * プログラマーのための YAML 入門 (初級編): [[url:https://magazine.rubyist.net/articles/0009/0009-YAML.html]]
+ * プログラマーのための YAML 入門 (中級編): [[url:https://magazine.rubyist.net/articles/0010/0010-YAML.html]]
+ * プログラマーのための YAML 入門 (実践編): [[url:https://magazine.rubyist.net/articles/0011/0011-YAML.html]]
+ * プログラマーのための YAML 入門 (検証編): [[url:https://magazine.rubyist.net/articles/0012/0012-YAML.html]]
+ * プログラマーのための YAML 入門 (探索編): [[url:https://magazine.rubyist.net/articles/0013/0013-YAML.html]]
 
 その他
 

--- a/refm/api/src/yaml/stream.rd
+++ b/refm/api/src/yaml/stream.rd
@@ -10,9 +10,9 @@ YAML ドキュメントを複数保持することができるストリームク
 
 === 参考
 
-Rubyist Magazine: [[url:http://magazine.rubyist.net/]]
+Rubyist Magazine: [[url:https://magazine.rubyist.net/]]
 
- * プログラマーのための YAML 入門 (中級編): [[url:http://magazine.rubyist.net/?0010-YAML]]
+ * プログラマーのための YAML 入門 (中級編): [[url:https://magazine.rubyist.net/articles/0010/0010-YAML.html]]
 
 == class methods
 

--- a/refm/api/src/yaml/ypath.rd
+++ b/refm/api/src/yaml/ypath.rd
@@ -41,9 +41,9 @@ YAML ドキュメントから特定のデータを検索する機能を提供す
 
 === 参考
 
-Rubyist Magazine: [[url:http://magazine.rubyist.net/]]
+Rubyist Magazine: [[url:https://magazine.rubyist.net/]]
 
- * プログラマーのための YAML 入門 (探索編): [[url:http://magazine.rubyist.net/?0013-YAML]]
+ * プログラマーのための YAML 入門 (探索編): [[url:https://magazine.rubyist.net/articles/0013/0013-YAML.html]]
 
 == class methods
 

--- a/refm/api/src/zlib.rd
+++ b/refm/api/src/zlib.rd
@@ -6,7 +6,7 @@ gzip ファイルの読み書きもサポートします。
 === 参考
 
 : 標準添付ライブラリ紹介 【第 11 回】zlib 
-  [[url:http://magazine.rubyist.net/?0018-BundledLibraries]]
+  [[url:https://magazine.rubyist.net/articles/0018/0018-BundledLibraries.html]]
 
 @see [[url:http://zlib.net/]]
 

--- a/refm/doc/news/1.8.2.rd
+++ b/refm/doc/news/1.8.2.rd
@@ -35,9 +35,9 @@ ruby 1.8.2 での ruby 1.8.1 からの変更点です。
 * cgi の無限ループに陥る可能性のあるバグが修正されました。
   ((<URL:http://www.debian.org/security/2004/dsa-586>))
 * 一連の core dumps バグが修正されました。
-  ((<URL:http://magazine.rubyist.net/?0002-RubyCore>))
+  ((<URL:https://magazine.rubyist.net/articles/0002/0002-RubyCore.html>))
 * tk の変更点は 
-  ((<URL:http://magazine.rubyist.net/?0003-RubyTkMovement>)) 
+  ((<URL:https://magazine.rubyist.net/articles/0003/0003-RubyTkMovement.html>))
   を参照して下さい。
 * soap, wsdl の変更点は
   ((<URL:http://rrr.jin.gr.jp/projects/soap4r/wiki/Changes-ruby181_ruby182>))

--- a/refm/doc/spec/def.rd
+++ b/refm/doc/spec/def.rd
@@ -437,7 +437,7 @@ yield を呼び出すことです。
 #@end
 
 #@since 2.0.0
-@see [[url:http://magazine.rubyist.net/?0041-200Special-kwarg]]
+@see [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-kwarg.html]]
 #@end
 
 ====[a:operator] 演算子式の定義


### PR DESCRIPTION
rubima/magazine.rubyist.net#20 より。以下で機械的に変更しました。先方の修正が完了したら動作確認してWIPを外してマージの予定です。

```
$ find refm/ -type f | xargs sed -i .orig -e 's/\(magazine.rubyist.net\/\)\?/\1/g'
```