### PR TITLE
Fix broken links to OptionParser#ver

### DIFF
--- a/refm/api/src/optparse/OptionParser
+++ b/refm/api/src/optparse/OptionParser
@@ -396,7 +396,7 @@ end
 
 #@#noexample OptionParser#verを参照
 
-@see [[OptionParser#ver]]
+@see [[m:OptionParser#ver]]
 
 --- version=(ver)
 
@@ -406,7 +406,7 @@ end
 
 #@#noexample OptionParser#verを参照
 
-@see [[OptionParser#ver]]
+@see [[m:OptionParser#ver]]
 
 --- release       -> String
 
@@ -430,7 +430,7 @@ end
 
 #@#noexample OptionParser#verを参照
 
-@see [[OptionParser#ver]]
+@see [[m:OptionParser#ver]]
 
 --- ver    -> String
 


### PR DESCRIPTION
`OptionParser#ver`へのリンク書式が間違っていてリンクになっていなかったので修正します。


before

![200122231903](https://user-images.githubusercontent.com/4361134/72901758-abb95180-3d6d-11ea-978c-16f07017990b.png)


after


![200122231914](https://user-images.githubusercontent.com/4361134/72901759-ac51e800-3d6d-11ea-8f3a-1e70afe935a1.png)
