### PR TITLE
Fix a typo about File#utime

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -525,7 +525,7 @@ umask を変更します。変更前の umask の値を返します。
 
 @param atime 最終アクセス時刻を [[c:Time]] か、起算時からの経過秒数を数値で指定します。
 
-@param utime 更新時刻を [[c:Time]] か、起算時からの経過秒数を数値で指定します。
+@param mtime 更新時刻を [[c:Time]] か、起算時からの経過秒数を数値で指定します。
 
 @raise Errno::EXXX 変更に失敗した場合に発生します。
 


### PR DESCRIPTION
https://github.com/rurema/doctree/blob/master/refm/api/src/_builtin/File#L651

でのmtimeに対応する

https://github.com/rurema/doctree/blob/master/refm/api/src/_builtin/File#L663

でのパラメータ名がutimeになっています。

当該のパラメータはmodification timeを表すはずですので、下がタイポではないかと思います。
以上の理由からutime→mtimeと修正しました。
(man (2) utime などとも一貫しています。)

いかがでしょうか。
