### PR TITLE
Thread::Mutex.newの戻り値を2.3.0以降のものに修正

### DIFF
--- a/refm/api/src/thread/Mutex
+++ b/refm/api/src/thread/Mutex
@@ -23,7 +23,7 @@ Mutex(Mutal Exclusion = 相互排他ロック)は共有データを並行アク�
 
 == Class Methods
 
---- new -> Mutex
+--- new -> Thread::Mutex
 新しい mutex を生成して返します。
 
 #@#noexample :Mutex#unlock 等を参照


### PR DESCRIPTION
サンプルはともかくnewの戻り値は2.3.0以降のものがよさそうなので修正しました。