### PR TITLE
Add noexample comment of Object#trust

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1797,6 +1797,8 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 
 オブジェクトの「untrustマーク」を取り除きます。
 
+#@#noexample deprecated
+
 @see [[m:Object#untrusted?]],[[m:Object#untrust]]
 
 --- untrusted? -> bool


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Object/i/trust.html
* https://docs.ruby-lang.org/en/2.5.0/Object.html#method-i-trust

rdoc で Deprecated とあったため noexample にした

