### PR TITLE
Add sample code of Thread::Backtrace::Locations#inspect

### DIFF
--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -108,3 +108,21 @@ self が表すフレームを [[m:Kernel.#caller]] と同じ表現にした文�
 
 [[m:Thread::Backtrace::Location#to_s]] の結果を人間が読みやすいような文
 字列に変換したオブジェクトを返します。
+
+#@samplecode 例
+# foo.rb
+class Foo
+  attr_accessor :locations
+  def initialize(skip)
+    @locations = caller_locations(skip)
+  end
+end
+
+Foo.new(0..2).locations.map do |call|
+  puts call.inspect
+end
+
+# => "path/to/foo.rb:5:in `initialize'"
+# "path/to/foo.rb:9:in `new'"
+# "path/to/foo.rb:9:in `<main>'"
+#@end


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread=3a=3aBacktrace=3a=3aLocation/i/inspect.html
* https://docs.ruby-lang.org/en/2.5.0/Thread/Backtrace/Location.html#method-i-inspect

要約の例2をベースにしました
