### PR TITLE
`IO#ungetbyte` raises RangeError

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -2038,6 +2038,10 @@ self は読み込み用にオープンされていなければなりません。
 
 @param c バイト列(文字列)、もしくは0から255までの整数
 
+#@since 2.6.0
+@raise RangeError unsigned char の範囲外の値を書き戻そうとした時に発生します。
+#@end
+
 例:
 
    f = File.new("testfile")   #=> #<File:testfile>


### PR DESCRIPTION
see r65802 io.c: ungetbyte silently ignores upper bits