### PR TITLE
`ARGF.read_nonblock` can call with `exception:` and without `outbuf`

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -848,10 +848,12 @@ ch を返します。
 
 @param arg 出力するオブジェクトを任意個指定します。
 
+#@since 2.3.0
+--- read_nonblock(maxlen, exception: true)              -> String | Symbol | nil
+--- read_nonblock(maxlen, outbuf, exception: true)      -> String | Symbol | nil
+#@else
 --- read_nonblock(maxlen)              -> String
 --- read_nonblock(maxlen, outbuf)      -> String
-#@since 2.3.0
---- read_nonblock(maxlen, outbuf, exception: true)      -> String
 #@end
 #@# TODO: Windows では使えない？
 

--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -849,11 +849,9 @@ ch を返します。
 @param arg 出力するオブジェクトを任意個指定します。
 
 #@since 2.3.0
---- read_nonblock(maxlen, exception: true)              -> String | Symbol | nil
---- read_nonblock(maxlen, outbuf, exception: true)      -> String | Symbol | nil
+--- read_nonblock(maxlen, outbuf = nil, exception: true) -> String | Symbol | nil
 #@else
---- read_nonblock(maxlen)              -> String
---- read_nonblock(maxlen, outbuf)      -> String
+--- read_nonblock(maxlen, outbuf = nil) -> String
 #@end
 #@# TODO: Windows では使えない？
 


### PR DESCRIPTION
`exception:` は `outbuf` があってもなくても指定できるのと、デフォルト値があるので、まとめられると思ったのでまとめました。
わかれていると本文の「第二の形式」というのが曖昧になっていたので、その修正も兼ねています。