### PR TITLE
Add ENV.freeze since 2.7.0

### DIFF
--- a/refm/api/src/_builtin/ENV
+++ b/refm/api/src/_builtin/ENV
@@ -413,3 +413,7 @@ ENV.slice("unknown")    # => {}
 ENV.slice("foo", "baz") # => {"foo"=>"bar", "baz"=>"qux"}
 #@end
 #@end
+#@since 2.7.0
+--- freeze -> ()
+ENV.freeze は環境変数の変更を禁止できないため、[[c:TypeError]]を発生させます。
+#@end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/f53d7e4bfd604be6f8131c5460c29f4af16da117

```
 %  RBENV_VERSION=2.7.0 ruby -e 'p ENV.instance_eval{@a=1};ENV.freeze rescue p($!);p ENV.instance_eval{@b=2}'
 1
 #<TypeError: cannot freeze ENV>
 2
 %  RBENV_VERSION=2.6.5 ruby -e 'p ENV.instance_eval{@a=1};ENV.freeze rescue p($!);p ENV.instance_eval{@b=2}'
 1
 Traceback (most recent call last):
 	2: from -e:1:in `<main>'
 	1: from -e:1:in `instance_eval'
 -e:1:in `block in <main>': can't modify frozen #<Class:#<Object:0x00007fa095088508>> (FrozenError)
```