### PR TITLE
Add Enumerable#filter_map since Ruby 2.7

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -179,6 +179,23 @@ end
 @see [[m:Enumerable#reject]]
 @see [[m:Enumerable#grep]]
 
+#@since 2.7.0
+--- filter_map {|item| ... } -> [object]
+--- filter_map -> Enumerator
+
+各要素に対してブロックを評価した値のうち、真であった値の
+配列を返します。
+
+ブロックを省略した場合は、各要素に対してブロックを評価した値のうち、
+真であった値の配列を返すような [[c:Enumerator]] を返します。
+
+#@samplecode 例
+(1..10).filter_map { |i| i * 2 if i.even? } #=> [4, 8, 12, 16, 20]
+#@end
+
+@see [[m:Enumerable#filter]], [[m:Enumerable#map]]
+#@end
+
 --- grep(pattern)                -> [object]
 --- grep(pattern) {|item| ... }  -> [object]
 


### PR DESCRIPTION
#2071

Ruby 2.7から追加された Enumerable#filter_map のドキュメントを追加します。




RDoc: https://docs.ruby-lang.org/en/master/Enumerable.html#method-i-filter_map


サンプルコードはRDocから持ってきています。