### PR TITLE
Add example code for TracePoint#method_id

### DIFF
--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -310,8 +310,6 @@ foo 1
 
 @raise RuntimeError イベントフックの外側で実行した場合に発生します。
 
-@see [[m:TracePoint#callee_id]]
-
 #@samplecode
 class C
   def method_name
@@ -326,6 +324,8 @@ trace.enable do
   C.new.alias_name
 end
 #@end
+
+@see [[m:TracePoint#callee_id]]
 
 --- callee_id -> Symbol | nil
 
@@ -334,8 +334,6 @@ end
 
 @raise RuntimeError イベントフックの外側で実行した場合に発生します。
 
-@see [[m:TracePoint#method_id]]
-
 #@samplecode
 class C
   def method_name
@@ -350,6 +348,8 @@ trace.enable do
   C.new.alias_name
 end
 #@end
+
+@see [[m:TracePoint#method_id]]
 
 --- defined_class -> Class | module
 

--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -310,8 +310,23 @@ foo 1
 
 @raise RuntimeError イベントフックの外側で実行した場合に発生します。
 
-#@since 2.4.0
 @see [[m:TracePoint#callee_id]]
+
+#@samplecode
+class C
+  def method_name
+  end
+  alias alias_name method_name
+end
+
+trace = TracePoint.new(:call) do |tp|
+  p [tp.method_id, tp.callee_id] # => [:method_name, :alias_name]
+end
+trace.enable do
+  C.new.alias_name
+end
+#@end
+
 --- callee_id -> Symbol | nil
 
 イベントが発生したメソッドの呼ばれた名前を [[c:Symbol]] で返します。
@@ -335,7 +350,7 @@ trace.enable do
   C.new.alias_name
 end
 #@end
-#@end
+
 --- defined_class -> Class | module
 
 メソッドを定義したクラスかモジュールを返します。


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/1302 のコンフリクトを解消するのがちょっと大変そうだったので、PRを作り直しました。

サンプルコードには元からある`TracePoint#callee_id`と同じものを使っています。
またRuby 2.4でのバージョン分岐をなくしています。

cc/ @tbpgr 