### PR TITLE
fix sample code of IO.readlines(chomp: true)

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -610,7 +610,7 @@ opts でファイルを開くときのオプションを指定します。エン
 @param rs 行の区切りを文字列で指定します。rs に nil を指定すると行区切りなしとみなします。空文字列 "" を指定すると連続する改行を行の区切りとみなします(パラグラフモード)。
 @param limit 最大の読み込みバイト数
 #@since 2.4.0
-@param chomp true を指定すると各行の末尾から "\n", "\r", または "\r\n" を取り除きます。
+@param chomp true を指定すると各行の末尾から rs を取り除きます。
 #@end
 @param opts ファイルを開くときのオプション引数
 
@@ -623,9 +623,10 @@ IO.readlines("testfile", ",")        # => ["line1\nline2,", "\nline3\n"]
 #@end
 
 #@since 2.4.0
-#@samplecode 例: 各行の末尾から "\n", "\r", または "\r\n" を取り除く（chomp = true）
-IO.write("testfile", "line1\nline2,\nline3\n")
-IO.readlines("testfile", chomp: true)  # => ["line1", "line2,", "line3"]
+#@samplecode 例: rs を取り除く（chomp = true）
+IO.write("testfile", "line1,\rline2,\r\nline3,\n")
+IO.readlines("testfile", chomp: true)        # => ["line1,\rline2,", "line3,"]
+IO.readlines("testfile", "\r", chomp: true)  # => ["line1,", "line2,", "\nline3,\n"]
 #@end
 #@end
 


### PR DESCRIPTION
#1109 でいただいたレビュー指摘を `IO.readlines` にも適用しました