### PR TITLE
Add sample code of SignalException.new

### DIFF
--- a/refm/api/src/_builtin/SignalException
+++ b/refm/api/src/_builtin/SignalException
@@ -38,6 +38,17 @@
                   定した場合は to_int メソッドによる暗黙の型変換を試み
                   ます。
 
+#@samplecode 例
+signal_number = Signal.list["INT"]
+se = SignalException.new(signal_number) # => #<SignalException: SIGINT>
+se.signo # => 2
+#@end
+
+#@samplecode 例
+se = SignalException.new("INT") # => #<SignalException: SIGINT>
+se.signm # => "SIGINT"
+#@end
+
 @see [[m:Signal.#list]]
 
 == Instance Methods


### PR DESCRIPTION
* #433 

* https://docs.ruby-lang.org/ja/latest/method/SignalException/s/new.html
* https://docs.ruby-lang.org/en/2.5.0/SignalException.html#method-c-new

利用例を検索してみましたが、引数を片方使うパターンしか見つからなかったので
そちらの例のみ作ってあります。
