### PR TITLE
Use https instead of http

### DIFF
--- a/refm/api/src/_builtin/RubyVM__InstructionSequence
+++ b/refm/api/src/_builtin/RubyVM__InstructionSequence
@@ -11,7 +11,7 @@ RubyVM::InstructionSequence オブジェクトを元に命令シーケンスを�
 VM の命令シーケンスの一覧はRuby のソースコード中の insns.def から参照で
 きます。
 
- * [[url:http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/insns.def?view=markup]]
+ * [[url:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/insns.def?view=markup]]
 
 #@# The instruction sequence results will almost certainly change as Ruby
 #@# changes, so example output in this documentation may be different from what

--- a/refm/api/src/bigdecimal/ludcmp.rd
+++ b/refm/api/src/bigdecimal/ludcmp.rd
@@ -8,7 +8,7 @@ LU 分解を用いて、連立1次方程式 Ax = b の解 x を求める機能�
 
 Ruby のソースコード中の以下のサンプルスクリプトも参考にしてください。
 
- * [[url:http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/ext/bigdecimal/sample/linear.rb?view=markup]]
+ * [[url:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/ext/bigdecimal/sample/linear.rb?view=markup]]
 
 = module LUSolve
 

--- a/refm/api/src/bigdecimal/newton.rd
+++ b/refm/api/src/bigdecimal/newton.rd
@@ -62,7 +62,7 @@ require bigdecimal/ludcmp
 
 Ruby のソースコード中の以下のサンプルスクリプトも参考にしてください。
 
- * [[url:http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/ext/bigdecimal/sample/nlsolve.rb?view=markup]]
+ * [[url:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/ext/bigdecimal/sample/nlsolve.rb?view=markup]]
 
 = module Newton
 

--- a/refm/api/src/find.rd
+++ b/refm/api/src/find.rd
@@ -16,7 +16,7 @@ category File
   find('/foo','/bar') {|f| ...}
 
 以下は、ruby のアーカイブに含まれるサンプルスクリプト
-([[url:http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/sample/trojan.rb?view=markup]]) をこのモジュールで書き換えたものです。
+([[url:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/sample/trojan.rb?view=markup]]) をこのモジュールで書き換えたものです。
 
   #! /usr/bin/env ruby
   require "find"

--- a/refm/capi/src/class.c.rd
+++ b/refm/capi/src/class.c.rd
@@ -255,7 +255,7 @@ fmt のフォーマットは以下の通りです。
 
       def some_method(a, *rest, &block)
 
-@see [[url:http://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/doc/extension.ja.rdoc?view=markup]]
+@see [[url:https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/trunk/doc/extension.ja.rdoc?view=markup]]
 
 --- VALUE rb_singleton_class(VALUE obj)
 


### PR DESCRIPTION
svn.ruby-lang.org のリンクを https へ変更します。

今後のことを考えると github.com/ruby/ruby か git.ruby-lang.org のリンクへの書き換えも考えた方が良いかもしれません。