### PR TITLE
Add sample code of Thread::Backtrace::Locations#base_label

### DIFF
--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -80,6 +80,24 @@ self が表すフレームの基本ラベルを返します。通常、
 [[m:Thread::Backtrace::Location#label]] から修飾を取り除いたもので構成
 されます。
 
+#@samplecode 例
+# foo.rb
+class Foo
+  attr_accessor :locations
+  def initialize(skip)
+    @locations = caller_locations(skip)
+  end
+end
+
+Foo.new(0..2).locations.map do |call|
+  puts call.base_label
+end
+
+# => initialize
+# new
+# <main>
+#@end
+
 @see [[m:Thread::Backtrace::Location#label]]
 
 --- path -> String


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread=3a=3aBacktrace=3a=3aLocation/i/base_label.html
* https://docs.ruby-lang.org/en/2.5.0/Thread/Backtrace/Location.html#method-i-base_label

要約の例2をベースにしました
