### PR TITLE
Add sample code of CSV::FieldInfo#index=

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -1152,6 +1152,8 @@ csv.read         # => [["header1", "header2"], ["row1_1", "row1_2"]]
 
 @param val インデックスの値を指定します。
 
+#@#noexample
+
 --- line -> Integer
 
 行番号を返します。


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/CSV=3a=3aFieldInfo/i/index=3d.html

サンプルを作ったものの、実際の用途はちょっと想像できませんでした。
構造体だから setter もついているだけで、実は使わない？

