### PR TITLE
slice!(integer)の戻り値をIntegerからStringに修正

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2096,7 +2096,7 @@ pattern が正規表現で括弧を含む場合は、
 # ["ba", "z"]
 #@end
 
---- slice!(nth) -> Integer
+--- slice!(nth) -> String
 --- slice!(pos, len) -> String
 --- slice!(substr) -> String
 --- slice!(regexp, nth = 0) -> String


### PR DESCRIPTION
Stringのslice!(integer)の戻り値はIntegerではなく、Stringが正しいと思います。

[コアリファレンスにもslice!(integer)の戻り値はnew_strと記述されています](https://ruby-doc.org/core-2.7.1/String.html#method-i-slice-21)し、slice!(integer)のサンプルコードでも戻り値はStringです。