### PR TITLE
Fix see also link format

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -655,7 +655,7 @@ other_arrays の要素を自身の末尾に破壊的に連結します。
     a = [ 1, 2 ]
     a.concat(a, a)                    #=> [1, 2, 1, 2, 1, 2]
 
-see [[m:Array#+]]
+@see [[m:Array#+]]
 #@end
 
 --- delete(val)           -> object | nil

--- a/refm/capi/src/eval.c.rd
+++ b/refm/capi/src/eval.c.rd
@@ -838,7 +838,7 @@ Thread#pass の実体。
 他のスレッドに実行権を渡します。
 対象の特定はできません。
 
-see also: [[f:rb_thread_wait_fd]], [[f:rb_thread_wait_for]]
+@see [[f:rb_thread_wait_fd]], [[f:rb_thread_wait_for]]
 
 #@until 2.2.0
 --- int rb_thread_select(int max, fd_set *read, fd_set *write, fd_set *except, struct timeval *timeout)


### PR DESCRIPTION
see alsoリンクの書式が間違っているところがあったので修正します。
grepしたところ、書式が間違っているのはこの2箇所だけでした。


```bash
$ git grep -w '^see'
refm/api/src/_builtin/Array:see [[m:Array#+]]
refm/capi/src/eval.c.rd:see also: [[f:rb_thread_wait_fd]], [[f:rb_thread_wait_for]]
```