### PR TITLE
Fix conflict resolving by da85b55.

### DIFF
--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -242,7 +242,6 @@ GC.start  # => nil
 GC.count  # => 4
 #@end
 
-#@since 1.8.7
 --- stress -> bool
 
 GCがストレスモードかどうかを返します。


### PR DESCRIPTION
da85b55 でコンフリクト解消時に不要な行が入ってしまっていたため、CIが通らなくなっていたのを修正。