### PR TITLE
「手続きオブジェクトの挙動の詳細」の目次の順序を訂正

### DIFF
--- a/refm/doc/spec/lambda_proc.rd
+++ b/refm/doc/spec/lambda_proc.rd
@@ -2,9 +2,9 @@
 
  * [[ref:def]]
  * [[ref:should_use_next]]
- * [[ref:orphan]]
  * [[ref:block]]
  * [[ref:lambda_proc]]
+ * [[ref:orphan]]
 
 ===[a:def] 手続きオブジェクトとは
 


### PR DESCRIPTION
「手続きオブジェクトの挙動の詳細」
https://docs.ruby-lang.org/ja/2.7.0/doc/spec=2flambda_proc.html
の目次の順序が実際と違っていました。