### PR TITLE
Fix an error when running the statichtml task without a database

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,8 +21,9 @@ def generate_database(version)
 end
 
 def generate_statichtml(version)
-  puts "generate static html of #{version}"
   db = "/tmp/db-#{version}"
+  generate_database(version) unless File.exist?(db)
+  puts "generate static html of #{version}"
   outputdir = "/tmp/html/#{version}"
   bitclust_gem_path = File.expand_path('../..', `bundle exec gem which bitclust`)
   raise "bitclust gem not found" unless $?.success?


### PR DESCRIPTION
That error occurs when you run the task immediately after cloning a repo.

```console
$ rake statichtml:2.5.0
generate static html of 2.5.0
mkdir -p /tmp/html/2.5.0
entries:       100% |ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo| Time:   0:00:00
methods:       100% |ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo| Time:   0:00:00
capi:          100% |ooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo| Time:   0:00:00
creating /private/tmp/html/2.5.0/library/index.html ...bundler: failed to load command: bitclust (/Users/sinsoku/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/bin/bitclust)
Errno::ENOENT: No such file or directory @ rb_sysopen - /private/tmp/html/2.5.0/library/index.html
```

---

database を作らずに `statichtml:#{version}` タスクを実行したとき、エラーが発生するので修正しました。