### PR TITLE
Introduce misspell in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,8 @@ notifications:
     on_failure: always # [always|never|change] # default: always
     template:
       - "%{message} by @%{author}: See %{build_url}"
+before_install:
+  - 'go get github.com/client9/misspell/...'
+script:
+  - 'bundle exec rake'
+  - '$GOPATH/bin/misspell -error -i addopt $(git ls-files | grep -vF "refm/doc/news/1.8.4.rd")'


### PR DESCRIPTION
Close #1376

CIでmisspellを実行します。作業が遅くなってしまってすみませんでした。。

やっていることは以下のような感じです

* `go get` でmisspellをインストール
* `-error`オプションをつけて、たいぽを発見した際にexit statusが非0で終了するように
* `-i addopt`でたいぽではないものを無視(#1376 を参照)
* `refm/doc/news/1.8.4.rd`内でたいぽが2件でましたが、直すようなものではなさそう(コミットメッセージが引っかかっていた)なので、ファイルごと無視する様にしました。


なお、オプションなしでmisspellを実行すると以下の様になります

```
$ misspell .
.travis.yml:23:24: "addopt" is a misspelling of "adopt"
refm/capi/src/process.c.rd:6:20: "addopt" is a misspelling of "adopt"
refm/doc/news/2_2_0.rd:248:18: "addopt" is a misspelling of "adopt"
refm/doc/news/1.8.4.rd:569:54: "modifires" is a misspelling of "modifiers"
refm/doc/news/1.8.4.rd:988:11: "extention" is a misspelling of "extension"
```


#1376 の方で

> 現状それっぽいものといえば、`@param` などをtypoすると以下に引っかかって怒られるくらいなのでそれが集約できると嬉しいくらいでした。(Rakefileの方から該当の行を削除して、辞書に追加できるとうれしい)
>
> https://github.com/rurema/doctree/blob/master/Rakefile#L101-L108
> ただ、集約については辞書の追加方法を教えていただければmisspellの導入後に僕の方で対応ということでも問題ないかと思います。


という話がありましたが、見た感じmisspellには外から辞書を入れる方法が用意されていなさそうでした。
なので集約については考えず、misspellは単に「よくあるタイポを検出するだけのもの」と割り切ってしまうのが良いかなと思ったのですがいかがでしょうか？