### PR TITLE
`Object#then` since 2.6.0

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -689,13 +689,23 @@ self を引数としてブロックを評価し、self を返します。
 #@since 2.5.0
 @see [[m:Object#yield_self]]
 
---- yield_self{|x| ... } -> object
+--- yield_self {|x| ... } -> object
+#@since 2.6.0
+--- then {|x| ... } -> object
+#@end
 
 self を引数としてブロックを評価し、ブロックの結果を返します。
 
+#@since 2.6.0
 #@samplecode 例
-  "my string".yield_self {|s| s.upcase }   # => "MY STRING"
-  3.next.yield_self {|x| x**x }.to_s       # => "256"
+3.next.then {|x| x**x }.to_s             # => "256"
+"my string".yield_self {|s| s.upcase }   # => "MY STRING"
+#@end
+#@else
+#@samplecode 例
+"my string".yield_self {|s| s.upcase }   # => "MY STRING"
+3.next.yield_self {|x| x**x }.to_s       # => "256"
+#@end
 #@end
 
 @see [[m:Object#tap]]


### PR DESCRIPTION
- see [r63525](https://github.com/ruby/ruby/commit/d53ee008911b5c3b22cff1566a9ef7e7d4cbe183)
- [Feature #14594] https://bugs.ruby-lang.org/issues/14594