### PR TITLE
Fix JSON::Generator::State#ascii_only?.

### DIFF
--- a/refm/api/src/json/JSON__State
+++ b/refm/api/src/json/JSON__State
@@ -163,8 +163,8 @@ pp json_state.to_h
 
 --- ascii_only? -> bool
 
-Returns true, if NaN, Infinity, and -Infinity should be generated,
-otherwise returns false.
+Returns true, if only ASCII characters should be generated. Otherwise
+returns false.
 
 --- quirks_mode? -> bool
 --- quirks_mode  -> bool


### PR DESCRIPTION
#allow_nan? と同じになっていたのを修正(まだ英語のままですが)。

本家も同様の間違いがあったのでPR作成済み。

* https://github.com/flori/json/pull/366