### PR TITLE
ディレクトリを表す場合のPathname#empty?

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -727,7 +727,7 @@ FileTest.writable_real?(self.to_s) と同じです。
 #@since 2.4.0
 --- empty? -> bool
 #@end
-FileTest.zero?(self.to_s) と同じです。
+ディレクトリに対しては Dir.empty?(self.to_s) と同じ、他に対しては FileTest.zero?(self.to_s) と同じです。
 
 @see [[m:FileTest.#zero?]]
 


### PR DESCRIPTION
`Pathname#empty?` は、ディレクトリに対しては `Dir.empty?` の意味になるようです。

[pathname.c:path_empty_p](https://github.com/ruby/ruby/blob/ae92a9e4ed7665130c816ae3f8a6927242d367ad/ext/pathname/pathname.c#L1072)

