### PR TITLE
Singleton#clone と Singleton#dupの説明を追加しました

### DIFF
--- a/refm/api/src/singleton.rd
+++ b/refm/api/src/singleton.rd
@@ -19,14 +19,16 @@ new は private メソッドに移され、外部から呼び出そうとする�
 === サンプルコード
 
   require 'singleton'
+
   class SomeSingletonClass
     include Singleton
    #....
   end
+
   a = SomeSingletonClass.instance
-  b = SomeSingletonClass.instance  # a and b are same object
-  p [a,b]
-  a = SomeSingletonClass.new               # error (`new' is private)
+  b = SomeSingletonClass.instance # a and b are same object
+  p [a,b] # => [#<SomeSingletonClass:0x0000562e6e18ddd0>, #<SomeSingletonClass:0x0000562e6e18ddd0>]
+  a = SomeSingletonClass.new  # => NoMethodError (private method `new' called for SomeSingletonClass:Class)
 
 == Singleton Methods
 
@@ -37,3 +39,13 @@ new は private メソッドに移され、外部から呼び出そうとする�
 
 Singleton を include したクラスで定義されますので、
 正確には Singleton モジュールのメソッドではありません。
+
+== Instance Methods
+
+--- clone
+
+@raise TypeError このメソッドを呼び出した場合に発生します。
+
+--- dup
+
+@raise TypeError このメソッドを呼び出した場合に発生します。


### PR DESCRIPTION
## 概要

 以下のことをやりました。

- 既存のサンプルコードの更新
- Singleton#clone を追加
- Singleton#dup を追加

## 備考

マーシャル周りについて私があまり腑に落ちていないので意図的に　`Singleton._load`  と　`Singleton#_dump` を追加していません。

## 参考

- https://docs.ruby-lang.org/en/2.7.0/Singleton.html#method-c-instance
- https://github.com/ruby/singleton