### PR TITLE
Add noexample comment of Net::HTTPResponse#header

### DIFF
--- a/refm/api/src/net/Net__HTTPResponse
+++ b/refm/api/src/net/Net__HTTPResponse
@@ -66,6 +66,8 @@ msg は obsolete です。使わないでください。
 
 自分自身を返します。
 
+#@#noexample
+
 --- body -> String | () | nil
 --- entity -> String | () | nil
 


### PR DESCRIPTION
#433

* https://docs.ruby-lang.org/ja/latest/method/Net=3a=3aHTTPResponse/i/header.html

>互換性を保つためだけに導入されたメソッドです。 使わないでください。

とのことなので、 noexample にしました

