### PR TITLE
add sample code of Encoding::Converter#last_error

### DIFF
--- a/refm/api/src/_builtin/Encoding__Converter
+++ b/refm/api/src/_builtin/Encoding__Converter
@@ -161,7 +161,7 @@ Encoding::Converter オブジェクトの情報を簡単に表示します。
 
 --- last_error -> Exception | nil
 直前に変換器で発生した例外に相当する例外オブジェクトを返します
-直線の変換で例外が発生していない場合は nil を返します。
+直前の変換で例外が発生していない場合は nil を返します。
 
 #@samplecode
 ec = Encoding::Converter.new("utf-8", "iso-8859-1")

--- a/refm/api/src/_builtin/Encoding__Converter
+++ b/refm/api/src/_builtin/Encoding__Converter
@@ -164,13 +164,11 @@ Encoding::Converter オブジェクトの情報を簡単に表示します。
 直線の変換で例外が発生していない場合は nil を返します。
 
 #@samplecode
-ec = Encoding::Converter.new("UTF-16LE", "UTF-8")
-begin
-  ec.convert("\x00\xd8@\x00")
-rescue => e
-  p e #=> #<Encoding::InvalidByteSequenceError: "\x00\xD8" followed by "@\x00" on UTF-16LE>
-end
-ec.last_error #=> #<Encoding::InvalidByteSequenceError: "\x00\xD8" followed by "@\x00" on UTF-16LE>
+ec = Encoding::Converter.new("utf-8", "iso-8859-1")
+p ec.primitive_convert(src="\xf1abcd", dst="")       #=> :invalid_byte_sequence
+p ec.last_error      #=> #<Encoding::InvalidByteSequenceError: "\xF1" followed by "a" on UTF-8>
+p ec.primitive_convert(src, dst, nil, 1)             #=> :destination_buffer_full
+p ec.last_error      #=> nil
 #@end
 
 --- finish -> String

--- a/refm/api/src/_builtin/Encoding__Converter
+++ b/refm/api/src/_builtin/Encoding__Converter
@@ -163,6 +163,16 @@ Encoding::Converter オブジェクトの情報を簡単に表示します。
 直前に変換器で発生した例外に相当する例外オブジェクトを返します
 直線の変換で例外が発生していない場合は nil を返します。
 
+#@samplecode
+ec = Encoding::Converter.new("UTF-16LE", "UTF-8")
+begin
+  ec.convert("\x00\xd8@\x00")
+rescue => e
+  p e #=> #<Encoding::InvalidByteSequenceError: "\x00\xD8" followed by "@\x00" on UTF-16LE>
+end
+ec.last_error #=> #<Encoding::InvalidByteSequenceError: "\x00\xD8" followed by "@\x00" on UTF-16LE>
+#@end
+
 --- finish -> String
 変換処理を終了し、結果文字列の末尾を返します。
 変換元の文字列の末尾がバイト列の途中で終わっていた場合、保持しているバイト列全てを返します。


### PR DESCRIPTION
#433 

Encoding::Converter#last_error のサンプルコードを追加しています。primitive_convert でもよかったのですが、convert で例外が発生するケースが他のサンプルに見当たらず、あっても良いかと思い convert にしてあります。

https://docs.ruby-lang.org/ja/latest/class/Encoding=3a=3aConverter.html#I_LAST_ERROR