### PR TITLE
Thead -> Thread

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -383,7 +383,7 @@ Thread.DEBUG # => 1
 例:[[c:Thread#raise]] 発生のタイミングを制御する例
 
   th = Thread.new do
-    Thead.handle_interrupt(RuntimeError => :never) {
+    Thread.handle_interrupt(RuntimeError => :never) {
       begin
         # 安全にリソースの割り当てが可能
         Thread.handle_interrupt(RuntimeError => :immediate) {


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/master/method/Thread/s/handle_interrupt.html

![image](https://user-images.githubusercontent.com/1796864/96450942-d3ccd700-1251-11eb-8ae2-75f794933b18.png)

I can't find any other `thead` in this repo

```
$ git grep -w -i thead
refm/api/src/_builtin/Thread:    Thead.handle_interrupt(RuntimeError => :never) {
```