### PR TITLE
Add sample code of ObjectSpace#undefine_finalizer

### DIFF
--- a/refm/api/src/_builtin/ObjectSpace
+++ b/refm/api/src/_builtin/ObjectSpace
@@ -185,11 +185,11 @@ class Sample
   end
 end
 
-sample = Sample.new
+Sample.new
 GC.start
 # => finalize
 
-sample = Sample.new
+Sample.new
 sample.undef
 GC.start
 # ※何も出力されない

--- a/refm/api/src/_builtin/ObjectSpace
+++ b/refm/api/src/_builtin/ObjectSpace
@@ -168,6 +168,35 @@ obj を返します。
 
 @param obj ファイナライザを解除したいオブジェクトを指定します。
 
+#@samplecode 例
+class Sample
+  def Sample.callback
+    proc {
+      puts "finalize"
+    }
+  end
+
+  def initialize
+    ObjectSpace.define_finalizer(self, Sample.callback)
+  end
+
+  def undef
+    ObjectSpace.undefine_finalizer(self)
+  end
+end
+
+sample = Sample.new
+GC.start
+# => finalize
+
+sample = Sample.new
+sample.undef
+GC.start
+# ※何も出力されない
+#@end
+
+@see [[m:ObjectSpace.#define_finalizer]]
+
 #@since 1.9.1
 --- count_objects(result_hash = {}) -> Hash
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/ObjectSpace/m/undefine_finalizer.html
* https://docs.ruby-lang.org/en/2.5.0/ObjectSpace.html#method-c-undefine_finalizer

`ObjectSpace.#define_finalizer` とワンセットだと思うので `@see [[m:ObjectSpace.#define_finalizer]]` を追加しました。