### PR TITLE
`OpenSSL::PKCS12` is a `Class`

### DIFF
--- a/refm/api/src/openssl/PKCS12
+++ b/refm/api/src/openssl/PKCS12
@@ -1,4 +1,4 @@
-= module OpenSSL::PKCS12
+= class OpenSSL::PKCS12 < Object
 PKCS#12 (秘密鍵、証明書、関連するCA証明書を1つのファイルに保存する形式)
 を表すクラスです。
 


### PR DESCRIPTION
OpenSSL::PKCS12 はモジュールじゃなくクラスですね。

```
$ env ALL_RUBY_SINCE='2.5.0' all-ruby -e 'require "openssl"; p OpenSSL::PKCS12.class'
ruby-2.5.0          Class
...
ruby-2.7.1          Class
```
