### PR TITLE
ConditionVariable#broadcast and #signal returns self

### DIFF
--- a/refm/api/src/thread/ConditionVariable
+++ b/refm/api/src/thread/ConditionVariable
@@ -139,7 +139,7 @@ alias ConditionVariable
 
 == Instance Methods
 
---- broadcast -> [Thread]
+--- broadcast -> self
 
 状態変数を待っているスレッドをすべて再開します。再開された
 #@since 2.1.0
@@ -149,7 +149,7 @@ alias ConditionVariable
 #@end
 で指定した mutex のロックを試みます。
 
-@return 実行待ちしていたスレッドの配列を返します。
+@return 常に self を返します。
 
 #@samplecode 例
 mutex = Mutex.new
@@ -185,7 +185,7 @@ sleep 1
 # => a2
 #@end
 
---- signal -> Thread | nil
+--- signal -> self
 
 状態変数を待っているスレッドを1つ再開します。再開された
 #@since 2.1.0
@@ -195,8 +195,7 @@ sleep 1
 #@end
 で指定した mutex のロックを試みます。
 
-@return 状態を待っているスレッドがあった場合は、そのスレッドを返します。
-        そうでなければ nil を返します。
+@return 常に self を返します。
 
 #@since 1.9.2
 --- wait(mutex, timeout = nil) -> self


### PR DESCRIPTION
ごく一部のバージョンで現ドキュメント通りの挙動だったことがあるようですが、1.9.3 以降 self を返すようです。

```
$ docker run rubylang/all-ruby:latest ./all-ruby -r thread -e 'p ConditionVariable.new.broadcast'
ruby-0.49             /all-ruby/bin/ruby-0.49: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.49: No such file or directory - thread.
                  exit 1
ruby-0.50             /all-ruby/bin/ruby-0.50: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.50: No such file or directory - thread.
                  exit 1
ruby-0.51             /all-ruby/bin/ruby-0.51: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.51: No such file or directory - thread.
                  exit 1
ruby-0.54             /all-ruby/bin/ruby-0.54: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.54: No such file or directory - thread.
                  exit 1
ruby-0.55             /all-ruby/bin/ruby-0.55: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.55: No such file or directory - thread.
                  exit 1
ruby-0.60             /all-ruby/bin/ruby-0.60: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.60: No such file or directory - thread
                  exit 1
ruby-0.62             /all-ruby/bin/ruby-0.62: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.62: No such file or directory - thread
                  exit 1
ruby-0.63             /all-ruby/bin/ruby-0.63: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.63: No such file or directory - thread
                  exit 1
ruby-0.64             /all-ruby/bin/ruby-0.64: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.64: No such file or directory - thread
                  exit 1
ruby-0.65             /all-ruby/bin/ruby-0.65: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.65: No such file or directory - thread
                  exit 1
ruby-0.69             Unrecognized switch: -r
                  exit 1
...
ruby-0.76             Unrecognized switch: -r
                  exit 1
ruby-0.95             /all-ruby/bin/ruby-0.95: No such file to load -- thread
ruby-0.99.4-961224    -e:1: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.0-961225       -e:1: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.0-971002       -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
...
ruby-1.0-971225       -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a0            -e:1: NameError| Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a1            -e:1: NameError| Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a2            -e:1: NameError:Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a3            -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
...
ruby-1.1a9            -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1b0            -e:1: Uninitialized constant ConditionVariable (NameError)
                  exit 1
...
ruby-1.1b8            -e:1: Uninitialized constant ConditionVariable (NameError)
                  exit 1
ruby-1.1b9            []
...
ruby-1.1c9            []
ruby-1.1d0            /build-all-ruby/1.1d0/lib/ruby/thread.rb:66: [BUG] Segmentation fault
                  SIGABRT (signal 6)
ruby-1.1d1            []
...
ruby-1.3.4-990531     []
ruby-1.3.4-990611     /build-all-ruby/1.3.4-990611/lib/ruby/1.3/thread.rb:115:in `clone': can't clone nil (TypeError)
                      	from /build-all-ruby/1.3.4-990611/lib/ruby/1.3/thread.rb:115:in `dup'
                      	from /build-all-ruby/1.3.4-990611/lib/ruby/1.3/thread.rb:115:in `broadcast'
                      	from /build-all-ruby/1.3.4-990611/lib/ruby/1.3/thread.rb:115:in `exclusive'
                      	from /build-all-ruby/1.3.4-990611/lib/ruby/1.3/thread.rb:115:in `broadcast'
                      	from /tmp/rbI1gsVO:1
                  exit 1
