### PR TITLE
CSV#force_quotes?の説明をCSV.newのforce_quotesオプションに合わせるように修正。

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -849,7 +849,7 @@ csv.encoding # => #<Encoding:UTF-8>
 
 --- force_quotes? -> bool
 
-出力されるフィールドがクオートされる場合は、真を返します。
+出力される全てのフィールドがクオートされる場合は、真を返します。
 
 #@samplecode 例
 require "csv"


### PR DESCRIPTION
#1330 で気付いた点に対応しました。CSV.newのオプションの方に表現を合わせました。