### PR TITLE
Time.at の in: の説明を追加

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -57,44 +57,78 @@ yday は 1 から数えます。
 
 == Class Methods
 
---- at(time)    -> Time
+--- at(time)         -> Time
+#@since 2.6.0
+--- at(time, in:)    -> Time
+#@end
 
 time で指定した時刻の Time オブジェクトを返します。
 
+#@since 2.6.0
+キーワード引数 in でタイムゾーンを指定できます。タイムゾーンの指定がなく
+#@end
 引数が数値の場合、生成された Time オブジェクトのタイムゾーンは地方時となります。
 
 @param time Time オブジェクト、もしくは起算時からの経過秒数を表わす数値で指定します。
+#@since 2.6.0
+@param in "+HH:MM" や "-HH:MM" のような形式の文字列か "UTC" かミリタリータイムゾーンの文字列
+          または数値でタイムゾーンを指定します。
+#@end
 
-例:
-  Time.at(0)                 # => 1970-01-01 09:00:00 +0900
-  Time.at(Time.at(0))        # => 1970-01-01 09:00:00 +0900
-  Time.at(Time.at(0).getutc) # => 1970-01-01 00:00:00 UTC
-  Time.at(946702800)         # => 2000-01-01 14:00:00 +0900
-  Time.at(-284061600)        # => 1960-12-31 15:00:00 +0900
-  Time.at(946684800.2).usec  # => 200000
+#@samplecode
+Time.at(0)                                # => 1970-01-01 09:00:00 +0900
+Time.at(Time.at(0))                       # => 1970-01-01 09:00:00 +0900
+Time.at(Time.at(0).getutc)                # => 1970-01-01 00:00:00 UTC
+Time.at(946702800)                        # => 2000-01-01 14:00:00 +0900
+Time.at(-284061600)                       # => 1960-12-31 15:00:00 +0900
+Time.at(946684800.2).usec                 # => 200000
+#@since 2.6.0
+Time.at(1582721899, in: "+09:00")         #=> 2020-02-26 21:58:19 +0900
+Time.at(1582721899, in: "UTC")            #=> 2020-02-26 12:58:19 UTC
+Time.at(1582721899, in: "C")              #=> 2020-02-26 13:58:19 +0300
+#@end
+#@end
 
---- at(time, usec)    -> Time
+--- at(time, usec)         -> Time
+#@since 2.6.0
+--- at(time, usec, in:)    -> Time
+#@end
 
 time + (usec/1000000) の時刻を表す Time オブジェクトを返します。
 浮動小数点の精度では不十分な場合に使用します。
 
+#@since 2.6.0
+キーワード引数 in でタイムゾーンを指定できます。タイムゾーンの指定がない場合、
+#@end
 生成された Time オブジェクトのタイムゾーンは地方時となります。
 
 @param time 起算時からの経過秒数を表わす値を[[c:Integer]]、 [[c:Float]]、 [[c:Rational]]、または他の[[c:Numeric]]で指定します。
 
 @param usec マイクロ秒を[[c:Integer]]、 [[c:Float]]、 [[c:Rational]]、または他の[[c:Numeric]]で指定します。
 
+#@since 2.6.0
+@param in "+HH:MM" や "-HH:MM" のような形式の文字列か "UTC" かミリタリータイムゾーンの文字列
+          または数値でタイムゾーンを指定します。
+#@end
+
 例:
   Time.at(946684800, 123456.789).nsec  # => 123456789
 
 #@since 2.5.0
---- at(seconds, xseconds, unit) -> Time
+--- at(seconds, xseconds, unit)      -> Time
+#@since 2.6.0
+--- at(seconds, xseconds, unit, in:) -> Time
+#@end
 
 unit に応じて seconds + xseconds ミリ秒などの時刻を表す Time オブジェクトを返します。
 
 @param seconds 起算時からの経過秒数を表わす値を[[c:Integer]]、 [[c:Float]]、 [[c:Rational]]、または他の[[c:Numeric]]で指定します。
 @param xseconds unit に対応するミリ秒かマイクロ秒かナノ秒を指定します。
 @param unit :millisecond, :usec, :microsecond, :nsec, :nanosecond のいずれかを指定します。
+#@since 2.6.0
+@param in "+HH:MM" や "-HH:MM" のような形式の文字列か "UTC" かミリタリータイムゾーンの文字列
+          または数値でタイムゾーンを指定します。
+#@end
 
 例:
   Time.at(946684800, 123.456789, :millisecond).nsec  # => 123456789


### PR DESCRIPTION
- サンプルコードは https://github.com/ruby/ruby/commit/9a422fc010ab150438ef9dd66fd4c717f03927d9 から
- Time.at が in: に対応したのは 2.6 から
- `Time.at(0, in: 3600)` のように数値でも指定できたが、詳細な仕様が不明なので軽く言及
- samplecode に変更