### PR TITLE
Add sample code of Thread#status

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -761,6 +761,19 @@ thr.safe_level              # => 1
 
 [[m:Thread#alive?]] が真を返すなら、このメソッドも真です。
 
+#@samplecode 例
+a = Thread.new { raise("die now") }
+b = Thread.new { Thread.stop }
+c = Thread.new { Thread.exit }
+d = Thread.new { sleep }
+d.kill                  # => #<Thread:0x401b3678 aborting>
+a.status                # => nil
+b.status                # => "sleep"
+c.status                # => false
+d.status                # => "aborting"
+Thread.current.status   # => "run"
+#@end
+
 @see [[m:Thread#alive?]], [[m:Thread#stop?]]
 
 --- stop?    -> bool


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread/i/status.html
* https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-i-status

実際に実行すると、実行タイミングによってstatusが変わるのですが
aborting だけは一回も出ませんでした。
意図的に出力を固定にするようなサンプルを書く方法がわからなかったので、
ひとまず rdoc のままになってます。
