### PR TITLE
Add Array#minmax since Ruby 2.7

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2408,6 +2408,27 @@ a < b のとき負の整数を、期待しています。
 @see [[m:Enumerable#min]]
 #@end
 
+#@since 2.7.0
+--- minmax                 -> [object, object]
+--- minmax{|a, b| ... }    -> [object, object]
+
+自身の各要素のうち最小の要素と最大の要素を
+要素とするサイズ 2 の配列を返します。
+
+一つ目の形式は、各要素がすべて <=> メソッドを実装していることを仮定し
+ています。二つ目の形式では、要素同士の比較をブロックを用いて行います。
+
+#@samplecode
+a = %w(albatross dog horse)
+a.minmax                                 #=> ["albatross", "horse"]
+a.minmax{|a,b| a.length <=> b.length }   #=> ["dog", "albatross"]
+[].minmax # => [nil, nil]
+#@end
+
+@see [[m:Enumerable#minmax]]
+
+#@end
+
 #@since 2.4.0
 --- sum(init=0)                    -> object
 --- sum(init=0) {|e| expr }        -> object

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1061,12 +1061,18 @@ Enumerable オブジェクトの各要素のうち最小の要素と最大の要
 実装していることを仮定しています。二つ目の形式では、要素同士の比較を
 ブロックを用いて行います。
 
-   a = %w(albatross dog horse)
-   a.minmax                                 #=> ["albatross", "horse"]
-   a.minmax{|a,b| a.length <=> b.length }   #=> ["dog", "albatross"]
-   [].minmax # => [nil, nil]
+#@samplecode
+a = %w(albatross dog horse)
+a.minmax                                 #=> ["albatross", "horse"]
+a.minmax{|a,b| a.length <=> b.length }   #=> ["dog", "albatross"]
+[].minmax # => [nil, nil]
+#@end
 
+#@since 2.7.0
+@see [[m:Enumerable#sort]], [[m:Array#minmax]]
+#@else
 @see [[m:Enumerable#sort]]
+#@end
 
 #@since 1.9.1
 --- minmax_by                -> Enumerator


### PR DESCRIPTION
#2071

Ruby 2.7から追加された `Array#minmax` のドキュメントを追加します。

RDoc: https://docs.ruby-lang.org/en/master/Array.html#method-i-minmax