ruby-1.3.4-990624     /build-all-ruby/1.3.4-990624/lib/ruby/1.3/thread.rb:115:in `clone': can't clone nil (TypeError)
                      	from /build-all-ruby/1.3.4-990624/lib/ruby/1.3/thread.rb:115:in `dup'
                      	from /build-all-ruby/1.3.4-990624/lib/ruby/1.3/thread.rb:115:in `broadcast'
                      	from /build-all-ruby/1.3.4-990624/lib/ruby/1.3/thread.rb:115:in `exclusive'
                      	from /build-all-ruby/1.3.4-990624/lib/ruby/1.3/thread.rb:115:in `broadcast'
                      	from /tmp/rb9ZMfAP:1
                  exit 1
ruby-1.3.4-990625     nil
ruby-1.3.5            nil
ruby-1.3.6            []
...
ruby-1.8.5-p231       []
ruby-1.8.6-preview1   #<ConditionVariable:0x7f4976f64840>
ruby-1.8.6-preview2   #<ConditionVariable:0x7f47210d4840>
ruby-1.8.6-preview3   #<ConditionVariable:0x7f7739ab7860>
ruby-1.8.6            #<ConditionVariable:0x7fa81ab21708>
ruby-1.8.6-p36        #<ConditionVariable:0x7efd6c8af708>
ruby-1.8.6-p110       #<ConditionVariable:0x7fdf89819708>
ruby-1.8.6-p111       #<ConditionVariable:0x7f2f7af31708>
ruby-1.8.6-p114       #<ConditionVariable:0x7fef1d878700>
ruby-1.8.6-p230       #<ConditionVariable:0x7f6fff59d708>
ruby-1.8.6-p286       #<ConditionVariable:0x7fb80a06a710>
ruby-1.8.6-p287       #<ConditionVariable:0x7f355d5a8720>
ruby-1.8.6-p368       #<ConditionVariable:0x7fa109bb06f0>
ruby-1.8.6-p369       #<ConditionVariable:0x7f60a56d46f8>
ruby-1.8.6-p383       #<ConditionVariable:0x7f079f7546f0>
ruby-1.8.6-p388       #<ConditionVariable:0x7f62af96b6f8>
ruby-1.8.6-p398       #<ConditionVariable:0x7f50729dc6e0>
ruby-1.8.6-p399       #<ConditionVariable:0x7f187086f6e8>
ruby-1.8.6-p420       #<ConditionVariable:0x7f7aaacd56f0>
ruby-1.8.7-preview1   #<ConditionVariable:0x7f2cb896b0e0>
ruby-1.8.7-preview2   #<ConditionVariable:0x7f8a91db60a0>
ruby-1.8.7-preview3   #<ConditionVariable:0x7f766201de18>
ruby-1.8.7-preview4   #<ConditionVariable:0x7fe3d836ed68>
ruby-1.8.7            #<ConditionVariable:0x7fcf9b9f7708>
ruby-1.8.7-p17        #<ConditionVariable:0x7f2a2d4e96f8>
ruby-1.8.7-p22        #<ConditionVariable:0x7fa08e45c708>
ruby-1.8.7-p71        #<ConditionVariable:0x7ff856fa6710>
ruby-1.8.7-p72        #<ConditionVariable:0x7f620d295718>
ruby-1.8.7-p160       #<ConditionVariable:0x7fcdff3ee6d8>
ruby-1.8.7-p173       #<ConditionVariable:0x7fc35728b6e0>
ruby-1.8.7-p174       #<ConditionVariable:0x7f850284b6e0>
ruby-1.8.7-p248       #<ConditionVariable:0x7f32587406d0>
ruby-1.8.7-p249       #<ConditionVariable:0x7f54bf34c6d0>
ruby-1.8.7-p299       #<ConditionVariable:0x7f4d263556e0>
ruby-1.8.7-p301       #<ConditionVariable:0x7f30a32356d8>
ruby-1.8.7-p302       #<ConditionVariable:0x7f6783af66e8>
ruby-1.8.7-p330       #<ConditionVariable:0x7f8577bfa6e0>
ruby-1.8.7-p334       #<ConditionVariable:0x7fa173eea6d0>
ruby-1.8.7-p352       #<ConditionVariable:0x7f30cf6cc6e8>
ruby-1.8.7-p357       #<ConditionVariable:0x7f4e831296d8>
ruby-1.8.7-p358       #<ConditionVariable:0x7f009c5396e0>
ruby-1.8.7-p370       #<ConditionVariable:0x7f26faffa6e0>
ruby-1.8.7-p371       #<ConditionVariable:0x7f6eddb146f0>
ruby-1.8.7-p373       #<ConditionVariable:0x7fc881fb06e8>
ruby-1.8.7-p374       #<ConditionVariable:0x7fef436f46d8>
ruby-1.9.0-0          []
...
ruby-1.9.2-preview1   []
ruby-1.9.2-preview3   #<ConditionVariable:0x0055a8c89fe8b0 @waiters=[], @waiters_mutex=#<Mutex:0x0055a8c89fe860>>
ruby-1.9.2-rc1        #<ConditionVariable:0x0055e12026d958 @waiters=[], @waiters_mutex=#<Mutex:0x0055e12026d908>>
ruby-1.9.2-rc2        #<ConditionVariable:0x0055ec6669a958 @waiters=[], @waiters_mutex=#<Mutex:0x0055ec6669a908>>
ruby-1.9.2-p0         #<ConditionVariable:0x0055c36e532000 @waiters=[], @waiters_mutex=#<Mutex:0x0055c36e531fb0>>
ruby-1.9.2-p136       #<ConditionVariable:0x005630f0d91ff8 @waiters=[], @waiters_mutex=#<Mutex:0x005630f0d91fa8>>
ruby-1.9.2-p180       #<ConditionVariable:0x0055accc927010 @waiters=[], @waiters_mutex=#<Mutex:0x0055accc926fc0>>
ruby-1.9.2-p290       #<ConditionVariable:0x0055e29363f148 @waiters=[], @waiters_mutex=#<Mutex:0x0055e29363f0f8>>
ruby-1.9.2-p318       #<ConditionVariable:0x0055607f6ef160 @waiters=[], @waiters_mutex=#<Mutex:0x0055607f6ef110>>
ruby-1.9.2-p320       #<ConditionVariable:0x005624e1e66160 @waiters=[], @waiters_mutex=#<Mutex:0x005624e1e66110>>
ruby-1.9.2-p330       #<ConditionVariable:0x0055df2d450148 @waiters=[], @waiters_mutex=#<Mutex:0x0055df2d4500f8>>
ruby-1.9.3-preview1   #<ConditionVariable:0x00559d63c5fd90 @waiters=[], @waiters_mutex=#<Mutex:0x00559d63c5fd40>>
ruby-1.9.3-rc1        #<ConditionVariable:0x005592b4c5e210 @waiters=[], @waiters_mutex=#<Mutex:0x005592b4c5e1c0>>
ruby-1.9.3-p0         #<ConditionVariable:0x0055f074f0a0e0 @waiters=[], @waiters_mutex=#<Mutex:0x0055f074f0a090>>
ruby-1.9.3-p105       #<ConditionVariable:0x00558b6f01a248 @waiters=[], @waiters_mutex=#<Mutex:0x00558b6f01a1f8>>
ruby-1.9.3-p125       #<ConditionVariable:0x0055f6a0702578 @waiters=[], @waiters_mutex=#<Mutex:0x0055f6a0702528>>
ruby-1.9.3-p194       #<ConditionVariable:0x005601a051f430 @waiters=[], @waiters_mutex=#<Mutex:0x005601a051f3e0>>
ruby-1.9.3-p286       #<ConditionVariable:0x00564e28ed1490 @waiters=[], @waiters_mutex=#<Mutex:0x00564e28ed1440>>
ruby-1.9.3-p327       #<ConditionVariable:0x00558910013df0 @waiters=[], @waiters_mutex=#<Mutex:0x00558910013da0>>
ruby-1.9.3-p362       #<ConditionVariable:0x005611266d7530 @waiters=[], @waiters_mutex=#<Mutex:0x005611266d74e0>>
ruby-1.9.3-p374       #<ConditionVariable:0x00558f78bab898 @waiters=[], @waiters_mutex=#<Mutex:0x00558f78bab848>>
ruby-1.9.3-p385       #<ConditionVariable:0x0055a1005c8d60 @waiters=[], @waiters_mutex=#<Mutex:0x0055a1005c8d10>>
ruby-1.9.3-p392       #<ConditionVariable:0x0056003ff4ed00 @waiters=[], @waiters_mutex=#<Mutex:0x0056003ff4ecb0>>
ruby-1.9.3-p426       #<ConditionVariable:0x0055c4839e9d30 @waiters=[], @waiters_mutex=#<Mutex:0x0055c4839e9ce0>>
ruby-1.9.3-p429       #<ConditionVariable:0x0055d4f5f41bc0 @waiters=[], @waiters_mutex=#<Mutex:0x0055d4f5f41b70>>
ruby-1.9.3-p448       #<ConditionVariable:0x00555994c3c358 @waiters=[], @waiters_mutex=#<Mutex:0x00555994c3c308>>
ruby-1.9.3-p484       #<ConditionVariable:0x00564d60aa7338 @waiters=[], @waiters_mutex=#<Mutex:0x00564d60aa72e8>>
ruby-1.9.3-p545       #<ConditionVariable:0x005563329ca8c0 @waiters=[], @waiters_mutex=#<Mutex:0x005563329ca870>>
ruby-1.9.3-p547       #<ConditionVariable:0x0055af9db978d0 @waiters=[], @waiters_mutex=#<Mutex:0x0055af9db97880>>
ruby-1.9.3-p550       #<ConditionVariable:0x0055ec7abc08b0 @waiters=[], @waiters_mutex=#<Mutex:0x0055ec7abc0860>>
ruby-1.9.3-p551       #<ConditionVariable:0x00561687c798b0 @waiters=[], @waiters_mutex=#<Mutex:0x00561687c79860>>
ruby-2.0.0-preview1   #<ConditionVariable:0x0055e8cb064460 @waiters=[], @waiters_mutex=#<Mutex:0x0055e8cb064398>>
ruby-2.0.0-preview2   #<ConditionVariable:0x0055bc0efccdd8 @waiters={}, @waiters_mutex=#<Mutex:0x0055bc0efccc98>>
ruby-2.0.0-rc1        #<ConditionVariable:0x005615a98b4ab0 @waiters={}, @waiters_mutex=#<Mutex:0x005615a98b49c0>>
ruby-2.0.0-rc2        #<ConditionVariable:0x00561b32ec6b90 @waiters={}, @waiters_mutex=#<Mutex:0x00561b32ec6a78>>
ruby-2.0.0-p0         #<ConditionVariable:0x005606924fb5e8 @waiters={}, @waiters_mutex=#<Mutex:0x005606924fb598>>
ruby-2.0.0-p195       #<ConditionVariable:0x00560b3f817ab8 @waiters={}, @waiters_mutex=#<Mutex:0x00560b3f817a68>>
ruby-2.0.0-p247       #<ConditionVariable:0x0055bf3c183a98 @waiters={}, @waiters_mutex=#<Mutex:0x0055bf3c183a48>>
ruby-2.0.0-p353       #<ConditionVariable:0x0055be1ff72cd0 @waiters={}, @waiters_mutex=#<Mutex:0x0055be1ff72c80>>
ruby-2.0.0-p451       #<ConditionVariable:0x00561fa6549900 @waiters={}, @waiters_mutex=#<Mutex:0x00561fa65498b0>>
ruby-2.0.0-p481       #<ConditionVariable:0x00564666c658b0 @waiters={}, @waiters_mutex=#<Mutex:0x00564666c65860>>
ruby-2.0.0-p576       #<ConditionVariable:0x00556400ef5ab0 @waiters={}, @waiters_mutex=#<Mutex:0x00556400ef5a60>>
ruby-2.0.0-p594       #<ConditionVariable:0x0055e715a058c8 @waiters={}, @waiters_mutex=#<Mutex:0x0055e715a05878>>
ruby-2.0.0-p598       #<ConditionVariable:0x00558351ac9980 @waiters={}, @waiters_mutex=#<Mutex:0x00558351ac9930>>
ruby-2.0.0-p643       #<ConditionVariable:0x0055abe6389900 @waiters={}, @waiters_mutex=#<Mutex:0x0055abe63898b0>>
ruby-2.0.0-p645       #<ConditionVariable:0x00558cf14098f8 @waiters={}, @waiters_mutex=#<Mutex:0x00558cf14098a8>>
ruby-2.0.0-p647       #<ConditionVariable:0x0055919410d8a0 @waiters={}, @waiters_mutex=#<Mutex:0x0055919410d850>>
ruby-2.0.0-p648       #<ConditionVariable:0x005585921098f8 @waiters={}, @waiters_mutex=#<Mutex:0x005585921098a8>>
ruby-2.1.0-preview1   #<Thread::ConditionVariable:0x0055be4874d798>
ruby-2.1.0-preview2   #<Thread::ConditionVariable:0x005653bf3d8858>
ruby-2.1.0-rc1        #<Thread::ConditionVariable:0x0055e537016900>
ruby-2.1.0            #<Thread::ConditionVariable:0x00559dbe672a80>
ruby-2.1.1            #<Thread::ConditionVariable:0x00555eb26dba08>
ruby-2.1.2            #<Thread::ConditionVariable:0x0055ebc577a3b0>
ruby-2.1.3            #<Thread::ConditionVariable:0x005616589bb170>
ruby-2.1.4            #<Thread::ConditionVariable:0x005628773831f0>
ruby-2.1.5            #<Thread::ConditionVariable:0x00563772707150>
ruby-2.1.6            #<Thread::ConditionVariable:0x00564f770ff240>
ruby-2.1.7            #<Thread::ConditionVariable:0x0055957ab8ca08>
ruby-2.1.8            #<Thread::ConditionVariable:0x0056195051d758>
ruby-2.1.9            #<Thread::ConditionVariable:0x005597bf79d6d0>
ruby-2.1.10           #<Thread::ConditionVariable:0x005606fe8bd778>
ruby-2.2.0-preview1   #<Thread::ConditionVariable:0x00563fb9212b00>
ruby-2.2.0-preview2   #<Thread::ConditionVariable:0x0055c4242257c0>
ruby-2.2.0-rc1        #<Thread::ConditionVariable:0x005574565650e8>
ruby-2.2.0            #<Thread::ConditionVariable:0x00561fe237d270>
ruby-2.2.1            #<Thread::ConditionVariable:0x00559f53e01300>
ruby-2.2.2            #<Thread::ConditionVariable:0x005604f3e55300>
ruby-2.2.3            #<Thread::ConditionVariable:0x0055cebb61bd88>
ruby-2.2.4            #<Thread::ConditionVariable:0x005627d8debdd0>
ruby-2.2.5            #<Thread::ConditionVariable:0x0055b519b1d8d8>
ruby-2.2.6            #<Thread::ConditionVariable:0x005582131cbde0>
ruby-2.2.7            #<Thread::ConditionVariable:0x005654f9a3fdf0>
ruby-2.2.8            #<Thread::ConditionVariable:0x005634937f6c78>
ruby-2.2.9            #<Thread::ConditionVariable:0x00558b12f0ad00>
ruby-2.2.10           #<Thread::ConditionVariable:0x0056450a3803d8>
ruby-2.3.0-preview1   #<Thread::ConditionVariable:0x0055b749020ef8>
ruby-2.3.0-preview2   #<Thread::ConditionVariable:0x00556f51360ec8>
ruby-2.3.0            #<Thread::ConditionVariable:0x0055d8486a6910>
ruby-2.3.1            #<Thread::ConditionVariable:0x005566e599f498>
ruby-2.3.2            #<Thread::ConditionVariable:0x005629ea01aff8>
ruby-2.3.3            #<Thread::ConditionVariable:0x0055a72a853118>
ruby-2.3.4            #<Thread::ConditionVariable:0x0056446a7d7120>
ruby-2.3.5            #<Thread::ConditionVariable:0x0000562844d252e0>
ruby-2.3.6            #<Thread::ConditionVariable:0x00005571f1f6d1d8>
ruby-2.3.7            #<Thread::ConditionVariable:0x0000560d9f8d3a58>
ruby-2.3.8            #<Thread::ConditionVariable:0x00005570572ef668>
ruby-2.4.0-preview1   #<Thread::ConditionVariable:0x0055c4f02a72a8>
ruby-2.4.0-preview2   #<Thread::ConditionVariable:0x00563187c66d30>
ruby-2.4.0-preview3   #<Thread::ConditionVariable:0x005600c28147f0>
ruby-2.4.0-rc1        #<Thread::ConditionVariable:0x005611c29d70b8>
ruby-2.4.0            #<Thread::ConditionVariable:0x0056331ad01490>
ruby-2.4.1            #<Thread::ConditionVariable:0x005563ad24a110>
ruby-2.4.2            #<Thread::ConditionVariable:0x000055a8a3c03900>
ruby-2.4.3            #<Thread::ConditionVariable:0x000055939a4e3490>
ruby-2.4.4            #<Thread::ConditionVariable:0x0000563e413335d0>
ruby-2.4.5            #<Thread::ConditionVariable:0x0000561a98ed1850>
ruby-2.4.6            #<Thread::ConditionVariable:0x0000558e5ade2180>
ruby-2.4.7            #<Thread::ConditionVariable:0x00005566e054a320>
ruby-2.4.9            #<Thread::ConditionVariable:0x000055ce01c11428>
ruby-2.5.0-preview1   #<Thread::ConditionVariable:0x000055661ddfcc20>
ruby-2.5.0-rc1        #<Thread::ConditionVariable:0x00005557ce53f950>
ruby-2.5.0            #<Thread::ConditionVariable:0x00005653ea28a930>
ruby-2.5.1            #<Thread::ConditionVariable:0x000055af9c20e558>
ruby-2.5.2            #<Thread::ConditionVariable:0x0000555fd7f3b768>
ruby-2.5.3            #<Thread::ConditionVariable:0x000056473b6e3ba0>
ruby-2.5.4            #<Thread::ConditionVariable:0x00005607e9524f30>
ruby-2.5.5            #<Thread::ConditionVariable:0x000055a8b26343d0>
ruby-2.5.6            #<Thread::ConditionVariable:0x000055eeadb8ce90>
ruby-2.5.7            #<Thread::ConditionVariable:0x0000562c854b6600>
ruby-2.6.0-preview1   #<Thread::ConditionVariable:0x0000557f01d158c8>
ruby-2.6.0-preview2   #<Thread::ConditionVariable:0x000056122e4ca978>
ruby-2.6.0-preview3   #<Thread::ConditionVariable:0x000055c0adeb67c0>
ruby-2.6.0-rc1        #<Thread::ConditionVariable:0x000055b7908d66c8>
ruby-2.6.0-rc2        #<Thread::ConditionVariable:0x0000555bd7dde978>
ruby-2.6.0            #<Thread::ConditionVariable:0x000055846798afd0>
ruby-2.6.1            #<Thread::ConditionVariable:0x000055572436e568>
ruby-2.6.2            #<Thread::ConditionVariable:0x00005591b4e9e058>
ruby-2.6.3            #<Thread::ConditionVariable:0x0000564b2bf61c20>
ruby-2.6.4            #<Thread::ConditionVariable:0x000055bc9bb34068>
ruby-2.6.5            #<Thread::ConditionVariable:0x000055badc63bbf8>
ruby-2.7.0-preview1   #<Thread::ConditionVariable:0x000055d49807ea78>
ruby-2.7.0-preview2   #<Thread::ConditionVariable:0x00005624402f27d0>
ruby-2.7.0-preview3   #<Thread::ConditionVariable:0x0000556b857d1040>
ruby-2.7.0-rc1        #<Thread::ConditionVariable:0x000055c701fd2c58>
ruby-2.7.0-rc2        #<Thread::ConditionVariable:0x00005558fa0156c8>
ruby-2.7.0            #<Thread::ConditionVariable:0x0000557240bb36b0>
```

