### PR TITLE
Vector#cross の例外の書式誤り

### DIFF
--- a/refm/api/src/matrix/Vector
+++ b/refm/api/src/matrix/Vector
@@ -380,8 +380,8 @@ self の次元が n であるとき、 vs は n-2 個の
 n次元ベクトルでなければなりません。
 
 @param vs クロス積を取るベクトルの集合
-@raise ExceptionForMatrix::ErrOperationNotDefined
-       self の次元が1以下であるときに発生します。
+@raise ExceptionForMatrix::ErrOperationNotDefined self の
+        次元が1以下であるときに発生します。
 @raise ArgumentError vs のベクトルの個数が n-2 以外である場合に発生します。
 
 #@end


### PR DESCRIPTION
例外の説明部分がコードサンプルとして解釈・表示されていた。
改行の入れ方を変えたら直った。

なぜこうなるのかはよく分からない。