### PR TITLE
Add noexample comment of Object#untrusted?

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1806,6 +1806,8 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 
 オブジェクトの「untrustマーク」がセットされている時真を返します。
 
+#@#noexample deprecated
+
 @see [[m:Object#trust]],[[m:Object#untrust]]
 
 --- untrust -> self


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Object/i/untrusted=3f.html
* https://docs.ruby-lang.org/en/2.5.0/Object.html#method-i-untrusted-3F

rdoc で Deprecated とあったため noexample にした