### PR TITLE
Add Enumerator.produce since Ruby 2.7

### DIFF
--- a/refm/api/src/_builtin/Enumerator
+++ b/refm/api/src/_builtin/Enumerator
@@ -102,6 +102,8 @@ initial 引数が渡された場合、最初にブロックを呼び出す時に
 
 ブロックが例外 [[c:StopIteration]]を投げた場合、繰り返しが終了します。
 
+@param initial ブロックに最初に渡される値です。任意のオブジェクトを渡せます。
+
 #@samplecode 例
 # 1, 2, 3, 4, ... と続く Enumerator
 Enumerator.produce(1, &:succ)
@@ -131,8 +133,6 @@ PATTERN = %r{\d+|[-/+*]}
 Enumerator.produce { scanner.scan(PATTERN) }.slice_after { scanner.eos? }.first
 # => ["7", "+", "38", "/", "6"]
 #@end
-
-@param initial ブロックに最初に渡される値です。任意のオブジェクトを渡せます。
 #@end
 
 == Methods

--- a/refm/api/src/_builtin/Enumerator
+++ b/refm/api/src/_builtin/Enumerator
@@ -91,6 +91,50 @@ new に渡されたブロックが終了した時点で each の繰り返しが�
 
   p fib.take(10) #=> [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 
+#@since 2.7.0
+--- produce(initial = nil) { |prev| ... } -> Enumerator
+
+与えられたブロックを呼び出し続ける、停止しない Enumerator を返します。
+ブロックの戻り値が、次にブロックを呼び出す時に引数として渡されます。
+initial 引数が渡された場合、最初にブロックを呼び出す時にそれがブロック
+呼び出しの引数として渡されます。initial が渡されなかった場合は nil が
+渡されます。
+
+ブロックが例外 [[c:StopIteration]]を投げた場合、繰り返しが終了します。
+
+#@samplecode 例
+# 1, 2, 3, 4, ... と続く Enumerator
+Enumerator.produce(1, &:succ)
+
+# next を呼ぶたびランダムな数値を返す Enumerator
+Enumerator.produce { rand(10) }
+
+# ツリー構造の祖先ノードを列挙する Enumerator
+ancestors = Enumerator.produce(node) { |prev| node = prev.parent or raise StopIteration }
+enclosing_section = ancestors.find { |n| n.type == :section }
+#@end
+
+このメソッドは Enumerable の各メソッドと組み合わせて使うことで、
+while や until ループのような処理を実装できます。
+例えば [[m:Enumerable#detect]], [[m:Enumerable#slice_after]], [[m:Enumerable#take_while]]
+などと合わせて使えるでしょう。
+
+#@samplecode Enumerable のメソッドと組み合わせる例
+# 次の火曜日を返す例
+require "date"
+Enumerator.produce(Date.today, &:succ).detect(&:tuesday?)
+
+# シンプルなレキサーの例
+require "strscan"
+scanner = StringScanner.new("7+38/6")
+PATTERN = %r{\d+|[-/+*]}
+Enumerator.produce { scanner.scan(PATTERN) }.slice_after { scanner.eos? }.first
+# => ["7", "+", "38", "/", "6"]
+#@end
+
+@param initial ブロックに最初に渡される値です。任意のオブジェクトを渡せます。
+#@end
+
 == Methods
 
 --- each {...}        -> object


### PR DESCRIPTION
#2071 

Ruby 2.7から追加された Enumerator.produce のドキュメントを追加します。


RDoc: https://docs.ruby-lang.org/en/2.7.0/Enumerator.html#method-c-produce


基本的にRDocに沿って翻訳しています。