### PR TITLE
`cause:` keyword argument of `raise`

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -2167,10 +2167,10 @@ varname のフックを全て解除します。
 
 --- raise -> ()
 --- fail  -> ()
---- raise(message) -> ()
---- fail(message)  -> ()
---- raise(error_type, message = nil, backtrace = caller(0)) -> ()
---- fail(error_type, message = nil, backtrace = caller(0))  -> ()
+--- raise(message, cause: $!) -> ()
+--- fail(message, cause: $!)  -> ()
+--- raise(error_type, message = nil, backtrace = caller(0), cause: $!) -> ()
+--- fail(error_type, message = nil, backtrace = caller(0), cause: $!)  -> ()
 
 例外を発生させます。
 発生した例外は変数 [[m:$!]] に格納されます。また例外が
@@ -2198,6 +2198,10 @@ error_type として例外ではないクラスやオブジェクトを指定し
 @param message 例外のメッセージとなる文字列です。
 @param backtrace 例外発生時のスタックトレースで、[[m:Kernel.#caller]] の戻り値と同じ
   形式で指定しなければいけません。
+@param cause 現在の例外([[m:$!]])の代わりに [[m:Exception#cause]] に設定する例外を指定します。
+#@since 2.6.0
+  [[c:Exception]] オブジェクトまたは nil を指定できます。
+#@end
 @raise TypeError exception メソッドが例外オブジェクトを返さなかった場合に発生します。
 
 例外の捕捉の例を示します。


### PR DESCRIPTION
ref r66525

`cause:` が指定できるようになったのは 2.2 からのようなので分岐していません。
2.6.0 で `cause:` に指定できるのが Exception または nil に制限されましたが、過去のバージョンで任意のオブジェクトを受け付けるのはできても推奨されないと思うので、明記していません。
`rescue` されずに終了したに `cause:` をたどって出力されるようになったため、循環参照するような指定はできませんが、実装の詳細になると思ったため、明記していません。

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.1 ./all-ruby -e 'raise "hoge", cause: nil'
ruby-2.1.0          -e:1:in `raise': exception class/object expected (TypeError)
                    	from -e:1:in `<main>'
                #<Process::Status: pid 7 exit 1>
...
ruby-2.1.10         -e:1:in `raise': exception class/object expected (TypeError)
                    	from -e:1:in `<main>'
                #<Process::Status: pid 27 exit 1>
ruby-2.2.0-preview1 -e:1:in `<main>': hoge (RuntimeError)
                #<Process::Status: pid 29 exit 1>
...
ruby-2.6.0-preview2 -e:1:in `<main>': hoge (RuntimeError)
                #<Process::Status: pid 113 exit 1>
```