### PR TITLE
Revise documentation of Kernel.#autoload with nested module with Ruby 2.5+

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -320,7 +320,7 @@ case ではクラス、モジュールの所属関係をチェックすること
 
 @param const_name [[c:String]] または [[c:Symbol]] で指定します。
        なお、const_name には、"::" 演算子を含めることはできません。
-       つまり、self のモジュール直下に定義された定数しか指定できません。
+       つまり、self の直下に定義された定数しか指定できません。
 
 @param feature [[m:Kernel.#require]] と同様な方法で autoload する対象を指定する。
 

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -320,16 +320,91 @@ case ではクラス、モジュールの所属関係をチェックすること
 
 @param const_name [[c:String]] または [[c:Symbol]] で指定します。
        なお、const_name には、"::" 演算子を含めることはできません。
-       つまり、トップレベルの定数しか指定できません。
+       つまり、self のモジュール直下に定義された定数しか指定できません。
 
 @param feature [[m:Kernel.#require]] と同様な方法で autoload する対象を指定する。
 
-@see [[m:Kernel.#autoload]]
+#@samplecode
+# ------- /tmp/foo.rb ---------
+class Foo
+  class Bar
+  end
+end
+# ----- end of /tmp/foo.rb ----
 
-例:
-  Date # NameError: uninitialized constant Date
-  autoload :Date, 'date'
-  Date # => Date
+class Foo
+  autoload :Bar, '/tmp/foo'
+end
+p Foo::Bar #=> Foo::Bar
+#@end
+
+以下のようにモジュールを明示的にレシーバとして呼び出すこともできます。
+
+#@samplecode
+# ------- /tmp/foo.rb ---------
+class Foo
+  class Bar
+  end
+end
+# ----- end of /tmp/foo.rb ----
+
+class Foo
+end
+Foo.autoload :Bar, '/tmp/foo'
+p Foo::Bar #=> Foo::Bar
+#@end
+
+#@since 2.5.0
+以下のように、autoload したライブラリがネストした定数を定義しない場
+合、NameError が発生します。
+
+#@samplecode
+# ------- /tmp/bar.rb ---------
+class Bar
+end
+# ----- end of /tmp/bar.rb ----
+
+class Foo
+  autoload :Bar, '/tmp/bar.rb'
+end
+p Foo::Bar
+#=> -:4:in `<main>': uninitialized constant Foo::Bar (NameError)
+#@end
+#@else
+以下のように、autoload したライブラリがネストした定数を定義しない場
+合、一見、正常に動作しているように見えるので注意が必要です(警告メッ
+セージが出ています)。
+
+#@samplecode
+# ------- /tmp/bar.rb ---------
+class Bar
+end
+# ----- end of /tmp/bar.rb ----
+
+class Foo
+  autoload :Bar, '/tmp/bar.rb'
+end
+p Foo::Bar
+p Foo.autoload?(:Bar)
+#=> -:4: warning: toplevel constant Bar referenced by Foo::Bar
+#   Bar
+#   nil
+#@end
+
+これは以下のようにネストせずに定義したのと同じことです。
+
+#@samplecode
+class Foo
+end
+class Bar
+end
+p Foo::Bar
+#=> -:5: warning: toplevel constant Bar referenced by Foo::Bar
+#   Bar
+#@end
+#@end
+
+@see [[m:Kernel.#autoload]]
 
 --- autoload?(const_name) -> String | nil
 autoload 定数がまだ定義されてない(ロードされていない) ときにそのパス名を返します。

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1056,76 +1056,22 @@ require_relative を呼出すと必ず失敗します。
 定数 const_name を最初に参照した時に feature を
 [[m:Kernel.#require]] するように設定します。
 
-const_name には、 "::" 演算子を含めることはできません
-（ネストした定数を指定する方法は後述）。
+const_name には、 "::" 演算子を含めることはできません。
+ネストした定数を指定する方法は [[m:Module#autoload]] を参照してください。
 
 @param const_name 定数をString または Symbol で指定します。
 @param feature require と同様な方法で autoload する対象を指定します。
 @raise LoadError featureのロードに失敗すると発生します。
 
-    ------- /tmp/foo.rb ---------
-    class Bar
-    end
-    ----- end of /tmp/foo.rb ----
+#@samplecode
+# ------- /tmp/foo.rb ---------
+class Bar
+end
+# ----- end of /tmp/foo.rb ----
 
-    autoload :Bar, '/tmp/foo'
-    p Bar #=> Bar
-
-=== ネストした定義内の定数
-
-const_name には、 "::" 演算子を含めることはできないので、 Kernel.#autoload 
-ではトップレベルの定数しか指定できません。
-
-[[m:Module#autoload]] と組み合わせることで、任意のクラス／モジュールの定数を autoload できます。
-やはりconst_name に "::" 演算子を含めることはで
-きませんが、以下のように定義する事ができます。
-
-    ------- /tmp/foo.rb ---------
-    class Foo
-      class Bar
-      end
-    end
-    ----- end of /tmp/foo.rb ----
-
-    class Foo
-      autoload :Bar, '/tmp/foo'
-    end
-    p Foo::Bar #=> Foo::Bar
-
-あるいは、以下のようにもできます。
-
-    class Foo
-    end
-    Foo.autoload :Bar, '/tmp/foo'
-    p Foo::Bar #=> Foo::Bar
-
-以下のように、autoload したライブラリがネストした定数を定義しない場
-合、一見、正常に動作しているように見えるので注意が必要です(警告メッ
-セージが出ています)。
-
-      ------- /tmp/bar.rb ---------
-      class Bar
-      end
-      ----- end of /tmp/bar.rb ----
-
-      class Foo
-        autoload :Bar, '/tmp/bar.rb'
-      end
-      p Foo::Bar
-      p Foo.autoload?(:Bar)
-      #=> -:4: warning: toplevel constant Bar referenced by Foo::Bar
-      #   Bar
-      #   nil
-
-これは以下のようにネストせずに定義したのと同じことです。
-
-      class Foo
-      end
-      class Bar
-      end
-      p Foo::Bar
-      #=> -:5: warning: toplevel constant Bar referenced by Foo::Bar
-      #   Bar
+autoload :Bar, '/tmp/foo'
+p Bar #=> Bar
+#@end
 
 @see [[m:Kernel.#autoload?]],[[m:Module#autoload]],[[m:Kernel.#require]]
 


### PR DESCRIPTION
Fix #689



ネストしたモジュールの説明は Kernel.#autoload ではなく Module#autoload の説明なので、そちらに説明を移しました。
また、Ruby 2.5で分岐して、ネストしたモジュールをautloadしようとした時にエラーが出ることを書いています。
またついでにsamplecode化をしています。





# スクリーンショット

Kernel.#module

![200218211406](https://user-images.githubusercontent.com/4361134/74735344-d676c700-5293-11ea-8b2b-e909d0819e08.png)



Module#autoload (2.4まで)

![200218212050](https://user-images.githubusercontent.com/4361134/74735702-92d08d00-5294-11ea-9d96-ec748b0bde00.png)


Module#autoload (2.5以上)

![200218212025](https://user-images.githubusercontent.com/4361134/74735675-851b0780-5294-11ea-9840-1a25f593826e.png)


