### PR TITLE
Bignum and Float can't be taint since 2.0.0 because they are frozen.

### DIFF
--- a/refm/doc/spec/safelevel.rd
+++ b/refm/doc/spec/safelevel.rd
@@ -221,8 +221,13 @@ CGI等でユーザからの入力を処理するのに適しています。
      その [[c:Proc]] オブジェクトが call されると、記憶していたセーフレベルで実行される。
    * 汚染された文字列を第二引数に指定して [[m:Kernel.#trap]]/[[m:Kernel.#trace_var]] を
      実行するとその時点で例外 [[c:SecurityError]] が発生する。
-   * 実装の都合上 [[c:Fixnum]], [[c:Symbol]], true, false, nil は汚染されない。
-     なお [[c:Bignum]], [[c:Float]] は汚染されることは注意が必要。
+#@since 2.4.0
+   * 実装の都合上 [[c:Integer]], [[c:Float]], [[c:Symbol]], true,
+     false, nil は汚染されない。
+#@else
+   * 実装の都合上 [[c:Fixnum]], [[c:Bignum]], [[c:Float]],
+     [[c:Symbol]], true, false, nil は汚染されない。
+#@end
 
 === 使用例
 


### PR DESCRIPTION
#1200 で追加で見つかった点を修正。2.0.0から `Fixnums, Bignums and Floats are frozen.` であること、2.4からInteger統合された点から1つだけ分岐を行った。

```
$ rbenv each ruby -ve '
    v =10000000000000000000000000
    p({value: v, class: v.class, frozen: v.frozen?, tainted: v.tainted?, tainted_after_taint: v.taint.tainted?})'
ruby 1.9.3p547 (2014-05-14 revision 45962) [x86_64-darwin13.3.0]
{:value=>10000000000000000000000000, :class=>Bignum, :frozen=>false, :tainted=>false, :tainted_after_taint=>true}
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-darwin15.6.0]
-e:3:in `taint': can't modify frozen Bignum (RuntimeError)
        from -e:3:in `<main>'
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-darwin13.0]
-e:3:in `taint': can't modify frozen Bignum (RuntimeError)
        from -e:3:in `<main>'
ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-darwin15]
{:value=>10000000000000000000000000, :class=>Bignum, :frozen=>true, :tainted=>false, :tainted_after_taint=>false}

$ rbenv each ruby -ve '
    v = 1.0
    p({value: v, class: v.class, frozen: v.frozen?, tainted: v.tainted?, tainted_after_taint: v.taint.tainted?})'
ruby 1.9.3p547 (2014-05-14 revision 45962) [x86_64-darwin13.3.0]
{:value=>1.0, :class=>Float, :frozen=>false, :tainted=>false, :tainted_after_taint=>true}
ruby 2.0.0p648 (2015-12-16 revision 53162) [x86_64-darwin15.6.0]
-e:3:in `taint': can't modify frozen Float (RuntimeError)
        from -e:3:in `<main>'
ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-darwin13.0]
-e:3:in `taint': can't modify frozen Float (RuntimeError)
        from -e:3:in `<main>'
ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-darwin15]
{:value=>1.0, :class=>Float, :frozen=>true, :tainted=>false, :tainted_after_taint=>false}
...
```
