### PR TITLE
Module#freezeの例外クラスにFrozenErrorの分岐を追加

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -702,14 +702,10 @@ inherit に真を指定すると
 モジュールを凍結（内容の変更を禁止）します。
 
 凍結したモジュールにメソッドの追加など何らかの変更を加えようとした場合に
-#@since 1.9.1
 #@since 2.5.0
 [[c:FrozenError]]
 #@else
 [[c:RuntimeError]]
-#@end
-#@else
-[[c:TypeError]]
 #@end
 が発生します。
 

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -701,13 +701,17 @@ inherit に真を指定すると
 
 モジュールを凍結（内容の変更を禁止）します。
 
+凍結したモジュールにメソッドの追加など何らかの変更を加えようとした場合に
 #@since 1.9.1
-凍結したモジュールにメソッドの追加など何らかの変更を加えようとした場合
-に [[c:RuntimeError]] が発生します。
+#@since 2.5.0
+[[c:FrozenError]]
 #@else
-凍結したモジュールにメソッドの追加など何らかの変更を加えようとした場合
-に [[c:TypeError]] が発生します。
+[[c:RuntimeError]]
 #@end
+#@else
+[[c:TypeError]]
+#@end
+が発生します。
 
 @see [[m:Object#freeze]]
 


### PR DESCRIPTION
#2250 で投稿させていただいた、
「Module#freezeの例外クラスがRuntimeErrorのままになっている」件の
Pull Requestとなります。

補足 :
Module#freezeの例外クラス変更は今回で2度目ということで、複数の条件分岐が
生じましたので `#@since` をネストする形でご提案させていただきました。

提案させていただいたコード
```txt
凍結したモジュールにメソッドの追加など何らかの変更を加えようとした場合に
#@since 1.9.1
#@since 2.5.0
[[c:FrozenError]]
#@else
[[c:RuntimeError]]
#@end
#@else
[[c:TypeError]]
#@end
が発生します。
```

慣習や記述ルールを誤っていましたら申し訳ありません。
以上、宜しくお願いいたします。