### PR TITLE
rubygems の gemspec 中の引用符抜けを訂正；gemspec を #@samplecode 化

### DIFF
--- a/refm/api/src/rubygems.rd
+++ b/refm/api/src/rubygems.rd
@@ -112,26 +112,30 @@ Proxy サーバ経由で Gem パッケージをインストールするには以
 最小の gemspec は以下のようになります。ビルドするために必要な最小の gemspec なので出来上がるのは
 メタデータのみを含む Gem パッケージです。また、いくつかの警告が表示されます。
 
-  Gem::Specification.new do |s|
-    s.name    = 'hello'
-    s.version = '0.0.0'
-    s.summary = 'hello summary'
-  end
+#@samplecode gemspec
+Gem::Specification.new do |s|
+  s.name    = 'hello'
+  s.version = '0.0.0'
+  s.summary = 'hello summary'
+end
+#@end
 
 実用的なライブラリを作成するための gemspec の例を示します。
 警告メッセージが出力されないようにいくつか設定を追加しています。
 
-  Gem::Specification.new do |s|
-    s.name              = 'hello'
-    s.version           = '0.0.0'
-    s.summary           = 'hello summary'
-    s.files             = ['lib/hello.rb']
-    s.authors           = ['Hello Author']
-    s.email             = 'hello_author@example.com'
-    s.homepage          = 'http://example.com/hello/'
-    s.description       = 'hello description'
-    s.rubyforge_project = 'hello'
-  end
+#@samplecode gemspec
+Gem::Specification.new do |s|
+  s.name              = 'hello'
+  s.version           = '0.0.0'
+  s.summary           = 'hello summary'
+  s.files             = ['lib/hello.rb']
+  s.authors           = ['Hello Author']
+  s.email             = 'hello_author@example.com'
+  s.homepage          = 'http://example.com/hello/'
+  s.description       = 'hello description'
+  s.rubyforge_project = 'hello'
+end
+#@end
 
 : name
   この Gem の名前を指定します。
@@ -154,47 +158,50 @@ Proxy サーバ経由で Gem パッケージをインストールするには以
 
 実行可能なファイル (コマンド) を含む場合の gemspec は以下のようになります。
 
-  Gem::Specification.new do |s|
-    s.name              = 'hello'
-    s.version           = '0.0.0'
-    s.summary           = 'hello summary'
-    s.files             = ['bin/hello', 'lib/hello.rb']
-    s.executables       = ['hello']
-    s.authors           = ['Hello Author']
-    s.email             = 'hello@example.com'
-    s.homepage          = 'http://example.com/hello'
-    s.rubyforge_project = 'hello'
-    s.description       = 'hello description'
-  end
+#@samplecode gemspec
+Gem::Specification.new do |s|
+  s.name              = 'hello'
+  s.version           = '0.0.0'
+  s.summary           = 'hello summary'
+  s.files             = ['bin/hello', 'lib/hello.rb']
+  s.executables       = ['hello']
+  s.authors           = ['Hello Author']
+  s.email             = 'hello@example.com'
+  s.homepage          = 'http://example.com/hello'
+  s.rubyforge_project = 'hello'
+  s.description       = 'hello description'
+end
+#@end
 
 ライブラリの例に加えて executables を追加しています。
 
 また、以下のように Rakefile にタスクを追加することもできます。
 
-  require 'rake/gempackagetask'
-  
-  PKG_FILES = FileList[
-    'lib/hello.rb',
-    'spec/*'
-  ]
-  spec = Gem::Specification.new do |s|
-    s.name             = 'hello'
-    s.version          = '0.0.1'
-    s.author           = 'Hello Author'
-    s.email            = 'hello@example.com
-    s.homepage         = 'http://example.com/hello'
-    s.platform         = Gem::Platform::RUBY
-    s.summary          = 'Hello Gem'
-    s.files            = PKG_FILES.to_a
-    s.require_path     = 'lib'
-    s.has_rdoc         = false
-    s.extra_rdoc_files = ['README']
-  end
-  
-  Rake::GemPackageTask.new(spec) do |pkg|
-    pkg.gem_spec = spec
-  end
+#@samplecode gemspec
+require 'rake/gempackagetask'
 
+PKG_FILES = FileList[
+  'lib/hello.rb',
+  'spec/*'
+]
+spec = Gem::Specification.new do |s|
+  s.name             = 'hello'
+  s.version          = '0.0.1'
+  s.author           = 'Hello Author'
+  s.email            = 'hello@example.com'
+  s.homepage         = 'http://example.com/hello'
+  s.platform         = Gem::Platform::RUBY
+  s.summary          = 'Hello Gem'
+  s.files            = PKG_FILES.to_a
+  s.require_path     = 'lib'
+  s.has_rdoc         = false
+  s.extra_rdoc_files = ['README']
+end
+
+Rake::GemPackageTask.new(spec) do |pkg|
+  pkg.gem_spec = spec
+end
+#@end
 
 @see [[c:Gem::Specification]], [[lib:rake]]
 


### PR DESCRIPTION
rubygems のページ
https://docs.ruby-lang.org/ja/2.7.0/library/rubygems.html
の「Gem パッケージを作成する」に挙がっている gemspec のうち，一つに `'` 抜けがあり，SyntaxError になっていました。
（「 また、以下のように Rakefile にタスクを追加することもできます。」のあとのもの）

これを修正がてら，この節の gemspec を `#@samplecode` 形式に書き直しました。

追記：コミットメッセージが「引用符抜けを削除」になっていますが，「削除」でなく「訂正」でした。