### PR TITLE
drb のタイポ修正：マーシャンリング→マーシャリング

### DIFF
--- a/refm/api/src/drb.rd
+++ b/refm/api/src/drb.rd
@@ -18,7 +18,7 @@ dRuby は
   * そこからのメソッド呼び出し
   * メソッド呼出の引数/返り値を [[c:Marshal]] でバイト列に変換(マーシャリング)
     して通信先のプロセスと受け渡しすること
-    
+
 ができます。これらはすべて透過的に行われます。
 
 リモートプロセスにあるオブジェクトはローカルには [[c:DRb::DRbObject]] の
@@ -69,7 +69,7 @@ CORBA の IDL のようなリモートオブジェクトのインターフェー
 proxy として動作し、proxy のメソッドを呼び出すと上に説明した通りの
 方法でリモートオブジェクトのメソッドを呼び出します。
 
-マーシャンリング可能なオブジェクトを DRbObject でリファレンスとして
+マーシャリング可能なオブジェクトを DRbObject でリファレンスとして
 渡したい、つまりコピーでなくリファレンスで渡したい場合は
 そのオブジェクトに
 [[c:DRb::DRbUndumped]] を [[m:Module#include]] します。
@@ -97,7 +97,7 @@ dRuby でインターネット上に公開するサービスを作るべきで�
   class << ro
     # リモートオブジェクトの instance_eval を呼ぶため
     # ローカルオブジェクトの instance_eval を取り除く
-    undef :instance_eval  
+    undef :instance_eval
   end
   ro.instance_eval("DANGEROUS RUBY CODE!")
 
@@ -263,17 +263,17 @@ dRuby のサービス(サーバ)を起動します。
 
 #@# --- to_id(obj)
 #@# #@todo
-#@# 
+#@#
 #@# Get a reference id for an object using the current server.
-#@# 
+#@#
 #@# This raises a DRbServerNotFound error if there is no current
 #@# server. See #current_server.
-#@# 
+#@#
 #@# --- to_obj(ref)
 #@# #@todo
-#@# 
+#@#
 #@# Convert a reference into an object using the current server.
-#@# 
+#@#
 #@# This raises a DRbServerNotFound error if there is no current
 #@# server. See #current_server.
 


### PR DESCRIPTION
ついでに行末スペース削除