### PR TITLE
URI::{parse,join} raise URI::InvalidComponentError

### DIFF
--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -44,6 +44,8 @@ URI を要素に分割した文字列の配列を返します。
 
 @param uri_str パースしたい URI を文字列として与えます。
 
+@raise URI::InvalidComponentError 各要素が適合しない場合に発生します。
+
 @raise URI::InvalidURIError パースに失敗した場合に発生します。
 
 例:
@@ -69,7 +71,11 @@ URI オブジェクトを返します。
   URI.parse(uri_str) + path + ...
 
 @param uri_str URI 文字列
+
 @param path 後ろに連結する文字列
+
+@raise URI::InvalidComponentError 各要素が適合しない場合に発生します。
+
 @raise URI::InvalidURIError パースに失敗した場合に発生します。
 
 例:


### PR DESCRIPTION
```
irb(main):001:0> RUBY_VERSION
=> "2.5.1"
irb(main):002:0> require "uri"
=> true

irb(main):003:0> URI::parse("mailto:foo@")
Traceback (most recent call last):
        6: from /Users/uasi/.rbenv/versions/2.5.1/bin/irb:11:in `<main>'
        5: from (irb):3
        4: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/common.rb:237:in `parse'
        3: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:76:in `parse'
        2: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:76:in `new'
        1: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/mailto.rb:150:in `initialize'
URI::InvalidComponentError (unrecognised opaque part for mailtoURL: foo@)

irb(main):004:0> URI::join("mailto:foo@", "example.com")
Traceback (most recent call last):
        8: from /Users/uasi/.rbenv/versions/2.5.1/bin/irb:11:in `<main>'
        7: from (irb):5
        6: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/common.rb:275:in `join'
        5: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:88:in `join'
        4: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:117:in `convert_to_uri'
        3: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:76:in `parse'
        2: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/rfc3986_parser.rb:76:in `new'
        1: from /Users/uasi/.rbenv/versions/2.5.1/lib/ruby/2.5.0/uri/mailto.rb:150:in `initialize'
URI::InvalidComponentError (unrecognised opaque part for mailtoURL: foo@)
```