### PR TITLE
Update NET::HTTPHeader#proxy_basic_auth return value. (see gh-1524)

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -1919,7 +1919,7 @@ req = Net::HTTP::Get.new(uri.request_uri)
 req.method # => "GET"
 #@end
 
---- proxy_basic_auth(account, password) -> ()
+--- proxy_basic_auth(account, password) -> [String]
 
 Proxy 認証のために Proxy-Authorization: ヘッダをセットします。
 


### PR DESCRIPTION
#1524 で判明した本文側の修正の対応です。本体の最後の行が代入文で常に `[String]` が返ると思いますので、修正しました。