### PR TITLE
CSV::FieldInfo#header、#header=の間違いを修正。 (see gh-1426)

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -1191,16 +1191,16 @@ csv.read         # => [["header1", "header2"], ["row1_1", "row1_2"]]
 
 @param val 行番号を指定します。
 
---- header -> Array
+--- header -> String | nil
 
-利用可能な場合はヘッダを表す配列を返します。
+利用可能な場合はヘッダを表す文字列を返します。
 
 
 --- header=(val)
 
-ヘッダを表す配列をセットします。
+ヘッダを表す文字列をセットします。
 
-@param val ヘッダを表す配列を指定します。
+@param val ヘッダを表す文字列を指定します。
 
 = class CSV::MalformedCSVError < RuntimeError
 


### PR DESCRIPTION
CSV::FieldInfo#header、#header=は1つのフィールドを表し、該当のフィールドのヘッダのみが#headerで取れると思うため修正しました。rbenv eachする分には全て配列ではなく文字列になっていたのと、以下では既に配列は入ってないように見えたというところです。より前に戻ればあったりするのかもしれませんが、現状は不要かと思いますので分岐は入れませんでした。

* https://github.com/ruby/ruby/blob/v1_9_1_431/lib/csv.rb#L2172-L2173