### PR TITLE
ripperのリンク先が404になっているため削除。

### DIFF
--- a/refm/api/src/ripper.rd
+++ b/refm/api/src/ripper.rd
@@ -10,11 +10,6 @@ Ruby プログラムを解析するためのライブラリです。
 
 Ruby プログラムのパーサです。
 
-以下を参照して下さい。
-
-  * [[url:http://i.loveruby.net/w/RipperTutorial.html]]
-  * [[url:http://i.loveruby.net/w/RipperTutorial.TokenStreamInterface.html]]
-
 Ruby プログラムをテキストとして扱いたい場合、
 例えばソース色付けを行いたい場合は、
 [[c:Ripper::Filter]] クラスを使うとよいでしょう。

--- a/refm/api/src/ripper/filter.rd
+++ b/refm/api/src/ripper/filter.rd
@@ -11,25 +11,25 @@
 
   require 'ripper'
   require 'cgi'
-  
+
   class Ruby2HTML < Ripper::Filter
     def on_default(event, tok, f)
       f << CGI.escapeHTML(tok)
     end
-  
+
     def on_comment(tok, f)
       f << %Q[<span class="comment">#{CGI.escapeHTML(tok)}</span>]
     end
-  
+
     def on_tstring_beg(tok, f)
       f << %Q[<span class="string">#{CGI.escapeHTML(tok)}]
     end
-  
+
     def on_tstring_end(tok, f)
       f << %Q[#{CGI.escapeHTML(tok)}</span>]
     end
   end
-  
+
   Ruby2HTML.new(ARGF).parse('')
 
 Ruby プログラムを解析して、[[m:Ripper::SCANNER_EVENTS]] にあるスキャナ

--- a/refm/api/src/ripper/sexp.rd
+++ b/refm/api/src/ripper/sexp.rd
@@ -18,7 +18,7 @@ Ruby プログラム str を解析して S 式のツリーにして返します�
 
   require 'ripper'
   require 'pp'
-  
+
   pp Ripper.sexp("def m(a) nil end")
     # => [:program,
           [[:def,
@@ -65,7 +65,7 @@ Ruby プログラム str を解析して S 式のツリーにして返します�
 
   require 'ripper'
   require 'pp'
-  
+
   pp Ripper.sexp_raw("def m(a) nil end")
     # => [:program,
           [:stmts_add,


### PR DESCRIPTION
http://i.loveruby.net/ 以下からripperの情報がなくなってるようなので削除しました。 `ripper site:http://i.loveruby.net/` で検索してもないようです。本体に取り込まれてしばらく経ってるからかもしれません。