### PR TITLE
Add Fiber#raise since Ruby 2.7.0

### DIFF
--- a/refm/api/src/_builtin/Fiber
+++ b/refm/api/src/_builtin/Fiber
@@ -141,6 +141,49 @@ Thread クラスが表すスレッド間をまたがるファイバーの切り�
  p a  #=> :foo
 
 == Instance Methods
+#@since 2.7.0
+--- raise                                            -> object
+--- raise(message)                                   -> object
+--- raise(exception, message = nil, backtrace = nil) -> object
+
+自身が表すファイバーが最後に [[m:Fiber.yield]] を呼んだ場所で例外を発生させます。
+
+Fiber.yield が呼ばれていないかファイバーがすでに終了している場合、
+[[c:FiberError]] が発生します。
+
+引数を渡さない場合、[[c:RuntimeError]] が発生します。
+message 引数を渡した場合、message 引数をメッセージとした RuntimeError
+が発生します。
+
+その他のケースでは、最初の引数は [[c:Exception]] か Exception
+のインスタンスを返す exception メソッドを持ったオブジェクトである
+必要があります。
+この場合、2つ目の引数に例外のメッセージを渡せます。また3つ目の引数に
+例外発生時のスタックトレースを指定できます。
+
+@param message 例外のメッセージとなる文字列です。
+@param exception 発生させる例外です
+@param backtrace 例外発生時のスタックトレースです。文字列の配列で指定します。
+
+#@samplecode 例
+f = Fiber.new { Fiber.yield }
+f.resume
+f.raise "Error!" # => Error! (RuntimeError)
+#@end
+
+#@samplecode ファイバー内のイテレーションを終了させる例
+f = Fiber.new do
+  loop do
+    Fiber.yield(:loop)
+  end
+  :exit
+end
+
+p f.resume              # => :loop
+p f.raise StopIteration # => :exit
+#@end
+#@end
+
 --- resume(*arg = nil)   -> object
 
 自身が表すファイバーへコンテキストを切り替えます。

--- a/refm/api/src/_builtin/Fiber
+++ b/refm/api/src/_builtin/Fiber
@@ -146,7 +146,7 @@ Thread クラスが表すスレッド間をまたがるファイバーの切り�
 --- raise(message)                                   -> object
 --- raise(exception, message = nil, backtrace = nil) -> object
 
-自身が表すファイバーが最後に [[m:Fiber.yield]] を呼んだ場所で例外を発生させます。
+selfが表すファイバーが最後に [[m:Fiber.yield]] を呼んだ場所で例外を発生させます。
 
 Fiber.yield が呼ばれていないかファイバーがすでに終了している場合、
 [[c:FiberError]] が発生します。

--- a/refm/api/src/_builtin/Fiber
+++ b/refm/api/src/_builtin/Fiber
@@ -162,7 +162,7 @@ message 引数を渡した場合、message 引数をメッセージとした Run
 例外発生時のスタックトレースを指定できます。
 
 @param message 例外のメッセージとなる文字列です。
-@param exception 発生させる例外です
+@param exception 発生させる例外です。
 @param backtrace 例外発生時のスタックトレースです。文字列の配列で指定します。
 
 #@samplecode 例


### PR DESCRIPTION
#2071 

Ruby 2.7から追加された `Fiber#raise` のドキュメントを追加します。

RDoc: https://docs.ruby-lang.org/en/master/Fiber.html#method-i-raise
2.7.0時点のドキュメントだと記述が間違っているので、masterのドキュメントを参照しています。 https://bugs.ruby-lang.org/issues/16912


