### PR TITLE
scanメソッドの説明のtypoを修正 Fix #2253 

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2080,7 +2080,7 @@ pattern が正規表現で括弧を含む場合は、
 "foobarbazfoobarbaz".scan(/ba./) {|s| p s }
     # => "bar"
     #    "baz"
-    #    "baz"
+    #    "bar"
     #    "baz"
 
 "foobarbazfoobarbaz".scan("ba") {|s| p s }

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2078,22 +2078,22 @@ pattern が正規表現で括弧を含む場合は、
 
 #@samplecode 例
 "foobarbazfoobarbaz".scan(/ba./) {|s| p s }
-    # => "bar"
-    #    "baz"
-    #    "bar"
-    #    "baz"
+# "bar"
+# "baz"
+# "bar"
+# "baz"
 
 "foobarbazfoobarbaz".scan("ba") {|s| p s }
-    # => "ba"
-    #    "ba"
-    #    "ba"
-    #    "ba"
+# "ba"
+# "ba"
+# "ba"
+# "ba"
 
 "foobarbazfoobarbaz".scan(/(ba)(.)/) {|s| p s }
-    # => ["ba", "r"]
-    #    ["ba", "z"]
-    #    ["ba", "r"]
-    #    ["ba", "z"]
+# ["ba", "r"]
+# ["ba", "z"]
+# ["ba", "r"]
+# ["ba", "z"]
 #@end
 
 --- slice!(nth) -> Integer


### PR DESCRIPTION
あわせて出力の例を更新しました