### PR TITLE
Update   send  

### DIFF
--- a/refm/api/src/_builtin/BasicObject
+++ b/refm/api/src/_builtin/BasicObject
@@ -196,7 +196,7 @@ Object クラスは様々な便利なメソッドや [[c:Kernel]] から受け�
   mail.send :delete, "gentle", "readers"       # => "(Mail#send) - delete gentle,readers"
   mail.__send__ :delete, "gentle", "readers"   # => "(Mail#delete) - delete gentle,readers"
 
-@see [[m:Object#__send__]]
+@see [[m:Object#send]]
 
 #@since 1.9.3
 --- __id__ -> Integer

--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -58,7 +58,7 @@
   p methods[3].call       # => "baz"
 
 しかし、レシーバを固定させる(Method オブジェクトはレシーバを保持する)必
-要がないなら [[m:Object#send]]を使う方法も有用。
+要がないなら [[m:Object#public_send]]を使う方法も有用。
 
   class Foo
     def foo() "foo" end
@@ -74,9 +74,9 @@
 
   # キーを使って関連するメソッドを呼び出す
   # レシーバは任意(Foo クラスのインスタンスである必要もない)
-  p Foo.new.send(methods[1])      # => "foo"
-  p Foo.new.send(methods[2])      # => "bar"
-  p Foo.new.send(methods[3])      # => "baz"
+  p Foo.new.public_send(methods[1])      # => "foo"
+  p Foo.new.public_send(methods[2])      # => "bar"
+  p Foo.new.public_send(methods[3])      # => "baz"
 
 @see [[m:Object#method]]
 

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1113,7 +1113,7 @@ public メソッドだけ呼び出せれば良い場合は
   p Foo.new.send(methods[2])      # => "bar"
   p Foo.new.send(methods[3])      # => "baz"
 
-@see [[m:Object#public_send]], [[m:Object#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
+@see [[m:Object#public_send]], [[m:BasicObject#__send__]], [[m:Object#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
 
 --- public_send(name, *args) -> object
 

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1071,8 +1071,6 @@ inspect メソッドをオーバーライドしなかった場合、クラス名
 
 --- send(name, *args) -> object
 --- send(name, *args) { .... } -> object
---- __send__(name, *args) -> object
---- __send__(name, *args) { .... } -> object
 
 オブジェクトのメソッド name を args を引数に
 して呼び出し、メソッドの実行結果を返します。
@@ -1114,7 +1112,6 @@ send, __send__ は、メソッドの呼び出し制限
 
 @see [[m:Object#public_send]], [[m:Object#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
 
-#@since 1.9.1
 --- public_send(name, *args) -> object
 
 オブジェクトの public メソッド name を args を引数にして呼び出し、メソッ
@@ -1133,8 +1130,7 @@ send, __send__ は、メソッドの呼び出し制限
 
   1.public_send(:puts, "hello")  # => NoMethodError
 
-@see [[m:Object#send]]
-#@end
+@see [[m:BasicObject#__send__]], [[m:Object#send]]
 
 --- _dump(limit) -> String
 
@@ -1408,13 +1404,8 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
   p me #=> #<Method: Integer#abs>
   p me.call #=> 365
 
-#@since 2.1.0
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#singleton_method]]
-#@else
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]]
-#@end
+@see [[m:Module#instance_method]], [[c:Method]], [[m:BasicObject#__send__]], [[m:Object#send]], [[m:Kernel.#eval]], [[m:Object#singleton_method]]
 
-#@since 2.1.0
 --- singleton_method(name) -> Method
 
 オブジェクトの特異メソッド name をオブジェクト化した [[c:Method]] オブ
@@ -1440,8 +1431,7 @@ clone や dup はオブジェクト自身を複製するだけで、オブジェ
    m.call   #=> "Hi, @iv = 99"
    m = k.singleton_method(:hello) # => NameError
 
-@see [[m:Module#instance_method]], [[c:Method]], [[m:Object#__send__]], [[m:Kernel.#eval]], [[m:Object#method]]
-#@end
+@see [[m:Module#instance_method]], [[c:Method]], [[m:BasicObject#__send__]], [[m:Object#send]], [[m:Kernel.#eval]], [[m:Object#method]]
 
 --- define_singleton_method(symbol, method) -> Symbol
 --- define_singleton_method(symbol) { ... } -> Symbol

--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1085,6 +1085,9 @@ send, __send__ は、メソッドの呼び出し制限
 にかかわらず任意のメソッドを呼び出せます。
 [[ref:d:spec/def#limit]] も参照してください。
 
+public メソッドだけ呼び出せれば良い場合は
+[[m:Object#public_send]] を使う方が良いでしょう。
+
 @param name 文字列か[[c:Symbol]] で指定するメソッド名です。
 @param args 呼び出すメソッドに渡す引数です。
 

--- a/refm/doc/news/2_4_0.rd
+++ b/refm/doc/news/2_4_0.rd
@@ -12,7 +12,7 @@
 
   * 条件式での多重代入ができるようになりました [[feature:10617]]
   * [[m:Symbol#to_proc]] でメソッド呼び出し元での Refinements が有効になりました [[feature:9451]]
-  * [[m:Kernel#send]] や [[m:BasicObject#__send__]] でメソッドを呼び出したときに Refinements が有効になりました [[feature:11476]]
+  * [[m:Object#send]] や [[m:BasicObject#__send__]] でメソッドを呼び出したときに Refinements が有効になりました [[feature:11476]]
   * 後置 rescue をメソッドの引数内に書けるようになりました [[feature:12686]]
   * トップレベルで return を書けるようになりました [[feature:4840]]
 


### PR DESCRIPTION
- `BasicObject#__send__` になって `Object#__send__` はなくなっていていたので削除
- `public_send` を推奨する文を追加
- `send` を使っている例を `public_send` を使うように変更