### PR TITLE
Allow to use local bitclust

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,14 @@ source "https://rubygems.org"
 
 gem "rake"
 
-git "https://github.com/rurema/bitclust.git" do
+bitclust_gems = proc do
   gem "bitclust-core"
   gem "bitclust-dev"
   gem "refe2"
 end
-
+bitclust_path = ENV.fetch('BITCLUST_PATH', '../bitclust')
+if File.directory?(bitclust_path)
+  path bitclust_path, &bitclust_gems
+else
+  git 'https://github.com/rurema/bitclust.git', &bitclust_gems
+end


### PR DESCRIPTION
bitclust の変更のテストをやりやすくするため、
doctree と一緒に bitlcust も git clone しているときに
優先的に使うようにします。