```
$ docker run rubylang/all-ruby:latest ./all-ruby -r thread -e 'p ConditionVariable.new.signal'
ruby-0.49             /all-ruby/bin/ruby-0.49: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.49: No such file or directory - thread.
                  exit 1
ruby-0.50             /all-ruby/bin/ruby-0.50: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.50: No such file or directory - thread.
                  exit 1
ruby-0.51             /all-ruby/bin/ruby-0.51: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.51: No such file or directory - thread.
                  exit 1
ruby-0.54             /all-ruby/bin/ruby-0.54: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.54: No such file or directory - thread.
                  exit 1
ruby-0.55             /all-ruby/bin/ruby-0.55: invalid option -- 'r'
                      /all-ruby/bin/ruby-0.55: No such file or directory - thread.
                  exit 1
ruby-0.60             /all-ruby/bin/ruby-0.60: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.60: No such file or directory - thread
                  exit 1
ruby-0.62             /all-ruby/bin/ruby-0.62: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.62: No such file or directory - thread
                  exit 1
ruby-0.63             /all-ruby/bin/ruby-0.63: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.63: No such file or directory - thread
                  exit 1
ruby-0.64             /all-ruby/bin/ruby-0.64: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.64: No such file or directory - thread
                  exit 1
ruby-0.65             /all-ruby/bin/ruby-0.65: unrecognized option `-r'
                      /all-ruby/bin/ruby-0.65: No such file or directory - thread
                  exit 1
