### PR TITLE
Fix return type of Rake::FileTask#timestamp

### DIFF
--- a/refm/api/src/rake/Rake__FileTask
+++ b/refm/api/src/rake/Rake__FileTask
@@ -28,7 +28,7 @@ file "test.txt" do |task|
 end
 #@end
 
---- timestamp -> Time
+--- timestamp -> Time | Rake::LateTime
 
 ファイルタスクのタイムスタンプを返します。
 


### PR DESCRIPTION
timestamp の返り値はファイルが存在すれば Time で、存在しないときは Rake::LateTime のインスタンスをさす Rake::LATE になる。
https://github.com/ruby/rake/blob/4fe73ff6b19ea1d8490b0442c75fc3a53815c4cf/lib/rake/file_task.rb#L20-L27