### PR TITLE
Reduce the minimum string buffer size

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -198,8 +198,12 @@ String.try_convert(/re/)      # => nil
 --- new(string = "", encoding: string.encoding) -> String
 #@end
 #@since 2.4.0
-#@# 127 は STR_BUF_MIN_SIZE。string.c 参照。
+#@# capacityのデフォルトのサイズは STR_BUF_MIN_SIZE。string.c 参照。
+#@since 2.7.0
+--- new(string = "", encoding: string.encoding, capacity: 63) -> String
+#@else
 --- new(string = "", encoding: string.encoding, capacity: 127) -> String
+#@end
 --- new(string = "", encoding: string.encoding, capacity: string.bytesize) -> String
 #@end
 


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/2151 でString.new でデフォルトで確保されるcapacityのサイズが127から63に減ったので、それをるりまにも反映します。




https://github.com/ruby/ruby/blob/ruby_2_6/string.c#L1347
https://github.com/ruby/ruby/blob/ruby_2_7/string.c#L1311