### PR TITLE
Add sample code of IO#sync

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1577,6 +1577,14 @@ offset 位置への移動が成功すれば 0 を返します。
 
 @raise IOError 既に close されていた場合に発生します。 
 
+#@samplecode 例
+File.open("testfile", "w") do |f|
+  f.sync      # => false
+  f.sync = true
+  f.sync      # => true
+end
+#@end
+
 --- sync=(newstate)
 
 自身を同期モードに設定すると、出力関数の呼出毎にバッファがフラッシュされます。
@@ -1584,6 +1592,8 @@ offset 位置への移動が成功すれば 0 を返します。
 @param newstate 自身を同期モードに設定するかを boolean で指定します。
 
 @raise IOError 既に close されていた場合に発生します。 
+
+@see [[m:IO#sync]]
 
 --- sysread(maxlen, outbuf = "")   -> String
 


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/IO/i/sync.html
* https://docs.ruby-lang.org/en/2.5.0/IO.html#method-i-sync

rdoc のケースを参考に

* ファイルの作成処理を追加
* ファイル処理をブロックに変更
* true / false の切替えを確認

できるサンプルにしました。
また、 `IO#sync` のサンプルで `IO#sync=` の内容を含めたので
`IO#sync=` 側は `IO#sync` への `@see` にしました