### PR TITLE
Add sample code of Module#public_constant

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -1580,6 +1580,29 @@ name で指定した定数の可視性を public に変更します。
 
 @return self を返します。
 
+#@samplecode 例
+module SampleModule
+  class SampleInnerClass
+  end
+
+  # => 非公開クラスであることを明示するために private にする
+  private_constant :SampleInnerClass
+end
+
+begin
+  SampleModule::SampleInnerClass
+rescue => e
+  e # => #<NameError: private constant SampleModule::SampleInnerClass referenced>
+end
+
+module SampleModule
+  # => 非公開クラスであることは承知で利用するために public にする
+  public_constant :SampleInnerClass
+end
+
+SampleModule::SampleInnerClass # => SampleModule::SampleInnerClass
+#@end
+
 @see [[m:Module#private_constant]], [[m:Object#untrusted?]]
 
 #@end


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/2.5.0/method/Module/i/public_constant.html
* https://docs.ruby-lang.org/en/2.5.0/Module.html#method-i-public_constant
* https://bugs.ruby-lang.org/issues/2366

bugs ruby より

>今の Ruby には、クラスが公開 API かどうかを伝える手段がドキュメント
>しかありません。そのため、ERB::Compiler など、ライブラリの中の公開
>でない (と思われる) inner class を外から自由に参照できてしまいます。
>
>これを防ぐためには、匿名クラスを用いて定義すれば大分隠蔽できますが、
>記述が相当煩雑になってしまいます。また、そのようにしてしまうと、
>「非公開というのは承知の上で敢えて使いたい」という要求に答えにくく
>なります。
>
>そこで、定数に public/private の属性を指定できるようにするのはどう
>でしょうか。

とのことから、クラスが非公開であることを明示するために `private_constant` が追加され、
非公開を承知で使いたいので private から public に変更したいときに `public_constant` を利用する、という解釈をしました。

## 関連
https://github.com/rurema/doctree/pull/775