### PR TITLE
bigdecimalライブラリを更新

### DIFF
--- a/refm/api/src/bigdecimal/BigDecimal
+++ b/refm/api/src/bigdecimal/BigDecimal
@@ -214,8 +214,13 @@ NaN を表す [[c:BigDecimal]] オブジェクトを返します。
 == Class Methods
 
 #@until 2.7.0
+#@since 2.6.0
+--- new(s, exception: true)    -> BigDecimal
+--- new(s, n, exception: true) -> BigDecimal
+#@else
 --- new(s)    -> BigDecimal
 --- new(s, n) -> BigDecimal
+#@end
 
 このメソッドは deprecated です。[[m:Kernel.#BigDecimal]] を使用してください。
 

--- a/refm/api/src/bigdecimal/math.rd
+++ b/refm/api/src/bigdecimal/math.rd
@@ -65,7 +65,7 @@ x の平方根を prec で指定した精度で計算します。
 
   require "bigdecimal/math"
 
-  puts BigMath::sqrt(BigDecimal.new('2'), 10) #=> 0.14142135623730950488016883515E1
+  puts BigMath::sqrt(BigDecimal('2'), 10) #=> 0.14142135623730950488016883515E1
 
 #@else
 
@@ -73,7 +73,7 @@ x の平方根を prec で指定した精度で計算します。
   require "bigdecimal/math"
 
   include BigMath
-  puts sqrt(BigDecimal.new('2'), 10) #=> 0.14142135623730950488016883515E1
+  puts sqrt(BigDecimal('2'), 10) #=> 0.14142135623730950488016883515E1
 
 #@end
 
@@ -94,7 +94,7 @@ x の正弦関数を prec で指定した精度で計算します。単位はラ
 
   require "bigdecimal/math"
 
-  puts BigMath::sin(BigDecimal.new('0.5'), 10) #=> 0.479425538604203000273287935689073955184741E0
+  puts BigMath::sin(BigDecimal('0.5'), 10) #=> 0.479425538604203000273287935689073955184741E0
 
 #@else
 
@@ -102,7 +102,7 @@ x の正弦関数を prec で指定した精度で計算します。単位はラ
   require "bigdecimal/math"
 
   include BigMath
-  puts sin(BigDecimal.new('0.5'), 10) #=> 0.479425538604203000273287935689073955184741E0
+  puts sin(BigDecimal('0.5'), 10) #=> 0.479425538604203000273287935689073955184741E0
 
 #@end
 
@@ -123,7 +123,7 @@ x の余弦関数を prec で指定した精度で計算します。単位はラ
 
   require "bigdecimal/math"
 
-  puts BigMath::cos(BigDecimal.new('0.5'), 10) #=> 0.8775825618903727161162815826327690580439923E0
+  puts BigMath::cos(BigDecimal('0.5'), 10) #=> 0.8775825618903727161162815826327690580439923E0
 
 #@else
 
@@ -131,7 +131,7 @@ x の余弦関数を prec で指定した精度で計算します。単位はラ
   require "bigdecimal/math"
 
   include BigMath
-  puts cos(BigDecimal.new('0.5'), 10) #=> 0.8775825618903727161162815826327690580439923E0
+  puts cos(BigDecimal('0.5'), 10) #=> 0.8775825618903727161162815826327690580439923E0
 
 #@end
 
@@ -154,7 +154,7 @@ x に無限大や NaN を指定した場合には NaN を返します。
 
   require "bigdecimal/math"
 
-  puts BigMath::atan(BigDecimal.new('0.5'), 10) #=> 0.463647609000806116214256237466868871528608E0
+  puts BigMath::atan(BigDecimal('0.5'), 10) #=> 0.463647609000806116214256237466868871528608E0
 
 #@else
 
@@ -162,7 +162,7 @@ x に無限大や NaN を指定した場合には NaN を返します。
   require "bigdecimal/math"
 
   include BigMath
-  puts atan(BigDecimal.new('0.5'), 10) #=> 0.463647609000806116214256237466868871528608E0
+  puts atan(BigDecimal('0.5'), 10) #=> 0.463647609000806116214256237466868871528608E0
 
 #@end
 


### PR DESCRIPTION
feccd98 に併せて以下の2点を修正しました。

* BigDecimal.newにもexceptionを使える事を記載
* BigDecimal.newを使用してるサンプルを全て置き換え