### PR TITLE
DateTime class is deprecated

### DIFF
--- a/refm/api/src/date/DateTime
+++ b/refm/api/src/date/DateTime
@@ -2,6 +2,9 @@
 
 日付だけでなく時刻も扱える [[c:Date]] のサブクラスです。
 
+DateTime は deprecated とされているため、
+[[c:Time]]を使うことを推奨します。
+
 === 簡単なつかいかた
 
   require 'date'


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/15712 からの流れで https://github.com/ruby/date/commit/58ca6e6a3ee20c72a77266e0f74920b12a06ee9d で RDoc にも deprecated という記述が追加されたので、るりまにも追加します。