### PR TITLE
SignalException.newの引数を修正。 (fix gh-1227)

### DIFF
--- a/refm/api/src/_builtin/SignalException
+++ b/refm/api/src/_builtin/SignalException
@@ -22,6 +22,7 @@
 
 == Singleton Methods
 
+--- new(sig_number)           -> SignalException
 --- new(sig_name)             -> SignalException
 --- new(sig_number, sig_name) -> SignalException
 


### PR DESCRIPTION
#1227 に対応しました。