### PR TITLE
Update Module#attr

### DIFF
--- a/refm/api/src/_builtin/Module.attr
+++ b/refm/api/src/_builtin/Module.attr
@@ -1,4 +1,6 @@
---- attr(name, assignable = false) -> nil
+--- attr(*name) -> nil
+--- attr(name, true) -> nil
+--- attr(name, false) -> nil
 
 インスタンス変数読み取りのためのインスタンスメソッド name を定義します。
 
@@ -8,17 +10,16 @@
     @name
   end
 
-省略可能な第 2 引数 assignable が指定されその値が真である
-場合には、属性の書き込み用メソッド name= も同時に定義されます。
+第 2 引数 が true で指定された場合には、属性の書き込み用メソッド name= も同時に定義されます。
 その定義は次の通りです。
 
   def name=(val)
     @name = val
   end
 
-@param name [[c:String]] または [[c:Symbol]] で指定します。
+第 2 引数 に true か false を指定する方法は非推奨になりました。
 
-@param assignable true を指定するとインスタンス変数書き込み用のインスタンスメソッドも定義します。
+@param name [[c:String]] または [[c:Symbol]] で指定します。
 
 --- attr_accessor(*name) -> nil
 


### PR DESCRIPTION
ref: https://ruby-jp.slack.com/archives/CM3PCPNQ5/p1565322056048900

Output with `bitclust htmlfile refm/api/src/_builtin/Module --target='Module#attr' --ruby=2.5.0`
---

<img width="1049" alt="スクリーンショット 2019-08-16 17 45 08" src="https://user-images.githubusercontent.com/1180335/63155604-daf4c580-c04d-11e9-8cf0-8d8fd0213d40.png">

この変更は 1.9.0 時に起こったもののようなので、分岐は不要と判断しました。

https://github.com/ruby/ruby/commit/b5d9cbe8e8bb5c0eb826ce68a81aa5579359b5e8
https://github.com/ruby/ruby/blob/b5d9cbe8e8bb5c0eb826ce68a81aa5579359b5e8/version.h#L1
