### PR TITLE
Update IO.binwrite example.

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -743,8 +743,8 @@ offset を指定しないと、書き込みの末尾でファイルを
 #@# TODO: 2.4以上のみを対象できる状況になったらString#unpack1でunpack('m').firstを置き換える。
 #@samplecode 例
 # 8x8の真っ白なPNG画像データ。
-png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAIAAABLbSncAAAAAXNSR0IArs4c6QAAAARnQU1BAACx
-jwv8YQUAAAAQSURBVBhXY/iPAwwpif//Aboev0GEdLc5AAAAAElFTkSuQmCC'.unpack('m').first
+png = 'iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAAAAADhZOFXAAAADklEQVQIW2P4DwUMlDEA98A/wTjP
+QBoAAAAASUVORK5CYII='.unpack('m').first
 
 # 期待する先頭16バイトの16進ダンプ: どの環境でも同じ。
 puts png[0...16].unpack('C*').map {|c| '%02x' % c }.join(' ')


### PR DESCRIPTION
https://github.com/rurema/doctree/commit/03511a4e2214db4d87067ad473629b56b4ac25ba#r28235611 の話に対応しました。

pngcrushでsRGBチャンクとgAMAチャンクを取り除いています。

```
$ pngcrush -rem alla -l 9 ...
```

一応確認もしています。

```
png.scan(/\w{4}/) # => ["IHDR", "IDAT", "IEND"]
```

Windowsでの確認がまだなのでそれが終わればWIPを外す予定です。