### PR TITLE
add force_encoding example

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3268,9 +3268,11 @@ euc_str.encoding    # => #<Encoding:EUC-JP>
 s = [164, 164, 164, 237, 164, 207].pack("C*")
 p s.encoding                                  #=> ASCII-8BIT
 p s.force_encoding("EUC-JP")                  #=> "いろは"
+p s.force_encoding(Encoding::EUC_JP)          #=> "いろは"
 
 u = [12411, 12408, 12392].pack("U*")
 u.force_encoding("UTF-8")                     #=> "ほへと"
+u.force_encoding(Encoding::UTF_8)             #=> "ほへと"
 #@end
 
 --- ascii_only?  -> bool


### PR DESCRIPTION
# 背景

```
@param encoding   変更するエンコーディング情報を表す文字列か Encoding オブジェクトを指定します。
```

とあるが、「Encoding オブジェクト」の実例がないため、実際に動くかわからない。
そのため、例を追加した。