### PR TITLE
`Enumerator::ArithmeticSequence#begin` may return nil

### DIFF
--- a/refm/api/src/_builtin/Enumerator__ArithmeticSequence
+++ b/refm/api/src/_builtin/Enumerator__ArithmeticSequence
@@ -9,7 +9,11 @@ ArithmeticSequenceオブジェクトは、[[m:Numeric#step]], [[m:Range#step]] �
 
 == Instance Methods
 
+#@since 2.7.0
 --- begin -> Numeric | nil
+#@else
+--- begin -> Numeric
+#@end
 
 初項 (始端) を返します。
 

--- a/refm/api/src/_builtin/Enumerator__ArithmeticSequence
+++ b/refm/api/src/_builtin/Enumerator__ArithmeticSequence
@@ -9,7 +9,7 @@ ArithmeticSequenceオブジェクトは、[[m:Numeric#step]], [[m:Range#step]] �
 
 == Instance Methods
 
---- begin -> Numeric
+--- begin -> Numeric | nil
 
 初項 (始端) を返します。
 


### PR DESCRIPTION
ref https://github.com/ruby/ruby/commit/48313f129abd464c69853a66af22adbad260b82e

```
% ruby -ve 'p (nil..).first'
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin18]
nil
% ruby -ve 'p (nil..).begin'
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin18]
nil
```