### PR TITLE
Fix `Pathname#<=>`'s return value

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -128,7 +128,7 @@ other は Pathname オブジェクトでなければなりません。
          false
          false
 
---- <=>(other) -> bool
+--- <=>(other) -> -1 | 0 | 1 | nil
 
 パス名を比較します。other と同じなら 0 を、ASCII順で self が大きい場合
 は正、other が大きい場合は負を返します。大文字小文字は区別されます。


### PR DESCRIPTION
`<=>` はIntegerを返しますが、`bool`と書かれていたので直しました。
grepしたところ、ほかの`<=>`のドキュメントでは`bool`と書かれているところはなさそうでした。
`-1 | 0 | 1`, `-1 | 0 | 1 | nil` と `Integer` で表記ゆれがあるので、この際どれかに統一しても良さそうです。一番細かくて正確な `-1 | 0 | 1 | nil`が良いかなと思います。


```
$ git grep -F -- '--- <=>' 
refm/api/src/_builtin/Array:--- <=>(other)    -> -1 | 0 | 1 | nil
refm/api/src/_builtin/Array:--- <=>(other)    -> -1 | 0 | 1
refm/api/src/_builtin/Bignum:--- <=>(other) -> Fixnum | nil
refm/api/src/_builtin/File__Stat:--- <=>(o) -> Integer | nil
refm/api/src/_builtin/Fixnum:--- <=>(other) -> Fixnum
refm/api/src/_builtin/Float:--- <=>(other) -> 1 | 0 | -1 | nil
refm/api/src/_builtin/Integer:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/_builtin/Module:--- <=>(other) -> Integer | nil
refm/api/src/_builtin/Numeric:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/_builtin/Object:--- <=>(other) -> 0 | nil
refm/api/src/_builtin/Rational:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/_builtin/String:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/_builtin/Symbol:--- <=>(other) -> -1 | 0 | 1
refm/api/src/_builtin/Time:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/bigdecimal/BigDecimal:--- <=>(other) -> -1 | 0 | 1 | nil
refm/api/src/date/Date:--- <=> (other) -> Integer
refm/api/src/fiddle/2.0/Fiddle__Pointer:--- <=>(other)    -> Integer
refm/api/src/ipaddr.rd:--- <=>(other) -> Integer | nil
refm/api/src/openssl/BN:--- <=>(other) -> -1 | 0 | 1
refm/api/src/openssl/X509__Name:--- <=>(ohter) ->  -1 | 0 | 1 
refm/api/src/pathname.rd:--- <=>(other) -> bool
refm/api/src/rake/Rake__EarlyTime:--- <=>(other) -> Integer
refm/api/src/rdoc/RDoc__Context:--- <=>(other) -> -1 | 0 | 1
refm/api/src/rexml/comment.rd:--- <=>(other) -> -1 | 0 | 1
refm/api/src/rexml/text.rd:--- <=>(other) -> -1 | 0 | 1
refm/api/src/rubygems/dependency.rd:--- <=>(other) -> Integer
refm/api/src/rubygems/requirement.rd:#@#--- <=>(other) -> Integer
refm/api/src/rubygems/version/Gem__Version:--- <=>(other) -> Integer | nil
refm/api/src/webrick/httpversion.rd:--- <=>(other)    -> -1 | 0 | 1 | nil
```