### PR TITLE
Add document for (Proc|Method)#(<<|>>) since Ruby 2.6

### DIFF
--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -132,6 +132,94 @@ self[] の形の呼び出しは通常のメソッド呼び出しに見た目を
   m[1]      # => "foo called with arg 1"
   m.call(2) # => "foo called with arg 2"
 
+#@since 2.6.0
+--- <<(callable) -> Proc
+
+self と引数を合成した Proc を返します。
+
+戻り値の Proc は可変長の引数を受け取ります。
+戻り値の Proc を呼び出すと、まず受け取った引数を callable に渡して呼び出し、
+その戻り値を self に渡して呼び出した結果を返します。
+
+[[m:Method#>>]] とは呼び出しの順序が逆になります。
+
+@param callable Proc、Method、もしくは任意の call メソッドを持ったオブジェクト。
+
+#@samplecode 例
+def f(x)
+  x * x
+end
+
+def g(x)
+  x + x
+end
+
+# (3 + 3) * (3 + 3)
+p (method(:f) << method(:g)).call(3) # => 36
+#@end
+
+#@samplecode call を定義したオブジェクトを渡す例
+class WordScanner
+  def self.call(str)
+    str.scan(/\w+/)
+  end
+end
+
+File.write('testfile', <<~TEXT)
+  Hello, World!
+  Hello, Ruby!
+TEXT
+
+pipeline = method(:pp) << WordScanner << File.method(:read)
+pipeline.call('testfile') # => ["Hello", "World", "Hello", "Ruby"]
+#@end
+
+@see [[m:Proc#<<]], [[m:Proc#>>]]
+
+--- >>(callable) -> Proc
+
+self と引数を合成した Proc を返します。
+
+戻り値の Proc は可変長の引数を受け取ります。
+戻り値の Proc を呼び出すと、まず受け取った引数を self に渡して呼び出し、
+その戻り値を callable に渡して呼び出した結果を返します。
+
+[[m:Method#<<]] とは呼び出しの順序が逆になります。
+
+@param callable Proc、Method、もしくは任意の call メソッドを持ったオブジェクト。
+
+#@samplecode 例
+def f(x)
+  x * x
+end
+
+def g(x)
+  x + x
+end
+
+# (3 * 3) + (3 * 3)
+p (method(:f) >> method(:g)).call(3) # => 18
+#@end
+
+#@samplecode call を定義したオブジェクトを渡す例
+class WordScanner
+  def self.call(str)
+    str.scan(/\w+/)
+  end
+end
+
+File.write('testfile', <<~TEXT)
+  Hello, World!
+  Hello, Ruby!
+TEXT
+
+pipeline = File.method(:read) >> WordScanner >> method(:pp)
+pipeline.call('testfile') # => ["Hello", "World", "Hello", "Ruby"]
+#@end
+
+@see [[m:Proc#<<]], [[m:Proc#>>]]
+#@end
+
 --- arity -> Integer
 
 メソッドが受け付ける引数の数を返します。

--- a/refm/api/src/_builtin/Proc
+++ b/refm/api/src/_builtin/Proc
@@ -125,6 +125,84 @@ Proc.new は、Proc#initialize が定義されていれば
 #@# --- dup -> Proc
 #@# nodoc
 
+#@since 2.6.0
+--- <<(callable) -> Proc
+
+self と引数を合成した Proc を返します。
+
+戻り値の Proc は可変長の引数を受け取ります。
+戻り値の Proc を呼び出すと、まず受け取った引数を callable に渡して呼び出し、
+その戻り値を self に渡して呼び出した結果を返します。
+
+[[m:Proc#>>]] とは呼び出しの順序が逆になります。
+
+@param callable Proc、Method、もしくは任意の call メソッドを持ったオブジェクト。
+
+#@samplecode 例
+f = proc { |x| x * x }
+g = proc { |x| x + x }
+
+# (3 + 3) * (3 + 3)
+p (f << g).call(3) # => 36
+#@end
+
+#@samplecode call を定義したオブジェクトを渡す例
+class WordScanner
+  def self.call(str)
+    str.scan(/\w+/)
+  end
+end
+
+File.write('testfile', <<~TEXT)
+  Hello, World!
+  Hello, Ruby!
+TEXT
+
+pipeline = proc { |data| puts "word count: #{data.size}" } << WordScanner << File.method(:read)
+pipeline.call('testfile') # => word count: 4
+#@end
+
+@see [[m:Method#<<]], [[m:Method#>>]]
+
+--- >>(callable) -> Proc
+
+self と引数を合成した Proc を返します。
+
+戻り値の Proc は可変長の引数を受け取ります。
+戻り値の Proc を呼び出すと、まず受け取った引数を self に渡して呼び出し、
+その戻り値を callable に渡して呼び出した結果を返します。
+
+[[m:Proc#<<]] とは呼び出しの順序が逆になります。
+
+@param callable Proc、Method、もしくは任意の call メソッドを持ったオブジェクト。
+
+#@samplecode 例
+f = proc { |x| x * x }
+g = proc { |x| x + x }
+
+# (3 * 3) + (3 * 3)
+p (f >> g).call(3) # => 18
+#@end
+
+#@samplecode call を定義したオブジェクトを渡す例
+class WordScanner
+  def self.call(str)
+    str.scan(/\w+/)
+  end
+end
+
+File.write('testfile', <<~TEXT)
+  Hello, World!
+  Hello, Ruby!
+TEXT
+
+pipeline = proc { |fname| File.read(fname) } >> WordScanner >> method(:p)
+pipeline.call('testfile') # => ["Hello", "World", "Hello", "Ruby"]
+#@end
+
+@see [[m:Method#<<]], [[m:Method#>>]]
+#@end
+
 --- arity -> Integer
 
 Proc オブジェクトが受け付ける引数の数を返します。


### PR DESCRIPTION
#1977

Ruby 2.6 から追加された、 `Proc#>>`, `Proc#<<`, `Method#>>`, `Method#<<` のドキュメントを追加します。

説明文やサンプルコードは、RDocのものをベースにしています。
https://docs.ruby-lang.org/en/2.7.0/Proc.html#method-i-3E-3E

