### PR TITLE
Add sample code of Thread.DEBUG

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -245,6 +245,10 @@ synchronize を呼び出しているだけで、Thread.exclusive していない
 使用するためには、THREAD_DEBUG を -1 にして Ruby をコンパイルする必要が
 あります。
 
+#@samplecode 例
+Thread.DEBUG # => 0
+#@end
+
 --- DEBUG=(val)
 
 スレッドのデバッグレベルを val に設定します。


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread/s/DEBUG.html
* https://docs.ruby-lang.org/en/2.5.0/Thread.html#method-c-DEBUG
* https://github.com/ruby/ruby/blob/4e09f414fc6e0bdc5cdf6863f5698464ac3e8a7d/thread.c

@hkdnet さんに協力してもらったので git commit に Co-authored-by hkdnet を追加しています

* https://help.github.com/articles/creating-a-commit-with-multiple-authors/

また、以下は記載内容を詳しくする場合の @hkdnet さんからの提案です。

```
DEBUG -> Integer
    スレッドのデバッグレベルを返します。
    スレッドのデバッグレベルが 0 のときはなにもしません。
    それ以外の場合は、スレッドのデバッグログを標準出力に出力します。
    初期値は 0 です。
    使用するためには、THREAD_DEBUG を -1 にして Ruby をコンパイルする必要が あります。
DEBUG=(val)
    スレッドのデバッグレベルを設定します。val が truthy のときは Integer に変換してから設定します。
    falsy のときは 0 を設定します。
    使用するためには、THREAD_DEBUG を -1 にして Ruby をコンパイルする必要が あります。
```