### PR TITLE
BigDecimal deprecated

### DIFF
--- a/refm/api/src/bigdecimal/BigDecimal
+++ b/refm/api/src/bigdecimal/BigDecimal
@@ -355,11 +355,13 @@ num を [[c:BigDecimal]] に変換した結果を返します。
 @raise TypeError 変換できないオブジェクトを指定した場合に発生します。
 #@end
 
+#@until 2.6.0
 --- ver -> String
 
 このメソッドは deprecated です。
 #@since 2.5.0
 [[m:BigDecimal::VERSION]] を使用してください。
+#@end
 #@end
 
 == Instance Methods

--- a/refm/api/src/bigdecimal/BigDecimal
+++ b/refm/api/src/bigdecimal/BigDecimal
@@ -203,6 +203,7 @@ NaN を表す [[c:BigDecimal]] オブジェクトを返します。
 
 == Class Methods
 
+#@until 2.7.0
 --- new(s)    -> BigDecimal
 --- new(s, n) -> BigDecimal
 
@@ -211,6 +212,7 @@ NaN を表す [[c:BigDecimal]] オブジェクトを返します。
 新しい BigDecimal オブジェクトを生成します。
 
 詳しくは [[m:Kernel.#BigDecimal]] を参照してください。
+#@end
 
 --- mode(s)    -> Integer | nil
 --- mode(s, v) -> Integer | nil


### PR DESCRIPTION
`BigDecimal.allocate` と `BigDecimal.ver` が 2.6.0 で消えましたが、 `BigDecimal.allocate` はドキュメントが書かれていなかったので、 `BigDecimal.ver` だけ until 2.6.0 をつけました。
また `BigDecimal.new` の削除は延期されて、予定通り今の trunk では削除されているので until 2.7.0 をつけました。