### PR TITLE
Switch Range#=== to use cover? instead of include?

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -91,13 +91,17 @@ exclude_end が真ならば終端を含まない範囲オブジェクトを生
 
 == Instance Methods
 
+#@until 2.6.0
 --- ===(obj) -> bool
+#@end
 --- include?(obj) -> bool
 --- member?(obj) -> bool
 
 obj が範囲内に含まれている時に真を返します。
 
+#@until 2.6.0
 [[m:Range#===]] は主に case 式での比較に用いられます。
+#@end
 
 #@since 1.9.1
 <=> メソッドによる演算により範囲内かどうかを判定するには [[m:Range#cover?]] を使用してください。
@@ -116,15 +120,24 @@ include? が、[[m:Enumerable#include?]],[[m:Enumerable#member?]]
   p ("a" .. "c").include?("ba") # => false
   p ("a" .. "c").member?("ba")  # => false
 
+#@until 2.6.0
 @see [[ref:d:spec/control#case]]
+#@end
 #@since 1.9.1
 @see [[m:Range#cover?]]
 #@end
 
 #@since 1.9.1
+#@since 2.6.0
+--- ===(obj) -> bool
+#@end
 --- cover?(obj) -> bool
 
 obj が範囲内に含まれている時に真を返します。
+
+#@since 2.6.0
+[[m:Range#===]] は主に case 式での比較に用いられます。
+#@end
 
 [[m:Range#include?]] と異なり <=> メソッドによる演算により範囲内かどうかを判定します。
 [[m:Range#include?]] は原則として離散値を扱い、
@@ -155,6 +168,9 @@ Range#cover? は連続値を扱います。
   (Date.new(2014,1,3)..Date.new(2014,1,5)).cover?(Date.new(2014,1,5))             # => true
   (Time.new(2014,1,3)..Time.new(2014,1,5)).cover?(Time.new(2014,1,4,10,10,10))    # => true
 
+#@since 2.6.0
+@see [[ref:d:spec/control#case]]
+#@end
 @see [[m:Range#include?]]
 #@end
 


### PR DESCRIPTION
see https://bugs.ruby-lang.org/issues/14575