### PR TITLE
rubyforge_project を削除

### DIFF
--- a/refm/api/src/rubygems.rd
+++ b/refm/api/src/rubygems.rd
@@ -133,7 +133,6 @@ Gem::Specification.new do |s|
   s.email             = 'hello_author@example.com'
   s.homepage          = 'http://example.com/hello/'
   s.description       = 'hello description'
-  s.rubyforge_project = 'hello'
 end
 #@end
 
@@ -153,8 +152,6 @@ end
   この Gem のウェブサイトの URI を指定します。
 : description
   この Gem の長い説明を指定します。
-: rubyforge_project
-  Rubyforge にプロジェクトがある場合、そのプロジェクト名を指定します。
 
 実行可能なファイル (コマンド) を含む場合の gemspec は以下のようになります。
 
@@ -169,7 +166,6 @@ Gem::Specification.new do |s|
   s.email             = 'hello@example.com'
   s.homepage          = 'http://example.com/hello'
   s.rubyforge_project = 'hello'
-  s.description       = 'hello description'
 end
 #@end
 

--- a/refm/api/src/rubygems/specification.rd
+++ b/refm/api/src/rubygems/specification.rd
@@ -429,16 +429,6 @@ API ドキュメントを生成するときに rdoc コマンドに与えるオ�
 
 @param informations 情報を文字列の配列で指定します。
 
---- rubyforge_project -> String
-
-この Gem の RubyForge 上でのプロジェクト名を返します。
-
---- rubyforge_project=(project_name)
-
-この Gem の RubyForge 上でのプロジェクト名をセットします。
-
-@param project_name RubyForge 上のプロジェクト名を指定します。
-
 --- rubygems_version -> String
 
 この Gem パッケージを作成した RubyGems のバージョンを返します。


### PR DESCRIPTION
RubyForge は既に存在せず、また sample の通りに gemspec を作っても

> NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.

と言われます。そのため、削除してよいと思います。