### PR TITLE
Windows で check_format タスクが正しく動作するように

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,6 @@ UNRELEASED_VERSIONS = %w[2.8.0]
 ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 HTML_DIRECTORY_BASE = ENV.fetch("HTML_DIRECTORY_BASE", "/tmp/html/")
 
-Encoding.default_external = "UTF-8"
-
 def generate_database(version)
   puts "generate database of #{version}"
   db = "/tmp/db-#{version}"

--- a/Rakefile
+++ b/Rakefile
@@ -119,7 +119,7 @@ desc "Check documentation format"
 task check_format: [:statichtml] do
   res = []
   Dir.glob(File.join(HTML_DIRECTORY_BASE, '**/*.html')).each do |path|
-    html = File.read(path)
+    html = File.read(path, encoding: "UTF-8")
 
     a = html.lines.grep(/\[UNKNOWN_META_INFO\]/)
     if !a.empty?

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ UNRELEASED_VERSIONS = %w[2.8.0]
 ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 HTML_DIRECTORY_BASE = ENV.fetch("HTML_DIRECTORY_BASE", "/tmp/html/")
 
+Encoding.default_external = "UTF-8"
+
 def generate_database(version)
   puts "generate database of #{version}"
   db = "/tmp/db-#{version}"


### PR DESCRIPTION
Windows では Encoding.default_external が CP932（Windows 31J）になっていることが多いのですが，この場合，check_format タスクで HTML を CP932 で読み込んでしまいます。
すると，
https://github.com/rurema/doctree/blob/master/Rakefile#L124
の箇所

```rb
    a = html.lines.grep(/\[UNKNOWN_META_INFO\]/)
```

で

```
invalid byte sequence in Windows-31J (ArgumentError)
```

が出ます。
（`grep` で `Regexp#===` を実行するとき，文字列が CP932 としてありえないバイト列であることが発覚する）

これを抑止するため，Rakefile の先頭で Encoding.default_external を `"UTF-8"` にします。