### PR TITLE
「1+1i」の間にスペースを追加しました

### DIFF
--- a/refm/api/src/_builtin/Complex
+++ b/refm/api/src/_builtin/Complex
@@ -181,7 +181,7 @@ Complex(-0.0, -0.0).arg         #=> -3.141592653589793
 #@end
 
 #@samplecode 例
-(1+1i).finite?                   # => true
+(1 + 1i).finite?                 # => true
 (Float::INFINITY + 1i).finite?   # => false
 #@end
 


### PR DESCRIPTION
`Float::INFINITY + 1i` に合わせて `1+1i` の間にスペースを入れました。rdoc の [Complex#infinete?](https://docs.ruby-lang.org/en/2.7.0/Complex.html#method-i-infinite-3F) もそうなっているのですが、何か特別なコーディングルールとかでしたら教えてください :pray: