### PR TITLE
Suppress progress bar in CI (especially for Travis CI)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,13 +26,19 @@ def generate_statichtml(version)
   puts "generate static html of #{version}"
   bitclust_gem_path = File.expand_path('../..', `bundle exec gem which bitclust`)
   raise "bitclust gem not found" unless $?.success?
-  succeeded = system("bundle", "exec",
-                     "bitclust", "--database=#{db}",
-                     "statichtml", "--outputdir=#{File.join(HTML_DIRECTORY_BASE, version)}",
-                     "--templatedir=#{bitclust_gem_path}/data/bitclust/template.offline",
-                     "--catalog=#{bitclust_gem_path}/data/bitclust/catalog",
-                     "--fs-casesensitive",
-                     "--canonical-base-url=http://localhost:9292/latest/")
+  commands = [
+    "bundle", "exec",
+    "bitclust", "--database=#{db}",
+    "statichtml", "--outputdir=#{File.join(HTML_DIRECTORY_BASE, version)}",
+    "--templatedir=#{bitclust_gem_path}/data/bitclust/template.offline",
+    "--catalog=#{bitclust_gem_path}/data/bitclust/catalog",
+    "--fs-casesensitive",
+    "--canonical-base-url=http://localhost:9292/latest/"
+  ]
+  # To suppress progress bar
+  # because it exceeded Travis CI max log length
+  commands << "--quiet" if ENV['CI']
+  succeeded = system(*commands)
   raise "Failed to generate static html" unless succeeded
   File.unlink("/tmp/html/latest") rescue nil
   File.symlink(version, "/tmp/html/latest")


### PR DESCRIPTION
Travis CIが突然

> The job exceeded the maximum log length, and has been terminated.

と言ってコケるようになってしまいました。
https://travis-ci.org/rurema/doctree?utm_medium=notification&utm_source=github_status

そのため、出力の大半を占めているprogress barをCIでは表示しないようにします。



幸いbitclustの方で--quietオプションでprogress barを出し分けられるようになっているので、そのオプションを使います。

https://github.com/rurema/bitclust/blob/26aa59c4db8d46a397cda74d25af00ab66b0d990/lib/bitclust/subcommands/statichtml_command.rb#L240-L244
https://github.com/rurema/bitclust/blob/26aa59c4db8d46a397cda74d25af00ab66b0d990/lib/bitclust/subcommands/statichtml_command.rb#L140-L142