### PR TITLE
Enumerable#chunk で RuntimeError を出すサンプルを訂正

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1302,8 +1302,10 @@ open("/usr/share/dict/words", "r:iso-8859-1") {|f|
 それ以外のアンダースコアで始まるシンボルを指定した場合は例外が発生します。
 
 #@samplecode 例
-items.chunk { |item| :_underscore }
+[1, 2].chunk { |item| :_underscore }.to_a
 # => RuntimeError: symbols beginning with an underscore are reserved
+
+# 「.to_a」無しだと Enumerator を返すのみで例外は発生しない
 #@end
 
 nil、 :_separator はある要素を無視したい場合に用います。


### PR DESCRIPTION
 #2160 を解決します。（修正前は例外が発生しません）

元はレシーバーが `items` ですがが，これだとコピペしても試せないので，`[1, 2]` にしました。いかがでしょう？
また，何のために `.to_a` がついているのか直ちには分からないので，注釈を入れました。こちらもいかがでしょうか。