### PR TITLE
Ignore not compile-able files from check_prev_commit_format rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -92,10 +92,32 @@ task :statichtml => [*OLD_VERSIONS, *SUPPORTED_VERSIONS].map {|version| "statich
 desc "Check previous commit format"
 task :check_prev_commit_format do
   change_files = `git diff HEAD^ HEAD --name-only --diff-filter=d`.split
+  ignored_files = %w[
+     refm/api/src/_builtin/BasicObject.private_methods_from_Object
+     refm/api/src/_builtin/BasicObject.public_methods_from_Object
+     refm/api/src/_builtin/Module.alias_method
+     refm/api/src/_builtin/Module.attr
+     refm/api/src/_builtin/Module.define_method
+     refm/api/src/_builtin/Module.include
+     refm/api/src/_builtin/Module.prepend
+     refm/api/src/_builtin/Module.remove_method
+     refm/api/src/_builtin/Module.undef_method
+     refm/api/src/_builtin/constants
+     refm/api/src/_builtin/functions
+     refm/api/src/_builtin/functions_pp
+     refm/api/src/_builtin/specialvars
+     refm/api/src/rake/core_ext
+     refm/api/src/rdoc/RDoc__constants
+     refm/api/src/shell/builtincommands
+     refm/api/src/socket/constants
+     refm/api/src/tkextlib/tkDND/shape.rd
+     refm/api/src/tkextlib/tkDND/tkdnd.rd
+     refm/api/src/tkextlib/tktrans/tktrans.rd
+  ]
   res = []
   [*SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS].each do |v|
     change_files.each do |path|
-      if %r!\Arefm/api/!.match(path)
+      if %r!\Arefm/api/!.match(path) && !ignored_files.include?(path)
         htmls = []
         htmls << `bundle exec bitclust htmlfile --ruby=#{v} #{path}`
         raise "Failed to bitclust htmlfile, ruby: #{v}, path: #{path}" unless $?.success?


### PR DESCRIPTION
#1682 や #1648 でCIがコケてしまっている問題を修正します。

Problem
===


これらのPRでは、check_prev_commit_format rake taskがコケてしまっているのが原因でCIが落ちています。
これらのPRの内容自体には問題はなく、check_prev_commit_formatタスクの問題です。
このタスクは直前のコミットで変更があったファイルについて検査します。
コミットに「他のファイルからincludeされて使われるのが前提となっているファイル」が含まれていると、検査が失敗してしまいます。

上記のPRではその「他のファイルからincludeされて使われるのが前提となっているファイル」が変更されていたため、このタスクが失敗してCIが落ちています。


Solution
===


「他のファイルからincludeされて使われるのが前提となっているファイル」についてはスキップするようにしました。

プログラムからそのようなファイルであることを判定する方法が分からなかったので、若干ワークアラウンド的な方法を取っています。
既存の全てのファイルに対して`bitclust htmlfile`コマンドを実行して、コマンドが失敗したファイルのみをskipするようにしました。
なので本来`bitclust htmlfile`コマンドが通る可能性のあるファイルまでskipしてしまっているかもしれません(もしあったらおしえてください)。




このファイルのリストは次のプログラムを使って出しました。

```ruby
res = `git ls-files -z`.split("\0").reject do |path|
  system("bundle exec bitclust htmlfile --ruby=2.5.0 #{path}")
  $?.success?
end
pp res
# => ["faq/trap/nil.rd",
#  "refm/api/src/_builtin/BasicObject.private_methods_from_Object",
#  "refm/api/src/_builtin/BasicObject.public_methods_from_Object",
#  "refm/api/src/_builtin/Module.alias_method",
#  "refm/api/src/_builtin/Module.attr",
#  "refm/api/src/_builtin/Module.define_method",
#  "refm/api/src/_builtin/Module.include",
#  "refm/api/src/_builtin/Module.prepend",
#  "refm/api/src/_builtin/Module.remove_method",
#  "refm/api/src/_builtin/Module.undef_method",
#  "refm/api/src/_builtin/constants",
#  "refm/api/src/_builtin/functions",
#  "refm/api/src/_builtin/functions_pp",
#  "refm/api/src/_builtin/specialvars",
#  "refm/api/src/rake/core_ext",
#  "refm/api/src/rdoc/RDoc__constants",
#  "refm/api/src/shell/builtincommands",
#  "refm/api/src/socket/constants",
#  "refm/api/src/tkextlib/tkDND/shape.rd",
#  "refm/api/src/tkextlib/tkDND/tkdnd.rd",
#  "refm/api/src/tkextlib/tktrans/tktrans.rd",
#  "refm/capi/src/array.c.rd",
#  "refm/capi/src/class.c.rd",
#  "refm/capi/src/error.c.rd",
#  "refm/capi/src/eval.c.rd",
#  "refm/capi/src/gc.c.rd",
#  "refm/capi/src/io.c.rd",
#  "refm/capi/src/object.c.rd",
#  "refm/capi/src/parse.y.rd",
#  "refm/capi/src/ruby.h.rd",
#  "refm/capi/src/st.c.rd",
#  "refm/capi/src/string.c.rd",
#  "refm/capi/src/time.c.rd",
#  "refm/capi/src/variable.c.rd",
#  "refm/old/about.rd"]
```

これを実行したあとで`refm/api/`以下のファイル以外は無視していいことに気がついたので、このプログラムの出力結果から`refm/api/`以下のファイルを削ったものを、rakefileに書いています。


# Note

https://github.com/rurema/doctree/pull/1648#issuecomment-445466593 で

> オフトピ気味な話ですが、このチェックは直前のコミットだけではなくて、リポジトリに含まれるファイル全体に対して実行しても良い気がしますね。


と言っていましたが、全体に対して実行すると結構時間がかかりそうなので、高速化をしないと厳しそうですね。↑のチェックが通らないファイルを出すプログラムも、手元で実行に7分ぐらいかかっていました。


---


最善の策のPRではないと思っているのですが、CIがコケてしまっているPRのマージが止まってしまうよりかはマシな状況になるんじゃないかなと思っています。より良い方法があったらおしえてください🙏