### PR TITLE
Improve Hash#to_proc description

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -327,10 +327,12 @@ hash.to_h {|key, value| [key.upcase, value-32] } # => {"A"=>65, "B"=>66}
 #@since 2.3.0
 --- to_proc -> Proc
 
-self に対応する [[c:Proc]] オブジェクトを返します。
+self のキーに対応する値を返す [[c:Proc]] オブジェクトを返します。
 
-  h = {1 => 10, 2 => 20, 3 => 30}
-  [1, 2, 3].map(&h) # => [10, 20, 30]
+#@samplecode
+h = {1 => 10, 2 => 20, 3 => 30}
+[1, 2, 3].map(&h) # => [10, 20, 30]
+#@end
 #@end
 
 --- length -> Integer


### PR DESCRIPTION
`Hash#to_proc`の説明が、「self に対応する [[c:Proc]] オブジェクトを返します。」としか書かれていなくて、少し不親切だなと思ったので、キーに対応する値を返すことを明示しました。

> Returns a Proc which maps keys to values.

RDocでも上のように書かれているので、RDocの説明に近い形になるんじゃないかなと思います。
