### PR TITLE
 特殊変数 $-I から，サポートの終わったプラットフォームの記述を削除

### DIFF
--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -392,11 +392,9 @@ ARCH の値は Config::CONFIG['arch'] で得られます。
 
 コンパイル時のデフォルトパスは
 多くの UNIX システムでは "/usr/local/lib/ruby" です。
-[[d:platform/mswin32]]、[[d:platform/mingw32]]、[[d:platform/Cygwin]]、
-[[d:platform/bccwin32]]、[[d:platform/mswince]] 環境では
+[[d:platform/mswin32]]、[[d:platform/mingw32]]、[[d:platform/Cygwin]]
+環境では
 ruby.dll の位置からの相対で決まります。
-[[d:platform/DJGPP]] と [[d:platform/emx]] (OS/2) では
-ruby.exe の位置からの相対で決まります。
 
 #@until 1.9.1
 -T オプションで起動時に [[m:$SAFE]] を 1 以上に

--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -363,9 +363,6 @@ Rubyライブラリをロードするときの検索パスです。
 起動時にはコマンドラインオプション -I で指定したディレクトリ、
 環境変数 RUBYLIB の値、
 コンパイル時に指定したデフォルト値
-#@until 1.9.1
-、"." (カレントディレクトリ)
-#@end
 をこの順番で含みます。
 
 #@# 1.6.5 から以下のように変更されている
@@ -379,9 +376,6 @@ Rubyライブラリをロードするときの検索パスです。
   /usr/local/lib/ruby/site_ruby                サイト固有ライブラリ
   /usr/local/lib/ruby/VERSION                  標準ライブラリ
   /usr/local/lib/ruby/VERSION/ARCH             標準、システム依存、拡張ライブラリ
-#@until 1.9.1
-  .                                            カレントディレクトリ
-#@end
 
 #@#((-デフォルトの順序は 1.6.5 から変更されました-))
 上記表中の VERSION は Ruby のバージョンを表す文字列で、
@@ -395,11 +389,6 @@ ARCH の値は Config::CONFIG['arch'] で得られます。
 [[d:platform/mswin32]]、[[d:platform/mingw32]]、[[d:platform/Cygwin]]
 環境では
 ruby.dll の位置からの相対で決まります。
-
-#@until 1.9.1
--T オプションで起動時に [[m:$SAFE]] を 1 以上に
-設定したときは "." (カレントディレクトリ) はロードパスに入りません。
-#@end
 
 require 'foo' を実行すると、
 以下のように foo.rb と foo.so が交互に探索されます。


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/2.7.0/method/Kernel/v/=2dI.html

#2153 の解決の一環です。
特殊変数 $-I から，サポートの終わったプラットフォーム bccwin32，mswince，DJGPP，emx の記述を削除します。
ついでに古い分岐を削除します。