### PR TITLE
Fix sample code of Struct.#to_a

### DIFF
--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -220,7 +220,7 @@ p Foo.new.members  # => [:foo, :bar]
 --- to_a -> [object]
 構造体のメンバの値を配列にいれて返します。
 
-@samplecode 例
+#@samplecode 例
   Customer = Struct.new(:name, :address, :zip)
   Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345).to_a
   # => ["Joe Smith", "123 Maple, Anytown NC", 12345]

--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -220,10 +220,10 @@ p Foo.new.members  # => [:foo, :bar]
 --- to_a -> [object]
 構造体のメンバの値を配列にいれて返します。
 
-例えば以下のようにして passwd のエントリを出力できます。
-
-  require 'etc'
-  print Etc.getpwuid.values.join(":"), "\n"
+例:
+  Customer = Struct.new(:name, :address, :zip)
+  Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345).to_a
+  # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
 
 #@include(Struct.attention)
 

--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -220,10 +220,11 @@ p Foo.new.members  # => [:foo, :bar]
 --- to_a -> [object]
 構造体のメンバの値を配列にいれて返します。
 
-例:
+@samplecode 例
   Customer = Struct.new(:name, :address, :zip)
   Customer.new("Joe Smith", "123 Maple, Anytown NC", 12345).to_a
   # => ["Joe Smith", "123 Maple, Anytown NC", 12345]
+#@end
 
 #@include(Struct.attention)
 


### PR DESCRIPTION
The sample code for `Struct.#to_a` is incorrect.

The code does not describe the behavior of `Struct.#to_a`.
```
require 'etc'
print Etc.getpwuid.values.join(":"), "\n"
```