### PR TITLE
Update Struct#members

### DIFF
--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -104,23 +104,15 @@ Structをカスタマイズする場合はこの方法が推奨されます。�
     foo = Foo.new(1)
     p foo.values      # => [1, nil]
 
-#@since 1.9.1
 --- members -> [Symbol]
 (このメソッドは Struct の下位クラスにのみ定義されています)
 構造体のメンバの名前([[c:Symbol]])の配列を返します。
 
-    Foo = Struct.new(:foo, :bar)
-    p Foo.members      # => [:foo, :bar]
-
-#@else
---- members -> [String]
-(このメソッドは Struct の下位クラスにのみ定義されています)
-構造体のメンバの名前([[c:String]])の配列を返します。
-
-    Foo = Struct.new(:foo, :bar)
-    p Foo.members      # => ["foo", "bar"]
-
+#@samplecode 例
+Foo = Struct.new(:foo, :bar)
+p Foo.members      # => [:foo, :bar]
 #@end
+
 == Instance Methods
 
 --- [](member) -> object
@@ -218,11 +210,13 @@ Structをカスタマイズする場合はこの方法が推奨されます。�
   joe = Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345)
   joe.length   #=> 3
 
---- members -> [String]
-構造体のメンバの名前(文字列)の配列を返します。
+--- members -> [Symbol]
+構造体のメンバの名前([[c:Symbol]])の配列を返します。
 
-    Foo = Struct.new(:foo, :bar)
-    p Foo.new.members  # => ["foo", "bar"]
+#@samplecode 例
+Foo = Struct.new(:foo, :bar)
+p Foo.new.members  # => [:foo, :bar]
+#@end
 
 #@include(Struct.attention)
 


### PR DESCRIPTION
- `#members` returns `[Symbol]` instead of `[String]` since 1.9.
- Remove old branching.
- Use `#@samplecode`.

closes #1222