### PR TITLE
Add ref to def limit of module scope

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -1407,6 +1407,8 @@ module_function はメソッドに「モジュール関数」という属性を�
 引数が与えられた時には引数によって指定されたメソッドを private に
 設定します。
 
+可視性については [[ref:d:spec/def#limit]] を参照して下さい。
+
 @param name [[c:String]] または [[c:Symbol]] を 0 個以上指定します。
 
 @raise NameError 存在しないメソッド名を指定した場合に発生します。
@@ -1431,6 +1433,8 @@ module_function はメソッドに「モジュール関数」という属性を�
 引数が与えられた時には引数によって指定されたメソッドを protected
 に設定します。
 
+可視性については [[ref:d:spec/def#limit]] を参照して下さい。
+
 @param name [[c:String]] または [[c:Symbol]] を 0 個以上指定します。
 
 @raise NameError 存在しないメソッド名を指定した場合に発生します。
@@ -1444,6 +1448,8 @@ module_function はメソッドに「モジュール関数」という属性を�
 
 引数が与えられた時には引数によって指定されたメソッドを public に設
 定します。
+
+可視性については [[ref:d:spec/def#limit]] を参照して下さい。
 
 @param name [[c:String]] または [[c:Symbol]] を 0 個以上指定します。
 


### PR DESCRIPTION
#433

可視性全般に関して [クラス／メソッドの定義](http://rurema.clear-code.com/2.5.0/doc/spec=2fdef.html#limit) ページの `呼び出し制限` へリンクさせるのが良さそうに思ったので説明文に追記しています。

Rubyのメソッドの可視性については、私が以前 Qiita に書いていた記事へのアクセスが多いことから
Rubyプログラマのそこそこの人が疑問に思って調べることが多いように思います。

* https://qiita.com/tbpgr/items/6f1c0c7b77218f74c63e
    * 2018/04/06 時点で like 317, PV 34,824(ログインして、記事作成本人のみ確認可能)

## 関連
* https://github.com/rurema/doctree/pull/1172
