### PR TITLE
fix `OpenSSL::ASN1.#decode` typo link

### DIFF
--- a/refm/api/src/openssl/ASN1
+++ b/refm/api/src/openssl/ASN1
@@ -171,7 +171,7 @@ DER 表現の文字列を解析し、そこにエンコードされている ASN
 
 @param der DER形式の文字列
 @raise OpenSSL::ASN1::ASN1Error 解析に失敗した場合に発生します
-@see [[m:OpenSSl::ASN1.#decode]]
+@see [[m:OpenSSL::ASN1.#decode]]
 
 --- traverse(der) {|depth, off, hlen, len, constructed, tag_class, tag| ...} -> nil
 DER形式の文字列を解析し、そこに含まれる ASN.1 の値
@@ -192,7 +192,7 @@ DER形式の文字列を解析し、そこに含まれる ASN.1 の値
 
 @param der DER形式の文字列
 @raise OpenSSL::ASN1::ASN1Error 解析に失敗した場合に発生します
-@see [[m:OpenSSl::ASN1.#decode]]
+@see [[m:OpenSSL::ASN1.#decode]]
 
 --- Boolean(value) -> OpenSSL::ASN1::Boolean
 --- Boolean(value , tag , tagging , tag_class) -> OpenSSL::ASN1::Boolean

--- a/refm/api/src/openssl/ASN1__ASN1Data
+++ b/refm/api/src/openssl/ASN1__ASN1Data
@@ -64,4 +64,4 @@ ASN.1 値に対応するRubyのオブジェクトを変更します。
 --- to_der -> String
 ASN.1 値の DER 表現を返します。
 
-@see [[m:OpenSSL::ASN1.decode]]
+@see [[m:OpenSSL::ASN1.#decode]]


### PR DESCRIPTION
`OpenSSL::ASN1.#decode` に関連するリンクのタイポの修正です。以下、リンク先に 404 のあるペーです。

- https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aASN1/m/traverse.html
- https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aASN1=3a=3aASN1Data/i/to_der.html