### PR TITLE
Add link of Thread#[]=

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -461,6 +461,8 @@ val を name に対応するスレッド固有のデータとして格納しま�
 
 #@#noexample Thread#[]を参照
 
+@see [[m:Thread#[] ]]
+
 #@since 2.5.0
 --- fetch(name, default = nil) {|name| ... } -> object
 


### PR DESCRIPTION
`Thread#[]=`に`Thread#[]`へのリンクを追加した。
ref : https://github.com/rurema/doctree/pull/1126#issuecomment-372160706

https://docs.ruby-lang.org/ja/latest/method/Thread/i/=5b=5d=3d.html