### PR TITLE
Import documentations from RDoc

### DIFF
--- a/bin/generate-from-rdoc.rb
+++ b/bin/generate-from-rdoc.rb
@@ -1,0 +1,63 @@
+#!ruby
+
+# RDoc をるりまのドキュメントに変換します。
+# 新しく追加されたメソッドのドキュメントを書く際は、
+# このスクリプトで生成したドキュメントを元にるりまの
+# ドキュメントを書くと便利でしょう。
+# また一次対応としては、インポートしたドキュメントを
+# そのままるりまに反映しても構いません。
+
+
+# Usage:
+#   bin/generate-from-rdoc.rb [--since=VERSION] Klass#method
+#
+# Example:
+#   bin/generate-from-rdoc.rb --since=2.7.0 'Symbol#start_with?' >> refm/api/src/_builtin/Symbol
+
+require 'optparse'
+require 'open3'
+
+opt = ARGV.getopts('', 'since:')
+since = opt['since']
+
+md, status = Open3.capture2('ri', ARGV.first, '--format=markdown', '--no-pager')
+
+raise "executing ri is failed" unless status.success?
+raise md if md.match?(/\A.+not found/)
+
+lines = md.lines.drop_while { |l| !l.match?(/^---/) }.drop(1)
+
+# parse method signature
+signatures = []
+while (line = lines.shift) != "\n"
+  signatures << line
+end
+lines.shift 2
+
+# parse description and samplecode
+prev = :desc
+chunks = lines.chunk_while do |a, b|
+  next true if b == "\n"
+
+  cur = b.start_with?(' ') ? :code : :desc
+  (prev == cur).tap do
+    prev = cur
+  end
+end.to_a
+
+
+puts "\#@since #{since}" if since
+puts signatures.join.gsub(/^\s+(?:\w+\.)?/, '--- ')
+puts
+
+chunks.each.with_index do |lines, idx|
+  if lines[0].start_with?(" ")
+    puts "\#@samplecode"
+    puts lines.join.rstrip.gsub(/^    /, '')
+    puts "\#@end"
+  else
+    puts lines.join.rstrip
+  end
+  puts if idx != chunks.size - 1
+end
+puts "\#@end" if since

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -630,6 +630,58 @@ name で指定される名前の定数の値を取り出します。
   # 不適切な定数名を指定した場合
   Foo.const_set('foo', 1) # => NameError: wrong constant name foo
 
