### PR TITLE
Update Ruby for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 dist: bionic
 rvm:
-  - 2.3 # docs.ruby-lang.org use "ruby 2.3.3p222 (2016-11-21) [x86_64-linux-gnu]"
+  - 2.7.0 # docs.ruby-lang.org use ruby 2.7.0
 notifications:
   email:
     recipients:


### PR DESCRIPTION
~https://github.com/rurema/doctree/issues/2042#issuecomment-587441686 でるりまのビルドにRuby 2.5を使うようになりましたが、それがTravis CIに反映されていなかったので反映します。~


Slackの会話ログを見ると2.7を使うようになっているようなので、2.7にしました。