### PR TITLE
Fix syntax error on Ruby 3

### DIFF
--- a/refm/doc/news/2_7_0.rd
+++ b/refm/doc/news/2_7_0.rd
@@ -160,10 +160,8 @@ h = {}; def foo(a) a end; foo(h)    # {}
   * 「_1」などはまだローカル変数名として使えて、ローカル変数が優先されますが、
     警告が表示されます。
 
-#@samplecode
-_1 = 0            #=> warning: `_1' is reserved for numbered parameter; consider another name
-[1].each { p _1 } # prints 0 instead of 1
-#@end
+  _1 = 0            #=> warning: `_1' is reserved for numbered parameter; consider another name
+  [1].each { p _1 } # prints 0 instead of 1
 
 ==== ブロックなしの proc/lambda が deprecated
 


### PR DESCRIPTION
Ruby 3 (いまのmasterブランチ)では `_1` をローカル変数として使うとsyntax errorになっているようです。
https://github.com/ruby/ruby/pull/3163


そのため2.7.0のNEWS内のnumbered parametersのサンプルコードが、コンパイル時にsyntax errorとなってしまっていました。


```
$ bundle exec rake generate:2.7.0 statichtml:2.7.0
generate database of 2.7.0
Running bundle exec bitclust --database=/tmp/db-2.7.0 init version=2.7.0 encoding=UTF-8...
Running bundle exec bitclust --database=/tmp/db-2.7.0 update --stdlibtree=refm/api/src...
Running bundle exec bitclust --database=/tmp/db-2.7.0 --capi update refm/capi/src/array.c.rd refm/capi/src/bignum.c.rd refm/capi/src/class.c.rd refm/capi/src/error.c.rd refm/capi/src/eval.c.rd refm/capi/src/gc.c.rd refm/capi/src/io.c.rd refm/capi/src/object.c.rd refm/capi/src/parse.y.rd refm/capi/src/process.c.rd refm/capi/src/ruby.h.rd refm/capi/src/st.c.rd refm/capi/src/string.c.rd refm/capi/src/struct.c.rd refm/capi/src/time.c.rd refm/capi/src/variable.c.rd...
generate static html of 2.7.0
Running bundle exec bitclust --database=/tmp/db-2.7.0 statichtml --outputdir=/tmp/html/2.7.0 --templatedir=/home/pocke/ghq/github.com/rurema/bitclust/data/bitclust/template.offline --catalog=/home/pocke/ghq/github.com/rurema/bitclust/data/bitclust/catalog --fs-casesensitive --canonical-base-url=https://docs.ruby-lang.org/ja/latest/ --edit-base-url=https://github.com/rurema/doctree/edit/master/...
-:1:4 _1 is reserved for numbered parameter                                                                                                                                                                                                                                                                                                                                                                                            |
_1 = 0            #=> warning: `_1' is reserved for numbered parameter; consider another name
[1].each { p _1 } # prints 0 instead of 1
 (BitClust::SyntaxHighlighter::CompileError)
rake aborted!
Failed to generate static html
/home/pocke/ghq/github.com/rurema/doctree/Rakefile:49:in `generate_statichtml'
/home/pocke/ghq/github.com/rurema/doctree/Rakefile:82:in `block (3 levels) in <top (required)>'
/home/pocke/.rbenv/versions/trunk/bin/bundle:23:in `load'
/home/pocke/.rbenv/versions/trunk/bin/bundle:23:in `<main>'
Tasks: TOP => statichtml:2.7.0
(See full trace by running task with --trace)
```

これを防ぐため、`#@samplecode` を使わない形のコードブロックに修正しました。


