### PR TITLE
「DOSISH 対応」からサポートが終了したプラットフォームを削除

### DIFF
--- a/refm/doc/platform/DOSISH-support.rd
+++ b/refm/doc/platform/DOSISH-support.rd
@@ -6,8 +6,7 @@ ruby version 1.7 では、DOSISH対応(DOS/Windows のパス名の扱いに対�
 更)が含まれています。(現在の)変更点を以下に示します。
 
 なお、これらの変更は [[d:platform/mswin32]] 版、[[d:platform/mingw32]]
-版, [[d:platform/bccwin32]] 版, [[d:platform/human68k]] 版,
-[[d:platform/os2_emx]] 版の Ruby にのみあてはまります。
+版の Ruby にのみあてはまります。
 
 とりあえずの目標として、
 


### PR DESCRIPTION
#2153 の解決の一環です。
以下の三つのプラットフォームは既にサポートが終わっているので，言及を削除します。

- bccwin32
- Human68k
- os2_emx