### PR TITLE
Vector#/ は行列でなくベクトルを返す

### DIFF
--- a/refm/api/src/matrix/Vector
+++ b/refm/api/src/matrix/Vector
@@ -240,7 +240,7 @@ v には column_size が 1 の [[c:Matrix]] オブジェクトも指定できま
 #@since 1.9.2
 --- /(other) -> Vector
 
-self の各要素を数 other で割った行列を返します。
+self の各要素を数 other で割ったベクトルを返します。
 
 @param other self の各要素を割る [[c:Numeric]] オブジェクトを指定します。
 @raise ExceptionForMatrix::ErrOperationNotDefined other が Vector や Matrix 

--- a/refm/api/src/matrix/Vector
+++ b/refm/api/src/matrix/Vector
@@ -237,7 +237,6 @@ v には column_size が 1 の [[c:Matrix]] オブジェクトも指定できま
 @raise ExceptionForMatrix::ErrDimensionMismatch 自分自身と引数のベクト
        ルの要素の数(次元)が異なっていたときに発生します。
 
-#@since 1.9.2
 --- /(other) -> Vector
 
 self の各要素を数 other で割ったベクトルを返します。
@@ -245,7 +244,6 @@ self の各要素を数 other で割ったベクトルを返します。
 @param other self の各要素を割る [[c:Numeric]] オブジェクトを指定します。
 @raise ExceptionForMatrix::ErrOperationNotDefined other が Vector や Matrix 
        の場合に発生します
-#@end
 
 --- r -> Float
 --- magnitude -> Float


### PR DESCRIPTION
Vector#/ が行列を返すことになっていたので修正。

ついでにこのメソッドの箇所の不要な分岐を別コミットで削除。