### PR TITLE
Add noexample comment of Object#untrust

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1813,6 +1813,8 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 
 オブジェクトの「untrustマーク」をセットします。
 
+#@#noexample deprecated
+
 @see [[m:Object#trust]],[[m:Object#untrusted?]]
 #@end
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Object/i/untrust.html
* https://docs.ruby-lang.org/en/2.5.0/Object.html#method-i-untrust

rdoc で Deprecated とあったため noexample にした
