### PR TITLE
make WEBrick::HTTPAuth::BasicAuth sample to work

### DIFF
--- a/refm/api/src/webrick/httpauth/basicauth/HTTPAuth__BasicAuth
+++ b/refm/api/src/webrick/httpauth/basicauth/HTTPAuth__BasicAuth
@@ -17,7 +17,7 @@ HTTP の Basic 認証のためのクラスです。
       authenticator.authenticate(req, res)
       res.body = "hoge"
     }
-    srv.start # 127.0.0.1/basic_auth
+    srv.start # http://127.0.0.1:10080/basic_auth
 
 == Class Methods
 

--- a/refm/api/src/webrick/httpauth/basicauth/HTTPAuth__BasicAuth
+++ b/refm/api/src/webrick/httpauth/basicauth/HTTPAuth__BasicAuth
@@ -7,16 +7,17 @@ HTTP の Basic 認証のためのクラスです。
 
     require 'webrick'
     realm = "WEBrick's realm"
-    srv = HTTPServer.new({ :BindAddress => '127.0.0.1', :Port => 10080})
+    srv = WEBrick::HTTPServer.new({ :BindAddress => '127.0.0.1', :Port => 10080})
 
-    htpd = HTTPAuth::Htpasswd.new('dot.htpasswd')
+    htpd = WEBrick::HTTPAuth::Htpasswd.new('dot.htpasswd')
     htpd.set_passwd(nil, 'username', 'supersecretpass')
 
-    authenticator = HTTPAuth::BasicAuth.new(:UserDB => htpd, :Realm => realm)
+    authenticator = WEBrick::HTTPAuth::BasicAuth.new(:UserDB => htpd, :Realm => realm)
     srv.mount_proc('/basic_auth') {|req, res|
       authenticator.authenticate(req, res)
       res.body = "hoge"
     }
+    srv.start # 127.0.0.1/basic_auth
 
 == Class Methods
 


### PR DESCRIPTION
`HTTPXXX` should be `WEBrick::HTTPXXX`.