### PR TITLE
Fix parse error

### DIFF
--- a/refm/doc/news/2_7_0.rd
+++ b/refm/doc/news/2_7_0.rd
@@ -21,19 +21,25 @@ in [a, [b, *c]]
   p b #=> 1
   p c #=> [2, 3]
 end
+#@end
 
+#@samplecode
 case {a: 0, b: 1}
 in {a: 0, x: 1}
   :unreachable
 in {a: 0, b: var}
   p var #=> 1
 end
+#@end
 
+#@samplecode
 case -1
 in 0 then :unreachable
 in 1 then :unreachable
 end #=> NoMatchingPatternError
+#@end
 
+//emlist{
 json = <<END
 {
   "name": "Alice",
@@ -49,7 +55,7 @@ p age  #=> 2
 
 JSON.parse(json, symbolize_names: true) in {name: "Alice", children: [{name: "Charlie", age: age}]}
 #=> NoMatchingPatternError
-#@end
+//}
 
   * 詳細は [[url:https://speakerdeck.com/k_tsj/pattern-matching-new-feature-in-ruby-2-dot-7]] のスライドを参照してください。
   * スライドは少し古い内容になっていることに注意してください。


### PR DESCRIPTION
ruby-head で parse error になっていたのを修正。
https://github.com/rurema/bitclust/pull/149/checks?check_run_id=1335701718#step:7:25
```
-:28:40 syntax error, unexpected `in', expecting end-of-input
case [0, [1, 2, 3]]
in [a, [b, *c]]
  p a #=> 0
  p b #=> 1
  p c #=> [2, 3]
end

case {a: 0, b: 1}
in {a: 0, x: 1}
  :unreachable
in {a: 0, b: var}
  p var #=> 1
end

case -1
in 0 then :unreachable
in 1 then :unreachable
end #=> NoMatchingPatternError

json = <<END
{
  "name": "Alice",
  "age": 30,
  "children": [{ "name": "Bob", "age": 2 }]
}
END

JSON.parse(json, symbolize_names: true) in {name: "Alice", children: [{name: name, age: age}]}

p name #=> "Bob"
p age  #=> 2

JSON.parse(json, symbolize_names: true) in {name: "Alice", children: [{name: "Charlie", age: age}]}
#=> NoMatchingPatternError
 (BitClust::SyntaxHighlighter::ParseError)
```