### PR TITLE
Add link from BasicObject#instance_eval to BasicObject#instance_exec

### DIFF
--- a/refm/api/src/_builtin/BasicObject.public_methods_from_Object
+++ b/refm/api/src/_builtin/BasicObject.public_methods_from_Object
@@ -60,7 +60,7 @@ BasicObject を継承して作ったクラス内で instance_eval する場合�
   bar.call1 # => Object
   bar.call2 # raise NameError
 
-@see [[m:Module#module_eval]], [[m:Kernel.#eval]]
+@see [[m:Module#module_eval]], [[m:Kernel.#eval]], [[m:BasicObject#instance_exec]]
 
 --- instance_exec(*args) {|*vars| ... } -> object
 


### PR DESCRIPTION
issue #2059 で指摘されているように、`instance_eval`から`instance_exec`へのSEE_ALSOのリンクがなかったため追加しました。