### PR TITLE
fix link of `OpenSSL::OCSP::BasicResponse#copy_nonce`

### DIFF
--- a/refm/api/src/openssl/OCSP
+++ b/refm/api/src/openssl/OCSP
@@ -236,7 +236,7 @@ BasicResponse に nonce を追加します。
 
 引数を省略すると、ランダムな nonce を生成し利用します。
 
-通常はこのメソッドを使わず [[c:OpenSSL::OCSP::BasicResponse#copy_nonce]] を
+通常はこのメソッドを使わず [[m:OpenSSL::OCSP::BasicResponse#copy_nonce]] を
 用います。
 
 @param val 追加する nonce の値(文字列)


### PR DESCRIPTION
`OpenSSL::OCSP::BasicResponse#copy_nonce` へのリンクを修正です。
リンクの生成が間違っていてい 404 になっていたので修正しました。以下、修正箇所の含まれるペーです。

- https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aOCSP=3a=3aBasicResponse/i/add_nonce.html