### PR TITLE
IRB::Inspector.def_inspectorの例を修正

### DIFF
--- a/refm/api/src/irb/inspector.rd
+++ b/refm/api/src/irb/inspector.rd
@@ -49,7 +49,7 @@ irb コマンドで実行結果の出力方式(inspect_mode)を定義するた�
 例.
 
   # .irbrc
-  IRB::Inspector::INSPECTORS.def_inspector([:test]){ |v| v.to_s * 2 }
+  IRB::Inspector.def_inspector([:test]){ |v| v.to_s * 2 }
 
   $ irb --inspect test
   irb(main):001:0> :abc # => abcabc


### PR DESCRIPTION
```
root@dc5a99846a13:/all-ruby# ALL_RUBY_SINCE=ruby-2.0 ./all-ruby -r irb -e 'p IRB::Inspector::INSPECTORS.respond_to?(:def_inspector)'
ruby-2.0.0-p0       false
...
ruby-2.7.0          false
root@dc5a99846a13:/all-ruby# ALL_RUBY_SINCE=ruby-2.0 ./all-ruby -r irb -e 'p IRB::Inspector.respond_to?(:def_inspector)'
ruby-2.0.0-p0       true
...
ruby-2.7.0          true
```