### PR TITLE
Add a link to String#delete and String#delete!

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1172,6 +1172,8 @@ p "123456789".delete("2378")         #=> "14569"
 p "123456789".delete("2-8", "^4-6")  #=> "14569"
 #@end
 
+@see [[m:String#delete!]]
+
 --- delete!(*strs) -> self | nil
 
 self から strs に含まれる文字を破壊的に取り除きます。
@@ -1205,6 +1207,8 @@ str = "abc"
 p str.delete!("2378")         #=> "nil"
 p str                         #=> "abc"
 #@end
+
+@see [[m:String#delete]]
 
 #@since 2.4.0
 --- downcase(*options) -> String


### PR DESCRIPTION
`String#delete` 及び `String#delete!` に、それぞれに対するリンクがなかったので追加しました。
他のbang付きのメソッドでは相互リンクがあるのがほとんどなので、`String#delete`のページを見た時に「`String#delete!`もあった気がするけど、ここにリンクがないということは`delete!`ってないんだっけ……」とちょっと混乱してしまいました。
