### PR TITLE
Remove object superclass

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -1,4 +1,4 @@
-= object ARGF < ARGF.class
+= object ARGF
 
 スクリプトに指定した引数
 ([[m:Object::ARGV]] を参照) をファイル名とみなして、

--- a/refm/api/src/webrick/httpproxy/NullReader
+++ b/refm/api/src/webrick/httpproxy/NullReader
@@ -1,4 +1,4 @@
-= object WEBrick::NullReader < Object
+= object WEBrick::NullReader
 
 空のソケットのふりをするオブジェクトです。
 


### PR DESCRIPTION
object に親クラスが書いてあると database 生成時に以下のような警告が出ていたので削除しました。

```
singleton object class not implemented yet
```

修正前後で生成される HTML に違いが無いことは確認しました。