### PR TITLE
File#joinの説明を修正

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -393,11 +393,7 @@ path が pattern にマッチすれば真を返します。そうでない場合
 
 --- join(*item)    -> String
 
-File::SEPARATORを間に入れて文字列を連結します。
-
-  [item, item, ...].join(File::SEPARATOR)
-
-と同じです。[[d:platform/DOSISH-support]]で環境依存になる予定です。
+File::SEPARATORを間に入れて文字列を連結します。[[d:platform/DOSISH-support]]で環境依存になる予定です。
 
 @param item 連結したいディレクトリ名やファイル名を文字列で与えます。
 


### PR DESCRIPTION
以下の場合だと等価にならないので削除

```rb
require 'pathname'

p File.join(Pathname.new('/a'), '/b').to_s # => /a/b
p [Pathname.new('/a'), '/b'].join(File::SEPARATOR).to_s # => /a//b
```
