### PR TITLE
String#eql? で、大文字小文字を無視した比較方法として casecmp? を挙げた

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -2991,8 +2991,13 @@ str が "string" という内容の文字列でありさえすれば常に true 
 同一のオブジェクトであるかどうかを判定したいときは
 [[m:Object#equal?]] を使ってください。
 
+#@since 2.4.0
+アルファベットの大文字小文字を無視して比較したい場合は
+[[m:String#casecmp?]] を使ってください。
+#@else
 アルファベットの大文字小文字を無視して比較したい場合は、[[m:String#upcase]],
 [[m:String#downcase]] で大文字小文字を揃えてから比較してください。
+#@end
 
 [[c:Hash]] クラス内での比較に使われます。
 
@@ -3007,9 +3012,11 @@ p "".eql?("string")        # => false
 
 p "string".eql?("str" + "ing")   # => true   (内容が同じなら true)
 p "string".eql?("stringX".chop)  # => true   (内容が同じなら true)
+#@until 2.4.0
 
 p "string".upcase.eql?("String".upcase)     # => true
 p "string".downcase.eql?("String".downcase) # => true
+#@end
 #@end
 
 @see [[c:Hash]], [[m:String#<=>]], [[m:String#casecmp]], [[m:String#==]]


### PR DESCRIPTION
String#eql? で、大文字小文字を無視した比較方法として「upcase/downcase してから eql? する」という方法が記載されていましたが、 String#casecmp? が導入された 2.4.0 以降はこちらを記載した方がいいのではないかと思います。