### PR TITLE
Add sample code of Object#!~

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -870,6 +870,14 @@ self#=~(obj) を反転した結果と同じ結果を返します。
 
 @param other 判定するオブジェクトを指定します。
 
+#@samplecode 例
+obj = 'regexp'
+p (obj !~ /re/) # => false
+
+obj = nil
+p (obj !~ /re/) # => true
+#@end
+
 @see [[m:Object#=~]]
 #@end
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Object/i/=21=7e.html
* https://docs.ruby-lang.org/en/2.5.0/Object.html#method-i-21-7E

`Object#!~` は `Object#=~` の反転した結果ということなので、同じ条件を検証するサンプルにしました
