### PR TITLE
transform_keys accepts hash since 3.0.0

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -1586,17 +1586,27 @@ select! はオブジェクトが変更された場合に self を、
 @see [[m:Hash#transform_keys]]
 @see [[m:Hash#transform_keys!]]
 --- transform_keys {|key| ... } -> Hash
+#@since 3.0.0
+--- transform_keys(hash)        -> Hash
+#@end
 --- transform_keys              -> Enumerator
 
 すべてのキーに対してブロックを呼び出した結果で置き換えたハッシュを返します。
 値は変化しません。
 
+#@since 3.0.0
+@param hash 置き換え前のキーから置き換え後のキーへのハッシュを指定します。
+#@end
+
 #@samplecode 例
 h = { a: 1, b: 2, c: 3 }
-h.transform_keys {|k| k.to_s }  # => { "a" => 1, "b" => 2, "c" => 3 }
-h.transform_keys(&:to_s)        # => { "a" => 1, "b" => 2, "c" => 3 }
+h.transform_keys {|k| k.to_s }   # => {"a"=>1, "b"=>2, "c"=>3}
+#@since 3.0.0
+h.transform_keys(a: "a", d: "d") # => {"a"=>1, :b=>2, :c=>3}
+#@end
+h.transform_keys(&:to_s)         # => {"a"=>1, "b"=>2, "c"=>3}
 h.transform_keys.with_index {|k, i| "#{k}.#{i}" }
-                                # => { "a.0" => 1, "b.1" => 2, "c.2" => 3 }
+                                 # => {"a.0"=>1, "b.1"=>2, "c.2"=>3}
 #@end
 
 @see [[m:Hash#transform_keys!]]
@@ -1604,11 +1614,17 @@ h.transform_keys.with_index {|k, i| "#{k}.#{i}" }
 @see [[m:Hash#transform_values!]]
 
 --- transform_keys! {|key| ... } -> self
+#@since 3.0.0
+--- transform_keys!(hash)        -> self
+#@end
 --- transform_keys!                -> Enumerator
 
 すべての値に対してブロックを呼び出した結果でハッシュのキーを変更します。
 値は変化しません。
 
+#@since 3.0.0
+@param hash 置き換え前のキーから置き換え後のキーへのハッシュを指定します。
+#@end
 @return transform_keys! は常に self を返します。
         ブロックが与えられなかった場合は、[[c:Enumerator]] オブジェクトを
         返します。
@@ -1616,10 +1632,13 @@ h.transform_keys.with_index {|k, i| "#{k}.#{i}" }
 
 #@samplecode 例
 h = { a: 1, b: 2, c: 3 }
-h.transform_keys! {|k| k.to_s }  # => { "a" => 1, "b" => 2, "c" => 3 }
-h.transform_keys!(&:to_sym)      # => { a: 1, b: 2, c: 3 }
+h.transform_keys! {|k| k.to_s }   # => {"a"=>1, "b"=>2, "c"=>3}
+h.transform_keys!(&:to_sym)       # => {:a=>1, :b=>2, :c=>3}
+#@since 3.0.0
+h.transform_keys!(a: "a", d: "d") # => {"a"=>1, :b=>2, :c=>3}
+#@end
 h.transform_keys!.with_index {|k, i| "#{k}.#{i}" }
-                                 # => { "a.0" => 1, "b.1" => 2, "c.2" => 3 }
+                                  # => {"a.0"=>1, "b.1"=>2, "c.2"=>3}
 #@end
 
 @see [[m:Hash#transform_keys]]


### PR DESCRIPTION
`Hash#transform_keys` が Hash を受け付けるようになった変更です。
サンプルコード内の出力例が実際の出力とはちょっと違っていたので、実際の出力にあわせました。