### PR TITLE
Add KeyError.new with receiver: and key:, NoMethodError.new with receiver: since 2.6.0

### DIFF
--- a/refm/api/src/_builtin/KeyError
+++ b/refm/api/src/_builtin/KeyError
@@ -27,6 +27,7 @@ p err.message  # => "Message"
 p err.receiver # => {:foo=>1}
 p err.key      # => :bar
 #@end
+#@end
 #@since 2.5.0
 == Instance Methods
 

--- a/refm/api/src/_builtin/KeyError
+++ b/refm/api/src/_builtin/KeyError
@@ -5,6 +5,28 @@
 Ruby 1.8 以前では同様の場面で [[c:IndexError]] が発生していました。
 互換性のため、[[c:KeyError]] は [[c:IndexError]] のサブクラスになっています。
 
+#@since 2.6.0
+== Class Methods
+
+--- new(error_message = "")                   -> KeyError
+--- new(error_message = "", receiver:)        -> KeyError
+--- new(error_message = "", key:)             -> KeyError
+--- new(error_message = "", receiver:, key:)  -> KeyError
+
+例外オブジェクトを生成して返します。
+
+@param error_message エラーメッセージを表す文字列です
+
+@param receiver 原因となったメソッド呼び出しのレシーバ
+@param key      原因となったメソッド呼び出しのキー
+
+#@samplecode 例
+h = {foo: 1}
+err = KeyError.new("Message", receiver: h, key: :bar)
+p err.message  # => "Message"
+p err.receiver # => {:foo=>1}
+p err.key      # => :bar
+#@end
 #@since 2.5.0
 == Instance Methods
 

--- a/refm/api/src/_builtin/NoMethodError
+++ b/refm/api/src/_builtin/NoMethodError
@@ -26,6 +26,9 @@
 
 #@since 2.4.0
 --- new(error_message = "", name = nil, args = nil, priv = false) -> NoMethodError
+#@since 2.6.0
+--- new(error_message = "", name = nil, args = nil, receiver:) -> NoMethodError
+#@end
 #@else
 --- new(error_message = "", name = nil, args = nil) -> NoMethodError
 #@end
@@ -42,6 +45,9 @@
 @param priv private なメソッドを呼び出せる形式 (関数形式(レシーバを省略した形式)) で呼ばれたかどうかを指定します
 #@end
 
+#@since 2.6.0
+@param receiver 原因となったメソッド呼び出しのレシーバです
+#@end
 
 例:
 


### PR DESCRIPTION
#1048 のコンフリクト解消版です。以下以外はcherry-pickでそのまま取り込んでいます。

* f0f6ee9(NameErrorの修正): #1070 で既に入っていたので取り込まず
* c72f9ef(NoMethodErrorの修正): c089f60 と分岐がコンフリクトしてるのを解消
