### PR TITLE
Enumerable#chunk のサンプル（英単語頭文字）を改善

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1280,13 +1280,17 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 各チャンクの要素を持つ配列のペアを各要素とします。
 そのため、eachだと以下のようになります。
 
-  enum.chunk {|elt| key }.each {|key, ary| ... }
 #@until 2.3.0
+  enum.chunk {|elt| key }.each {|key, ary| ... }
   enum.chunk(initial_state) {|elt, state| key }.each {|key, ary| ... }
+#@else
+  enum.chunk {|elt| key }.each {|key, ary| ... }
 #@end
 
 例として、整数列を連続する奇数/偶数に分ける例を見てみます。
 「n.even?」の値が切り替わるところで区切られているのがわかるでしょう。
+
+#@samplecode 例
   [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5].chunk {|n|
     n.even?
   }.each {|even, ary|
@@ -1297,20 +1301,23 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
   #   [false, [1, 5, 9]]
   #   [true, [2, 6]]
   #   [false, [5, 3, 5]]
+#@end
 
 このメソッドは各要素が既にソートされている場合に便利です。
 以下の例では、テキスト辞書ファイル(中身がソートされている)
 に含まれる単語を先頭の文字ごとに数えています。
-  # line.ord は先頭の文字のコードポイントを返す
+大文字／小文字の違いを無視するため upcase しています。
+
+#@samplecode 例
   open("/usr/share/dict/words", "r:iso-8859-1") {|f|
-    f.chunk {|line| line.ord }.each {|ch, lines| p [ch.chr, lines.length] }
+    f.chunk {|line| line[0].upcase }.each {|ch, lines| p [ch, lines.length] }
   }
-  #=> ["\n", 1]
-  #   ["A", 1327]
-  #   ["B", 1372]
-  #   ["C", 1507]
-  #   ["D", 791]
+  #=> ["A", 17096]
+  #   ["B", 11070]
+  #   ["C", 19901]
+  #   ["D", 10896]
   #   ...
+#@end
 
 さらにこのメソッドは以下の値を特別扱いします。
 
@@ -1321,11 +1328,15 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 
 それ以外のアンダースコアで始まるシンボルを指定した場合は例外が発生します。
 
+#@samplecode 例
   items.chunk { |item| :_underscore }
   # => RuntimeError: symbols beginning with an underscore are reserved
+#@end
 
 nil、 :_separator はある要素を無視したい場合に用います。
 例として svn log の出力のハイフンの所で区切りたい場合を考えます。
+
+#@samplecode 例
   sep = "-"*72 + "\n" # ハイフンが72個の行
   IO.popen("svn log README") {|f|
     f.chunk {|line|
@@ -1343,18 +1354,23 @@ nil、 :_separator はある要素を無視したい場合に用います。
   #    "* README, README.ja: Add a note about default C flags.\n",
   #    "\n"]
   #   ...
+#@end
 
 テキストを空行で区切られた段落に分けたい場合にも nil が使えます。
+
+#@samplecode 例
   File.foreach("README").chunk {|line|
     /\A\s*\z/ !~ line || nil
   }.each {|_, lines|
     pp lines
   }
+#@end
 
 「:_alone」は要素を素通ししたい場合に用います。
 以下の例では「Foo#bar」という形式の行が連続している場合のみ
 チャンク化し、それ以外は素通しします。
 
+#@samplecode 例
   pat = /\A[A-Z][A-Za-z0-9_]+\#/
   open(filename) {|f|
     f.chunk {|line| pat =~ line ? $& : :_alone }.each {|key, lines|
@@ -1365,6 +1381,7 @@ nil、 :_separator はある要素を無視したい場合に用います。
       end
     }
   }
+#@end
 
 #@until 2.3.0
 チャンク化に状態遷移が必要な場合は、

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1291,16 +1291,16 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 「n.even?」の値が切り替わるところで区切られているのがわかるでしょう。
 
 #@samplecode 例
-  [3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5].chunk {|n|
-    n.even?
-  }.each {|even, ary|
-    p [even, ary]
-  }
-  #=> [false, [3, 1]]
-  #   [true, [4]]
-  #   [false, [1, 5, 9]]
-  #   [true, [2, 6]]
-  #   [false, [5, 3, 5]]
+[3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5].chunk {|n|
+  n.even?
+}.each {|even, ary|
+  p [even, ary]
+}
+# => [false, [3, 1]]
+#    [true, [4]]
+#    [false, [1, 5, 9]]
+#    [true, [2, 6]]
+#    [false, [5, 3, 5]]
 #@end
 
 このメソッドは各要素が既にソートされている場合に便利です。
@@ -1309,14 +1309,14 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 大文字／小文字の違いを無視するため upcase しています。
 
 #@samplecode 例
-  open("/usr/share/dict/words", "r:iso-8859-1") {|f|
-    f.chunk {|line| line[0].upcase }.each {|ch, lines| p [ch, lines.length] }
-  }
-  #=> ["A", 17096]
-  #   ["B", 11070]
-  #   ["C", 19901]
-  #   ["D", 10896]
-  #   ...
+open("/usr/share/dict/words", "r:iso-8859-1") {|f|
+  f.chunk {|line| line[0].upcase }.each {|ch, lines| p [ch, lines.length] }
+}
+# => ["A", 17096]
+#    ["B", 11070]
+#    ["C", 19901]
+#    ["D", 10896]
+#    ...
 #@end
 
 さらにこのメソッドは以下の値を特別扱いします。
@@ -1329,41 +1329,41 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 それ以外のアンダースコアで始まるシンボルを指定した場合は例外が発生します。
 
 #@samplecode 例
-  items.chunk { |item| :_underscore }
-  # => RuntimeError: symbols beginning with an underscore are reserved
+items.chunk { |item| :_underscore }
+# => RuntimeError: symbols beginning with an underscore are reserved
 #@end
 
 nil、 :_separator はある要素を無視したい場合に用います。
 例として svn log の出力のハイフンの所で区切りたい場合を考えます。
 
 #@samplecode 例
-  sep = "-"*72 + "\n" # ハイフンが72個の行
-  IO.popen("svn log README") {|f|
-    f.chunk {|line|
-      line != sep || nil
-    }.each {|_, lines|
-      pp lines
-    }
+sep = "-"*72 + "\n" # ハイフンが72個の行
+IO.popen("svn log README") {|f|
+  f.chunk {|line|
+    line != sep || nil
+  }.each {|_, lines|
+    pp lines
   }
-  #=> ["r20018 | knu | 2008-10-29 13:20:42 +0900 (Wed, 29 Oct 2008) | 2 lines\n",
-  #    "\n",
-  #    "* README, README.ja: Update the portability section.\n",
-  #    "\n"]
-  #   ["r16725 | knu | 2008-05-31 23:34:23 +0900 (Sat, 31 May 2008) | 2 lines\n",
-  #    "\n",
-  #    "* README, README.ja: Add a note about default C flags.\n",
-  #    "\n"]
-  #   ...
+}
+#=> ["r20018 | knu | 2008-10-29 13:20:42 +0900 (Wed, 29 Oct 2008) | 2 lines\n",
+#    "\n",
+#    "* README, README.ja: Update the portability section.\n",
+#    "\n"]
+#   ["r16725 | knu | 2008-05-31 23:34:23 +0900 (Sat, 31 May 2008) | 2 lines\n",
+#    "\n",
+#    "* README, README.ja: Add a note about default C flags.\n",
+#    "\n"]
+#   ...
 #@end
 
 テキストを空行で区切られた段落に分けたい場合にも nil が使えます。
 
 #@samplecode 例
-  File.foreach("README").chunk {|line|
-    /\A\s*\z/ !~ line || nil
-  }.each {|_, lines|
-    pp lines
-  }
+File.foreach("README").chunk {|line|
+  /\A\s*\z/ !~ line || nil
+}.each {|_, lines|
+  pp lines
+}
 #@end
 
 「:_alone」は要素を素通ししたい場合に用います。
@@ -1371,16 +1371,16 @@ nil、 :_separator はある要素を無視したい場合に用います。
 チャンク化し、それ以外は素通しします。
 
 #@samplecode 例
-  pat = /\A[A-Z][A-Za-z0-9_]+\#/
-  open(filename) {|f|
-    f.chunk {|line| pat =~ line ? $& : :_alone }.each {|key, lines|
-      if key != :_alone
-        print lines.sort.join('')
-      else
-        print lines.join('')
-      end
-    }
+pat = /\A[A-Z][A-Za-z0-9_]+\#/
+open(filename) {|f|
+  f.chunk {|line| pat =~ line ? $& : :_alone }.each {|key, lines|
+    if key != :_alone
+      print lines.sort.join('')
+    else
+      print lines.join('')
+    end
   }
+}
 #@end
 
 #@until 2.3.0

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1280,11 +1280,13 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 各チャンクの要素を持つ配列のペアを各要素とします。
 そのため、eachだと以下のようになります。
 
+#@samplecode
 #@until 2.3.0
-  enum.chunk {|elt| key }.each {|key, ary| ... }
-  enum.chunk(initial_state) {|elt, state| key }.each {|key, ary| ... }
+enum.chunk {|elt| key }.each {|key, ary| do_something }
+enum.chunk(initial_state) {|elt, state| key }.each {|key, ary| do_something }
 #@else
-  enum.chunk {|elt| key }.each {|key, ary| ... }
+enum.chunk {|elt| key }.each {|key, ary| do_something }
+#@end
 #@end
 
 例として、整数列を連続する奇数/偶数に分ける例を見てみます。

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1306,11 +1306,14 @@ enum.chunk {|elt| key }.each {|key, ary| do_something }
 #@end
 
 このメソッドは各要素が既にソートされている場合に便利です。
-以下の例では、テキスト辞書ファイル(中身がソートされている)
-に含まれる単語を先頭の文字ごとに数えています。
+
+以下の例では、テキスト辞書ファイルに含まれる単語の頭文字の頻度を調べています。
+このファイルは、Linux や macOS などで、ソートされた英語（など）の単語の
+リストを改行で区切って収めたものです。
 大文字／小文字の違いを無視するため upcase しています。
 
 #@samplecode 例
+# ファイルのエンコーディングは実際のファイルに合わせてください。
 open("/usr/share/dict/words", "r:iso-8859-1") {|f|
   f.chunk {|line| line[0].upcase }.each {|ch, lines| p [ch, lines.length] }
 }


### PR DESCRIPTION
/usr/share/dict/words にある英単語リスト（ABC 順にソートされている）から頭文字の出現頻度を表示するサンプルですが，大文字／小文字を無視してソートされているリストから，大文字／小文字を無視せずチャンク化しているので，期待通りの結果になりません。
（ファイルのソート順については環境によるかも？）

そこで，頭文字を upcase するよう改変しました。

また，頭文字の ord を取って，あとで chr しているのは必要ないので省きました。

ついでにこのメソッドのサンプルコードをすべて `#@samplecode` 形式に直しました。