### PR TITLE
2.5.0 以降で IO#write の例を両方残す

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1942,19 +1942,18 @@ IOポートに対して str を出力します。str が文字列でなけ
 
 @raise Errno::EXXX 出力に失敗した場合に発生します。
 
-#@since 2.5.0
-#@samplecode 例
-File.open("textfile", "w+") do |f|
-  f.write("This is", " a test\n")  # => 15
-end
-File.read("textfile")              # => "This is a test\n"
-#@end
-#@else
 #@samplecode 例
 File.open("textfile", "w+") do |f|
   f.write("This is")  # => 7
 end
 File.read("textfile") # => "This is"
+#@end
+#@since 2.5.0
+#@samplecode 複数引数の例
+File.open("textfile", "w+") do |f|
+  f.write("This is", " a test\n")  # => 15
+end
+File.read("textfile")              # => "This is a test\n"
 #@end
 #@end
 


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/1116#issuecomment-571546858