### PR TITLE
Add LL2NUM sample code

### DIFF
--- a/refm/capi/src/ruby.h.rd
+++ b/refm/capi/src/ruby.h.rd
@@ -250,6 +250,10 @@ cが’0’から’9’、’a’から’f’、’A’から’F’のとき�
 
 --- MACRO VALUE LL2NUM(long long v)
 
+例:
+   long long n = 42;
+   VALUE num = LL2NUM(n); // (long longの整数42をRubyのオブジェクトに変換)
+
 --- MACRO VALUE LONG2FIX(long i)
 
 INT2FIX と同じです。


### PR DESCRIPTION
C APIの`LL2NUM`マクロのサンプルコードを追加しました。実際のコードは以下の通りですね。

```c
   long long n = 42;
   VALUE num = LL2NUM(n); // (long longの整数42をRubyのオブジェクトに変換)
```