### PR TITLE
OpenSSL::Cipher::Cipher is deprecated. Use OpenSSL::Cipher instead

### DIFF
--- a/refm/api/src/openssl/PKey__RSA
+++ b/refm/api/src/openssl/PKey__RSA
@@ -21,7 +21,7 @@ RSA についてよく理解し、必要な場合のみにすべきです。
   # 秘密鍵をAES256で暗号化して private_key.pem に PEM 形式で保存
   passphrase = "!secret passphrase!"
   File.open("private_key.pem", "w") do |f|
-    f.write(rsa.export(OpenSSL::Cipher::Cipher.new("aes256"), passphrase))
+    f.write(rsa.export(OpenSSL::Cipher.new("aes256"), passphrase))
   end
   # 公開鍵をpublic_key.pemに保存
   public_key = rsa.public_key


### PR DESCRIPTION
`class OpenSSL::PKey::RSA`のサンプルコードで非推奨になっている`OpenSSL::Cipher::Cipher`を利用している箇所があったので、`OpenSSL::Cipher`に修正しました。