### PR TITLE
NotImplementedErrorのドキュメントをrdocに合わせ更新

### DIFF
--- a/refm/api/src/_builtin/NotImplementedError
+++ b/refm/api/src/_builtin/NotImplementedError
@@ -1,3 +1,7 @@
 = class NotImplementedError < ScriptError
 
-実装されていない機能が呼び出されたときに発生します。
+現在のプラットフォームで実装されていない機能が呼び出されたときに発生します。
+
+例えばfsyncやforkのシステムコールに依存するメソッドが呼び出されたとき、OSまたはRubyの実行環境がそれらのシステムコールをサポートしていない場合、この例外が発生します。
+
+注: もしforkがNotImplementedErrorを発生させる場合、respond_to?(:fork)はfalseを返します。

--- a/refm/api/src/_builtin/NotImplementedError
+++ b/refm/api/src/_builtin/NotImplementedError
@@ -4,4 +4,4 @@
 
 例えばfsyncやforkのシステムコールに依存するメソッドが呼び出されたとき、OSまたはRubyの実行環境がそれらのシステムコールをサポートしていない場合、この例外が発生します。
 
-注: もしforkがNotImplementedErrorを発生させる場合、respond_to?(:fork)はfalseを返します。
+forkがNotImplementedErrorを発生させる場合respond_to?(:fork)はfalseを返すことに注意してください。


### PR DESCRIPTION
> Raised when a feature is not implemented on the current platform. For example, methods depending on the fsync or fork system calls may raise this exception if the underlying operating system or Ruby runtime does not support them.
>
>Note that if fork raises a NotImplementedError, then respond_to?(:fork) returns false.
https://docs.ruby-lang.org/en/2.7.0/NotImplementedError.html