### PR TITLE
Fix document of Pathname#delete returned value

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -1177,8 +1177,8 @@ FileUtils.rm_r(self.to_s) と同じです。
 
 @see [[m:FileUtils.#rm_r]]
 
---- unlink -> 0
---- delete -> 0
+--- unlink -> Integer
+--- delete -> Integer
 self が指すディレクトリあるいはファイルを削除します。
 
 #@samplecode 例
@@ -1186,7 +1186,7 @@ require "pathname"
 
 pathname = Pathname("/path/to/sample")
 pathname.exist? # => true
-pathname.unlink # => 0
+pathname.unlink # => 1
 pathname.exist? # => false
 #@end
 


### PR DESCRIPTION
`Pathname#delete` の戻り値が0と書かれていましたが、実際には(少なくとも私の手元では)1が返ってきました。
`FIle.delete`のドキュメントには、戻り値がIntegerと書かれていて、かつsamplecode内では1が返っているので、そちらに合わせてPathnameのドキュメントも修正します。
https://github.com/rurema/doctree/blob/b51efa8d41887c33319617d5588976443ba1aa00/refm/api/src/_builtin/File#L170-L192