### PR TITLE
Add sample code of RubyVM::InstructionSequence#compile_option

### DIFF
--- a/refm/api/src/_builtin/RubyVM__InstructionSequence
+++ b/refm/api/src/_builtin/RubyVM__InstructionSequence
@@ -72,6 +72,24 @@ VM の命令シーケンスの一覧はRuby のソースコード中の insns.de
 命令シーケンスのコンパイル時のデフォルトの最適化オプションを Hash で返
 します。
 
+#@samplecode 例
+require "pp"
+pp RubyVM::InstructionSequence.compile_option
+
+# => {:inline_const_cache=>true,
+# :peephole_optimization=>true,
+# :tailcall_optimization=>false,
+# :specialized_instruction=>true,
+# :operands_unification=>true,
+# :instructions_unification=>false,
+# :stack_caching=>false,
+# :trace_instruction=>true,
+# :frozen_string_literal=>false,
+# :debug_frozen_string_literal=>false,
+# :coverage_enabled=>true,
+# :debug_level=>0}
+#@end
+
 @see [[m:RubyVM::InstructionSequence.compile_option=]]
 
 --- compile_option=(options)


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/RubyVM=3a=3aInstructionSequence/s/compile_option.html
* https://docs.ruby-lang.org/en/2.5.0/RubyVM/InstructionSequence.html#method-i-compile_option

to_a の出力が長いので迷いつつも、 pp を使ってみました。
好ましくない場合はご指摘ください。