### PR TITLE
platform/DJGPP を削除

### DIFF
--- a/refm/doc/platform/DJGPP.rd
+++ b/refm/doc/platform/DJGPP.rd
@@ -1,9 +1,0 @@
-###nonref
-
-= DJGPP
-
-16 bit OS である DOS上で 32 bit な環境を実現する DOS エクステンダとい
-う奴とそのコンパイル環境(という説明でいいのかな？)。かなり古い環境だが、
-今も利用者はいるらしい。
-
-[[url:http://www.delorie.com/djgpp/]] 参照。

--- a/refm/doc/platform/index.rd
+++ b/refm/doc/platform/index.rd
@@ -15,6 +15,4 @@ Ruby は様々な環境で動作するよう各方面の有志によって移植
       * [[d:platform/MinGW]], [[d:platform/mingw32]]
     * [[d:platform/Cygwin]]
   * [[d:platform/MacOSX]]
-  * MS-DOS
-    * [[d:platform/DJGPP]]
   * [[d:platform/GNU]], [[d:platform/GNU Hurd]]


### PR DESCRIPTION
#2153 の一環です。
#2215 により platform/DJGPP へのリンクが無くなったので，このページを削除します。
これで古いプラットフォームのページの削除が一段落します。