### PR TITLE
Add noexample of Kernel.#select.

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -712,6 +712,9 @@ int_encも指定されていた場合、入力された文字列をext_encでエ
 @param writes [[m:IO.select]] 参照
 @param excepts [[m:IO.select]] 参照
 @param timeout [[m:IO.select]] 参照
+
+#@#noexample IO.select を参照
+
 @see [[m:IO.select]]
 
 --- test(cmd, file) -> bool | Time | Integer | nil


### PR DESCRIPTION
#433 Kernel.#forkのついでにnoexampleにしてIO.select参照とだけしました。

* https://docs.ruby-lang.org/ja/latest/method/Kernel/m/select.html
* https://docs.ruby-lang.org/en/2.5.0/Kernel.html#method-i-select

io.c より、以下なので同じものが表示されてる事。るりまの方はIO.selectへのポインタのみのためです。

```
rb_define_global_function("select", rb_f_select, -1);
...
rb_define_singleton_method(rb_cIO, "select", rb_f_select, -1);
```