### PR TITLE
有限数列の最終項を指す用語を「末項」とします

### DIFF
--- a/refm/api/src/_builtin/Enumerator__ArithmeticSequence
+++ b/refm/api/src/_builtin/Enumerator__ArithmeticSequence
@@ -21,13 +21,13 @@ ArithmeticSequenceオブジェクトは、[[m:Numeric#step]], [[m:Range#step]] �
 
 --- end -> Numeric | nil
 
-上界 (終端) を返します。
+末項（終端）を返します。
 
 @see [[m:Enumerator::ArithmeticSequence#begin]]
 
 --- exclude_end? -> bool
 
-上界 (終端) を含まないとき真を返します。
+末項（終端）を含まないとき真を返します。
 
 --- step -> Numeric
 


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/2.7.0/class/Enumerator=3a=3aArithmeticSequence.html

Enumerator::ArithmeticSequence の最終項が「上界」となっていたのを「末項」に訂正します。