### PR TITLE
Fix sample code of Time#gmt_offset

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -726,7 +726,7 @@ self に 1 秒足した Time オブジェクトを生成して返します。
 
 タイムゾーンが協定世界時に設定されている場合は 0 を返します。
 
-  p Time.now.zone  # => "JST"
+  p Time.now.getgm.zone  # => "UTC"
   p Time.now.getgm.utc_offset
   # => 0
 


### PR DESCRIPTION
`Time#gmt_offset` のサンプルのうち、タイムゾーンが協定世界時に設定されている場合にコードを修正しました。
協定世界時に関するサンプルの中で地方時を指す `Time.now` の `zone` を示すのは不自然に見えたため、協定世界時を指す `Time` オブジェクト（`Time.now.getgm`）の `zone` を示すようにしました。
