### PR TITLE
Refine m17n example

### DIFF
--- a/refm/doc/spec/m17n.rd
+++ b/refm/doc/spec/m17n.rd
@@ -137,7 +137,7 @@ Ruby の String は、文字の列を扱うためだけでなく、バイトの�
 p Encoding::ISO_2022_JP.dummy? # => true
 s = "漢字".encode("ISO-2022-JP")
 p s[0]   #=> "\e"
-s + "b"  #=> Encoding::CompatibilityError: incompatible character encodings: ISO-2022-JP and US-ASCII
+s + "b"  #=> Encoding::CompatibilityError: incompatible character encodings: ISO-2022-JP and UTF-8
 #@end
 
 またダミーエンコーディングはスクリプトエンコーディングとして使うことができません。

--- a/refm/doc/spec/m17n.rd
+++ b/refm/doc/spec/m17n.rd
@@ -131,14 +131,17 @@ Ruby の String は、文字の列を扱うためだけでなく、バイトの�
 
  * String のインスタンスメソッドは 1 文字ではなく 1 バイトを単位として動作します。
  * エンコーディングの異なる 7bit クリーンな文字列との結合ができません。
-   例外 (EncodingCompatibilityError) が発生します。
+   例外 ([[c:Encoding::CompatibilityError]]) が発生します。
+
+#@samplecode
+p Encoding::ISO_2022_JP.dummy? # => true
+s = "漢字".encode("ISO-2022-JP")
+p s[0]   #=> "\e"
+s + "b"  #=> Encoding::CompatibilityError: incompatible character encodings: ISO-2022-JP and US-ASCII
+#@end
 
 またダミーエンコーディングはスクリプトエンコーディングとして使うことができません。
 
-例:
-  s = "漢字".encode("ISO-2022-JP")
-  p s[0]   #=> "\e"  
-  s + "b"  #=> EncodingCompatibilityError: incompatible character encodings: ISO-2022-JP and US-ASCII
 
 ===[a:script_encoding] スクリプトエンコーディング
 


### PR DESCRIPTION

m17nのexample codeをいい感じにします。


* サンプルコードの位置が「またダミーエンコーディングはスクリプトエンコーディングとして使うことができません。」にかかっていて分かりづらかったので、移動しています
  * Thanks @ko1
* `Encoding::ISO_2022_JP.dummy?`の実行結果を表示させて、これがダミーエンコーディングであることを明示しました
* エラークラスが`EncodingCompatibilityError`になっていましたが、実際は`Encoding::CompatibilityError`なので直しています。また、リンクを貼っています。
* `#@samplecode`化しています