### PR TITLE
MatchData のサンプルコードを新フォーマットに

### DIFF
--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -139,7 +139,7 @@ p $~.size       # => 4
 n 番目の部分文字列のオフセットの配列 [start, end] を返
 します。
 
-#@samplecode
+#@samplecode 例
 [ self.begin(n), self.end(n) ]
 #@end
 

--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -122,11 +122,7 @@ p $~.to_a       # => ["foobar", "foo", "bar", nil]
 p $~.captures   # => ["foo", "bar", nil]
 #@end
 
-#@since 2.4.0
 @see [[m:MatchData#to_a]], [[m:MatchData#named_captures]]
-#@else
-@see [[m:MatchData#to_a]]
-#@end
 
 --- length -> Integer
 --- size -> Integer
@@ -177,20 +173,6 @@ p $~.pre_match  # => "foo"
 #@end
 
 @see [[m:MatchData#post_match]]
-
-#@until 1.9.1
---- select {|s| ... } -> [String]
-各要素に対してブロックを評価した値が真であった要素を全て含む配列を
-返します。真になる要素がひとつもなかった場合は空の配列を返します。
-
-self.to_a.select { ... } と同じです。
-
-#@samplecode 例
-m = /(.)(.)(\d+)(\d)/.match("THX1138: The Movie")
-p m.select{|x| /X/ =~ x}   # => ["HX1138", "X"]
-#@end
-
-#@end
 
 --- string -> String
 
@@ -248,28 +230,21 @@ puts /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge").inspect
 
 0 番目は [[m:$&]] のようにマッチした文字列全体を表します。
 
-#@since 2.4.0
 @param index インデックスを整数またはシンボル(名前付きキャプチャの場合)で 0 個以上指定します。
-#@else
-@param index インデックスを整数で 0 個以上指定します。
-#@end
 
 #@samplecode 例
 m = /(foo)(bar)(baz)/.match("foobarbaz")
 # same as m.to_a.values_at(...)
 p m.values_at(0, 1, 2, 3, 4)      # => ["foobarbaz", "foo", "bar", "baz", nil]
 p m.values_at(-1, -2, -3, -4, -5) # => ["baz", "bar", "foo", nil, nil]
-#@since 2.4.0
 
 m = /(?<a>\d+) *(?<op>[+\-*\/]) *(?<b>\d+)/.match("1 + 2")
 m.to_a                   # => ["1 + 2", "1", "+", "2"]
 m.values_at(:a, :b, :op) # => ["1", "2", "+"]
 #@end
-#@end
 
 @see [[m:Array#values_at]], [[m:Array#[] ]]
 
-#@since 1.9.1
 --- names -> [String]
 
 名前付きキャプチャの名前を文字列配列で返します。
@@ -292,8 +267,6 @@ m = /a.*b/.match("abc")
 m.regexp # => /a.*b/
 #@end
 
-#@end
-#@since 1.9.2
 --- hash -> Integer
 
 self のマッチ対象になった文字列、元になった正規表現オブジェクト、マッチ
@@ -335,8 +308,6 @@ m2 = r.match("abcabc", 0) # => #<MatchData "abc">
 m1 == m2  # => true
 #@end
 
-#@end
-#@since 2.4.0
 --- named_captures -> Hash
 
 名前付きキャプチャをHashで返します。
@@ -358,4 +329,3 @@ m.named_captures # => {"a" => "x"}
 #@end
 
 @see [[m:MatchData#captures]]
-#@end

--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -20,14 +20,16 @@ n の値が負の時には末尾からのインデックスと見倣します(�
 
 @param n 返す部分文字列のインデックスを指定します。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.to_a       # => ["foobar", "foo", "bar", nil]
-  p $~[0]         # => "foobar"
-  p $~[1]         # => "foo"
-  p $~[2]         # => "bar"
-  p $~[3]         # => nil        (マッチしていない)
-  p $~[4]         # => nil        (範囲外)
-  p $~[-2]        # => "bar"
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.to_a       # => ["foobar", "foo", "bar", nil]
+p $~[0]         # => "foobar"
+p $~[1]         # => "foo"
+p $~[2]         # => "bar"
+p $~[3]         # => nil        (マッチしていない)
+p $~[4]         # => nil        (範囲外)
+p $~[-2]        # => "bar"
+#@end
 
 --- [](range) -> [String]
 
@@ -35,15 +37,19 @@ n の値が負の時には末尾からのインデックスと見倣します(�
 
 @param range start..end 範囲式。
 
-  /(foo)(bar)/ =~ "foobarbaz"
-  p $~[0..2]      # => ["foobar", "foo", "bar"]
+#@samplecode 例
+/(foo)(bar)/ =~ "foobarbaz"
+p $~[0..2]      # => ["foobar", "foo", "bar"]
+#@end
 
 --- [](start, length) -> [String]
 
 start 番目から length 個の要素を含む部分配列を返します。
 
-  /(foo)(bar)/ =~ "foobarbaz"
-  p $~[0, 3]      # => ["foobar", "foo", "bar"]
+#@samplecode 例
+/(foo)(bar)/ =~ "foobarbaz"
+p $~[0, 3]      # => ["foobar", "foo", "bar"]
+#@end
 
 @see [[m:Array#[] ]]
 
@@ -54,8 +60,11 @@ name という名前付きグループにマッチした文字列を返します
 @param name 名前(シンボルか文字列)
 @raise IndexError 指定した名前が正規表現内に含まれていない場合に発生します
 
-  /\$(?<dollars>\d+)\.(?<cents>\d+)/.match("$3.67")[:cents] # => "67"
-  /(?<alpha>[a-zA-Z]+)|(?<num>\d+)/.match("aZq")[:num] # => nil
+#@samplecode 例
+/\$(?<dollars>\d+)\.(?<cents>\d+)/.match("$3.67")[:cents] # => "67"
+/(?<alpha>[a-zA-Z]+)|(?<num>\d+)/.match("aZq")[:num] # => nil
+#@end
+
 --- begin(n) -> Integer | nil
 
 n 番目の部分文字列先頭のオフセットを返します。
@@ -67,12 +76,14 @@ n 番目の部分文字列がマッチしていなければ nilを返します�
 
 @raise IndexError 範囲外の n を指定した場合に発生します。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.begin(0)   # => 0
-  p $~.begin(1)   # => 0
-  p $~.begin(2)   # => 3
-  p $~.begin(3)   # => nil
-  p $~.begin(4)   # => `begin': index 4 out of matches (IndexError)
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.begin(0)   # => 0
+p $~.begin(1)   # => 0
+p $~.begin(2)   # => 3
+p $~.begin(3)   # => nil
+p $~.begin(4)   # => `begin': index 4 out of matches (IndexError)
+#@end
 
 @see [[m:MatchData#end]]
 
@@ -87,12 +98,14 @@ n 番目の部分文字列がマッチしていなければ nil を返します�
 
 @raise IndexError 範囲外の n を指定した場合に発生します。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.end(0)   # => 6
-  p $~.end(1)   # => 3
-  p $~.end(2)   # => 6
-  p $~.end(3)   # => nil
-  p $~.end(4)   # => `end': index 4 out of matches (IndexError)
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.end(0)   # => 6
+p $~.end(1)   # => 3
+p $~.end(2)   # => 6
+p $~.end(3)   # => nil
+p $~.end(4)   # => `end': index 4 out of matches (IndexError)
+#@end
 
 @see [[m:MatchData#begin]]
 
@@ -103,9 +116,11 @@ n 番目の部分文字列がマッチしていなければ nil を返します�
 [[m:MatchData#to_a]] と異なり [[m:$&]] を要素に含みません。
 グループにマッチした部分文字列がなければ対応する要素は nil になります。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.to_a       # => ["foobar", "foo", "bar", nil]
-  p $~.captures       # => ["foo", "bar", nil]
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.to_a       # => ["foobar", "foo", "bar", nil]
+p $~.captures   # => ["foo", "bar", nil]
+#@end
 
 #@since 2.4.0
 @see [[m:MatchData#to_a]], [[m:MatchData#named_captures]]
@@ -118,15 +133,19 @@ n 番目の部分文字列がマッチしていなければ nil を返します�
 
 部分文字列の数を返します(self.to_a.size と同じです)。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.size       # => 4
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.size       # => 4
+#@end
 
 --- offset(n) -> [Integer]
 
 n 番目の部分文字列のオフセットの配列 [start, end] を返
 します。
 
-  [ self.begin(n), self.end(n) ]
+#@samplecode
+[ self.begin(n), self.end(n) ]
+#@end
 
 と同じです。n番目の部分文字列がマッチしていなければ
 [nil, nil] を返します。
@@ -141,8 +160,10 @@ n 番目の部分文字列のオフセットの配列 [start, end] を返
 
 マッチした部分より後ろの文字列を返します([[m:$']]と同じ)。
 
-  /(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.post_match # => "baz"
+#@samplecode 例
+/(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.post_match # => "baz"
+#@end
 
 @see [[m:MatchData#pre_match]]
 
@@ -150,8 +171,10 @@ n 番目の部分文字列のオフセットの配列 [start, end] を返
 
 マッチした部分より前の文字列を返します([[m:$`]]と同じ)。
 
-  /(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.pre_match  # => "foo"
+#@samplecode 例
+/(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.pre_match  # => "foo"
+#@end
 
 @see [[m:MatchData#post_match]]
 
@@ -162,8 +185,10 @@ n 番目の部分文字列のオフセットの配列 [start, end] を返
 
 self.to_a.select { ... } と同じです。
 
-   m = /(.)(.)(\d+)(\d)/.match("THX1138: The Movie")
-   p m.select{|x| /X/ =~ x}   #=> ["HX1138", "X"]
+#@samplecode 例
+m = /(.)(.)(\d+)(\d)/.match("THX1138: The Movie")
+p m.select{|x| /X/ =~ x}   # => ["HX1138", "X"]
+#@end
 
 #@end
 
@@ -173,15 +198,19 @@ self.to_a.select { ... } と同じです。
 
 返す文字列はフリーズ([[m:Object#freeze]])されています。
 
-  m = /(.)(.)(\d+)(\d)/.match("THX1138.")
-  m.string   # => "THX1138."
+#@samplecode 例
+m = /(.)(.)(\d+)(\d)/.match("THX1138.")
+m.string   # => "THX1138."
+#@end
 
 --- to_a -> [String]
 
 [[m:$&]], [[m:$1]], [[m:$2]],... を格納した配列を返します。
 
-  /(foo)(bar)(BAZ)?/ =~ "foobarbaz"
-  p $~.to_a       # => ["foobar", "foo", "bar", nil]
+#@samplecode 例
+/(foo)(bar)(BAZ)?/ =~ "foobarbaz"
+p $~.to_a       # => ["foobar", "foo", "bar", nil]
+#@end
 
 @see [[m:MatchData#captures]]
 
@@ -189,25 +218,29 @@ self.to_a.select { ... } と同じです。
 
 マッチした文字列全体を返します。
 
-  /bar/ =~ "foobarbaz"
-  p $~            # => #<MatchData:0x401b1be4>
-  p $~.to_s       # => "bar"
+#@samplecode 例
+/bar/ =~ "foobarbaz"
+p $~            # => #<MatchData:0x401b1be4>
+p $~.to_s       # => "bar"
+#@end
 
 --- inspect -> String
 
 self の内容を人間に読みやすい文字列にして返します。
 
-  puts /.$/.match("foo").inspect
-  # => #<MatchData "o">
+#@samplecode 例
+puts /.$/.match("foo").inspect
+# => #<MatchData "o">
 
-  puts /(.)(.)(.)/.match("foo").inspect
-  # => #<MatchData "foo" 1:"f" 2:"o" 3:"o">
+puts /(.)(.)(.)/.match("foo").inspect
+# => #<MatchData "foo" 1:"f" 2:"o" 3:"o">
 
-  puts /(.)(.)?(.)/.match("fo").inspect
-  # => #<MatchData "fo" 1:"f" 2:nil 3:"o">
+puts /(.)(.)?(.)/.match("fo").inspect
+# => #<MatchData "fo" 1:"f" 2:nil 3:"o">
 
-  puts /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge").inspect
-  # => #<MatchData "hog" foo:"h" bar:"o" baz:"g">
+puts /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge").inspect
+# => #<MatchData "hog" foo:"h" bar:"o" baz:"g">
+#@end
 
 --- values_at(*index) -> [String]
 
@@ -221,15 +254,17 @@ self の内容を人間に読みやすい文字列にして返します。
 @param index インデックスを整数で 0 個以上指定します。
 #@end
 
-  m = /(foo)(bar)(baz)/.match("foobarbaz")
-  # same as m.to_a.values_at(...)
-  p m.values_at(0, 1, 2, 3, 4)      #=> ["foobarbaz", "foo", "bar", "baz", nil]
-  p m.values_at(-1, -2, -3, -4, -5) #=> ["baz", "bar", "foo", nil, nil]
-
+#@samplecode 例
+m = /(foo)(bar)(baz)/.match("foobarbaz")
+# same as m.to_a.values_at(...)
+p m.values_at(0, 1, 2, 3, 4)      # => ["foobarbaz", "foo", "bar", "baz", nil]
+p m.values_at(-1, -2, -3, -4, -5) # => ["baz", "bar", "foo", nil, nil]
 #@since 2.4.0
-  m = /(?<a>\d+) *(?<op>[+\-*\/]) *(?<b>\d+)/.match("1 + 2")
-  m.to_a               #=> ["1 + 2", "1", "+", "2"]
-  m.values_at(:a, :b, :op) #=> ["1", "2", "+"]
+
+m = /(?<a>\d+) *(?<op>[+\-*\/]) *(?<b>\d+)/.match("1 + 2")
+m.to_a                   # => ["1 + 2", "1", "+", "2"]
+m.values_at(:a, :b, :op) # => ["1", "2", "+"]
+#@end
 #@end
 
 @see [[m:Array#values_at]], [[m:Array#[] ]]
@@ -241,17 +276,21 @@ self の内容を人間に読みやすい文字列にして返します。
 
 self.regexp.names と同じです。
 
-    /(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge").names
-    #=> ["foo", "bar", "baz"]
+#@samplecode 例
+/(?<foo>.)(?<bar>.)(?<baz>.)/.match("hoge").names
+# => ["foo", "bar", "baz"]
 
-    m = /(?<x>.)(?<y>.)?/.match("a") #=> #<MatchData "a" x:"a" y:nil>
-    m.names                          #=> ["x", "y"]
+m = /(?<x>.)(?<y>.)?/.match("a") # => #<MatchData "a" x:"a" y:nil>
+m.names                          # => ["x", "y"]
+#@end
 
 --- regexp -> Regexp
 自身の元になった正規表現オブジェクトを返します。
 
-    m = /a.*b/.match("abc")
-    m.regexp #=> /a.*b/
+#@samplecode 例
+m = /a.*b/.match("abc")
+m.regexp # => /a.*b/
+#@end
 
 #@end
 #@since 1.9.2
@@ -304,18 +343,19 @@ m1 == m2  # => true
 
 Hashのキーは名前付きキャプチャの名前です。Hashの値はキーの名前に対応した名前付きグループのうち最後にマッチした文字列です。
 
-例:
-  m = /(?<a>.)(?<b>.)/.match("01")
-  m.named_captures #=> {"a" => "0", "b" => "1"}
+#@samplecode 例
+m = /(?<a>.)(?<b>.)/.match("01")
+m.named_captures # => {"a" => "0", "b" => "1"}
 
-  m = /(?<a>.)(?<b>.)?/.match("0")
-  m.named_captures #=> {"a" => "0", "b" => nil}
+m = /(?<a>.)(?<b>.)?/.match("0")
+m.named_captures # => {"a" => "0", "b" => nil}
 
-  m = /(?<a>.)(?<a>.)/.match("01")
-  m.named_captures #=> {"a" => "1"}
+m = /(?<a>.)(?<a>.)/.match("01")
+m.named_captures # => {"a" => "1"}
 
-  m = /(?<a>x)|(?<a>y)/.match("x")
-  m.named_captures #=> {"a" => "x"}
+m = /(?<a>x)|(?<a>y)/.match("x")
+m.named_captures # => {"a" => "x"}
+#@end
 
 @see [[m:MatchData#captures]]
 #@end


### PR DESCRIPTION
MatchData に出てくるすべてのサンプルコードを新フォーマットにします。
ついでに古い分岐を削除します。