### PR TITLE
Update example of `Module#>`

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -225,7 +225,7 @@ nil を返します。
 
   Prepended.ancestors # => [Awesome, Prepended]
   Awesome > Prepended # => true
-  Prepended > Awesome # => nil
+  Prepended > Awesome # => false
 
   Awesome > Awesome # => false
   Awesome > Object # => nil


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/779#issuecomment-568728818
```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.3 ./all-ruby -e 'module Awesome; end; module Included; include Awesome; end; module Prepended; prepend Awesome; end; p Prepended > Awesome'
ruby-2.3.0          nil
...
ruby-2.3.8          nil
ruby-2.4.0-preview1 false
...
ruby-2.7.0-rc2      false
```