### PR TITLE
Add sample code of Thread#set_trace_func

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -823,6 +823,31 @@ nil を渡すとトレースを解除します。
 
 設定したハンドラを返します。
 
+#@samplecode 例
+th = Thread.new do
+  class Trace
+  end
+  2.to_s
+  Thread.current.set_trace_func nil
+  3.to_s
+end
+th.set_trace_func lambda {|*arg| p arg }
+th.join
+
+# => ["line", "example.rb", 2, nil, #<Binding:0x00007fc8de87cb08>, nil]
+# => ["c-call", "example.rb", 2, :inherited, #<Binding:0x00007fc8de886770>, Class]
+# => ["c-return", "example.rb", 2, :inherited, #<Binding:0x00007fc8de8844e8>, Class]
+# => ["class", "example.rb", 2, nil, #<Binding:0x00007fc8de88e830>, nil]
+# => ["end", "example.rb", 3, nil, #<Binding:0x00007fc8de88d6b0>, nil]
+# => ["line", "example.rb", 4, nil, #<Binding:0x00007fc8de88c440>, nil]
+# => ["c-call", "example.rb", 4, :to_s, #<Binding:0x00007fc8de896f30>, Integer]
+# => ["c-return", "example.rb", 4, :to_s, #<Binding:0x00007fc8de894a50>, Integer]
+# => ["line", "example.rb", 5, nil, #<Binding:0x00007fc8de967b08>, nil]
+# => ["c-call", "example.rb", 5, :current, #<Binding:0x00007fc8de967798>, Thread]
+# => ["c-return", "example.rb", 5, :current, #<Binding:0x00007fc8de9673b0>, Thread]
+# => ["c-call", "example.rb", 5, :set_trace_func, #<Binding:0x00007fc8de966fc8>, Thread]
+#@end
+
 @param pr トレースハンドラ([[c:Proc]] オブジェクト) もしくは nil
 @see [[m:Thread#add_trace_func]] [[m:Kernel.#set_trace_func]]
 


### PR DESCRIPTION
`Thread#set_trace_func`にサンプルコードを追加します。

https://docs.ruby-lang.org/ja/latest/method/Thread/i/set_trace_func.html
https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-set_trace_func