### PR TITLE
Update `GC.start` document

### DIFF
--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -220,7 +220,11 @@ GC.enable    # => false
 ガーベージコレクトを開始します。
 
 [[m:GC#garbage_collect]] や [[m:ObjectSpace.#garbage_collect]] と同じ働きをします。
+#@since 2.3.0
+[[m:GC.disable]] により GC が禁止されている場合でもガベージコレクトを開始します。
+#@else
 [[m:GC.disable]] により GC が禁止されている場合は何もしません。
+#@end
 
 nil を返します。
 
@@ -404,7 +408,11 @@ GC 内部の統計情報を [[c:Hash]] で返します。
 ガーベージコレクトを開始します。
 
 [[m:GC.start]] や [[m:ObjectSpace.#garbage_collect]] と同じ働きをします。
+#@since 2.3.0
+[[m:GC.disable]] により GC が禁止されている場合でもガベージコレクトを開始します。
+#@else
 [[m:GC.disable]] により GC が禁止されている場合は何もしません。
+#@end
 
 nil を返します。
 


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/2382 の修正をるりまにも適用します。


`GC.start`のドキュメントには「[[m:GC.disable]] により GC が禁止されている場合は何もしません。
」とありますが、実際のところは`GC.disable`されていてもガベージコレクトをするようになっています。


changelogを見るとRuby 2.3からの変更のようなので、そのように分岐を書きました。
https://github.com/ruby/ruby/blob/800d205799175734c937693e2a85fceddfce2ffc/doc/ChangeLog-2.3.0#L1909-L1914

