### PR TITLE
Add Enumerator::Lazy#eager since Ruby 2.7

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -264,6 +264,26 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 @see [[m:Enumerable#drop_while]]
 
+#@since 2.7.0
+--- eager -> Enumerator
+
+自身を遅延評価しない Enumerator に変換して返します。
+
+#@samplecode 例
+lazy_enum = (1..).each.lazy
+
+# select が遅延評価されるので終了する
+p lazy_enum.class # => Enumerator::Lazy
+p lazy_enum.select { |n| n.even? }.first(5)
+# => [2, 4, 6, 8, 10]
+
+# select が遅延評価されないので終了しない
+enum = lazy_enum.eager
+p enum.class # => Enumerator
+p enum.select { |n| n.even? }.first(5)
+#@end
+#@end
+
 --- lazy -> self
 
 self を返します。


### PR DESCRIPTION
#2071 


Ruby 2.7 から追加された Enumerator::Lazy#eager のドキュメントを追加します。



RDoc: https://docs.ruby-lang.org/en/2.7.0/Enumerator/Lazy.html#method-i-eager


RDocにサンプルコードはなかったのと、NEWSにあったサンプルコードはしっくりこなかったので、適当に書きました。

* Enumerator::Lazy である意味があること
* eagerしてただの Enumerator になったことが分かりやすいこと

を考えて書いています。