### PR TITLE
Add a punctuation to `Range#cover?` document to improve readability

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -207,7 +207,7 @@ obj が範囲内に含まれている時に真を返します。
 Range#cover? は連続値を扱います。
 （数値については、例外として [[m:Range#include?]] も連続的に扱います。）
 
-[[m:Range#exclude_end?]]がfalseなら「begin <= obj <= end」を
+[[m:Range#exclude_end?]]がfalseなら「begin <= obj <= end」を、
 trueなら「begin <= obj < end」を意味します。
 
 #@since 2.6.0


### PR DESCRIPTION
`Range#cover?` のドキュメントが読みづらかったので修正です。


# Problem


![200513154950](https://user-images.githubusercontent.com/4361134/81780409-7493c980-9531-11ea-8d83-ad1b2ba4f010.png)

↑のような感じで読点なしで文が書かれているのですが、これだと少し文をパースする時に脳に負荷がかかります。
ソースコード内では改行がされていて文中の区切りがわかりやすかったのですが、生成されたドキュメントでは改行は消えるため、読みづらい文になっていました。


# Solution


文を読みやすくするために読点を入れます。