### PR TITLE
Fix sample format in csv temporary. (see gh-1366)

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -868,31 +868,31 @@ self の生成時に headers オプションに偽でない値が指定されて
 
 データソースは読み込み用にオープンされている必要があります。
 
-#@samplecode 例 headers: false
-require "csv"
+例 headers: false
 
-csv = CSV.new(DATA.read)
-csv.read
-# => [["header1", "header2"], ["row1_1", "row1_2"], ["row2_1", "row2_2"]]
+  require "csv"
 
-__END__
-header1,header2
-row1_1,row1_2
-row2_1,row2_2
-#@end
+  csv = CSV.new(DATA.read)
+  csv.read
+  # => [["header1", "header2"], ["row1_1", "row1_2"], ["row2_1", "row2_2"]]
 
-#@samplecode 例 headers: true
-require "csv"
+  __END__
+  header1,header2
+  row1_1,row1_2
+  row2_1,row2_2
 
-csv = CSV.new(DATA.read, headers: true)
-csv.read
-# => #<CSV::Table mode:col_or_row row_count:3>
+例 headers: true
 
-__END__
-header1,header2
-row1_1,row1_2
-row2_1,row2_2
-#@end
+  require "csv"
+
+  csv = CSV.new(DATA.read, headers: true)
+  csv.read
+  # => #<CSV::Table mode:col_or_row row_count:3>
+
+  __END__
+  header1,header2
+  row1_1,row1_2
+  row2_1,row2_2
 
 --- reopen(io) -> self
 
@@ -952,17 +952,17 @@ csv.read    # => [["header1", "header2"], ["row1_1", "row1_2"]]
 @return ヘッダを使用しない場合は配列を返します。
         ヘッダを使用する場合は [[c:CSV::Row]] を返します。
 
-#@samplecode 例
-require "csv"
+例
 
-csv = CSV.new(DATA.read)
-csv.readline # => ["header1", "header2"]
-csv.readline # => ["row1_1", "row1_2"]
+  require "csv"
 
-__END__
-header1,header2
-row1_1,row1_2
-#@end
+  csv = CSV.new(DATA.read)
+  csv.readline # => ["header1", "header2"]
+  csv.readline # => ["row1_1", "row1_2"]
+
+  __END__
+  header1,header2
+  row1_1,row1_2
 
 --- skip_blanks? -> bool
 


### PR DESCRIPTION
#1366 の修正までの間、旧式のフォーマットで表示する修正です。bitclustの修正後にrevertの予定です。