### PR TITLE
正規表現の参考文献を拡充

### DIFF
--- a/refm/doc/spec/regexp19
+++ b/refm/doc/spec/regexp19
@@ -845,6 +845,7 @@ Rubyで利用可能なメタ文字、メタ文字列の一覧です。
 これらの変数はスレッドローカルかつメソッドでローカルな変数です。
 
 ===[a:references] 参考文献
-  * 詳説正規表現(Jeffrey E. F. Friedl) 
-  * Onigmoのドキュメント
+  * 『正規表現技術入門――最新エンジン実装と理論的背景』新屋良磨、鈴木勇介、高田謙 著、技術評論社（2015） [[url:https://gihyo.jp/book/2015/978-4-7741-7270-5]]
+  * 『詳説正規表現　第3版』Jeffrey E. F. Friedl 著、オライリー・ジャパン（2008） [[url:https://www.oreilly.co.jp/books/9784873113593/]]
+  * Onigmoのドキュメント：[[url:https://github.com/k-takata/Onigmo/blob/master/doc/RE.ja]]
   * Ruby の tarball に含まれている doc/re.rdoc or doc/regexp.rdoc

--- a/refm/doc/spec/regexp19
+++ b/refm/doc/spec/regexp19
@@ -848,4 +848,4 @@ Rubyで利用可能なメタ文字、メタ文字列の一覧です。
   * 『正規表現技術入門――最新エンジン実装と理論的背景』新屋良磨、鈴木勇介、高田謙 著、技術評論社（2015） [[url:https://gihyo.jp/book/2015/978-4-7741-7270-5]]
   * 『詳説正規表現　第3版』Jeffrey E. F. Friedl 著、オライリー・ジャパン（2008） [[url:https://www.oreilly.co.jp/books/9784873113593/]]
   * Onigmoのドキュメント：[[url:https://github.com/k-takata/Onigmo/blob/master/doc/RE.ja]]
-  * Ruby の tarball に含まれている doc/re.rdoc or doc/regexp.rdoc
+  * Ruby の tarball に含まれている doc/regexp.rdoc：[[url:https://github.com/ruby/ruby/blob/master/doc/regexp.rdoc]]


### PR DESCRIPTION
「正規表現」のページ
https://docs.ruby-lang.org/ja/latest/doc/spec=2fregexp.html
の「参考文献」を拡充します。
修正のポイントは以下のとおりです。

- 「詳説正規表現(Jeffrey E. F. Friedl)」を第三版に改め，最低限の書誌情報を付けて，出版元のサイトの URL を付加
- 「Onigmoのドキュメント」に URL を付加
- 『正規表現技術入門』を追加

