### PR TITLE
pack テンプレート文字列の x，X，@ を訂正・改善

### DIFF
--- a/refm/api/src/_builtin/pack-template
+++ b/refm/api/src/_builtin/pack-template
@@ -703,21 +703,20 @@ n, N, v, V を用います。
 
 : x
 
-  ヌルバイト/1バイト読み飛ばす
+  ヌルバイト（pack）／1バイト読み飛ばし（unpack）
 #@samplecode
-    [?a, ?b].pack("CxC")    # => "a\000b"
-    [?a, ?b].pack("Cx3C")   # => "a\000\000\000b"
+    [97, 98].pack("CxC")    # => "a\x00b"
+    [97, 98].pack("Cx3C")   # => "a\x00\x00\x00b"
 
-    "a\000b".unpack("CxC")  # => [97, 98]
-    "a\377b".unpack("CxC")  # => [97, 98]
-    "a\377b".unpack("Cx3C") # => ArgumentError: x outside of string
+    "abc".unpack("CxC")  # => [97, 99]
+    "abc".unpack("Cx3C") # => ArgumentError: x outside of string
 #@end
 
 : X
 
   1バイト後退
 #@samplecode
-    [?a, ?b, ?c].pack("CCXC") # => "ac"
+    [97, 98, 99].pack("CCXC") # => "ac"
 
     "abcdef".unpack("x*XC") # => [102]
 #@end
@@ -726,9 +725,9 @@ n, N, v, V を用います。
 
   絶対位置への移動
 #@samplecode
-    [?a, ?b].pack("C @3 C") # => "a\000\000b"
+    [97, 98].pack("C @3 C") # => "a\x00\x00b"
 
-    "a\000\000b".unpack("C @3 C") # => [97, 98]
+    "abcd".unpack("C @3 C") # => [97, 100]
 #@end
 
 #@since 2.3.0


### PR DESCRIPTION
pack テンプレート文字列の `x`，`X`，`@` に対する訂正と改善です。
このファイルは以下の 3 箇所に include されています。

- https://docs.ruby-lang.org/ja/2.7.0/doc/pack_template.html
- https://docs.ruby-lang.org/ja/2.7.0/method/Array/i/pack.html
- https://docs.ruby-lang.org/ja/2.7.0/method/String/i/unpack.html

主な修正点は以下のとおりです。

- #694 を解決（Ruby 1.8 時代の整数リテラル `?a` を `97` に）
- `pack` の評価値の文字列中の 8 進表記 `\000` を 16 進表記 `\x00` に
- ヌルバイトを意味するのは pack のときであるであることを明記
- 1 バイト読み飛ばすのは unpack のときであるであることを明記
- `x` や `@` の `unpack` の例で 0x00 や 0xFF を持ち出す意味が無いので差し替え

`97` よりも `"a".ord` のほうが分かりやすいかとは思いますが，やや複雑ですし，すぐあとの `unpack` の例を見れば「ああ `"a"` が `97` なのか」と分かるので，これでいいと思います。

なお，コードに余計なインデントが付いていますが，これはこのファイルの全てのコードについて修正する必要があるので，別プルリクエストで対処したいと思います。
その際，`pack` の評価値の 8 進表記を 16 進に変えるのも同時に行いたいと思います。