### PR TITLE
Fix wrong exception class name in OpenSSL::PKey::EC

### DIFF
--- a/refm/api/src/openssl/PKey__EC
+++ b/refm/api/src/openssl/PKey__EC
@@ -47,7 +47,7 @@ OpenSSL::PKey::EC オブジェクトを生成します。
 
 @param obj ECオブジェクトの生成元(EC オブジェクト or EC::Group オブジェクト
            or 文字列)
-@raise OpenSSL::PKey::EC::ECError オブジェクトの生成に失敗した場合に発生します
+@raise OpenSSL::PKey::ECError オブジェクトの生成に失敗した場合に発生します
 
 == Instance methods
 --- group -> OpenSSL::PKey::EC::Group


### PR DESCRIPTION
Fixes #1250

`OpenSSL::PKey::EC`の特異メソッド`new`の説明の中で、例外発生時のExceptionのクラス名が、`OpenSSL::PKey::EC::ECError`になっていました。

これを、`OpenSSL::PKey::ECError`に修正しました。