### PR TITLE
Simplify Enumerable#include? example code

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -300,11 +300,12 @@ val と == の関係にある要素を含むとき真を返します。
 
 @param val   任意のオブジェクト
 
-例:
-  IO.constants.include? :SEEK_SET          #=> true
-  IO.constants.include? :SEEK_NO_FURTHER   #=> false
-  IO.constants.member? :SEEK_SET           #=> true
-  IO.constants.member? :SEEK_NO_FURTHER    #=> false
+#@samplecode 例
+[2, 4, 6].include? 2 #=> true
+[2, 4, 6].include? 1 #=> false
+[2, 4, 6].member? 2  #=> true
+[2, 4, 6].member? 1  #=> false
+#@end
 
 --- max    -> object | nil
 #@since 2.2.0


### PR DESCRIPTION
FIx https://github.com/rurema/doctree/issues/2303


`Enumerable#include?`の例を、より自明にしてみました。