### PR TITLE
Object#trust、#untrust、#untrusted?を更新

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1792,27 +1792,27 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 @see [[m:Object#taint]],[[m:Object#tainted?]]
 
 --- trust -> self
-#@todo
 
-オブジェクトの「untrustマーク」を取り除きます。
+このメソッドは deprecated です。
+[[m:Object#untaint]] と同じ動作をします。
 
 #@#noexample deprecated
 
 @see [[m:Object#untrusted?]],[[m:Object#untrust]]
 
 --- untrusted? -> bool
-#@todo
 
-オブジェクトの「untrustマーク」がセットされている時真を返します。
+このメソッドは deprecated です。
+[[m:Object#tainted?]] と同じ動作をします。
 
 #@#noexample deprecated
 
 @see [[m:Object#trust]],[[m:Object#untrust]]
 
 --- untrust -> self
-#@todo
 
-オブジェクトの「untrustマーク」をセットします。
+このメソッドは deprecated です。
+[[m:Object#taint]] と同じ動作をします。
 
 #@#noexample deprecated
 

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1791,7 +1791,6 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 @raise SecurityError セキュリティレベルが3以上の時にこのメソッドを使用すると発生します。
 @see [[m:Object#taint]],[[m:Object#tainted?]]
 
-#@since 1.9.1
 --- trust -> self
 #@todo
 
@@ -1818,7 +1817,6 @@ obj.instance_of?(c) が成立する時には、常に obj.kind_of?(c) も成立�
 #@#noexample deprecated
 
 @see [[m:Object#trust]],[[m:Object#untrusted?]]
-#@end
 
 #@since 1.9.2
 --- singleton_class -> Class


### PR DESCRIPTION
#1195 に対応。2.1.0で既にtaint系に置き換わっているため、分岐せずに修正。