### PR TITLE
CMath の冒頭のサンプルコードを改良する

### DIFF
--- a/refm/api/src/cmath.rd
+++ b/refm/api/src/cmath.rd
@@ -15,8 +15,20 @@ include Math
 
 #@samplecode 例
 require "cmath"
-CMath.sqrt(-9)# => (0+3.0i)
-CMath.sqrt!(4)# => 2.0
+
+# 複素数の範囲の立方根（の主値）= exp(1/3 πi)
+CMath.cbrt(-1) # => (0.5000000000000001+0.8660254037844386i)
+
+# 実数の範囲の立方根
+Math.cbrt(-1) # => -1.0
+
+include CMath
+
+# レシーバー無しで使える
+cbrt(-1) # => (0.5000000000000001+0.8660254037844386i)
+
+# cbrt! は Math.cbrt のエイリアス
+cbrt!(-1) # => -1.0
 #@end
 
 == Module Functions


### PR DESCRIPTION
CMath の冒頭のサンプルコードを以下の観点で書き直してみました。

* include CMath の働きが分かりやすいように
* `!` 付きメソッドの存在理由が分かりやすいように

後者に関して，同名メソッドの Math 版と CMath 版とで返り値が違うものがよいと考え，`cbrt` を選びました。
Math 版がエラーになるメソッドはいくつもあるのですが，どちらの版でも値が返るが別の値であるというメソッドはあまりないように思います。

このプルリクエストは  #1570 で挙げた課題の [4] に対応します。