ruby-0.69             Unrecognized switch: -r
                  exit 1
...
ruby-0.76             Unrecognized switch: -r
                  exit 1
ruby-0.95             /all-ruby/bin/ruby-0.95: No such file to load -- thread
ruby-0.99.4-961224    -e:1: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.0-961225       -e:1: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.0-971002       -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
...
ruby-1.0-971225       -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a0            -e:1: NameError| Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a1            -e:1: NameError| Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a2            -e:1: NameError:Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1a3            -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
...
ruby-1.1a9            -e:1: NameError: Uninitialized constant ConditionVariable
                  exit 1
ruby-1.1b0            -e:1: Uninitialized constant ConditionVariable (NameError)
                  exit 1
...
ruby-1.1b8            -e:1: Uninitialized constant ConditionVariable (NameError)
                  exit 1
ruby-1.1b9            nil
...
ruby-1.1c9            nil
ruby-1.1d0            /build-all-ruby/1.1d0/lib/ruby/thread.rb:66: [BUG] Segmentation fault
                  SIGABRT (signal 6)
ruby-1.1d1            nil
...
ruby-1.8.5-p231       nil
ruby-1.8.6-preview1   #<ConditionVariable:0x7fc451eb3850>
ruby-1.8.6-preview2   #<ConditionVariable:0x7f248f133840>
ruby-1.8.6-preview3   #<ConditionVariable:0x7fc1db916848>
ruby-1.8.6            #<ConditionVariable:0x7fdf37f78708>
ruby-1.8.6-p36        #<ConditionVariable:0x7fdec8c9b720>
ruby-1.8.6-p110       #<ConditionVariable:0x7fc37ba21700>
ruby-1.8.6-p111       #<ConditionVariable:0x7f55d1916710>
ruby-1.8.6-p114       #<ConditionVariable:0x7fca9c15e708>
ruby-1.8.6-p230       #<ConditionVariable:0x7fcc571c4708>
ruby-1.8.6-p286       #<ConditionVariable:0x7fb493188720>
ruby-1.8.6-p287       #<ConditionVariable:0x7f3df5680710>
ruby-1.8.6-p368       #<ConditionVariable:0x7fd0026906e8>
ruby-1.8.6-p369       #<ConditionVariable:0x7f6a608666f0>
ruby-1.8.6-p383       #<ConditionVariable:0x7f5d0f2676e0>
ruby-1.8.6-p388       #<ConditionVariable:0x7f0e124156f0>
ruby-1.8.6-p398       #<ConditionVariable:0x7f08eecf16f8>
ruby-1.8.6-p399       #<ConditionVariable:0x7f48b7c816d8>
ruby-1.8.6-p420       #<ConditionVariable:0x7f6e70e166e0>
ruby-1.8.7-preview1   #<ConditionVariable:0x7fac27f3a0e0>
ruby-1.8.7-preview2   #<ConditionVariable:0x7fe117a2b098>
ruby-1.8.7-preview3   #<ConditionVariable:0x7f2c1e0a2e08>
ruby-1.8.7-preview4   #<ConditionVariable:0x7f7734f2fd70>
ruby-1.8.7            #<ConditionVariable:0x7f7d8b7f5700>
ruby-1.8.7-p17        #<ConditionVariable:0x7f4389bb2708>
ruby-1.8.7-p22        #<ConditionVariable:0x7f39f5562710>
ruby-1.8.7-p71        #<ConditionVariable:0x7ff45f8d5710>
ruby-1.8.7-p72        #<ConditionVariable:0x7f1c88152718>
ruby-1.8.7-p160       #<ConditionVariable:0x7fc4c23946d8>
ruby-1.8.7-p173       #<ConditionVariable:0x7f3ea202e6e8>
ruby-1.8.7-p174       #<ConditionVariable:0x7f113c5006f0>
ruby-1.8.7-p248       #<ConditionVariable:0x7fc88c0f76f0>
ruby-1.8.7-p249       #<ConditionVariable:0x7f40e46136f0>
ruby-1.8.7-p299       #<ConditionVariable:0x7f9efa6096e0>
ruby-1.8.7-p301       #<ConditionVariable:0x7f0b0f29c6d0>
ruby-1.8.7-p302       #<ConditionVariable:0x7f1a403676d8>
ruby-1.8.7-p330       #<ConditionVariable:0x7f4da84196d0>
ruby-1.8.7-p334       #<ConditionVariable:0x7f09e164e6e0>
ruby-1.8.7-p352       #<ConditionVariable:0x7f670d09e6d0>
ruby-1.8.7-p357       #<ConditionVariable:0x7f20d72de6d8>
ruby-1.8.7-p358       #<ConditionVariable:0x7f3939e056e0>
ruby-1.8.7-p370       #<ConditionVariable:0x7fa3236c06d8>
ruby-1.8.7-p371       #<ConditionVariable:0x7fbd65d5a6e0>
ruby-1.8.7-p373       #<ConditionVariable:0x7f89e13236e8>
ruby-1.8.7-p374       #<ConditionVariable:0x7f9fdf62b6d8>
ruby-1.9.0-0          nil
...
ruby-1.9.2-preview1   nil
ruby-1.9.2-preview3   #<ConditionVariable:0x00557a3b7d58b0 @waiters=[], @waiters_mutex=#<Mutex:0x00557a3b7d5860>>
ruby-1.9.2-rc1        #<ConditionVariable:0x0055a8503dc6d0 @waiters=[], @waiters_mutex=#<Mutex:0x0055a8503dc680>>
ruby-1.9.2-rc2        #<ConditionVariable:0x005580dcbd3960 @waiters=[], @waiters_mutex=#<Mutex:0x005580dcbd3910>>
ruby-1.9.2-p0         #<ConditionVariable:0x005601ee63dff8 @waiters=[], @waiters_mutex=#<Mutex:0x005601ee63dfa8>>
ruby-1.9.2-p136       #<ConditionVariable:0x00560042d19d98 @waiters=[], @waiters_mutex=#<Mutex:0x00560042d19d48>>
ruby-1.9.2-p180       #<ConditionVariable:0x0056060a5ac010 @waiters=[], @waiters_mutex=#<Mutex:0x0056060a5abfc0>>
ruby-1.9.2-p290       #<ConditionVariable:0x00560c93c74160 @waiters=[], @waiters_mutex=#<Mutex:0x00560c93c74110>>
ruby-1.9.2-p318       #<ConditionVariable:0x00556e2a6a1ee8 @waiters=[], @waiters_mutex=#<Mutex:0x00556e2a6a1e98>>
ruby-1.9.2-p320       #<ConditionVariable:0x0055957cd35150 @waiters=[], @waiters_mutex=#<Mutex:0x0055957cd35100>>
ruby-1.9.2-p330       #<ConditionVariable:0x0055ec220fb158 @waiters=[], @waiters_mutex=#<Mutex:0x0055ec220fb108>>
ruby-1.9.3-preview1   #<ConditionVariable:0x0055d42bcbfd90 @waiters=[], @waiters_mutex=#<Mutex:0x0055d42bcbfd40>>
ruby-1.9.3-rc1        #<ConditionVariable:0x0055953b7a16a8 @waiters=[], @waiters_mutex=#<Mutex:0x0055953b7a1658>>
ruby-1.9.3-p0         #<ConditionVariable:0x0055fb6fe76088 @waiters=[], @waiters_mutex=#<Mutex:0x0055fb6fe76038>>
ruby-1.9.3-p105       #<ConditionVariable:0x0055805410dc20 @waiters=[], @waiters_mutex=#<Mutex:0x0055805410dbd0>>
ruby-1.9.3-p125       #<ConditionVariable:0x0055d2cad56428 @waiters=[], @waiters_mutex=#<Mutex:0x0055d2cad563d8>>
ruby-1.9.3-p194       #<ConditionVariable:0x00559f8c182208 @waiters=[], @waiters_mutex=#<Mutex:0x00559f8c1821b8>>
ruby-1.9.3-p286       #<ConditionVariable:0x00561ddb53f490 @waiters=[], @waiters_mutex=#<Mutex:0x00561ddb53f440>>
ruby-1.9.3-p327       #<ConditionVariable:0x0055f33d610e50 @waiters=[], @waiters_mutex=#<Mutex:0x0055f33d610e00>>
ruby-1.9.3-p362       #<ConditionVariable:0x00559ed625a560 @waiters=[], @waiters_mutex=#<Mutex:0x00559ed625a510>>
ruby-1.9.3-p374       #<ConditionVariable:0x00564e423f4558 @waiters=[], @waiters_mutex=#<Mutex:0x00564e423f4508>>
ruby-1.9.3-p385       #<ConditionVariable:0x0055810402cd00 @waiters=[], @waiters_mutex=#<Mutex:0x0055810402ccb0>>
ruby-1.9.3-p392       #<ConditionVariable:0x005628af354d18 @waiters=[], @waiters_mutex=#<Mutex:0x005628af354cc8>>
ruby-1.9.3-p426       #<ConditionVariable:0x0056340ff0fcf0 @waiters=[], @waiters_mutex=#<Mutex:0x0056340ff0fca0>>
ruby-1.9.3-p429       #<ConditionVariable:0x0055eb8480ed08 @waiters=[], @waiters_mutex=#<Mutex:0x0055eb8480ecb8>>
ruby-1.9.3-p448       #<ConditionVariable:0x0055c2ee1133a0 @waiters=[], @waiters_mutex=#<Mutex:0x0055c2ee113350>>
ruby-1.9.3-p484       #<ConditionVariable:0x00558ed59083a0 @waiters=[], @waiters_mutex=#<Mutex:0x00558ed5908350>>
ruby-1.9.3-p545       #<ConditionVariable:0x005589a41988d0 @waiters=[], @waiters_mutex=#<Mutex:0x005589a4198880>>
ruby-1.9.3-p547       #<ConditionVariable:0x0055e29bd9c8c0 @waiters=[], @waiters_mutex=#<Mutex:0x0055e29bd9c870>>
ruby-1.9.3-p550       #<ConditionVariable:0x0055cf765458d0 @waiters=[], @waiters_mutex=#<Mutex:0x0055cf76545880>>
ruby-1.9.3-p551       #<ConditionVariable:0x0055deb202c8d0 @waiters=[], @waiters_mutex=#<Mutex:0x0055deb202c880>>
ruby-2.0.0-preview1   #<ConditionVariable:0x005631dcf58408 @waiters=[], @waiters_mutex=#<Mutex:0x005631dcf58368>>
ruby-2.0.0-preview2   #<ConditionVariable:0x0056141eb04dd8 @waiters={}, @waiters_mutex=#<Mutex:0x0056141eb04c98>>
ruby-2.0.0-rc1        #<ConditionVariable:0x0055e7a7a3ca20 @waiters={}, @waiters_mutex=#<Mutex:0x0055e7a7a3c930>>
ruby-2.0.0-rc2        #<ConditionVariable:0x00559541872b80 @waiters={}, @waiters_mutex=#<Mutex:0x00559541872a68>>
ruby-2.0.0-p0         #<ConditionVariable:0x005614d9f2b6f8 @waiters={}, @waiters_mutex=#<Mutex:0x005614d9f2b608>>
ruby-2.0.0-p195       #<ConditionVariable:0x0055cd17c9bb90 @waiters={}, @waiters_mutex=#<Mutex:0x0055cd17c9bb40>>
ruby-2.0.0-p247       #<ConditionVariable:0x0056533d687a18 @waiters={}, @waiters_mutex=#<Mutex:0x0056533d6879c8>>
ruby-2.0.0-p353       #<ConditionVariable:0x005644a4ccae68 @waiters={}, @waiters_mutex=#<Mutex:0x005644a4ccae18>>
ruby-2.0.0-p451       #<ConditionVariable:0x005623de851968 @waiters={}, @waiters_mutex=#<Mutex:0x005623de851918>>
ruby-2.0.0-p481       #<ConditionVariable:0x0056122fa99830 @waiters={}, @waiters_mutex=#<Mutex:0x0056122fa997e0>>
ruby-2.0.0-p576       #<ConditionVariable:0x005595d2fc18f0 @waiters={}, @waiters_mutex=#<Mutex:0x005595d2fc18a0>>
ruby-2.0.0-p594       #<ConditionVariable:0x0055a650ba19d0 @waiters={}, @waiters_mutex=#<Mutex:0x0055a650ba1980>>
ruby-2.0.0-p598       #<ConditionVariable:0x00559c64f3d918 @waiters={}, @waiters_mutex=#<Mutex:0x00559c64f3d8c8>>
ruby-2.0.0-p643       #<ConditionVariable:0x005650dbf099e8 @waiters={}, @waiters_mutex=#<Mutex:0x005650dbf09998>>
ruby-2.0.0-p645       #<ConditionVariable:0x00558332035948 @waiters={}, @waiters_mutex=#<Mutex:0x005583320358f8>>
ruby-2.0.0-p647       #<ConditionVariable:0x0055d967f55960 @waiters={}, @waiters_mutex=#<Mutex:0x0055d967f55910>>
ruby-2.0.0-p648       #<ConditionVariable:0x005603120398f8 @waiters={}, @waiters_mutex=#<Mutex:0x005603120398a8>>
ruby-2.1.0-preview1   #<Thread::ConditionVariable:0x0055ebc2e0d7c0>
ruby-2.1.0-preview2   #<Thread::ConditionVariable:0x00560e23000848>
ruby-2.1.0-rc1        #<Thread::ConditionVariable:0x00563ea5bc27c8>
ruby-2.1.0            #<Thread::ConditionVariable:0x0055efe33c6aa8>
ruby-2.1.1            #<Thread::ConditionVariable:0x005610bc3ff868>
ruby-2.1.2            #<Thread::ConditionVariable:0x00560c3fb3e290>
ruby-2.1.3            #<Thread::ConditionVariable:0x0055b2d60a7100>
ruby-2.1.4            #<Thread::ConditionVariable:0x005576871af128>
ruby-2.1.5            #<Thread::ConditionVariable:0x0055ce17a37038>
ruby-2.1.6            #<Thread::ConditionVariable:0x0055c80bbc6ff0>
ruby-2.1.7            #<Thread::ConditionVariable:0x0055b065880a98>
ruby-2.1.8            #<Thread::ConditionVariable:0x0055e8129e1650>
ruby-2.1.9            #<Thread::ConditionVariable:0x00562ae202d678>
ruby-2.1.10           #<Thread::ConditionVariable:0x00559dd8be1650>
ruby-2.2.0-preview1   #<Thread::ConditionVariable:0x00558636f58770>
ruby-2.2.0-preview2   #<Thread::ConditionVariable:0x0055ddeb8b1950>
ruby-2.2.0-rc1        #<Thread::ConditionVariable:0x0055b7164e08b8>
ruby-2.2.0            #<Thread::ConditionVariable:0x0055c1f6569290>
ruby-2.2.1            #<Thread::ConditionVariable:0x005638f50f92c0>
ruby-2.2.2            #<Thread::ConditionVariable:0x00564f67591250>
ruby-2.2.3            #<Thread::ConditionVariable:0x0055c9df34d790>
ruby-2.2.4            #<Thread::ConditionVariable:0x0055cf40091b80>
ruby-2.2.5            #<Thread::ConditionVariable:0x00562b38b1d258>
ruby-2.2.6            #<Thread::ConditionVariable:0x0055b62381b7d8>
ruby-2.2.7            #<Thread::ConditionVariable:0x0055e1b22c7790>
ruby-2.2.8            #<Thread::ConditionVariable:0x0055eb23292c78>
ruby-2.2.9            #<Thread::ConditionVariable:0x00555bca4bac28>
ruby-2.2.10           #<Thread::ConditionVariable:0x0055a9fb6983e0>
ruby-2.3.0-preview1   #<Thread::ConditionVariable:0x0056075ce28fb0>
ruby-2.3.0-preview2   #<Thread::ConditionVariable:0x005610ad2a4d60>
ruby-2.3.0            #<Thread::ConditionVariable:0x0055e3f5c92870>
ruby-2.3.1            #<Thread::ConditionVariable:0x00557b72de35d0>
ruby-2.3.2            #<Thread::ConditionVariable:0x00560fd6dc6f68>
ruby-2.3.3            #<Thread::ConditionVariable:0x0055d379adaff0>
ruby-2.3.4            #<Thread::ConditionVariable:0x0055dcd3ddb020>
ruby-2.3.5            #<Thread::ConditionVariable:0x00005654efd413c8>
ruby-2.3.6            #<Thread::ConditionVariable:0x000055cd6232cf00>
ruby-2.3.7            #<Thread::ConditionVariable:0x00005587439cb920>
ruby-2.3.8            #<Thread::ConditionVariable:0x0000561fb76e7878>
ruby-2.4.0-preview1   #<Thread::ConditionVariable:0x00565448ca5470>
ruby-2.4.0-preview2   #<Thread::ConditionVariable:0x0055819259f7b8>
ruby-2.4.0-preview3   #<Thread::ConditionVariable:0x005650f70d4960>
ruby-2.4.0-rc1        #<Thread::ConditionVariable:0x00559dff7dee28>
ruby-2.4.0            #<Thread::ConditionVariable:0x0055daddb65478>
ruby-2.4.1            #<Thread::ConditionVariable:0x0055577ebf29a0>
ruby-2.4.2            #<Thread::ConditionVariable:0x000055ed628332b8>
ruby-2.4.3            #<Thread::ConditionVariable:0x00005561b74cb490>
ruby-2.4.4            #<Thread::ConditionVariable:0x000055fb25260b30>
ruby-2.4.5            #<Thread::ConditionVariable:0x0000557c66892a28>
ruby-2.4.6            #<Thread::ConditionVariable:0x000056082b556278>
ruby-2.4.7            #<Thread::ConditionVariable:0x0000564077a063c0>
ruby-2.4.9            #<Thread::ConditionVariable:0x0000561a2a6e2180>
ruby-2.5.0-preview1   #<Thread::ConditionVariable:0x000055de615bc918>
ruby-2.5.0-rc1        #<Thread::ConditionVariable:0x000055e6a3ea77e0>
ruby-2.5.0            #<Thread::ConditionVariable:0x00005644b342e9a8>
ruby-2.5.1            #<Thread::ConditionVariable:0x000055773edb8520>
ruby-2.5.2            #<Thread::ConditionVariable:0x00005619d9e83818>
ruby-2.5.3            #<Thread::ConditionVariable:0x000056347d957ba0>
ruby-2.5.4            #<Thread::ConditionVariable:0x0000560cd9c881b0>
ruby-2.5.5            #<Thread::ConditionVariable:0x0000564e95c8ad18>
ruby-2.5.6            #<Thread::ConditionVariable:0x000056011be25bb8>
ruby-2.5.7            #<Thread::ConditionVariable:0x0000558ca7068540>
ruby-2.6.0-preview1   #<Thread::ConditionVariable:0x000055eb160bd540>
ruby-2.6.0-preview2   #<Thread::ConditionVariable:0x000055c401d369c0>
ruby-2.6.0-preview3   #<Thread::ConditionVariable:0x0000562f312b2148>
ruby-2.6.0-rc1        #<Thread::ConditionVariable:0x00005626a5bce810>
ruby-2.6.0-rc2        #<Thread::ConditionVariable:0x0000556e9545a778>
ruby-2.6.0            #<Thread::ConditionVariable:0x000056084a3d6c30>
ruby-2.6.1            #<Thread::ConditionVariable:0x000055dfe08ee070>
ruby-2.6.2            #<Thread::ConditionVariable:0x0000560c374b0fe8>
ruby-2.6.3            #<Thread::ConditionVariable:0x00005605cacbddf8>
ruby-2.6.4            #<Thread::ConditionVariable:0x000055c29fea32a8>
ruby-2.6.5            #<Thread::ConditionVariable:0x0000563612faf0c0>
ruby-2.7.0-preview1   #<Thread::ConditionVariable:0x000055f59c09aa78>
ruby-2.7.0-preview2   #<Thread::ConditionVariable:0x00005597725e1e88>
ruby-2.7.0-preview3   #<Thread::ConditionVariable:0x000055f5d0b95c00>
ruby-2.7.0-rc1        #<Thread::ConditionVariable:0x000055d4c6d5e148>
ruby-2.7.0-rc2        #<Thread::ConditionVariable:0x0000556cea06f110>
ruby-2.7.0            #<Thread::ConditionVariable:0x0000556968756e18>
```
