### PR TITLE
「コマンド」を改善

### DIFF
--- a/refm/doc/spec/commands.rd
+++ b/refm/doc/spec/commands.rd
@@ -2,15 +2,24 @@
 
 Ruby では以下のコマンドが提供されます。
 
- * erb: 埋め込みRuby処理ツール
- * [[lib:irb]]: Ruby の対話インタフェース
- * [[lib:rdoc]]: RDoc
- * ri: RDoc で書かれた Ruby のドキュメントをコマンドラインから参照
- * ruby: Ruby 本体。[[ref:d:spec/rubycmd#ruby]] を参照。
+: erb
+  埋め込みRuby処理ツール。[[lib:erb]] を参照。
+: gem
+  Rubyのパッケージ管理ツール。[[ref:lib:rubygems#gem_command]] を参照。
+: irb
+  Ruby の対話インタフェース。[[lib:irb]] を参照。
+: rake
+  Ruby の内部 DSL で記述するビルドツール。[[lib:rake]] を参照。
+: rdoc
+  Ruby のソースファイルからドキュメントを生成するツール。[[lib:rdoc]] を参照。
+: ri
+  RDoc で書かれた Ruby のドキュメントをコマンドラインから閲覧するツール。
+: ruby
+  Ruby 本体。[[ref:d:spec/rubycmd#ruby]] を参照。
 #@until 2.2.0
- * testrb: ユニットテスト実行ツール
+: testrb
+  ユニットテスト実行ツール
 #@end
- * gem: Rubyのパッケージ管理ツール。[[ref:lib:rubygems#gem_command]] を参照。
 
 これらのコマンドは以下で説明される環境変数を参照します。
 


### PR DESCRIPTION
rake が抜けていたので追加
表記を ul から dl へ
コマンド名はリンクとせず、ライブラリーなどにリンク
「gem」だけが ABC 順を外していたので ABC 順に並べ替え
説明を若干修正