### PR TITLE
Fix error when `rake` without `bundle exec`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ def generate_statichtml(version)
   db = "/tmp/db-#{version}"
   generate_database(version) unless File.exist?(db)
   puts "generate static html of #{version}"
-  bitclust_gem_path = File.expand_path('../..', `gem which bitclust`)
+  bitclust_gem_path = File.expand_path('../..', `bundle exec gem which bitclust`)
   raise "bitclust gem not found" unless $?.success?
   commands = [
     "bundle", "exec",


### PR DESCRIPTION
何かの変更のタイミングで `rake` 単独で実行すると以下のようなエラーになってしまうようになって、 `bundle exec rake` にする必要があったのを、また `rake` 単独でも動くようにする修正です。

```
rake aborted!
bitclust gem not found
.../rurema/doctree/Rakefile:33:in `generate_statichtml'
.../rurema/doctree/Rakefile:81:in `block (3 levels) in <top (required)>'
```