### PR TITLE
Remove obsolete docs branches from Net::HTTP

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -66,42 +66,6 @@ category Network
 
 ==== プロクシ経由のアクセス
 
-#@until 2.0.0
-[[m:Net::HTTP.Proxy]] はプロクシ経由での接続を行なうクラスを
-生成して返します。このクラスは [[c:Net::HTTP]] と同じ
-メソッドを持ち、同じように動作をします。ただし
-接続する際には常にプロクシ経由となります。
-  require 'net/http'
-  
-  proxy_addr = 'your.proxy.host'
-  proxy_port = 8080
-          :
-  Net::HTTP::Proxy(proxy_addr, proxy_port).start('www.example.com') {|http|
-    # always connect to your.proxy.addr:8080
-          :
-  }
-
-また [[m:Net::HTTP.Proxy]] は第一引数が nil だと 
-Net::HTTP 自身を返すので
-上のコードのように書いておけばプロクシなしの場合にも対応できます。
-
-[[m:Net::HTTP.Proxy]] にはユーザ名とパスワードを取る
-オプション引数があり、以下のようにして
-プロクシの認証をすることができます。
-  proxy_host = 'your.proxy.host'
-  proxy_port = 8080
-  uri = URI.parse(ENV['http_proxy'])
-  proxy_user, proxy_pass = uri.userinfo.split(/:/) if uri.userinfo
-  Net::HTTP::Proxy(proxy_host, proxy_port,
-                   proxy_user, proxy_pass).start('www.example.com') {|http|
-    # always connect to your.proxy.addr:8080 using specified username and password
-          :
-  }
-
-このライブラリは環境変数 HTTP_PROXY を一切考慮しないこと
-に注意してください。プロクシを使いたい場合は上の例のように
-明示的に取り扱わなければなりません。
-#@else
 Net::HTTP は http_proxy 環境変数が存在するならば自動的に
 その URI を利用してプロクシを利用します。http_proxyを利用したくないならば
 [[m:Net::HTTP.new]] や [[m:Net::HTTP.start]] の proxy_addr 引数に
@@ -121,7 +85,7 @@ nil を渡してください。
 
 プロクシの認証をユーザ名とパスワードですることもできます。
 詳しくは [[m:Net::HTTP.new]] を参照してください。
-#@end
+
 
 ==== リダイレクトに対応する
 以下の例の fetch はリダイレクトに対応しています。
