### PR TITLE
Unlink WEBrick::HTTPUtils.#escape_form because the page is missing

### DIFF
--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -159,7 +159,7 @@ URI 文字列をエンコードした文字列を返します。
 [[m:ERB::Util.#url_encode]],
 [[m:CGI.escape]],
 [[m:URI.encode_www_form_component]],
-[[m:WEBrick::HTTPUtils.#escape_form]],
+WEBrick::HTTPUtils.#escape_form,
 [[m:WEBrick::HTTPUtils.#escape]]
 などの使用を検討してください。
 詳細は [[ruby-core:29293]] からのスレッドを参照してください。


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/URI/s/encode.html に `WEBrick::HTTPUtils.#escape_form`へのリンクがあるのですが、ページが未作成なので（[参考](https://github.com/rurema/doctree/blob/master/refm/api/src/webrick/httputils/HTTPUtils#L115-L116)）、リンクをクリックしても404になります。
ですので、ページが作成されるまでリンクを外しておいた方がいいのでは？と思いました。

（ただし、 https://docs.ruby-lang.org/ja/latest/class/WEBrick=3a=3aHTTPUtils.html を見ても`escape_form`が見当たらないので、結局読み手は困惑しそうですが・・・）