### PR TITLE
Float::ROUNDS is deprecated

### DIFF
--- a/refm/api/src/_builtin/Float
+++ b/refm/api/src/_builtin/Float
@@ -736,11 +736,16 @@ Float が取り得る最小の有限の値は -[[m:Float::MAX]] です。
 
 指数表現の基数です。
 
+#@until 2.8.0
 --- ROUNDS -> Integer
+
+この定数は deprecated です。使わないでください。
+
+#@# https://bugs.ruby-lang.org/issues/16044
 
 丸めモード (-1: 不定、0: 0.0 の方向に丸め、1: 四捨五入、2:正の無限
 大の方向に丸め、3:負の無限大の方向に丸め)です。
-
+#@end
 --- INFINITY -> Float
 
 浮動小数点数における正の無限大です。


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/ecef163cf9bbdffcf1466addc39daa92084d6b53
https://bugs.ruby-lang.org/issues/16044

`warning: constant Float::ROUNDS is deprecated` という警告が出るのは 2.7 からですが、 redmine の issue に書いてある説明から判断すると、そもそも使わない方が良さそうなので、分岐は 2.8 での削除だけにしています。