### PR TITLE
Update IO#closed?

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -850,6 +850,18 @@ end
 
 ポートがクローズされている時に真を返します。
 
+#@samplecode 例
+IO.write("testfile", "test")
+f = File.new("testfile")
+f.close         # => nil
+f.closed?       # => true
+f = IO.popen("/bin/sh","r+")
+f.close_write   # => nil
+f.closed?       # => false
+f.close_read    # => nil
+f.closed?       # => true
+#@end
+
 #@since 2.4.0
 --- each(rs = $/, chomp: false) {|line| ... }         -> self
 --- each(limit, chomp: false) {|line| ... }           -> self
@@ -897,18 +909,6 @@ limit で最大読み込みバイト数を指定します。ただしマルチ�
 #@end
 
 @raise IOError 自身が読み込み用にオープンされていなければ発生します。
-
-#@samplecode 例
-IO.write("testfile", "test")
-f = File.new("testfile")
-f.close         # => nil
-f.closed?       # => true
-f = IO.popen("/bin/sh","r+")
-f.close_write   # => nil
-f.closed?       # => false
-f.close_read    # => nil
-f.closed?       # => true
-#@end
 
 @see [[m:$/]], [[m:IO#gets]]
 

--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -854,7 +854,8 @@ end
 
 --- closed?    -> bool
 
-ポートがクローズされている時に真を返します。
+self が完全に(読み込み用と書き込み用の両方が)クローズされている場合に true を返します。
+そうでない場合は false を返します。
 
 #@samplecode 例
 IO.write("testfile", "test")

--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -807,6 +807,8 @@ f.close
 # f.read # => IOError (すでに close しているので read できない)
 #@end
 
+@see [[m:IO#closed?]], [[m:IO#close_read]], [[m:IO#close_write]]
+
 --- close_read    -> nil
 
 読み込み用の IO を close します。主にパイプや読み書き両用に作成し
@@ -827,6 +829,8 @@ IO.popen("/bin/sh","r+") do |f|
 end
 #@end
 
+@see [[m:IO#close]], [[m:IO#closed?]], [[m:IO#close_write]]
+
 --- close_write    -> nil
 
 書き込み用の IO を close します。
@@ -846,6 +850,8 @@ f = IO.popen("/bin/sh","r+") do |f|
 end
 #@end
 
+@see [[m:IO#close]], [[m:IO#closed?]], [[m:IO#close_read]]
+
 --- closed?    -> bool
 
 ポートがクローズされている時に真を返します。
@@ -861,6 +867,8 @@ f.closed?       # => false
 f.close_read    # => nil
 f.closed?       # => true
 #@end
+
+@see [[m:IO#close]], [[m:IO#close_read]], [[m:IO#close_write]]
 
 #@since 2.4.0
 --- each(rs = $/, chomp: false) {|line| ... }         -> self


### PR DESCRIPTION
IO#closed? を rdoc の内容に近いものに修正しました。

6951d70 で追加いただいたサンプルをclose_readとclose_writeの順番を入れ替えるものを追加するかどうかを考えた時に本文をrdocよりに修正すれば片方でいいと思ったのが一番の理由です。併せてサンプルの位置を移動しました。
