### PR TITLE
fix `OpenSSL::OCSP::Response#basic` typo link

### DIFF
--- a/refm/api/src/openssl/OCSP
+++ b/refm/api/src/openssl/OCSP
@@ -220,7 +220,7 @@ OCSP の Basic OCSP Response を表すクラスです。
 
 OCSP レスポンダからのレスポンス自体は
 [[c:OpenSSL::OCSP::Response]] のオブジェクトが表現していて、
-このオブジェクトの [[m:OpenSSL::OCSP::Request#basic]] によって
+このオブジェクトの [[m:OpenSSL::OCSP::Response#basic]] によって
 BasicResponse のオブジェクトを得ます。
 
 == Class Methods


### PR DESCRIPTION
`OpenSSL::OCSP::Response#basic` に関連するリンクのタイポの修正です。以下、リンク先に 404 のあるペーです。

https://docs.ruby-lang.org/ja/latest/class/OpenSSL=3a=3aOCSP=3a=3aBasicResponse.html