### PR TITLE
Remove `$LOADED_FEATURES` and `$PROGRAM_NAME` from `English` library

### DIFF
--- a/refm/api/src/English.rd
+++ b/refm/api/src/English.rd
@@ -41,18 +41,6 @@
     p $ERROR_POSITION #=> ["sample.rb:5"]
   end
 
-#@until 1.8.2
---- $LOADED_FEATURES -> [String]
-
-[[m:$"]] の別名
-
-  require "English"
-  require "find"
-
-  p $LOADED_FEATURES #=> ["English.rb", "find.rb"]
-
-#@end
-
 --- $FS              -> String | nil
 --- $FIELD_SEPARATOR -> String | nil
 
@@ -238,19 +226,6 @@
   $IGNORECASE = true # => warning: variable $= is no longer effective; ignored
   $IGNORECASE        # => warning: variable $= is no longer effective
                      #    false
-
---- $PROGRAM_NAME -> String
-
-[[m:$0]] の別名
-
-  require "English"
-  
-  p $PROGRAM_NAME
-  #end of sample.rb
-
-  ruby sample.rb  #=> "sample.rb"
-  ruby ./sample.rb #=> "./sample.rb"
-  ruby /home/hoge/bin/sample.rb #=> "/home/hoge/bin/sample.rb"
 
 --- $ARGV -> [String]
 

--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -309,9 +309,7 @@ Ruby起動時の初期値は 0 です。
 この変数はグローバルスコープ、読み取り専用です。
 
 --- $0 -> String
-#@since 1.8.2
 --- $PROGRAM_NAME -> String
-#@end
 
 現在実行中の Ruby スクリプトの名前を表す文字列です。
 
@@ -412,9 +410,7 @@ require 'foo' を実行すると、
 @see [[d:spec/rubycmd]], [[d:spec/envvars]]
 
 --- $"               -> [String]
-#@since 1.8.2
 --- $LOADED_FEATURES -> [String]
-#@end
 
 [[m:Kernel.#require]] でロードされたファイル名を含む配列です。
 


### PR DESCRIPTION
`$LOADED_FEATURES`と`$PROGRAM_NAME`はEnglishではなくビルドインで定義されているため、English libraryからは記述を削除しました。(詳しくは #1165 を参照。`$LOADED_FEATURES`に関してはIssueに記述はありませんが、`$PROGRAM_NAME`と同じコミットでEnglishから削除されています。)
また、ruremaではRuby 1.8, 1.9をサポートしていないので、不要となっている分岐を削除しました。


---

また #1165 の網羅されていないグローバル変数が存在する問題ですが、私の勘違いのようでした。
https://docs.ruby-lang.org/ja/latest/library/English.html の "追加・再定義されるメソッド" の一覧の中にはこれらの変数は存在しませんが、それらは`$FS`と`$FIELD_SEPARATOR`のように同じ変数に対する別名が複数定義されているもので、そのどちらかのみがこのリストに表示されているためにこの勘違いが発生したようでした。
この変数の個別のページ(例えば https://docs.ruby-lang.org/ja/latest/method/Kernel/v/FIELD_SEPARATOR.html )には`$FS`と`$FIELD_SEPARATOR`の両方が存在します。


これはこれで 紛らわしいのでこの "追加・再定義されるメソッド" にも両方の名前が表示されてほしいのですが、あまり良く理解していないので、このPRでは特にそれに関しては触っていません。(bitclustを弄る必要がある？？)

