### PR TITLE
Add sample code of Thread#fetch

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -472,6 +472,15 @@ name に対応するスレッド固有データがない時には、引数 defau
 @raise KeyError 引数defaultもブロックも与えられてない時、
                 name に対応するスレッド固有データがないと発生します。
 
+#@samplecode 例
+th = Thread.new { Thread.current[:name] = 'A' }
+th.join
+th.fetch(:name)   # => "A"
+th.fetch(:fetch, 'B')   # => "B"
+th.fetch('name')  {|name| "Thread" + name}  # => "A"
+th.fetch('fetch') {|name| "Thread" + name}  # => "Threadfetch"
+#@end
+
 @see [[m:Thread#[] ]]
 #@end
 


### PR DESCRIPTION
`Thread#fetch`にサンプルコードを追加します。
rdocにサンプルはありませんでした。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/fetch.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-fetch