### PR TITLE
Add Enumerator::Yielder documentation

### DIFF
--- a/refm/api/src/_builtin.rd
+++ b/refm/api/src/_builtin.rd
@@ -35,6 +35,7 @@ require を書かなくても使うことができます。
 #@since 2.0.0
 #@include(_builtin/Enumerator__Lazy)
 #@end
+#@include(_builtin/Enumerator__Yielder)
 #@include(_builtin/Exception)
 #@include(_builtin/FalseClass)
 #@include(_builtin/Fiber)

--- a/refm/api/src/_builtin/Enumerator
+++ b/refm/api/src/_builtin/Enumerator
@@ -52,7 +52,7 @@ args を指定すると、 method の呼び出し時に渡されます。
 
 --- new(size=nil){|y| ... }         -> Enumerator
 
-Enumerator オブジェクトを生成して返します。与えられたブロックは Enumerator::Yielder オブジェクトを
+Enumerator オブジェクトを生成して返します。与えられたブロックは [[c:Enumerator::Yielder]] オブジェクトを
 引数として実行されます。
 
 生成された Enumerator オブジェクトに対して each を呼ぶと、この生成時に指定されたブロックを
@@ -432,4 +432,3 @@ self の要素数を返します。
 #@# 以下のクラスはユーザが直接触れるべきではないのでドキュメントは
 #@# 書かない
 #@# = class Enumerator::Generator
-#@# = class Enumerator::Yielder

--- a/refm/api/src/_builtin/Enumerator__Yielder
+++ b/refm/api/src/_builtin/Enumerator__Yielder
@@ -1,0 +1,79 @@
+= class Enumerator::Yielder < Object
+
+[[m:Enumerator.new]] で使われるクラスで、直接使うものではありません。
+
+
+== Instance Methods
+
+--- <<(object) -> ()
+
+[[m:Enumerator.new]] で使うメソッドです。
+
+生成された Enumerator オブジェクトの each メソッドを呼ぶと
+Enumerator::Yielder オブジェクトが渡されたブロックが実行され、
+ブロック内の << が呼ばれるたびに each に渡されたブロックが
+<< に渡された値とともに繰り返されます。
+
+#@samplecode 例
+enum = Enumerator.new do |y|
+  y << 1
+  y << 2
+  y << 3
+end
+
+enum.each do |v|
+  p v
+end
+# => 1
+#    2
+#    3
+#@end
+
+#@since 2.7.0
+--- to_proc -> Proc
+
+[[m:Enumerator.new]] で使うメソッドです。
+
+引数を [[m:Enumerator::Yielder#yield]] に渡す [[c:Proc]] を返します。
+これは Enumerator::Yielder オブジェクトを他のメソッドにブロック引数と
+して直接渡すために使えます。
+
+#@samplecode 例
+text = <<-END
+Hello
+こんにちは
+END
+
+enum = Enumerator.new do |y|
+  text.each_line(&y)
+end
+
+enum.each do |line|
+  p line
+end
+# => "Hello\n"
+#    "こんにちは\n"
+#@end
+#@end
+
+
+--- yield(*object) -> ()
+
+[[m:Enumerator.new]] で使うメソッドです。
+
+生成された Enumerator オブジェクトの each メソッドを呼ぶと
+Enumerator::Yielder オブジェクトが渡されたブロックが実行され、
+ブロック内の yield メソッドが呼ばれるたびに each に渡された
+ブロックが yield メソッドに渡された値とともに繰り返されます。
+
+#@samplecode 例
+enum = Enumerator.new do |y|
+  y.yield 1, 2, 3
+end
+
+enum.each do |x, y, z|
+  p [x, y, z]
+end
+# => [1, 2, 3]
+#@end
+


### PR DESCRIPTION
Enumerator::Yielderのドキュメントを追加します。


このクラスは`Enumerator.new`からのみ使われるべきものなので、クラスの説明にも「直接使うものではありません」と書いています。
https://github.com/rurema/doctree/issues/1141

ただ、説明がないと`Enumerator.new`から使う時に迷ってしまうと思うので、ドキュメントを書くことは必要だと思っています。


また、合わせて Ruby 2.7で追加された`Enumerator::Yielder.to_proc`のドキュメントも書いています。 #2071 
RDoc: https://docs.ruby-lang.org/en/2.7.0/Enumerator/Yielder.html#method-i-to_proc




RDocでは `<<` と `yield` メソッドのドキュメントがありませんが、このドキュメントがないと`Enumerator.new`からどうやって使うべきか分かりづらいなと思ったので、あえて書きました。


---


ruby-jp slackの方で多少議論をしたので貼っておきます。

![200525000056](https://user-images.githubusercontent.com/4361134/82757354-e49c2c80-9e1a-11ea-8ed4-a8696b80f9ae.png)
