### PR TITLE
Add noexample comment of Thread.exclusive

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -238,6 +238,8 @@ synchronize を呼び出しているだけで、Thread.exclusive していない
 [[c:Mutex]] や [[c:Monitor]] などの他の排他制御の方法を検討してください。
 #@end
 
+#@#noexample deprecated
+
 --- DEBUG -> Integer
 
 スレッドのデバッグレベルを返します。


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread/s/exclusive.html
* https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-c-exclusive

実行すすると以下の警告がでるので noexample にしました。

```
Thread.exclusive is deprecated, use Thread::Mutex
```

その他、参考資料

* https://fiveteesixone.lackland.io/2016/01/03/thread-exclusive-is-deprecated-use-mutex/
* https://bugs.ruby-lang.org/issues/11904
