### PR TITLE
Add sample code of Encoding::Converter's source_encoding and destination_encoding

### DIFF
--- a/refm/api/src/_builtin/Encoding__Converter
+++ b/refm/api/src/_builtin/Encoding__Converter
@@ -92,10 +92,20 @@ Encoding::Converter オブジェクトの情報を簡単に表示します。
 
 @return 変換元のエンコーディング
 
+#@samplecode
+ec = Encoding::Converter.new("utf-8", "euc-jp")
+ec.source_encoding #=> #<Encoding:UTF-8>
+#@end
+
 --- destination_encoding -> Encoding
 変換先のエンコーディングを返します。
 
 @return 変換先のエンコーディング
+
+#@samplecode
+ec = Encoding::Converter.new("utf-8", "euc-jp")
+ec.destination_encoding #=> #<Encoding:EUC-JP>
+#@end
 
 --- convpath -> Array
 変換器が行う変換の経路を配列にして返します。


### PR DESCRIPTION
#433 

ちょっと必要かどうか悩んだのですが、念のためサンプル追加しました。

https://docs.ruby-lang.org/ja/latest/method/Encoding=3a=3aConverter/i/source_encoding.html
https://docs.ruby-lang.org/ja/latest/method/Encoding=3a=3aConverter/i/destination_encoding.html