### PR TITLE
misspell からの除外を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
       run: 'go get github.com/client9/misspell/...'
     - name: Run misspell
       run: |
-        $HOME/go/bin/misspell -error -i addopt $(git ls-files | grep -vF "refm/doc/news/1.8.4.rd")
+        git ls-files -z | xargs -0 $HOME/go/bin/misspell -error -i addopt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
   - 'go get github.com/client9/misspell/...'
 script:
   - 'bundle exec rake'
-  - '$GOPATH/bin/misspell -error -i addopt $(git ls-files | grep -vF "refm/doc/news/1.8.4.rd")'
+  - 'git ls-files -z | xargs -0 $GOPATH/bin/misspell -error -i addopt'

--- a/refm/doc/news/1.8.4.rd
+++ b/refm/doc/news/1.8.4.rd
@@ -985,7 +985,7 @@ ruby 1.8.4 での ruby 1.8.3 からの変更点です。
 #         options.  [ruby-dev:27449]
 #
 
-    --with-extention オプション追加。((<ruby-dev:27449>))
+    --with-extension オプション追加。((<ruby-dev:27449>))
 
 : mkmf: find_executable() [compat]
 

--- a/refm/doc/news/1.8.4.rd
+++ b/refm/doc/news/1.8.4.rd
@@ -566,7 +566,7 @@ ruby 1.8.4 での ruby 1.8.3 からの変更点です。
 #       * ext/tk/lib/tk.rb: add Tk.pkgconfig_list and Tk.pkgconfig_get
 #         [Tk8.5 feature].
 #
-#       * ext/tk/lib/tk/text.rb: supports new indices modifires on a Text
+#       * ext/tk/lib/tk/text.rb: supports new indices modifiers on a Text
 #         widget [Tk8.5 feature].
 #
 


### PR DESCRIPTION
misspell で除外する原因になっていた typo を修正して、1.8.4.rd だけ除外していたのをやめるようにしました。