### PR TITLE
Add sample code of ThreadGroup.new

### DIFF
--- a/refm/api/src/_builtin/ThreadGroup
+++ b/refm/api/src/_builtin/ThreadGroup
@@ -39,6 +39,14 @@ Thread.new{ ... } はエラーになりません。生成されたスレッド�
 
 新たな ThreadGroup を生成して返します。
 
+#@samplecode 例
+thread_group = ThreadGroup.new
+thread_group.add Thread.new { sleep 0.1; Thread.new { sleep 1 }; sleep 1 }
+thread_group.add Thread.new { sleep 2 }
+sleep 0.5
+thread_group.list # => [#<Thread:0x007fc6f1842d70 sleep>, #<Thread:0x007fc6f1842c80 sleep>, #<Thread:0x007fc6f080dba8 sleep>]
+#@end
+
 == Instance Methods
 
 --- add(thread)    -> self


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/ThreadGroup/s/new.html

new のサンプルは、インスタンスを作ったあとのちょっとした利用まで含めているケースを見るので
Tread の Group であることが伝わりそうなものにしてみました。
