### PR TITLE
Rational#to_i のサンプルを改良

### DIFF
--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -420,7 +420,7 @@ Rational(2, 3).to_i   # => 0
 Rational(3).to_i      # => 3
 Rational(300.6).to_i  # => 300
 Rational(98, 71).to_i # => 1
-Rational(-31, 2).to_i  # => -15
+Rational(-31, 2).to_i # => -15
 #@end
 
 precision を指定した場合は指定した桁数で切り捨てた整数か

--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -420,7 +420,7 @@ Rational(2, 3).to_i   # => 0
 Rational(3).to_i      # => 3
 Rational(300.6).to_i  # => 300
 Rational(98, 71).to_i # => 1
-Rational(-3, 2).to_i  # => -1
+Rational(-31, 2).to_i  # => -15
 #@end
 
 precision を指定した場合は指定した桁数で切り捨てた整数か

--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -420,7 +420,7 @@ Rational(2, 3).to_i   # => 0
 Rational(3).to_i      # => 3
 Rational(300.6).to_i  # => 300
 Rational(98, 71).to_i # => 1
-Rational(-30, 2).to_i # => -15
+Rational(-3, 2).to_i  # => -1
 #@end
 
 precision を指定した場合は指定した桁数で切り捨てた整数か


### PR DESCRIPTION
元の Rational(-30, 2) だと，そもそも整数なので切り捨て効果が分かりにくく，また負数の場合にどちらに丸められるのかが例からは分かりません。

そこで，floor, ceil, round でも採用されている Rational(-3, 2) に取り換えました。