### PR TITLE
yaml の要約のコードを修正

### DIFF
--- a/refm/api/src/yaml.rd
+++ b/refm/api/src/yaml.rd
@@ -8,12 +8,12 @@ require 'yaml'
 data = ["Taro san", "Jiro san", "Saburo san"]
 str_r = YAML.dump(data)
 
-str_l = <<EOT
----
-- Taro san
-- Jiro san
-- Saburo san
-EOT
+str_l = <<~YAML_EOT
+  ---
+  - Taro san
+  - Jiro san
+  - Saburo san
+YAML_EOT
 
 p str_r == str_l  # => true
 #@end
@@ -22,12 +22,12 @@ p str_r == str_l  # => true
 require 'yaml'
 require 'date'
 
-str_l = <<YAML_EOT
-Tanaka Taro: {age: 35, birthday: 1970-01-01}
-Suzuki Suneo: {
-  age: 13,
-  birthday: 1992-12-21
-}
+str_l = <<~YAML_EOT
+  Tanaka Taro: {age: 35, birthday: 1970-01-01}
+  Suzuki Suneo: {
+    age: 13,
+    birthday: 1992-12-21
+  }
 YAML_EOT
 
 str_r = {}
@@ -47,22 +47,22 @@ p str_r == YAML.load(str_l)  # => true
 require 'yaml'
 require 'stringio'
 
-strio_r = StringIO.new(<<EOT)
----
-time: 2008-02-25 17:03:12 +09:00
-target: YAML
-version: 4
-log: |
-  例を加えた。
-  アブストラクトを修正した。
----
-time: 2008-02-24 17:00:35 +09:00
-target: YAML
-version: 3
-log: |
-  アブストラクトを書いた。
+strio_r = StringIO.new(<<~YAML_EOT)
+  ---
+  time: 2008-02-25 17:03:12 +09:00
+  target: YAML
+  version: 4
+  log: |
+    例を加えた。
+    アブストラクトを修正した。
+  ---
+  time: 2008-02-24 17:00:35 +09:00
+  target: YAML
+  version: 3
+  log: |
+    アブストラクトを書いた。
 
-EOT
+YAML_EOT
 
 YAML.load_stream(strio_r).sort_by{ |a| a["version"] }.each do |obj|
   puts "version %d\ntime %s\ntarget:%s\n%s\n" % obj.values_at("version", "time", "target", "log")
@@ -79,7 +79,7 @@ end
 #  target:YAML
 #  例を加えた。
 #  アブストラクトを修正した。
-#  
+#
 #@end
 
 === バックエンドの選択

--- a/refm/api/src/yaml.rd
+++ b/refm/api/src/yaml.rd
@@ -2,72 +2,85 @@ category FileFormat
 
 構造化されたデータを表現するフォーマットであるYAML (YAML Ain't Markup Language) を扱うためのライブラリです。
 
-例1: 構造化された配列
-  require 'yaml'
+#@samplecode 例1: 構造化された配列
+require 'yaml'
 
-  data = [ "Taro san", "Jiro san", "Saburo san"]
-  str_r = YAML.dump(data)
+data = ["Taro san", "Jiro san", "Saburo san"]
+str_r = YAML.dump(data)
 
-  str_l =<<EOT
-  --- 
-  - Taro san
-  - Jiro san
-  - Saburo san
-  EOT
+str_l = <<EOT
+---
+- Taro san
+- Jiro san
+- Saburo san
+EOT
 
-  p str_r == str_l #=> true
+p str_r == str_l  # => true
+#@end
 
-例2: 構造化されたハッシュ
+#@samplecode 例2: 構造化されたハッシュ
+require 'yaml'
+require 'date'
 
-  require 'yaml'
-  require 'date'
+str_l = <<YAML_EOT
+Tanaka Taro: {age: 35, birthday: 1970-01-01}
+Suzuki Suneo: {
+  age: 13,
+  birthday: 1992-12-21
+}
+YAML_EOT
 
-  str_l =<<YAML_EOT
-  Tanaka Taro: { age: 35, birthday: 1970-01-01}
-  Suzuki Suneo: {
-    age: 13,
-    birthday: 1992-12-21
-  }
-  YAML_EOT
+str_r = {}
+str_r["Tanaka Taro"] = {
+  "age" => 35,
+  "birthday" => Date.new(1970, 1, 1)
+}
+str_r["Suzuki Suneo"] = {
+  "age" => 13,
+  "birthday" => Date.new(1992, 12, 21)
+}
 
-  str_r = {}
-  str_r["Tanaka Taro"] = {
-    "age" => 35,
-    "birthday" => Date.new(1970, 1, 1)
-  }
-  str_r["Suzuki Suneo"] = {
-    "age" => 13,
-    "birthday" => Date.new(1992, 12, 21)
-  }
+p str_r == YAML.load(str_l)  # => true
+#@end
 
-  p str_r == YAML.load(str_l) #=> true
+#@samplecode 例3: 構造化されたログ
+require 'yaml'
+require 'stringio'
 
-例3: 構造化されたログ
+strio_r = StringIO.new(<<EOT)
+---
+time: 2008-02-25 17:03:12 +09:00
+target: YAML
+version: 4
+log: |
+  例を加えた。
+  アブストラクトを修正した。
+---
+time: 2008-02-24 17:00:35 +09:00
+target: YAML
+version: 3
+log: |
+  アブストラクトを書いた。
 
-  require 'yaml'
-  require 'stringio'
+EOT
 
-  strio_r = StringIO.new(<<EOT
-  ---
-  time: 2008-02-25 17:03:12 +09:00
-  target: YAML
-  version: 4
-  log: | 
-    例を加えた。
-    アブストラクトを修正した。
-  ---
-  time: 2008-02-24 17:00:35 +09:00
-  target: YAML
-  version: 3
-  log: | 
-    アブストラクトを書いた。 
+YAML.load_stream(strio_r).sort_by{ |a| a["version"] }.each do |obj|
+  puts "version %d\ntime %s\ntarget:%s\n%s\n" % obj.values_at("version", "time", "target", "log")
+end
 
-  EOT
-  )
-
-  YAML.load_stream(strio_r).documents.sort{|a, b| a["version"] <=> b["version"]}.each{|obj|
-    printf "version %d\ntime %s\ntarget:%s\n%s\n", obj["version"], obj["time"], obj["target"], obj["log"]
-  }
+# =>
+#  version 3
+#  time 2008-02-24 17:00:35 +0900
+#  target:YAML
+#  アブストラクトを書いた。
+#
+#  version 4
+#  time 2008-02-25 17:03:12 +0900
+#  target:YAML
+#  例を加えた。
+#  アブストラクトを修正した。
+#  
+#@end
 
 === バックエンドの選択
 


### PR DESCRIPTION
yaml のページ
https://docs.ruby-lang.org/ja/2.7.0/library/yaml.html
の「要約」に載っている三つのサンプルコードを修正します。

修正の主なポイントは以下のとおりです。

- https://github.com/rurema/doctree/issues/2157 を解決（例 3 で，Ruby 2.0 以降存在しないメソッドが使われていた）
- サンプルコードのフォーマットを `#@samplecode` に
- 例 3 で `sort_by`，`String#%`，`Hash#values_at` などを用いて簡素に
- 例 3 で，何が出力されるかを追記