### PR TITLE
Ignore vendor/bundle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Gemfile.lock
 /.bundle
+/vendor/bundle


### PR DESCRIPTION
ローカル環境のRubyをクリーンに保ちたいので、リファレンスを生成する環境を構築するために以下のコマンドを実行しても、 `vendor/bundle` ディレクトリがGit管理下に含まれないようにしたいです。

```
bundle install --path vendor/bundle
```