### PR TITLE
Revise Rational#quo documentation

### DIFF
--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -96,9 +96,7 @@ r - 0.5              # => 0.25
 
 @param other 自身を割る数
 
-other に [[c:Float]] を指定した場合は、計算結果を [[c:Float]] で返しま
-す。ただし 0 以外の整数に等しい場合は [[c:Rational]] で返します。
-#@# r28844 と r28886
+other に [[c:Float]] を指定した場合は、計算結果を [[c:Float]] で返します。
 
 #@samplecode 例
 r = Rational(3, 4)


### PR DESCRIPTION
Rational#quo のドキュメントを修正します。

ここで「other に Float を指定した場合は、計算結果を Float で返します。ただし 0 以外の整数に等しい場合は Rational で返します。」と書かれています。
ですが、「ただし 0 以外の整数に等しい場合は Rational で返します。」は現在の挙動と異なるようでした。現在はotherがFloatの場合は戻り値もFloatになっています。
「ただし 0 以外の整数に等しい場合は Rational で返します。」というのは、1.9.3と2.0.0のみの挙動のようです。


```bash
$ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-1.8.0 ./all-ruby -rrational -e 'p Rational(3, 4) / 2.0'
ruby-1.8.0            0.375
...
ruby-1.9.2-p330       0.375
ruby-1.9.3-preview1   (3/8)
...
ruby-2.0.0-p648       (3/8)
ruby-2.1.0-preview1   0.375
...
ruby-2.7.0            0.375
```



どうやら色々あって変更がrevertされたようです。
https://bugs.ruby-lang.org/issues/5515


そのため、ドキュメントの記述も実際の挙動に合わせて修正しています。


なお、サンプルコードには実際の挙動に合った戻り値が書かれているので修正は不要でした :heavy_check_mark: 