### PR TITLE
reopen/redefinedされたclass/module/objectは内容のチェックをskipするように修正

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,8 @@ task :check_prev_commit_format do
         htmls = []
         htmls << `bundle exec bitclust htmlfile --ruby=#{v} #{path}`
         raise "Failed to bitclust htmlfile, ruby: #{v}, path: #{path}" unless $?.success?
-        File.read(path).scan(/^=[^=]\w+\s*(\S+)\s*(?:<\s*(\S+))?/).each do |k, pk|
+        File.read(path).scan(/^=([^=]\w+)\s*(\S+)\s*(?:<\s*(\S+))?/).each do |t, k, pk|
+          next if /\bre(open|define)\b/.match(t)
           html = `bundle exec bitclust htmlfile --ruby=#{v} --target=#{k} #{path}`
           raise "Failed to bitclust htmlfile, ruby: #{v}, target: #{k}, path: #{path}" unless $?.success?
           htmls << html


### PR DESCRIPTION
#1202 のマージでTravisからエラーが挙がったのを修正。bitclust htmlできないものをしようとしてたため。