### PR TITLE
ENV.slice since 2.6.0

### DIFF
--- a/refm/api/src/_builtin/ENV
+++ b/refm/api/src/_builtin/ENV
@@ -354,3 +354,18 @@ select! はオブジェクトが変更された場合に self を、
 
 @see [[m:ENV.delete_if]],[[m:ENV.reject!]], [[m:Hash#keep_if]], [[m:Hash#select!]],
 #@end
+#@since 2.6.0
+--- slice(*keys) -> Hash
+
+引数で指定されたキーとその値だけを含む Hash を返します。
+
+#@samplecode 例
+ENV["foo"] = "bar"
+ENV["baz"] = "qux"
+ENV["bar"] = "rab"
+ENV.slice()             # => {}
+ENV.slice("")           # => {}
+ENV.slice("unknown")    # => {}
+ENV.slice("foo", "baz") # => {"foo"=>"bar", "baz"=>"qux"}
+#@end
+#@end


### PR DESCRIPTION
- https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?revision=63188&view=revision
- https://bugs.ruby-lang.org/issues/14559

実行例はテストからとってきました。