### PR TITLE
Fix description of `$1`, `$2`, ...

### DIFF
--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -135,8 +135,8 @@ Ruby起動時の初期値は nil です。
 
 番号 n はいくらでも大きな正整数を利用できます。
 
-[[m:Regexp.last_match]][1],
-[[m:Regexp.last_match]][2], ... と同じ。
+[[m:Regexp.last_match]](1),
+[[m:Regexp.last_match]](2), ... と同じ。
 
 これらの変数はローカルスコープかつスレッドローカル、読み取り専用です。
 


### PR DESCRIPTION
`Regexp.last_match[1]` raise `NoMethodError` without matching,
but `$1` and `Regexp.last_match(1)` return `nil`.