### PR TITLE
MatchData#== のサンプルコードの誤ったインデントを修正

### DIFF
--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -269,29 +269,32 @@ false を返します。
 
 @param other 比較対象のオブジェクトを指定します。
 
-    #@samplecode 文字列
-    s = "abc"
-    m1 = s.match("a")
-    m2 = s.match("b")
-    m1 == m2  #=> false
-    m2 = s.match("a")
-    m1 == m2  #=> true
+#@samplecode 文字列
+s = "abc"
+m1 = s.match("a")
+m2 = s.match("b")
+m1 == m2  # => false
+m2 = s.match("a")
+m1 == m2  # => true
+#@end
 
-    #@samplecode 正規表現
-    r = /abc/
-    m1 = r.match("abc")  #=> #<MatchData "abc">
-    m2 = r.match("abcde")  #=> #<MatchData "abc">
-    m1 == m2  #=> false
-    m2 = r.match("abc")  #=> #<MatchData "abc">
-    m1 == m2  #=> true
+#@samplecode 正規表現
+r = /abc/
+m1 = r.match("abc")   # => #<MatchData "abc">
+m2 = r.match("abcde") # => #<MatchData "abc">
+m1 == m2  # => false
+m2 = r.match("abc")   # => #<MatchData "abc">
+m1 == m2  # => true
+#@end
 
-    #@samplecode 正規表現のマッチした位置
-    r = /abc/
-    m1 = r.match("abcabc")  #=> #<MatchData "abc">
-    m2 = r.match("abcabc", 3)  #=> #<MatchData "abc">
-    m1 == m2  #=> false
-    m2 = r.match("abcabc", 0)  #=> #<MatchData "abc">
-    m1 == m2  #=> true
+#@samplecode 正規表現のマッチした位置
+r = /abc/
+m1 = r.match("abcabc")    # => #<MatchData "abc">
+m2 = r.match("abcabc", 3) # => #<MatchData "abc">
+m1 == m2  # => false
+m2 = r.match("abcabc", 0) # => #<MatchData "abc">
+m1 == m2  # => true
+#@end
 
 #@end
 #@since 2.4.0


### PR DESCRIPTION
#2069 を解決します。

なお，MatchData の他のサンプルコードはみな旧形式ですが，https://github.com/rurema/bitclust/issues/97 の問題があるため `#@samplecode` の形式に直せないものがいくつもあります。
他のサンプルコードは https://github.com/rurema/bitclust/issues/97 が修正されるのを待ちたいと思います。