+#@since 2.7.0
+--- const_source_location(sym, inherit=true)   -> [String, Integer]
+--- const_source_location(str, inherit=true)   -> [String, Integer]
+
+Returns the Ruby source filename and line number containing the
+definition of the constant specified. If the named constant is not
+found, `nil` is returned. If the constant is found, but its source
+location can not be extracted (constant is defined in C code), empty
+array is returned.
+
+*inherit* specifies whether to lookup in `mod.ancestors` (`true` by
+default).
+
+#@samplecode
+# test.rb:
+class A         # line 1
+  C1 = 1
+  C2 = 2
+end
+
+module M        # line 6
+  C3 = 3
+end
+
+class B < A     # line 10
+  include M
+  C4 = 4
+end
+
+class A # continuation of A definition
+  C2 = 8 # constant redefinition; warned yet allowed
+end
+
+p B.const_source_location('C4')           # => ["test.rb", 12]
+p B.const_source_location('C3')           # => ["test.rb", 7]
+p B.const_source_location('C1')           # => ["test.rb", 2]
+
+p B.const_source_location('C3', false)    # => nil  -- don't lookup in ancestors
+
+p A.const_source_location('C2')           # => ["test.rb", 16] -- actual (last) definition place
+
+p Object.const_source_location('B')       # => ["test.rb", 10] -- top-level constant could be looked through Object
+p Object.const_source_location('A')       # => ["test.rb", 1] -- class reopening is NOT considered new definition
+
+p B.const_source_location('A')            # => ["test.rb", 1]  -- because Object is in ancestors
+p M.const_source_location('A')            # => ["test.rb", 1]  -- Object is not ancestor, but additionally checked for modules
+
+p Object.const_source_location('A::C1')   # => ["test.rb", 2]  -- nesting is supported
+p Object.const_source_location('String')  # => []  -- constant is defined in C code
+#@end
+#@end
+
 #@since 1.9.1
 --- constants(inherit = true) -> [Symbol]
 #@else

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -2005,6 +2005,40 @@ self が [[m:Module#prepend]] されたときに対象のクラスまたはモ�
 @see [[m:Module#included]], [[m:Module#prepend]], [[m:Module#prepend_features]]
 #@end
 
+#@since 2.7.0
+--- ruby2_keywords(method_name, ...)    -> self
+
+For the given method names, marks the method as passing keywords through
+a normal argument splat.  This should only be called on methods that
+accept an argument splat (`*args`) but not explicit keywords or a
+keyword splat.  It marks the method such that if the method is called
+with keyword arguments, the final hash argument is marked with a special
+flag such that if it is the final element of a normal argument splat to
+another method call, and that method call does not include explicit
+keywords or a keyword splat, the final element is interpreted as
+keywords. In other words, keywords will be passed through the method to
+other methods.
+
+This should only be used for methods that delegate keywords to another
+method, and only for backwards compatibility with Ruby versions before
+2.7.
+
+This method will probably be removed at some point, as it exists only
+for backwards compatibility. As it does not exist in Ruby versions
+before 2.7, check that the module responds to this method before calling
+it. Also, be aware that if this method is removed, the behavior of the
+method will change so that it does not pass through keywords.
+
+#@samplecode
+module Mod
+  def foo(meth, *args, &block)
+    send(:"do_#{meth}", *args, &block)
+  end
+  ruby2_keywords(:foo) if respond_to?(:ruby2_keywords, true)
+end
+#@end
+#@end
+
 #@since 2.1.0
 --- singleton_class? -> bool
 

--- a/refm/api/src/_builtin/Proc
+++ b/refm/api/src/_builtin/Proc
@@ -454,3 +454,36 @@ Proc オブジェクトが引数を取らなければ空の配列を返します
 
 @see [[m:Method#parameters]], [[m:UnboundMethod#parameters]]
 #@end
+
+#@since 2.7.0
+--- ruby2_keywords -> proc
+
+Marks the proc as passing keywords through a normal argument splat. This
+should only be called on procs that accept an argument splat (`*args`)
+but not explicit keywords or a keyword splat.  It marks the proc such
+that if the proc is called with keyword arguments, the final hash
+argument is marked with a special flag such that if it is the final
+element of a normal argument splat to another method call, and that
+method call does not include explicit keywords or a keyword splat, the
+final element is interpreted as keywords.  In other words, keywords will
+be passed through the proc to other methods.
+
+This should only be used for procs that delegate keywords to another
+method, and only for backwards compatibility with Ruby versions before
+2.7.
+
+This method will probably be removed at some point, as it exists only
+for backwards compatibility. As it does not exist in Ruby versions
+before 2.7, check that the proc responds to this method before calling
+it. Also, be aware that if this method is removed, the behavior of the
+proc will change so that it does not pass through keywords.
+
+#@samplecode
+module Mod
+  foo = ->(meth, *args, &block) do
+    send(:"do_#{meth}", *args, &block)
+  end
+  foo.ruby2_keywords if foo.respond_to?(:ruby2_keywords)
+end
+#@end
+#@end

--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -486,6 +486,17 @@ self を文字列に変換します(始端と終端のオブジェクトは #ins
   h = { 1 => "C", 2 => "Go", 3 => "Ruby" }
   (1..3).min { |a, b| h[a].length <=> h[b].length }   # => 1
 
+#@since 2.7.0
+--- minmax                       -> [obj, obj]
+--- minmax {| a,b | block }      -> [obj, obj]
+
+Returns a two element array which contains the minimum and the maximum
+value in the range.
+
+Can be given an optional block to override the default comparison method
+`a <=> b`.
+#@end
+
 --- max               -> object | nil
 
 範囲内の最大の値を返します。

--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -421,6 +421,20 @@ rangeで指定したインデックスの範囲に含まれる部分文字列を
 
 @see [[m:String#empty?]]
 
+#@since 2.7.0
+--- end_with?([suffixes]+)   -> true or false
+
+Returns true if `sym` ends with one of the `suffixes` given.
+
+#@samplecode
+:hello.end_with?("ello")               #=> true
+
+# returns true if one of the +suffixes+ matches.
+:hello.end_with?("heaven", "ello")     #=> true
+:hello.end_with?("heaven", "paradise") #=> false
+#@end
+#@end
+
 #@since 2.4.0
 --- upcase(*options) -> Symbol
 #@else

--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -184,6 +184,22 @@ other が同じシンボルの時に真を返します。
   :aaa == :aaa    #=> true
   :aaa == :xxx    #=> false
 
+#@since 2.7.0
+--- start_with?([prefixes]+)   -> true or false
+
+Returns true if `sym` starts with one of the `prefixes` given. Each of
+the `prefixes` should be a String or a Regexp.
+
+#@samplecode
+:hello.start_with?("hell")               #=> true
+:hello.start_with?(/H/i)                 #=> true
+
+# returns true if one of the prefixes matches.
+:hello.start_with?("heaven", "hell")     #=> true
+:hello.start_with?("heaven", "paradise") #=> false
+#@end
+#@end
+
 --- succ -> Symbol
 --- next -> Symbol
 

--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -390,6 +390,36 @@ true を返します。そうでない場合に false を返します。
   Time.now.asctime.encoding   # => #<Encoding:US-ASCII>
   Time.now.ctime              # => "Fri Nov 10 00:00:32 2017"
 
+#@since 2.7.0
+--- ceil([ndigits])   -> new_time
+
+Ceils sub seconds to a given precision in decimal digits (0 digits by
+default). It returns a new Time object. `ndigits` should be zero or a
+positive integer.
+
+#@samplecode
+require 'time'
+
+t = Time.utc(2010,3,30, 5,43,25.0123456789r)
+t.iso8601(10)          #=> "2010-03-30T05:43:25.0123456789Z"
+t.ceil.iso8601(10)     #=> "2010-03-30T05:43:26.0000000000Z"
+t.ceil(0).iso8601(10)  #=> "2010-03-30T05:43:26.0000000000Z"
+t.ceil(1).iso8601(10)  #=> "2010-03-30T05:43:25.1000000000Z"
+t.ceil(2).iso8601(10)  #=> "2010-03-30T05:43:25.0200000000Z"
+t.ceil(3).iso8601(10)  #=> "2010-03-30T05:43:25.0130000000Z"
+t.ceil(4).iso8601(10)  #=> "2010-03-30T05:43:25.0124000000Z"
+
+t = Time.utc(1999,12,31, 23,59,59)
+(t + 0.4).ceil.iso8601(3)    #=> "2000-01-01T00:00:00.000Z"
+(t + 0.9).ceil.iso8601(3)    #=> "2000-01-01T00:00:00.000Z"
+(t + 1.4).ceil.iso8601(3)    #=> "2000-01-01T00:00:01.000Z"
+(t + 1.9).ceil.iso8601(3)    #=> "2000-01-01T00:00:01.000Z"
+
+t = Time.utc(1999,12,31, 23,59,59)
+(t + 0.123456789).ceil(4).iso8601(6)  #=> "1999-12-31T23:59:59.123500Z"
+#@end
+#@end
+
 --- gmt?    -> bool
 --- utc?    -> bool
 

--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -859,6 +859,36 @@ yday は 1 から数えます。
   "%10.6f" % t.to_f   #=> "1505688305.417368"
   t.usec              #=> 417368
 
+#@since 2.7.0
+--- floor([ndigits])   -> new_time
+
+Floors sub seconds to a given precision in decimal digits (0 digits by
+default). It returns a new Time object. `ndigits` should be zero or a
+positive integer.
+
+#@samplecode
+require 'time'
+
+t = Time.utc(2010,3,30, 5,43,25.123456789r)
+t.iso8601(10)           #=> "2010-03-30T05:43:25.1234567890Z"
+t.floor.iso8601(10)     #=> "2010-03-30T05:43:25.0000000000Z"
+t.floor(0).iso8601(10)  #=> "2010-03-30T05:43:25.0000000000Z"
+t.floor(1).iso8601(10)  #=> "2010-03-30T05:43:25.1000000000Z"
+t.floor(2).iso8601(10)  #=> "2010-03-30T05:43:25.1200000000Z"
+t.floor(3).iso8601(10)  #=> "2010-03-30T05:43:25.1230000000Z"
+t.floor(4).iso8601(10)  #=> "2010-03-30T05:43:25.1234000000Z"
+
+t = Time.utc(1999,12,31, 23,59,59)
+(t + 0.4).floor.iso8601(3)    #=> "1999-12-31T23:59:59.000Z"
+(t + 0.9).floor.iso8601(3)    #=> "1999-12-31T23:59:59.000Z"
+(t + 1.4).floor.iso8601(3)    #=> "2000-01-01T00:00:00.000Z"
+(t + 1.9).floor.iso8601(3)    #=> "2000-01-01T00:00:00.000Z"
+
+t = Time.utc(1999,12,31, 23,59,59)
+(t + 0.123456789).floor(4).iso8601(6)  #=> "1999-12-31T23:59:59.123400Z"
+#@end
+#@end
+
 #@since 1.9.1
 
 --- friday? -> bool

--- a/refm/api/src/_builtin/Warning
+++ b/refm/api/src/_builtin/Warning
@@ -27,6 +27,11 @@ etc.
 :   experimental features
 
     *   Pattern matching
+
+--- []=(category, flag) -> flag
+
+Sets the warning flags for `category`. See Warning.[] for the
+categories.
 #@end
 
 --- warn(*message) -> nil

--- a/refm/api/src/_builtin/Warning
+++ b/refm/api/src/_builtin/Warning
@@ -8,6 +8,27 @@
 
 == Class Methods
 
+#@since 2.7.0
+--- [](p1) -> true or false
+
+Returns the flag to show the warning messages for `category`. Supported
+categories are:
+
+`:deprecated`
+:   deprecation warnings
+
+    *   assignment of non-nil value to `$,` and `$;`
+    *   keyword arguments
+    *   proc/lambda without block
+
+etc.
+
+`:experimental`
+:   experimental features
+
+    *   Pattern matching
+#@end
+
 --- warn(*message) -> nil
 
 引数 message を標準エラー出力 [[m:$stderr]] に出力します。


### PR DESCRIPTION
Fix #2295 


新規追加されたメソッドの内、日本語版ドキュメントが存在しないもののドキュメントをRDocからインポートします。



このPRでは、RDocのドキュメントをるりま用に整形するスクリプトを追加しています。
また、そのスクリプトを使って Ruby 2.7 で組み込みライブラリに追加されたメソッドを追加しています。
Ruby 2.6 で追加されたメソッドや、標準ライブラリの差分は、追加されたメソッドを列挙するのが大変なので一旦手を付けていません。

また、スクリプトで生成されたドキュメントをそのまま使っています。
生成されたドキュメントに手を加えていたら、「とりあえず英語版ドキュメントを追加する」という本来の目的が達成できなくなるためです。手を入れる必要があれば、別のPRでやっていくのが良いかなあと思います。

ただし、`Warning`モジュールに関してはうまくドキュメントが生成できなかったので、多少手を入れています。


