### PR TITLE
Stirng#index の返り値の型を訂正

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1711,7 +1711,7 @@ p "".hex      # => 0
 "hello".include? ?h     #=> true
 #@end
 
---- index(pattern, pos = 0) -> Integer
+--- index(pattern, pos = 0) -> Integer | nil
 
 文字列のインデックス pos から右に向かって pattern を検索し、
 最初に見つかった部分文字列の左端のインデックスを返します。


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/2.7.0/method/String/i/index.html
`String#index` の返り値が単に `Integer` となっていましたが，`nil` を返すこともあります。