### PR TITLE
Add sample code of Thread::Backtrace::Locations#to_s

### DIFF
--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -104,6 +104,24 @@ self が表すフレームの絶対パスを返します。
 self が表すフレームを [[m:Kernel.#caller]] と同じ表現にした文字列を返し
 ます。
 
+#@samplecode 例
+# foo.rb
+class Foo
+  attr_accessor :locations
+  def initialize(skip)
+    @locations = caller_locations(skip)
+  end
+end
+
+Foo.new(0..2).locations.map do |call|
+  puts call.to_s
+end
+
+# => path/to/foo.rb:5:in `initialize'
+# path/to/foo.rb:9:in `new'
+# path/to/foo.rb:9:in `<main>'
+#@end
+
 --- inspect -> String
 
 [[m:Thread::Backtrace::Location#to_s]] の結果を人間が読みやすいような文


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Thread=3a=3aBacktrace=3a=3aLocation/i/to_s.html
* https://docs.ruby-lang.org/en/2.5.0/Thread/Backtrace/Location.html#method-i-to_s

要約の例2をベースにしました
