### PR TITLE
Move matrix error classes. (closes gh-1561)

### DIFF
--- a/refm/api/src/matrix.rd
+++ b/refm/api/src/matrix.rd
@@ -13,5 +13,14 @@ category Math
 
 #@# [2002-04-02]  by [[unknown:すす|URL:mailto:sugawah@attglobal.net]]
 
+= class ExceptionForMatrix::ErrDimensionMismatch < StandardError
+行列/ベクトル計算時に次元が合わない場合に発生する例外です。
+
+= class ExceptionForMatrix::ErrNotRegular < StandardError
+逆行列計算時に行列が正則でない場合に発生する例外です。
+
+= class ExceptionForMatrix::ErrOperationNotDefined < StandardError
+演算時にクラスが適切でない場合に発生する例外です。
+
 #@include(matrix/Vector)
 #@include(matrix/Matrix)

--- a/refm/api/src/matrix/Matrix
+++ b/refm/api/src/matrix/Matrix
@@ -1346,15 +1346,6 @@ lup.solve(Matrix[[1, 3], [-1, 0]])  #=> Matrix[[(1/1), (2/1)], [(-1/1), (-1/1)]]
 #@end
 #@end
 
-= class ExceptionForMatrix::ErrDimensionMismatch < StandardError
-行列/ベクトル計算時に次元が合わない場合に発生する例外です。
-
-= class ExceptionForMatrix::ErrNotRegular < StandardError
-逆行列計算時に行列が正則でない場合に発生する例外です。
-
-= class ExceptionForMatrix::ErrOperationNotDefined < StandardError
-演算時にクラスが適切でない場合に発生する例外です。
-
 #@#== ChangeLog
 #@#
 #@#*[2004-04-23] by [[unknown:坂野|URL:mailto:mas@star.le.ac.uk]]

--- a/refm/api/src/matrix/Vector
+++ b/refm/api/src/matrix/Vector
@@ -613,10 +613,6 @@ v は配列互換(size メソッドと [] メソッドを持つ)オブジェク�
 すべての要素がゼロであれば true を返します。
 #@end
 
-= class ExceptionForMatrix::ErrDimensionMismatch < StandardError
-= class ExceptionForMatrix::ErrNotRegular < StandardError
-= class ExceptionForMatrix::ErrOperationNotDefined < StandardError
-
 #@since 1.9.3
 = class Vector::ZeroVectorError < StandardError
 ベクトルが 0 でエラーとなる([[m:Vector#normalize]] など)場合に


### PR DESCRIPTION
以前は Matrix::ErrDimensionMismatch のように別々の例外だったようですが、少なくとも 1.8.7 からは共通の例外クラスになっているようなので移動しました。