### PR TITLE
csv におけるブロック無し CSV.parse のコメントの文言修正

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -72,23 +72,36 @@ include Enumerable
 === 読み込み
 
 #@samplecode
-require 'csv'
+require "csv"
+
+csv_text = <<~CSV_TEXT
+  Ruby,1995
+  Rust,2010
+CSV_TEXT
+
+IO.write "sample.csv", csv_text
 
 # ファイルから一行ずつ
-CSV.foreach("path/to/file.csv") do |row|
-  # use row here...
+CSV.foreach("sample.csv") do |row|
+  p row
 end
+# => ["Ruby", "1995"]
+#    ["Rust", "2010"]
 
 # ファイルから一度に
-arr_of_arrs = CSV.read("path/to/file.csv")
+p CSV.read("sample.csv")
+# => [["Ruby", "1995"], ["Rust", "2010"]]
 
 # 文字列から一行ずつ
-CSV.parse("CSV,data,String") do |row|
-  # use row here...
+CSV.parse(csv_text) do |row|
+  p row
 end
+# => ["Ruby", "1995"]
+#    ["Rust", "2010"]
 
 # 文字列から一度に
-arr_of_arrs = CSV.parse("CSV,data,String")
+p CSV.parse(csv_text)
+# => [["Ruby", "1995"], ["Rust", "2010"]]
 #@end
 
 === 書き込み

--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -87,7 +87,7 @@ CSV.parse("CSV,data,String") do |row|
   # use row here...
 end
 
-# 文字列から一行ずつ
+# 文字列から一度に
 arr_of_arrs = CSV.parse("CSV,data,String")
 #@end
 


### PR DESCRIPTION
[CSV](https://docs.ruby-lang.org/ja/2.7.0/class/CSV.html) の「読み込み」のサンプルでブロック無しの `CSV.parse` に「文字列から一行ずつ」とあるのは「文字列から一度に」の誤りでしょう。