### PR TITLE
Net::HTTP.get系メソッドの引数の順番を実装に合わせる

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -250,7 +250,7 @@ proxy_addr に :ENV を指定すると環境変数 http_proxy からプロクシ
 文字列として返します。
 
 対象の指定方法は [[c:URI]] で指定するか、
-(host, port, path) で指定するかのいずれかです。
+(host, path, port) で指定するかのいずれかです。
 
 @param uri データの取得対象を [[c:URI]] で指定します。
 @param host 接続先のホストを文字列で指定します。
@@ -264,7 +264,7 @@ proxy_addr に :ENV を指定すると環境変数 http_proxy からプロクシ
 [[m:$stdout]] に出力します。
 
 対象の指定方法は [[c:URI]] で指定するか、
-(host, port, path) で指定するかのいずれかです。
+(host, path, port) で指定するかのいずれかです。
 
 @param uri データの取得対象を [[c:URI]] で指定します。
 @param host 接続先のホストを文字列で指定します。
@@ -286,7 +286,7 @@ proxy_addr に :ENV を指定すると環境変数 http_proxy からプロクシ
 [[c:Net::HTTPResponse]] として返します。
 
 対象の指定方法は [[c:URI]] で指定するか、
-(host, port, path) で指定するかのいずれかです。
+(host, path, port) で指定するかのいずれかです。
 
 @param uri データの取得対象を [[c:URI]] で指定します。
 @param host 接続先のホストを文字列で指定します。


### PR DESCRIPTION
fix https://github.com/rurema/doctree/issues/2246

```ruby
irb(main):021:0>  Net::HTTP.get('example.com', '/', '80'); nil
=> nil
irb(main):022:0>  Net::HTTP.get_response('example.com', '/', '80'); nil
=> nil
irb(main):023:0>  Net::HTTP.get_print('example.com', '/', '80'); nil
<!doctype html>
[...]
```
