### PR TITLE
Add IO#set_encoding_by_bom since 2.7.0

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -2247,6 +2247,32 @@ opt のハッシュで外部エンコーディングを内部エンコーディ�
     io = File.open(file)
     io.set_encoding("ASCII-8BIT", "EUC-JP")
 
+#@since 2.7.0
+--- set_encoding_by_bom -> Encoding | nil
+
+BOM から IO のエンコーディングを設定します。
+
+自身が BOM から始まる場合、BOM を読み進めて外部エンコーディングをセットし、セットしたエンコーディングを返します。
+BOM が見つからなかった場合は nil を返します。
+
+自身がバイナリモードでないかすでにエンコーディングがセットされている場合、例外が発生します。
+
+#@samplecode 例
+File.write("bom.txt", "\u{FEFF}abc")
+File.open("bom.txt", "rb") do |io|
+  p io.set_encoding_by_bom    #=>  #<Encoding:UTF-8>
+  str = io.read
+  p str                       #=>  "abc"
+  p str.encoding              #=>  #<Encoding:UTF-8>
+end
+
+File.write("nobom.txt", "abc")
+File.open("nobom.txt", "rb") do |io|
+  p io.set_encoding_by_bom    #=>  nil
+end
+#@end
+#@end
+
 --- autoclose=(bool)
 
 auto-close フラグを設定します。


### PR DESCRIPTION
#2071 

Ruby 2.7 で追加された IO#set_encoding_by_bom のドキュメントを追加します。

RDoc: https://docs.ruby-lang.org/en/2.7.0/IO.html#method-i-set_encoding_by_bom

サンプルコードはRDocのものをベースに、`FIle.open`にブロックを渡す形にしたり、読み込んだ文字列のencodingを明示したりしています。

