### PR TITLE
Move link to Exception.to_tty? from #full_message. (see gh-1161)

### DIFF
--- a/refm/api/src/_builtin/Exception
+++ b/refm/api/src/_builtin/Exception
@@ -239,6 +239,6 @@ rescue => e
   p e.full_message   # => "\e[1mTraceback \e[m(most recent call last):\ntest.rb:2:in `<main>': \e[1mtest (\e[4;1mRuntimeError\e[m\e[1m)\n\e[m"
 end
 #@end
-#@end
 
 @see [[m:Exception.to_tty?]]
+#@end


### PR DESCRIPTION
Exception.to_tty? へのリンクが 2.4.0 の時に #cause の方に行ってしまっていたので修正しました。