### PR TITLE
Add sample code of Thread::Backtrace::Locations#absolute_path

### DIFF
--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -97,6 +97,24 @@ self が表すフレームのファイル名を返します。
 
 self が表すフレームの絶対パスを返します。
 
+#@samplecode 例
+# foo.rb
+class Foo
+  attr_accessor :locations
+  def initialize(skip)
+    @locations = caller_locations(skip)
+  end
+end
+
+Foo.new(0..2).locations.map do |call|
+  puts call.absolute_path
+end
+
+# => path/to/foo.rb
+# path/to/foo.rb
+# path/to/foo.rb
+#@end
+
 @see [[m:Thread::Backtrace::Location#path]]
 
 --- to_s -> String

--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -110,9 +110,9 @@ Foo.new(0..2).locations.map do |call|
   puts call.absolute_path
 end
 
-# => path/to/foo.rb
-# path/to/foo.rb
-# path/to/foo.rb
+# => /path/to/foo.rb
+# /path/to/foo.rb
+# /path/to/foo.rb
 #@end
 
 @see [[m:Thread::Backtrace::Location#path]]


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread=3a=3aBacktrace=3a=3aLocation/i/absolute_path.html
* https://docs.ruby-lang.org/en/2.5.0/Thread/Backtrace/Location.html#method-i-absolute_path

要約の例2をベースにしました
