### PR TITLE
Fix broken link

### DIFF
--- a/refm/doc/spec/control.rd
+++ b/refm/doc/spec/control.rd
@@ -379,7 +379,7 @@ for や each で配列要素を複数個ずつ取得しながらループする�
 
           break
 
-          break val          
+          break val
 
 break はもっとも内側のループを脱出します。ループとは
 
@@ -409,7 +409,7 @@ break によりループを抜けた for やイテレータは nil
 
           next
 
-          next val              
+          next val
 
 
 nextはもっとも内側のループの次の繰り返しにジャンプします。
@@ -600,7 +600,7 @@ rescue 節が存在する時には rescue 節の本体が実行されます。
              #<RuntimeError: error message>
 
 例外の一致判定は，発生した例外が rescue 節で指定した
-クラスのインスタンスであるかどうかで行われます。 
+クラスのインスタンスであるかどうかで行われます。
 
 error_type が省略された時は [[c:StandardError]] のサブクラスであ
 る全ての例外を捕捉します。Rubyの組み込み例外は([[c:SystemExit]] や
@@ -608,7 +608,7 @@ error_type が省略された時は [[c:StandardError]] のサブクラスであ
 [[c:StandardError]] のサブクラスです。
 
 例外クラスのクラス階層については
-[[unknown:組み込みクラス／モジュール／例外クラス/例外クラス]]
+[[lib:_builtin]]
 を参照してください。
 
 rescue では error_type は通常の引数と同じように評価され、
@@ -662,7 +662,7 @@ rescue修飾子を伴う式の値は例外が発生しなければ式1、例外�
 
           p(open("nonexistent file") rescue false)
           => parse error
-          
+
           p((open("nonexistent file") rescue false))
           => false
 


### PR DESCRIPTION
添付画像の赤線部分のリンクが壊れていたのを修正しました。例外クラスそのものを取り扱うページが見つからなかったので、組み込みライブラリのページを指すようにしています。

![image](https://user-images.githubusercontent.com/82371/38799407-6cb6dc12-419f-11e8-9cfc-38e92a6a30b4.png)
