### PR TITLE
String#tr のサンプルコードを拡充

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2765,6 +2765,14 @@ replace の最後の文字が無限に続くものとして扱われます。
 p "foo".tr("f", "X")      # => "Xoo"
 p "foo".tr('a-z', 'A-Z')  # => "FOO"
 p "FOO".tr('A-Z', 'a-z')  # => "foo"
+
+# シーザー暗号の復号
+p "ORYV".tr("A-Z", "D-ZA-C") # => "RUBY"
+
+# 全角英数字といくつかの記号の半角化
+email = "ｒｕｂｙ−ｌａｎｇ＠ｅｘａｍｐｌｅ．ｃｏｍ"
+p email.tr("０-９ａ-ｚＡ-Ｚ．＠−", "0-9a-zA-Z.@-")
+# => "ruby-lang@example.com"
 #@end
 
 @see [[m:String#tr_s]]

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2775,7 +2775,7 @@ p email.tr("０-９ａ-ｚＡ-Ｚ．＠−", "0-9a-zA-Z.@-")
 # => "ruby-lang@example.com"
 #@end
 
-@see [[m:String#tr_s]]
+@see [[m:String#tr!]], [[m:String#tr_s]]
 
 --- tr!(pattern, replace) -> self | nil
 


### PR DESCRIPTION
#2210 を解決します。`tr` らしい使い方としてシーザー暗号も追加しました。

ついでに String#tr! への参照を追加しました。