### PR TITLE
Add more examples to Pathname#sub_ext

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -1284,8 +1284,12 @@ File.open などの引数に渡す際に呼ばれるメソッドです。 Pathna
 #@samplecode 例
 require "pathname"
 
-Pathname('/usr/bin/shutdown').sub_ext('.rb')    # => #<Pathname:/usr/bin/shutdown.rb>
-Pathname('/home/user/test.txt').sub_ext('.pdf') # => #<Pathname:/home/user/test.pdf>
+Pathname('/usr/bin/shutdown').sub_ext('.rb')      # => #<Pathname:/usr/bin/shutdown.rb>
+Pathname('/home/user/test.txt').sub_ext('.pdf')   # => #<Pathname:/home/user/test.pdf>
+Pathname('/home/user/test').sub_ext('.pdf')       # => #<Pathname:/home/user/test.pdf>
+Pathname('/home/user/test.').sub_ext('.pdf')      # => #<Pathname:/home/user/test..pdf>
+Pathname('/home/user/.test').sub_ext('.pdf')      # => #<Pathname:/home/user/.test.pdf>
+Pathname('/home/user/test.tar.gz').sub_ext('.xz') # => #<Pathname:/home/user/test.tar.xz>
 #@end
 
 #@end


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/1706#issuecomment-581868463 の対応です。
上のコメントの他に、`.test`のようなドット始まりのファイルの場合も例に追加しました。