### PR TITLE
Rename collect_tasks to collect_command_line_tasks

### DIFF
--- a/refm/api/src/rake/Rake__Application
+++ b/refm/api/src/rake/Rake__Application
@@ -22,7 +22,7 @@ Rake で使用するメインのクラスです。
 
 @param loader ローダーを指定します。
 
---- collect_tasks(argv) -> Array
+--- collect_command_line_tasks(argv) -> Array
 
 コマンドライン引数を解析して実行するタスクのリストを返します。
 


### PR DESCRIPTION
rake のリポジトリを見ると collect_tasks が collect_command_line_tasks に rename されているが、るりま上は collect_tasks のままだったので名前を変更しました。

https://github.com/ruby/rake/commit/bfafc3a034866f276dc9709a010f7fbc50237683

