### PR TITLE
An option to pass to `Integer`, `Float`, to return `nil` instead of raise an exception

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1534,7 +1534,11 @@ arg に to_ary, to_a のいずれのメソッドも定義されていない場�
 
 @see [[m:String#to_f]],[[c:Float]]
 
+#@since 2.6.0
+--- Integer(arg, base = 0, exception: true) -> Integer | nil
+#@else
 --- Integer(arg, base = 0) -> Integer
+#@end
 
 引数を整数([[c:Fixnum]],[[c:Bignum]])に変換した結果を返します。
 
@@ -1552,6 +1556,11 @@ arg に to_ary, to_a のいずれのメソッドも定義されていない場�
             ら基数を判断します。その場合に認識できるプリフィクスは、0b
             (2 進数)、0 (8 進数)、0o (8 進数)、0d (10 進数)、0x (16 進
             数) です。
+
+#@since 2.6.0
+@param exception false を指定すると、変換できなかった場合、
+                 例外を発生する代わりに nil を返します。
+#@end
 
 @raise ArgumentError 整数と見なせない文字列を引数に指定した場合に発生します。
 @raise TypeError メソッド to_int, to_i を持たないオブジェクトを引数に指定したか、to_int, to_i

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1495,7 +1495,11 @@ arg に to_ary, to_a のいずれのメソッドも定義されていない場�
 
 @see [[m:Object#to_a]],[[m:Object#to_ary]],[[c:Array]]
 
+#@since 2.6.0
+--- Float(arg, exception: true) -> Float | nil
+#@else
 --- Float(arg) -> Float
+#@end
 
 引数を浮動小数点数([[c:Float]])に変換した結果を返します。
 
@@ -1505,6 +1509,10 @@ arg に to_ary, to_a のいずれのメソッドも定義されていない場�
 メソッド Float は文字列に対し [[m:String#to_f]] よりも厳密な変換を行います。
 
 @param arg 変換対象のオブジェクトです。
+#@since 2.6.0
+@param exception false を指定すると、変換できなかった場合、
+                 例外を発生する代わりに nil を返します。
+#@end
 @raise ArgumentError 整数や浮動小数点数と見なせない文字列を引数に指定した場合に発生します。
 @raise TypeError nil またはメソッド to_f を持たないオブジェクトを引数に指定したか、
                  to_f が浮動小数点数を返さなかった場合に発生します。

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -2324,7 +2324,11 @@ Complex(a, b) を a+bi として計算した [[c:Complex]] オブジェクトを
 
 [注意] Complex.new、Complex.new! は 1.9 系では廃止されました。
 
+#@since 2.6.0
+--- Rational(x, y = 1, exception: true) -> Rational | nil
+#@else
 --- Rational(x, y = 1) -> Rational
+#@end
 
 引数を有理数([[c:Rational]])に変換した結果を返します。
 
@@ -2332,6 +2336,11 @@ Complex(a, b) を a+bi として計算した [[c:Complex]] オブジェクトを
 
 @param y 変換対象のオブジェクトです。省略した場合は x だけを用いて
          [[c:Rational]] オブジェクトを作成します。
+
+#@since 2.6.0
+@param exception false を指定すると、変換できなかった場合、
+                 例外を発生する代わりに nil を返します。
+#@end
 
 @raise ArgumentError 変換できないオブジェクトを指定した場合に発生します。
 

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -2290,8 +2290,13 @@ bind によらずに特定のオブジェクトのコンテキストで expr を
 
 @see [[m:Kernel.#__method__]]
 
+#@since 2.6.0
+--- Complex(r, i = 0, exception: true) -> Complex | nil
+--- Complex(s, exception: true)        -> Complex | nil
+#@else
 --- Complex(r, i = 0) -> Complex
 --- Complex(s)        -> Complex
+#@end
 
 実部が r、虚部が i である [[c:Complex]] クラスのオブジェクトを生成します。
 
@@ -2300,6 +2305,11 @@ bind によらずに特定のオブジェクトのコンテキストで expr を
 @param i 生成する複素数の虚部。省略した場合は 0 です。
 
 @param s 生成する複素数を表す文字列。
+
+#@since 2.6.0
+@param exception false を指定すると、変換できなかった場合、
+                 例外を発生する代わりに nil を返します。
+#@end
 
 @raise ArgumentError 変換できないオブジェクトを指定した場合に発生します。
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/12732