### PR TITLE
File.{setuid?,setgid?,sticky?} support for IO objects since 1.9.0

### DIFF
--- a/refm/api/src/_builtin/FileTest
+++ b/refm/api/src/_builtin/FileTest
@@ -241,7 +241,7 @@ FileTest.readable?("testfile")      # => false
 ファイルが [[man:setuid(2)]] されている時に真を返
 します。そうでない場合、ファイルが存在しない場合、あるいはシステムコールに失敗した場合などには false を返します。
 
-@param file ファイル名を表す文字列を指定します。
+@param file ファイル名を表す文字列か IO オブジェクトを指定します。
 
 @raise IOError 指定された IO オブジェクト file が既に close されていた場合に発生します。
 
@@ -259,7 +259,7 @@ FileTest.setuid?("testfile")      # => false
 ファイルが [[man:setgid(2)]] されている時に真を返
 します。そうでない場合、ファイルが存在しない場合、あるいはシステムコールに失敗した場合などには false を返します。
 
-@param file ファイル名を表す文字列を指定します。
+@param file ファイル名を表す文字列か IO オブジェクトを指定します。
 
 #@samplecode 例
 require 'fileutils'
@@ -308,7 +308,7 @@ FileTest.size?("testfile")      # => nil
 ファイルの sticky ビット([[man:chmod(2)]] 参照)が
 立っている時に真を返します。そうでない場合、ファイルが存在しない場合、あるいはシステムコールに失敗した場合などには false を返します。
 
-@param file ファイル名を表す文字列を指定します。
+@param file ファイル名を表す文字列か IO オブジェクトを指定します。
 
 #@samplecode 例
 require 'fileutils'


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/39a840d084d2f24d44deb7b506ca15924fa48589 で rdoc に `File.{setuid?,setgid?,sticky?}` が IO もサポートしていると追加しているのを反映します。(こちらでは FileTest に書いてあります。)