@@ -207,29 +171,6 @@ CGIやサーバの実装者に対し `&' の代わりに
 [[lib:cgi]] ライブラリを使って CGI スクリプトを書く場合はこれらの違いを気にする
 必要はありません。
 
-#@until 1.9.3
-=== 新しい仕様への変更と移行措置について
-
-net/http 1.1 の挙動を使いたい場合には[[m:Net::HTTP.version_1_1]] を呼ん
-でください。その後 [[m:Net::HTTP.version_1_2]] を呼ぶと挙動が 1.2 に戻
-ります。
-
-  # example
-  Net::HTTP.start {|http1| ...(http1 has 1.2 features)... }
-  
-  Net::HTTP.version_1_1
-  Net::HTTP.start {|http2| ...(http2 has 1.1 features)... }
-  
-  Net::HTTP.version_1_2
-  Net::HTTP.start {|http3| ...(http3 has 1.2 features)... }
-
-ただし、この機能はスレッドセーフではありません。
-つまり、複数スレッドでそれぞれに version_1_1 や version_1_2 を呼んだ場合、
-次に生成する Net::HTTP オブジェクトがどちらのバージョンになるかは保証できません。
-アプリケーション全体でどちらかのバージョンに固定する必要があります。
-
-通常この機能は使わないはずです。1.2固定で利用してください。
-#@end
 
 = class Net::HTTP < Object
 alias HTTPSession
@@ -238,19 +179,14 @@ HTTP のクライアントのためのクラスです。
 
 == Class Methods
 
-#@until 2.0.0
---- new(address, port = 80, proxy_addr = nil, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
-#@else
 --- new(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
-#@end
 
 新しい [[c:Net::HTTP]] オブジェクトを生成します。
 
-#@since 2.0.0
 proxy_addr に :ENV を指定すると自動的に環境変数 http_proxy からプロクシの URI を
 取り出し利用します。この場合環境変数 http_proxy が定義されていない場合には
 プロクシは利用せず直接接続します。
-#@end
+
 
 明示的にプロクシのホスト名とポート番号を指定してプロクシを利用することもできます。
 このときには proxy_addr にホスト名もしくは IP アドレスを渡します。
@@ -267,13 +203,8 @@ proxy_addr に :ENV を指定すると自動的に環境変数 http_proxy から
 @param proxy_pass プロクシの認証のパスワードを指定します。
 
 
-#@until 2.0.0
---- start(address, port = 80, proxy_addr = nil, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
---- start(address, port = 80, proxy_addr = nil, proxy_port = nil, proxy_user=nil, proxy_pass=nil) {|http| .... } -> object
-#@else
 --- start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
 --- start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) {|http| .... } -> object
-#@end
 
 新しい [[c:Net::HTTP]] オブジェクトを生成し、
 TCP コネクション、 HTTP セッションを開始します。
@@ -285,11 +216,9 @@ TCP コネクション、 HTTP セッションを開始します。
 ブロックを与えなかった場合には生成したオブジェクトを渡します。
 利用後にはこのオブジェクトを [[m:Net::HTTP#finish]] してください。
 
-#@since 2.0.0
 proxy_addr に :ENV を指定すると環境変数 http_proxy からプロクシの URI を
 取り出し利用します。環境変数 http_proxy が定義されていない場合には
 プロクシは利用しません。
-#@end
 
 このメソッドは以下と同じです。
 
@@ -302,9 +231,7 @@ proxy_addr に :ENV を指定すると環境変数 http_proxy からプロクシ
 @param proxy_port プロクシのポートを指定します。
 @param proxy_user プロクシの認証のユーザ名を指定します。省略した場合には認証はなされません。
 @param proxy_pass プロクシの認証のパスワードを指定します。
-#@since 2.0.0
 @raise Net::OpenTimeout 接続がタイムアウトしたときに発生します
-#@end
 @see [[m:Net::HTTP.new]], [[m:Net::HTTP#start]]
 
 --- get(uri) -> String
@@ -445,58 +372,25 @@ HTTP のデフォルトポート (80) を返します。
 --- https_default_port -> Integer
 HTTPS のデフォルトポート (443) を返します。
 
-
-#@until 1.9.3
---- version_1_1 -> ()
-ライブラリの動作をバージョン1.1互換にします。
-
-@see [[m:Net::HTTP.version_1_2]], [[m:Net::HTTP.version_1_1?]]
-     [[m:Net::HTTP.version_1_2?]]
-#@end
-
-#@since 1.9.3
 --- version_1_1? -> false
 --- is_version_1_1? -> false
 何もしません。互換性のために残されており、常に false を返します。
 
 @see [[m:Net::HTTP.version_1_2]], [[m:Net::HTTP.version_1_2?]]
-#@else
---- version_1_1? -> bool
---- is_version_1_1? -> bool 
-ライブラリの動作がバージョン1.1互換である場合に真を返します。
 
-@see [[m:Net::HTTP.version_1_1]], [[m:Net::HTTP.version_1_2]]
-     [[m:Net::HTTP.version_1_2?]]
-#@end
 
-#@since 1.9.3
 --- version_1_2 -> true
 何もしません。互換性のために残されており、常に true を返します。
 
 @see [[m:Net::HTTP.version_1_1?]], [[m:Net::HTTP.version_1_2?]]
-#@else
---- version_1_2 -> ()
-ライブラリの動作をバージョン1.2互換、つまり
-通常の動作にします。
 
-@see [[m:Net::HTTP.version_1_1]], [[m:Net::HTTP.version_1_1?]]
-     [[m:Net::HTTP.version_1_2?]]
-#@end
 
-#@since 1.9.3
 --- version_1_2? -> true
 --- is_version_1_2? -> true
 何もしません。互換性のために残されており、常に true を返します。
 
 @see [[m:Net::HTTP.version_1_2]], [[m:Net::HTTP.version_1_1?]]
-#@else
---- version_1_2? -> bool
---- is_version_1_2? -> bool 
-ライブラリの動作がバージョン1.2互換である場合に真を返します。
 
-@see [[m:Net::HTTP.version_1_1]], [[m:Net::HTTP.version_1_2]]
-     [[m:Net::HTTP.version_1_1?]]
-#@end
 
 == Instance Methods
 
@@ -514,9 +408,8 @@ TCP コネクションを張り、HTTP セッションを開始します。
 利用後にはこのオブジェクトを [[m:Net::HTTP#finish]] してください。
 
 @raise IOError すでにセッションが開始していた場合に発生します。
-#@since 2.0.0
 @raise Net::OpenTimeout 接続がタイムアウトしたときに発生します
-#@end
+
 
 --- started? -> bool
 --- active? -> bool
@@ -566,7 +459,6 @@ io に nil を指定するとデバッグ出力を止めます。
 
 接続するポート番号を返します。
 
-#@since 2.0.0
 --- local_host -> String | nil
 
 接続に用いるローカルホスト名を返します。
@@ -638,7 +530,6 @@ end
 
 @see [[m:Net::HTTP#local_port=]], [[m:Net::HTTP#local_host]]
 
-#@end
 
 @see [[m:Net::HTTP.new]]
 --- proxy? -> bool
@@ -657,13 +548,9 @@ end
 
 proxyaddr は時代遅れのメソッドです。
 
-#@until 2.0.0
-@see [[m:Net::HTTP.Proxy]]
-#@else
 @see [[m:Net::HTTP#proxy_address=]], [[m:Net::HTTP#proxy_port]], [[m:Net::HTTP.new]]
-#@end
 
-#@since 2.0.0
+
 --- proxy_address=(address)
 
 プロクシのアドレス(ホスト名、IPアドレス)を指定します。
@@ -673,7 +560,7 @@ proxyaddr は時代遅れのメソッドです。
 @param address プロクシのホスト名、もしくはIPアドレスを表す文字列
 
 @see [[m:Net::HTTP#proxy_address=]], [[m:Net::HTTP#proxy_port]], [[m:Net::HTTP.new]]
-#@end
+
 
 --- proxy_port -> Integer|nil
 --- proxyport -> Integer|nil
@@ -683,13 +570,10 @@ proxyaddr は時代遅れのメソッドです。
 プロクシを使わない場合は nil を返します。
 
 proxyport は時代遅れのメソッドです。
-#@until 2.0.0
-@see [[m:Net::HTTP.Proxy]]
-#@else
-@see [[m:Net::HTTP#proxy_port=]], [[m:Net::HTTP#proxy_address]], [[m:Net::HTTP.new]]
-#@end
 
-#@since 2.0.0
+@see [[m:Net::HTTP#proxy_port=]], [[m:Net::HTTP#proxy_address]], [[m:Net::HTTP.new]]
+
+
 --- proxy_port=(port)
 
 プロクシのポート番号を設定します。
@@ -698,7 +582,7 @@ proxyport は時代遅れのメソッドです。
 
 @param port ポート番号(整数、文字列)
 @see [[m:Net::HTTP#proxy_port]], [[m:Net::HTTP#proxy_address]], [[m:Net::HTTP.new]]
-#@end
+
 
 --- proxy_pass -> String|nil
 プロクシ経由で接続し、さらにプロクシのユーザ認証を
@@ -706,13 +590,8 @@ proxyport は時代遅れのメソッドです。
 を返します。
 
 そうでないなら nil を返します。
-#@until 2.0.0
-@see [[m:Net::HTTP.Proxy]]
-#@else
 @see [[m:Net::HTTP#proxy_pass=]], [[m:Net::HTTP#proxy_user]], [[m:Net::HTTP.new]]
-#@end
 
-#@since 2.0.0
 --- proxy_pass=(pass)
 プロクシのユーザ認証のパスワードを設定します。
 
@@ -720,7 +599,7 @@ proxyport は時代遅れのメソッドです。
 
 @param pass パスワード文字列
 @see [[m:Net::HTTP#proxy_pass]], [[m:Net::HTTP#proxy_user]], [[m:Net::HTTP.new]]
-#@end
+
 
 --- proxy_user -> String|nil
 プロクシ経由で接続し、さらにプロクシのユーザ認証を
@@ -729,13 +608,9 @@ proxyport は時代遅れのメソッドです。
 
 そうでないなら nil を返します。
 
-#@until 2.0.0
-@see [[m:Net::HTTP.Proxy]]
-#@else
 @see [[m:Net::HTTP#proxy_pass]], [[m:Net::HTTP#proxy_user=]], [[m:Net::HTTP.new]]
-#@end
 
-#@since 2.0.0
+
 --- proxy_user=(user)
 プロクシのユーザ認証のユーザ名を設定します。
 
@@ -743,9 +618,8 @@ proxyport は時代遅れのメソッドです。
 
 @param user ユーザ名文字列
 @see [[m:Net::HTTP#proxy_pass]], [[m:Net::HTTP#proxy_user]], [[m:Net::HTTP.new]]
-#@end
 
-#@since 2.0.0
+
 --- proxy_uri -> String|nil
 
 このメソッドは内部用なので使わないでください。
@@ -773,36 +647,23 @@ proxyport は時代遅れのメソッドです。
 @param boolean プロクシ情報を環境変数から得るかどうかを指定する真偽値
 
 @see [[m:Net::HTTP#proxy_from_env?]] 
-#@end
+
 
 --- open_timeout -> Integer|nil
 接続時に待つ最大秒数を返します。
 
-#@until 2.0.0
-この秒数たってもコネクションが
-開かなければ例外 [[c:TimeoutError]] を発生します。
-#@else
 この秒数たってもコネクションが
 開かなければ例外 [[c:Net::OpenTimeout]] を発生します。
-#@end
-#@until 2.3.0
-デフォルトは nil(タイムアウトしない)です。
-#@else
+
 デフォルトは60(秒)です。
-#@end
 
 @see [[m:Net::HTTP#read_timeout]], [[m:Net::HTTP#open_timeout=]]
 
 --- open_timeout=(seconds)
 接続時に待つ最大秒数を設定します。
 
-#@until 2.0.0
-この秒数たってもコネクションが
-開かなければ例外 [[c:TimeoutError]] を発生します。
-#@else
 この秒数たってもコネクションが
 開かなければ例外 [[c:Net::OpenTimeout]] を発生します。
-#@end
 nilを設定するとタイムアウトしなくなります。
 
 以下のコネクションを開くメソッドで有効です。
@@ -818,13 +679,8 @@ nilを設定するとタイムアウトしなくなります。
 読みこみ([[man:read(2)]]) 一回でブロックしてよい最大秒数
 を返します。
 
-#@until 2.0.0
-この秒数たっても読みこめなければ例外 [[c:TimeoutError]]
-を発生します。
-#@else
 この秒数たっても読みこめなければ例外 [[c:Net::ReadTimeout]]
 を発生します。
-#@end
 
 nilはタイムアウトしないことを意味します。
 
@@ -837,13 +693,9 @@ nilはタイムアウトしないことを意味します。
 読みこみ([[man:read(2)]]) 一回でブロックしてよい最大秒数を
 設定します。
 
-#@until 2.0.0
-この秒数たっても読みこめなければ例外 [[c:TimeoutError]]
-を発生します。
-#@else
 この秒数たっても読みこめなければ例外 [[c:Net::ReadTimeout]]
 を発生します。
-#@end
+
 nilを設定するとタイムアウトしなくなります。
 
 このタイムアウト秒数はサーバとやりとりするメソッドで有効です。
@@ -885,7 +737,7 @@ Windows では Net::WriteTimeout は発生しません。
 @see [[m:Net::HTTP#open_timeout]], [[m:Net::HTTP#read_timeout]], [[m:Net::HTTP#write_timeout]]
 #@end
 
-#@since 2.0.0
+
 --- keep_alive_timeout -> Integer
 以前のリクエストで使ったコネクションの再利用(keep-alive)を許可する秒数を
 返します。
@@ -905,8 +757,6 @@ Windows では Net::WriteTimeout は発生しません。
 が2秒である場合が多いからです。
 
 @see [[m:Net::HTTP#keep_alive_timeout]]
-
-#@end
 
 --- continue_timeout -> Integer | nil
 「100 Continue」レスポンスを待つ秒数を返します。
@@ -1408,14 +1258,9 @@ dest を指定した場合には
 --- use_ssl? -> bool
 SSLを利用して接続する場合に真を返します。
 
-#@until 1.9.2
-[[lib:net/https]] を使わない場合には常に偽を返します。
-#@end
-
 @see [[lib:net/https]], [[lib:openssl]] 
 
 
-#@since 1.9.2
 --- use_ssl=(bool)
 HTTP で SSL/TLS を使うかどうかを設定します。
 
@@ -1618,7 +1463,6 @@ SSL/TLS が有効でなかったり、接続前である場合には nil
 @param ciphers 利用可能にする共通鍵暗号の種類
 @see [[m:Net::HTTP#ciphers]]
 
-#@end
 
 = module Net::HTTPHeader
 HTTP ヘッダのためのモジュールです。


### PR DESCRIPTION
Net::HTTP の古い分岐を消しています．次の変更のための準備です．