### PR TITLE
Add sample code of Thread#backtrace

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -831,6 +831,29 @@ nil を渡すとトレースを解除します。
 
 スレッドがすでに終了している場合は nil を返します。
 
+#@samplecode 例
+class C1
+  def m1
+    sleep 5
+  end
+  def m2
+    m1
+  end
+end
+
+th = Thread.new {C1.new.m2; Thread.stop}
+th.backtrace
+# => [
+#      [0] "(irb):3:in `sleep'",
+#      [1] "(irb):3:in `m1'",
+#      [2] "(irb):6:in `m2'",
+#      [3] "(irb):10:in `block in irb_binding'"
+#    ]
+
+th.kill
+th.backtrace   # => nil
+#@end
+
 #@end
 
 #@since 2.0.0


### PR DESCRIPTION
`Thread#backtrace`にサンプルコードを追加します。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/backtrace.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-backtrace