### PR TITLE
encode_www_formとencode_www_form_componentにenc追加

### DIFF
--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -246,7 +246,7 @@ enc で指定したエンコーディングの文字列が URL エンコード�
 @raise ArgumentError str のフォーマットが不正である場合に発生します
 @see [[m:URI.encode_www_form_component]], [[m:URI.decode_www_form]]
 
---- encode_www_form(enum) -> String
+--- encode_www_form(enum, enc=nil) -> String
 enum から URL-encoded form data を生成します。
 
 HTML5 で定義されている application/x-www-form-urlencoded 形式の
@@ -286,9 +286,10 @@ UTF-8 に変換する場合など)。
 にもとづいて実装されています。
 
 @param enum エンコードするデータ列([key, value] という形のデータの列)
+@param enc 指定された場合、パーセントエンコーディングする前に、このエンコーディングに変換
 @see [[m:URI.encode_www_form_component]], [[m:URI.decode_www_form]]
 
---- encode_www_form_component(str) -> String
+--- encode_www_form_component(str, enc=nil) -> String
 文字列を URL-encoded form data の1コンポーネント
 としてエンコードした文字列を返します。
 
@@ -302,6 +303,7 @@ UTF-8 に変換する場合など)。
 にもとづいて実装されています。
 
 @param str エンコードする文字列
+@param enc 指定された場合、パーセントエンコーディングする前に、strをこのエンコーディングに変換
 @see [[m:URI.decode_www_form_component]], [[m:URI.encode_www_form]]
 #@end
 == Constants

--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -282,7 +282,7 @@ UTF-8 に変換する場合など)。
 を使っています。
 
 このメソッドは
-[[url:https://www.w3.org/TR/html5/sec-forms.html#urlencoded-form-data]]
+[[url:https://url.spec.whatwg.org/#concept-urlencoded-serializer]]
 にもとづいて実装されています。
 
 @param enum エンコードするデータ列([key, value] という形のデータの列)
@@ -299,7 +299,7 @@ UTF-8 に変換する場合など)。
 空白は + に変換し、その他は %XX に、変換します。
 
 このメソッドは
-[[url:https://www.w3.org/TR/html5/sec-forms.html#urlencoded-form-data]]
+[[url:https://www.w3.org/TR/2013/CR-html5-20130806/forms.html#url-encoded-form-data]]
 にもとづいて実装されています。
 
 @param str エンコードする文字列


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/4a50d447d9618b2e3df126e159aa1d735e429a70
で追加されていたようなので、バージョン分岐は入れていません。

URL もこの時点のものではなく、最新の uri/common.rb のものに更新しました。