### PR TITLE
Update Enumerator::Lazy's method list.

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -16,6 +16,13 @@ map や select などのメソッドの遅延評価版を提供するための�
 #@end
  * take, take_while
  * drop, drop_while
+ * slice_before, slice_after, slice_when
+#@since 2.4.0
+ * chunk, chunk_while
+ * uniq
+#@else
+ * chunk
+#@end
  * zip (※互換性のため、ブロックを渡さないケースのみlazy)
 
 Lazyオブジェクトは、[[m:Enumerable#lazy]]メソッドによって生成されます。


### PR DESCRIPTION
#1042 で先頭のメソッドリストに更新が必要である事に気付いたので見直しました。slice_whenが2.2.0以降ですが、不要なので分岐は追加していません。