### PR TITLE
Add Array#filter since 2.6.0

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2249,6 +2249,27 @@ srand()が有効です。
 [[c:Enumerator]] オブジェクトを返します。
 
 @see [[m:Array#select!]]
+--- select    -> Enumerator
+#@since 2.6.0
+--- filter    -> Enumerator
+#@end
+--- select {|item| ... }   -> [object]
+#@since 2.6.0
+--- filter {|item| ... }   -> [object]
+#@end
+
+各要素に対してブロックを評価した値が真であった要素を全て含む配列を
+返します。真になる要素がひとつもなかった場合は空の配列を返します。
+
+ブロックを省略した場合は、各要素に対しブロックを評価し
+真になった値の配列を返すような [[c:Enumerator]] を返します。
+
+#@samplecode
+[1,2,3,4,5].select                      # => #<Enumerator: [1, 2, 3, 4, 5]:select>
+[1,2,3,4,5].select { |num| num.even? }  # => [2, 4]
+#@end
+@see [[m:Enumerable#select]]
+@see [[m:Array#select!]]
 --- select! {|item| block } -> self | nil
 --- select! -> Enumerator
 #@since 2.6.0


### PR DESCRIPTION
- `Enumerable#select` があったため、書かれていなかった `Array#select` 自体も追加