### PR TITLE
Fix artifact job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       run: bundle exec rake
 
     - name: Create tarballs
+      if: ${{ runner.os != 'Windows' }}
       run: |
         set -ex
         mkdir /tmp/artifact
@@ -52,6 +53,14 @@ jobs:
         for d in *.*; do
           tar acf ../artifact/$d.tar.xz $d
         done
+    - name: Create tarballs
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        mkdir /tmp/artifact
+        cd /tmp/html
+        ls -Name "*.*" | foreach {
+          tar acf "../artifact/${_}.tar.xz" $_
+        }
     - uses: actions/upload-artifact@v2
       with:
         name: statichtml-${{ matrix.os }}
@@ -70,7 +79,6 @@ jobs:
       run: bundle exec rake
     - name: Rename generated html and generate diff
       run: |
-        set -x
         cd /tmp
         mv -v html html.base
         git diff --no-index html.base html.pr --stat || :

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,15 @@ jobs:
     - name: Create tarballs
       run: |
         set -ex
+        mkdir /tmp/artifact
         cd /tmp/html
         for d in *.*; do
-          tar acf ../$d.tar.xz $d
+          tar acf ../artifact/$d.tar.xz $d
         done
     - uses: actions/upload-artifact@v2
       with:
-        name: statichtml
-        path: /tmp/2.?.0.tar.xz
+        name: statichtml-${{ matrix.os }}
+        path: /tmp/artifact/2.?.0.tar.xz
 
     - name: Rename generated html
       run: |
@@ -73,11 +74,11 @@ jobs:
         cd /tmp
         mv -v html html.base
         git diff --no-index html.base html.pr --stat || :
-        git diff --no-index html.base html.pr --output html.diff || :
+        git diff --no-index html.base html.pr --output artifact/html.diff || :
     - uses: actions/upload-artifact@v2
       with:
-        name: diff
-        path: /tmp/html.diff
+        name: diff-${{ matrix.os }}
+        path: /tmp/artifact/html.diff
 
   misspell:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       run: bundle exec rake
 
   artifact:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 


### PR DESCRIPTION
Github Actions の `artifact` ジョブが動いていなかったので修正しました。

- 不足していた `strategy.matrix.os` の定義を追加
  - これまでの PR ステータスでは green に見えますが、以下のような失敗通知が届いていました
      ![image](https://user-images.githubusercontent.com/7571111/85229490-e4487e80-b424-11ea-85e4-507d0ba68a23.png)
- 成果物の一時置き場を `/tmp` から `/tmp/artifact` へ変更
  - Mac の `/tmp` は `/private/tmp` へのシンボリックとなっていることが、`action/upload-artifact` でのエラー要因となります
  - 参考: https://github.com/rurema/doctree/runs/792862859
- `for` 文を使うステップのみ、Windows を分離して PowerShell の `foreach` に置き換え
- 同名 artifact を上書きしないよう、名前に OS を含むよう変更
