### PR TITLE
Avoid incorrectly parsing on Ruby 1.8.7 and 1.9.3

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2317,9 +2317,11 @@ find-any モードは [[man:bsearch(3)]] のように動作します。ブロッ
 @raise TypeError ブロックの評価結果が true、false、nil、数値以外であっ
                  た場合に発生します。
 
-#@until 2.3.0
+#@end
+#@if("2.0.0" <= version and version < "2.3.0")
 @see [[m:Range#bsearch]], [[url:http://magazine.rubyist.net/?0041-200Special-note#l15]]
-#@else
+#@end
+#@since 2.3.0
 @see [[m:Array#bsearch_index]], [[m:Range#bsearch]], [[url:http://magazine.rubyist.net/?0041-200Special-note#l15]]
 
 --- bsearch_index { |x| ... } -> Integer | nil
@@ -2351,7 +2353,6 @@ ary.bsearch_index { |x| 4 - x / 2 } # => nil
 #@end
 
 @see [[m:Array#bsearch]]
-#@end
 #@end
 
 #@since 2.4.0


### PR DESCRIPTION
The `statichtml` task occurs an error.

```console
$ rake statichtml:1.9.3
generate database of 1.9.3
refm/api/src/_builtin/ARGF:1: singleton object class not implemented yet
refm/api/src/tk/TkCore__INTERP:1: singleton object class not implemented yet
refm/api/src/webrick/httpproxy/NullReader:2: singleton object class not implemented yet
generate static html of 1.9.3
例: find-minimum モード:6:1 unknown regexp options - lt (BitClust::SyntaxHighlighter::CompileError)
rake aborted!
Failed to generate static html
```

Because it will fail to parse the document with deeply nested conditions.
And it will generate an incorrect database that contains syntax error code.

---

Ruby 1.8.7 と 1.9.3 で `statichtml` タスクがエラーになるので修正しました。

ドキュメント内の条件分岐のネストが深いとパースに失敗してしまい、syntax error のコードを含むDBが作られてしまいます。

エラーを避けるために、条件分岐のネストを浅くしました。