### PR TITLE
Update timeout example. (closes gh-1241)

### DIFF
--- a/refm/api/src/timeout.rd
+++ b/refm/api/src/timeout.rd
@@ -83,7 +83,7 @@ exception_class を指定した場合には [[c:Timeout::Error]] の代わりに
   t = 5
   min = [ 0, 0]
   begin
-    timeout(t){
+    Timeout.timeout(t){
       calc_pi(min)
     }
   rescue Timeout::Error
@@ -101,7 +101,7 @@ exception_class を指定した場合には [[c:Timeout::Error]] の代わりに
 
   class MYError < Exception;end
   begin
-    timeout(5, MYError) {
+    Timeout.timeout(5, MYError) {
       sleep(30)
     }
   rescue MYError => err
@@ -129,7 +129,7 @@ Socket などは DNSの名前解決に時間がかかった場合割り込めま
   t = 0.1
   start = Time.now
   begin
-    timeout(t) {
+    Timeout.timeout(t) {
       p TCPSocket.gethostbyname("www.ruby-lang.org")
       # (A)
     }
@@ -187,7 +187,7 @@ timeout による割り込みは [[m:Kernel.#system]] によって呼び出さ�
   begin
     pid = nil
     com = nil
-    timeout(t) {
+    Timeout.timeout(t) {
       # system だととまらない
       # system("./loop.sh")
       com = IO.popen("./loop.sh")
@@ -233,7 +233,7 @@ timeout を捕捉しないようにライブラリ内で [[c:TimeoutError]] の�
         class Foo
           FooTimeoutError = Class.new(TimeoutError)
           def longlongtime_method
-            timeout(100, FooTimeoutError) {
+            Timeout.timeout(100, FooTimeoutError) {
                ...
             }
           end


### PR DESCRIPTION
古い記述になっていたのを修正。警告が表示されなくなる事を確認した。