### PR TITLE
Add noexample comment of IO#printf

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1201,6 +1201,8 @@ C 言語の printf と同じように、format に従い引数
 
 @raise Errno::EXXX 出力に失敗した場合に発生します。
 
+#@#noexample Kernel.#printf を参照
+
 @see [[m:Kernel.#printf]]
 
 --- putc(ch)    -> object


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/IO/i/printf.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-printf

Kernel.#printf 参照でよいかなと思い noexample にしてみました

