### PR TITLE
Remove Module#yaml_as, psych_yaml_as from 2.5.0

### DIFF
--- a/refm/api/src/psych/core_ext.rd
+++ b/refm/api/src/psych/core_ext.rd
@@ -65,6 +65,7 @@ syck が廃止された場合  psych_to_yaml は廃止
 
 == Instance Methods
 
+#@until 2.5.0
 --- yaml_as(tag) -> ()
 --- psych_yaml_as(tag) -> ()
 
@@ -94,4 +95,3 @@ syck が廃止された場合  psych_y は廃止
 される予定であるため、特別の事情がない限り y を用いてください。
 
 @param objects YAML document に変換する Ruby のオブジェクト
-

--- a/refm/api/src/psych/core_ext.rd
+++ b/refm/api/src/psych/core_ext.rd
@@ -78,6 +78,7 @@ syck が廃止された場合  psych_to_yaml は廃止
 かわりに使ってください。
 
 @param tag 対象のクラスに関連付けるタグの文字列
+#@end
 
 = reopen Kernel
 


### PR DESCRIPTION
NEWS for Ruby 2.5.0
https://docs.ruby-lang.org/ja/2.7.0/doc/news=2f2_5_0.html
によれば，[Module#psych_yaml_as](https://docs.ruby-lang.org/ja/2.7.0/method/Module/i/psych_yaml_as.html), `psych_yaml_as` は Ruby 2.5.0 で削除されました。