### PR TITLE
Add .gitattributes to determine filetype

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rd linguist-language=text


### PR DESCRIPTION
`.gitattributes`ファイルを足すことによって、 `.rd` ファイルが R言語のファイルだと認識されないようにします。

これによって、GitHub上で`.rd`ファイルがテキストファイルとみなされます。
そのため、よくわからないsyntax highlightがされないようになったり、このリポジトリがR言語のプロジェクトだと勘違いされないようになります。

とりあえずファイルタイプをtextにしてみましたが、もっとよい候補があったら教えてください。
https://github.com/github/linguist/blob/master/lib/linguist/languages.yml にあるファイルタイプを使えるはずです。