### PR TITLE
Update ENV document

### DIFF
--- a/refm/api/src/_builtin/ENV
+++ b/refm/api/src/_builtin/ENV
@@ -6,8 +6,8 @@ extend Enumerable
 ます。ただし、Hash と異なり、ENV のキーと値には文字列しか
 とることができません。
 
-ENV で得られる文字列は ENV['PATH'] を除いて汚染されていま
-す。オブジェクトの汚染に関しては [[d:spec/safelevel]] を参照して下さい。
+ENV で得られる文字列は ENV['PATH'] 以外は常に汚染されています。
+オブジェクトの汚染に関しては [[d:spec/safelevel]] を参照して下さい。
 ENV['PATH'] はその要素が誰でも書き込み可能なディレクトリを含ん
 でいる場合に限り汚染されます。
 
@@ -245,15 +245,14 @@ ENV オブジェクトを文字列化します。 [[m:Hash#inspect]] と同じ�
 @param hash  キーと値の対応関係を指定します。 to_hash でハッシュに変換されます。
 
 --- select                      -> Enumerator
---- select {|key, value| ... }  -> [[String, String]]
+--- select {|key, value| ... }  -> Hash
 #@since 2.6.0
 --- filter                      -> Enumerator
---- filter {|key, value| ... }  -> [[String, String]]
+--- filter {|key, value| ... }  -> Hash
 #@end
 
-環境変数名と値についてブロックを評価し、真を返したものを集めた配列を返
-します。配列の各要素は配列となり、第一要素が変数名、第二要素が値になり
-ます。
+環境変数名と値についてブロックを評価し、真を返したものを集めたハッシュ
+を返します。
 
 --- shift -> [String, String]
 
@@ -353,7 +352,11 @@ self を返します。
 るような要素を環境変数に残します。
 
 keep_if は常に self を返します。
+#@since 2.6.0
+select! と filter! はオブジェクトが変更された場合に self を、
+#@else
 select! はオブジェクトが変更された場合に self を、
+#@end
 されていない場合に nil を返します。
 
 ブロックが省略された場合には [[c:Enumerator]] を返します。


### PR DESCRIPTION
ENV のドキュメントを修正しました。


## 冒頭の説明の修正


ドキュメントの冒頭で「ENV で得られる文字列は ENV['PATH'] を除いて汚染されています。」とありますが、これだと`ENV['PATH']`は汚染されていないのかなと思ってしまった(実際は汚染されていたりされていなかったりする)ので、少し文章をいじりました。



## selectの修正

`ENV#select`が`[[String, String]]`を返すと書かれていますが、実際にはHashを返します。
これは1.9からの挙動のようなので、特に分岐は入れていません。


```bash
$ ruby -ve 'p ENV.select{|k, _| k == "TERM"}'
ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]
[["TERM", "xterm"]]


$ ruby -ve 'p ENV.select{|k, _| k == "TERM"}'
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
{"TERM"=>"xterm"}
```

## filter! の修正

細かいですが、2.6から`select!`のaliasとして`filter!`が追加されたのに対して、メソッドの説明が漏れていたので修正しています