### PR TITLE
Add sample code of Thread#[]

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -416,6 +416,21 @@ name に対応するスレッド固有データがなければ nil を返し
 
 @param name スレッド固有データのキーを文字列か [[c:Symbol]] で指定します。
 
+#@samplecode 例
+[
+  Thread.new { Thread.current["name"] = "A" },
+  Thread.new { Thread.current[:name]  = "B" },
+  Thread.new { Thread.current["name"] = "C" }
+].each do |th|
+  th.join
+  puts "#{th.inspect}: #{th[:name]}"
+end
+
+# => #<Thread:0x00000002a54220 dead>: A
+# => #<Thread:0x00000002a541a8 dead>: B
+# => #<Thread:0x00000002a54130 dead>: C
+#@end
+
 #@since 2.5.0
 @see [[m:Thread#fetch]]
 #@end


### PR DESCRIPTION
`Thread#[]`にサンプルコードを追加します。
サンプルは rdoc から持ってきています。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/=5b=5d.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-5B-5D