### PR TITLE
Remove deprecated `sudo: false` in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 dist: xenial
 rvm:


### PR DESCRIPTION
- https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
- https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments