### PR TITLE
Windows で generate:statichtml タスクの例外を抑える

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ def generate_statichtml(version)
   raise "Failed to generate static html" unless succeeded
   latest = File.join(HTML_DIRECTORY_BASE, "latest")
   File.unlink(latest) rescue nil
-  File.symlink(version, latest)
+  File.symlink(version, latest) rescue puts "Can not symlink to latest"
 end
 
 task :default => [:generate, :check_format]

--- a/Rakefile
+++ b/Rakefile
@@ -40,9 +40,6 @@ def generate_statichtml(version)
   commands << "--quiet" if ENV['CI']
   succeeded = system(*commands)
   raise "Failed to generate static html" unless succeeded
-  latest = File.join(HTML_DIRECTORY_BASE, "latest")
-  File.unlink(latest) rescue nil
-  File.symlink(version, latest) rescue puts "Can not symlink to latest"
 end
 
 task :default => [:generate, :check_format]


### PR DESCRIPTION
Windows だとシンボリックリンクには管理者権限が必要なため，管理者としてコマンドプロンプトを開かないかぎり，generate:statichtml タスクの最後の

```rb
File.symlink(version, latest)
```

で Permission denied が出て死にます。
このシンボリックリンク作成に失敗しても `latest` でアクセスできないだけなので大した問題ではないのですが，事情を知らないユーザーはタスク全体がダメだったと勘違いしそうです。

メッセージの改善案とか，そもそもメッセージ無しでよいのでは，などご意見をお願いします。