### PR TITLE
Add documentation for Pathname#ascend and descend of blockless form

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -1191,8 +1191,11 @@ pathname.exist? # => false
 #@end
 
 --- ascend {|pathname| ... } -> nil
+--- ascend                   -> Enumerator
+
 self のパス名から親方向に辿っていったときの各パス名を新しい Pathname オ
 ブジェクトとして生成し、ブロックへの引数として渡して実行します。
+ブロックを省略した場合は、上記の処理を行うような [[c:Enumerator]] を返します。
 
   require 'pathname'
 
@@ -1213,9 +1216,11 @@ self のパス名から親方向に辿っていったときの各パス名を新
 
 
 --- descend {|pathname| ... } -> nil
+--- descend                   -> Enumerator
 self のパス名の親から子供へと辿っていったときの各パス名を新しい
 Pathname オブジェクトとして生成し、ブロックへの引数として渡して実行しま
 す。
+ブロックを省略した場合は、上記の処理を行うような [[c:Enumerator]] を返します。
 
   require 'pathname'
 


### PR DESCRIPTION
`Pathname#ascend` および `descend` メソッドがブロックを受け取らない時の説明が抜けていたので追加します。
この変更はRuby 2.3からのもののようなので、分岐は入れていません。

https://github.com/ruby/ruby/blob/9db95707159117052527b0f0498527512b6a9730/doc/NEWS-2.3.0#stdlib-updates-outstanding-ones-only
[Feature #11052]