### PR TITLE
Replace trunk with master in URL

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -1673,7 +1673,7 @@ refinements 機能の詳細については以下を参照してください。
 
  * [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-refinement.html]]
 #@since 2.1.0
- * [[url:https://docs.ruby-lang.org/en/trunk/syntax/refinements_rdoc.html]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html]]
 #@else
  * [[url:https://docs.ruby-lang.org/en/2.0.0/syntax/refinements_rdoc.html]]
 #@end
@@ -1776,7 +1776,7 @@ self が特異クラスの場合に true を返します。そうでなければ
 
 有効にした拡張の有効範囲については以下を参照してください。
 
- * [[url:https://docs.ruby-lang.org/en/trunk/syntax/refinements_rdoc.html#label-Scope]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html#label-Scope]]
 
 @param module 有効にするモジュールを指定します。
 

--- a/refm/api/src/_builtin/RubyVM__InstructionSequence
+++ b/refm/api/src/_builtin/RubyVM__InstructionSequence
@@ -11,7 +11,7 @@ RubyVM::InstructionSequence オブジェクトを元に命令シーケンスを�
 VM の命令シーケンスの一覧はRuby のソースコード中の insns.def から参照で
 きます。
 
- * [[url:https://github.com/ruby/ruby/blob/trunk/insns.def]]
+ * [[url:https://github.com/ruby/ruby/blob/master/insns.def]]
 
 #@# The instruction sequence results will almost certainly change as Ruby
 #@# changes, so example output in this documentation may be different from what

--- a/refm/api/src/_builtin/main
+++ b/refm/api/src/_builtin/main
@@ -120,7 +120,7 @@ hypot(3, 4)  # => 5.0
 有効にした拡張の有効範囲については以下を参照してください。
 
 #@since 2.1.0
- * [[url:https://docs.ruby-lang.org/en/trunk/syntax/refinements_rdoc.html#label-Scope]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html#label-Scope]]
 #@else
  * [[url:https://docs.ruby-lang.org/en/2.0.0/syntax/refinements_rdoc.html#label-Scope]]
 #@end

--- a/refm/api/src/bigdecimal/ludcmp.rd
+++ b/refm/api/src/bigdecimal/ludcmp.rd
@@ -7,7 +7,7 @@ LU 分解を用いて、連立1次方程式 Ax = b の解 x を求める機能�
 
 Ruby のソースコード中の以下のサンプルスクリプトも参考にしてください。
 
- * [[url:https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/sample/linear.rb]]
+ * [[url:https://github.com/ruby/ruby/blob/master/ext/bigdecimal/sample/linear.rb]]
 
 = module LUSolve
 

--- a/refm/api/src/bigdecimal/newton.rd
+++ b/refm/api/src/bigdecimal/newton.rd
@@ -61,7 +61,7 @@ require bigdecimal/ludcmp
 
 Ruby のソースコード中の以下のサンプルスクリプトも参考にしてください。
 
- * [[url:https://github.com/ruby/ruby/blob/trunk/ext/bigdecimal/sample/nlsolve.rb]]
+ * [[url:https://github.com/ruby/ruby/blob/master/ext/bigdecimal/sample/nlsolve.rb]]
 
 = module Newton
 

--- a/refm/api/src/find.rd
+++ b/refm/api/src/find.rd
@@ -16,7 +16,7 @@ category File
   find('/foo','/bar') {|f| ...}
 
 以下は、ruby のアーカイブに含まれるサンプルスクリプト
-([[url:https://github.com/ruby/ruby/blob/trunk/sample/trojan.rb]]) をこのモジュールで書き換えたものです。
+([[url:https://github.com/ruby/ruby/blob/master/sample/trojan.rb]]) をこのモジュールで書き換えたものです。
 
   #! /usr/bin/env ruby
   require "find"

--- a/refm/capi/src/class.c.rd
+++ b/refm/capi/src/class.c.rd
@@ -255,7 +255,7 @@ fmt のフォーマットは以下の通りです。
 
       def some_method(a, *rest, &block)
 
-@see [[url:https://github.com/ruby/ruby/blob/trunk/doc/extension.ja.rdoc]]
+@see [[url:https://github.com/ruby/ruby/blob/master/doc/extension.ja.rdoc]]
 
 --- VALUE rb_singleton_class(VALUE obj)
 


### PR DESCRIPTION
URL中のtrunkをmasterに置換します。

https://docs.ruby-lang.org/en/trunk/syntax/refinements_rdoc.html
のようなRDocへのURLは、trunkがリンク切れになっていたので、masterへの置換が必要です。

また、
https://github.com/ruby/ruby/blob/trunk/insns.def
のようなGitHubのtrunkブランチへのリンクも置換しています。こちらは現状リンクが切れているわけではないですがついでにやっています。





このPRを適用すると、git grepでtrunkを探しても以下の2箇所だけになります。

```
$ git grep -w trunk
refm/api/src/matrix/Matrix:#@# TODO: trunk では修正済み(Bug #7228)
refm/doc/news/1.8.4.rd:#         DryRun (backported from trunk, rev 1.66). [ruby-core:05954]
```


> #@# TODO: trunk では修正済み(Bug #7228)

これはドキュメントの方を直す必要がありそうだなと思いましたが、このPRでは特に手を付けていません。
