### PR TITLE
`Integer#to_f` may return -Infinity

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -544,10 +544,11 @@ self を浮動小数点数([[c:Float]])に変換します。
 
 self が [[c:Float]] の範囲に収まらない場合、[[m:Float::INFINITY]] を返します。
 
-例:
-
-  1.to_f                       # => 1.0
-  (Float::MAX.to_i * 2).to_f   # => Infinity
+#@samplecode
+1.to_f                       # => 1.0
+(Float::MAX.to_i * 2).to_f   # => Infinity
+(-Float::MAX.to_i * 2).to_f  # => -Infinity
+#@end
 
 --- <=>(other) -> -1 | 0 | 1 | nil
 


### PR DESCRIPTION
- self が Float の範囲に収まらない場合、Float::INFINITY を返します。」とありますが -Float::INFINITY の場合もあるので、例を追加しました。
- `#@samplecode` に変更しました。