### PR TITLE
Add a task to check unnecessary indentation in samplecode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -144,11 +144,11 @@ task :check_indent_in_samplecode do
   errors = []
   `git grep -F --name-only '\#@samplecode'`.lines(chomp: true).each do |path|
     lines = File.read(path).lines(chomp: true)
-    lines.each.with_index(1) do |line, idx|
+    lines.each.with_index(1) do |line, lineno|
       next unless line.start_with?('#@samplecode')
-      next unless lines[idx].start_with?(' ')
+      next unless lines[lineno].start_with?(' ')
 
-      errors << "#{path}:#{idx}: \#@samplecode の中に不要なインデントがあります。削除してください"
+      errors << "#{path}:#{lineno}: \#@samplecode の中に不要なインデントがあります。削除してください"
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -144,11 +144,11 @@ task :check_indent_in_samplecode do
   errors = []
   `git grep -F --name-only '\#@samplecode'`.lines(chomp: true).each do |path|
     lines = File.read(path).lines(chomp: true)
-    lines.each.with_index do |line, idx|
+    lines.each.with_index(1) do |line, idx|
       next unless line.start_with?('#@samplecode')
-      next unless lines[idx + 1].start_with?(' ')
+      next unless lines[idx].start_with?(' ')
 
-      errors << "#{path}:#{idx + 1}: \#@samplecode の中に不要なインデントがあります。削除してください"
+      errors << "#{path}:#{idx}: \#@samplecode の中に不要なインデントがあります。削除してください"
     end
   end
 


### PR DESCRIPTION
https://github.com/rurema/doctree/pull/2192 でサンプルコード内の不要なインデントを削除しています。
こちらのPRでは、↑のPRのような不要なインデントが再発しないように、rake taskを追加してインデントをチェックしています。


このPRではまだ既存のコード内にインデントが含まれているためこのrake taskはコケますが、 #2192 をマージするとタスクが通るようになります。