### PR TITLE
Add forgotten "mask" parameter to Integer#nobits? and anybits?

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -970,7 +970,7 @@ self & mask == mask と等価です。
 
 @see [[m:Integer#anybits?]]
 @see [[m:Integer#nobits?]]
---- anybits? -> bool
+--- anybits?(mask) -> bool
 self & mask のいずれかのビットが 1 なら true を返します。
 
 self & mask != 0 と等価です。
@@ -986,7 +986,7 @@ self & mask != 0 と等価です。
 
 @see [[m:Integer#allbits?]]
 @see [[m:Integer#nobits?]]
---- nobits? -> bool
+--- nobits?(mask) -> bool
 self & mask のすべてのビットが 0 なら true を返します。
 
 self & mask == 0 と等価です。


### PR DESCRIPTION
`Integer#anybits?`と`Integer#nobits?`は`mask`引数を受け取りますが、それが漏れていたので追記します。

なお、類似のメソッドである `allbits?` には mask 引数が書かれていました。