### PR TITLE
Add noexample comment of Pathname#binread

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -383,6 +383,15 @@ IO.read(self.to_s, *args)と同じです。
 --- binread(*args) -> String | nil
 IO.binread(self.to_s, *args)と同じです。
 
+#@samplecode 例
+require "pathname"
+
+pathname = Pathname("testfile")
+pathname.binread           # => "This is line one\nThis is line two\nThis is line three\nAnd so on...\n"
+pathname.binread(20)       # => "This is line one\nThi"
+pathname.binread(20, 10)   # => "ne one\nThis is line "
+#@end
+
 @see [[m:IO.binread]]
 
 #@end


### PR DESCRIPTION
#433 

* https://docs.ruby-lang.org/ja/latest/method/Pathname/i/binread.html
* https://docs.ruby-lang.org/en/2.5.0/Pathname.html#method-i-binread

Pathname#atime, Pathname#basename は事前に example を追加しましたが、 `IO.binread` と同じ という風になっているメソッドに関しては、一律 noexample のほうがいいでしょうか？

## 関連
* https://github.com/rurema/doctree/pull/1673
* https://github.com/rurema/doctree/pull/1675
