### PR TITLE
Finish HTTP connection after GET.

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -594,15 +594,17 @@ nil の場合システムが適当にローカルホストを
 
 @param host ホスト名、もしくはアドレスを示す文字列
 
-  require 'net/http'
-  
-  http = Net::HTTP.new("www.example.com")
-  http.local_host = "192.168.0.5"
-  http.local_port = "53043"
-  
-  http.start
-  p http.get("/").body
+#@samplecode 例
+require 'net/http'
 
+http = Net::HTTP.new("www.example.com")
+http.local_host = "192.168.0.5"
+http.local_port = "53043"
+
+http.start do |h|
+  p h.get("/").body
+end
+#@end
 
 @see [[m:Net::HTTP#local_host=]], [[m:Net::HTTP#local_port]]
 
@@ -626,14 +628,17 @@ nil の場合システムが適当にローカルポートを
 
 @param port ローカルポート(数値、もしくはサービス名文字列)
 
-  require 'net/http'
-  
-  http = Net::HTTP.new("www.example.com")
-  http.local_host = "192.168.0.5"
-  http.local_port = "53043"
-  
-  http.start
-  p http.get("/").body
+#@samplecode 例
+require 'net/http'
+
+http = Net::HTTP.new("www.example.com")
+http.local_host = "192.168.0.5"
+http.local_port = "53043"
+
+http.start do |h|
+  p h.get("/").body
+end
+#@end
 
 @see [[m:Net::HTTP#local_port=]], [[m:Net::HTTP#local_host]]
 


### PR DESCRIPTION
#1068 などでIOをブロック化しておくようにしていますが、net/http関連のサンプルでも同様かと思います(HTTPアクセスを沢山発行するプログラムで参考にしてしまうと困るかもしれない)ので、local_host, local_portのサンプルを修正しました。ブロックパラメータは他のサンプルにあわせてhにしています。他にもあるかと思いますが、とりあえずは2つほど。

```
# 修正前。
http.start
p http.get("/").body
p http.started? # => true (コネクション繋いだまま)

# 修正後。
http.start do |h|
  p h.get("/").body
end

p http.started? # => false (コネクション閉じられてる)
```