### PR TITLE
open-uriで追加されるURI#readの等価とされるコードを修正

### DIFF
--- a/refm/api/src/open-uri.rd
+++ b/refm/api/src/open-uri.rd
@@ -277,7 +277,7 @@ options には [[c:Hash]] を与えます。理解するハッシュの
 --- read(options = {})     -> String
 
 自身が表す内容を読み込んで文字列として返します。
-self.open(options={}).read と同じです。
+self.open(options={}) {|io| io.read } と同じです。
 このメソッドによって返される文字列は [[c:OpenURI::Meta]]
 によって extend されています。
 


### PR DESCRIPTION
「`open(options={}).read` と同じ」とされると、終了処理がきちんと行われないように見えて使用が躊躇われます。

[実装](https://github.com/ruby/ruby/blob/9ffa3795a311cef45b6d34054aa04936e12f43d7/lib/open-uri.rb)を見たところ、ブロック付き呼び出しと等価とするのが適切だと思いました。

`URI#open.read` すると、読み終わったあともファイルディスクリプタを開いたままですが `URI.open {|io| io.read }` だと問題ありません。

```rb
# u = URI('https://www.google.co.jp')
system("lsof -p #{$$}|wc -l") #=> 38
u.open.read
system("lsof -p #{$$}|wc -l") #=> 39 # 1増える
u.open {|io| io.read }
system("lsof -p #{$$}|wc -l") #=> 39 # こっちなら増えない
u.read
system("lsof -p #{$$}|wc -l") #=> 39 # これも増えない
```

