### PR TITLE
Modify the error message of protected method

### DIFF
--- a/refm/doc/spec/def.rd
+++ b/refm/doc/spec/def.rd
@@ -627,7 +627,7 @@ extend については、[[m:Object#extend]] を参照して
         obj = Foo.new
 
         # そのままでは呼べない
-        obj.foo rescue nil    # => -:11 - private method `foo' called for #<Foo:0x401a1860> (NameError)
+        obj.foo rescue nil    # => -:11 - protected method `foo' called for #<Foo:0x401a1860> (NameError)
 
         # クラス定義内でも呼べない
         class Foo


### PR DESCRIPTION
## Summary
The error message should be `'protected method 'foo' called...'` when a protected method is called on an instance outside of its class. This PR tries to modify this as it behaves.

Thanks.

## Actual result
```ruby
irb(main):006:0> RUBY_VERSION
=> "2.7.0"

irb(main):007:1* class Foo
irb(main):008:2*   def foo
irb(main):009:2*     p caller.last
irb(main):010:1*   end
irb(main):011:1*   protected :foo
irb(main):012:0> end
=> Foo
irb(main):013:0> obj = Foo.new
irb(main):014:0> obj.foo
Traceback (most recent call last):
        4: from /Users/itosho/.rbenv/versions/2.7.0/bin/irb:23:in `<main>'
        3: from /Users/itosho/.rbenv/versions/2.7.0/bin/irb:23:in `load'
        2: from /Users/itosho/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/irb-1.2.1/exe/irb:11:in `<top (required)>'
        1: from (irb):14
NoMethodError (protected method `foo' called for #<Foo:0x00007ff2490f86e0>)
Did you mean?  for
```