### PR TITLE
Add sample code of Thread#add_trace_func

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -813,6 +813,26 @@ b.inspect   # => "#<Thread:0x00007fdbaf8f7d10@(irb):3 dead>"
 追加したハンドラを返します。
 
 @param pr トレースハンドラ([[c:Proc]] オブジェクト)
+
+#@samplecode 例
+th = Thread.new do
+  class Trace
+  end
+  43.to_s
+end
+th.add_trace_func lambda {|*arg| p arg }
+th.join
+
+# => ["line", "example.rb", 4, nil, #<Binding:0x00007f98e107d0d8>, nil]
+# => ["c-call", "example.rb", 4, :inherited, #<Binding:0x00007f98e1087448>, Class]
+# => ["c-return", "example.rb", 4, :inherited, #<Binding:0x00007f98e1085d00>, Class]
+# => ["class", "example.rb", 4, nil, #<Binding:0x00007f98e108f210>, nil]
+# => ["end", "example.rb", 5, nil, #<Binding:0x00007f98e108e5e0>, nil]
+# => ["line", "example.rb", 6, nil, #<Binding:0x00007f98e108d4b0>, nil]
+# => ["c-call", "example.rb", 6, :to_s, #<Binding:0x00007f98e1097aa0>, Integer]
+# => ["c-return", "example.rb", 6, :to_s, #<Binding:0x00007f98e1095cc8>, Integer]
+#@end
+
 @see [[m:Thread#set_trace_func]] [[m:Kernel.#set_trace_func]]
 
 --- set_trace_func(pr) -> Proc | nil


### PR DESCRIPTION
`Thread#add_trace_func`にサンプルコードを追加します。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/add_trace_func.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-add_trace_func