### PR TITLE
Add sample code of RubyVM::InstructionSequence#to_a

### DIFF
--- a/refm/api/src/_builtin/RubyVM__InstructionSequence
+++ b/refm/api/src/_builtin/RubyVM__InstructionSequence
@@ -326,6 +326,36 @@ self の情報を 14 要素の配列にして返します。
 
   命令シーケンスを構成する命令とオペランドの配列の配列。
 
+
+#@samplecode 例
+require 'pp'
+
+iseq = RubyVM::InstructionSequence.compile('num = 1 + 2')
+pp iseq.to_a
+# ※ Ruby 2.5.0 での実行結果
+# => ["YARVInstructionSequence/SimpleDataFormat",
+# 2,
+# 0,
+# 1,
+# {:arg_size=>0, :local_size=>2, :stack_max=>2},
+# "<compiled>",
+# "<compiled>",
+# nil,
+# 1,
+# :top,
+# [:num],
+# 0,
+# [],
+# [1,
+#  [:trace, 1],
+#  [:putobject_OP_INT2FIX_O_1_C_],
+#  [:putobject, 2],
+#  [:opt_plus, {:mid=>:+, :flag=>256, :orig_argc=>1, :blockptr=>nil}],
+#  [:dup],
+#  [:setlocal_OP__WC__0, 2],
+#  [:leave]]]
+#@end
+
 --- eval -> object
 
 self の命令シーケンスを評価してその結果を返します。


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/RubyVM=3a=3aInstructionSequence/i/to_a.html
* https://docs.ruby-lang.org/en/2.5.0/RubyVM/InstructionSequence.html#method-i-to_a

to_a の出力が長いので迷いつつも、 pp を使ってみました。
好ましくない場合はご指摘ください。
