### PR TITLE
Mark some Array methods as overridden

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -537,6 +537,28 @@ other に配列以外のオブジェクトを指定した場合は nil を返し
   [ "a", "c", 7 ] == [ "a", "c", 7 ]     #=> true
   [ "a", "c", 7 ] == [ "a", "d", "f" ]   #=> false
 
+#@since 2.6.0
+--- all?               -> bool
+--- all? {|item| ... } -> bool
+--- all?(pattern)      -> bool
+
+すべての要素が真である場合に true を返します。
+偽である要素があれば、ただちに false を返します。
+
+ブロックを伴う場合は、各要素に対してブロックを評価し、すべての結果
+が真である場合に true を返します。ブロックが偽を返した時点で、
+ただちに false を返します。
+
+@param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
+
+例:
+    # すべて正の数か？
+    p [5,  6, 7].all? {|v| v > 0 }   # => true
+    p [5, -1, 7].all? {|v| v > 0 }   # => false
+    p [].all? {|v| v > 0 }           # => true
+    p %w[ant bear cat].all?(/t/)     # => false
+#@end
+
 #@since 2.2.0
 --- any?               -> bool
 --- any? {|item| ... } -> bool
@@ -1345,6 +1367,51 @@ nil でない要素の数を返します。
 例:
   p [1, nil, 3, nil].nitems              #=> 2
   p [1, nil, 3, nil].nitems{|e| e == 1}  #=> 2
+#@end
+
+#@since 2.6.0
+--- none?               -> bool
+--- none?{|obj| ... }   -> bool
+--- none?(pattern)      -> bool
+
+ブロックを指定しない場合は、 配列のすべての
+要素が偽であれば真を返します。そうでなければ偽を返します。
+
+ブロックを指定した場合は、配列のすべての要素を
+ブロックで評価した結果が、すべて偽であれば真を返します。
+そうでなければ偽を返します。
+
+@param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
+
+   %w{ant bear cat}.none? {|word| word.length == 5}  # => true
+   %w{ant bear cat}.none? {|word| word.length >= 4}  # => false
+   %w{ant bear cat}.none?(/d/)                       # => true
+   [].none?                                          # => true
+   [nil].none?                                       # => true
+   [nil,false].none?                                 # => true
+   [nil, false, true].none?                          # => false
+
+--- one?                -> bool
+--- one?{|obj| ... }    -> bool
+--- one?(pattern)       -> bool
+
+ブロックを指定しない場合は、 配列の要素のうち
+ちょうど一つだけが真であれば、真を返します。
+そうでなければ偽を返します。
+
+ブロックを指定した場合は、配列の要素を
+ブロックで評価した結果、一つの要素だけが真であれば真を返します。
+そうでなければ偽を返します。
+
+@param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
+
+   %w{ant bear cat}.one? {|word| word.length == 4}   # => true
+   %w{ant bear cat}.one? {|word| word.length > 4}    # => false
+   %w{ant bear cat}.one?(/t/)                        # => false
+   [ nil, true, 99 ].one?                            # => false
+   [ nil, true, false ].one?                         # => true
+   [ nil, true, 99 ].one?(Integer)                   # => true
+   [].one?                                           # => false
 #@end
 
 --- pack(template)                      -> String

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -844,21 +844,13 @@ delete_if は常に self を返しますが、reject! は要素が 1 つ以上�
    a = [1, 2, 3, 4, 5, 0]
    a.drop(3)             # => [4, 5, 0]
 
-#@since 1.9.1
 --- drop_while                    -> Enumerator
-#@else
---- drop_while                    -> Enumerable::Enumerator
-#@end
 --- drop_while {|element| ... }   -> Array
 
 ブロックを評価して最初に偽となった要素の手前の要素まで捨て、
 残りの要素を配列として返します。
 
-#@since 1.9.1
 ブロックを指定しなかった場合は、[[c:Enumerator]] を返します。
-#@else
-ブロックを指定しなかった場合は、[[c:Enumerable::Enumerator]] を返します。
-#@end
 
    a = [1, 2, 3, 4, 5, 0]
    a.drop_while {|i| i < 3 }   # => [3, 4, 5, 0]
@@ -1527,21 +1519,15 @@ buffer のサイズ(capacity)が足りなければ、packはメモリを確保�
 
 @see [[m:Array#assoc]]
 
-#@since 1.9.1
 --- reject               -> Enumerator
-#@else
---- reject               -> Enumerable::Enumerator
-#@end
 --- reject {|item| ... } -> [object]
 
 各要素に対してブロックを評価し、
 その値が偽であった要素を集めた新しい配列を返します。
 条件を反転させた select です。
 
-#@since 1.9.1
 ブロックを省略した場合は、各要素に対しブロックを評価し
 偽になった値の配列を返すような [[c:Enumerator]] を返します。
-#@end
 
 例:
 
@@ -1792,11 +1778,7 @@ fruits # => ["fig", "pear", "apple"]
    a = [1, 2, 3, 4, 5, 0]
    a.take(3)             # => [1, 2, 3]
 
-#@since 1.9.1
 --- take_while                    -> Enumerator
-#@else
---- take_while                    -> Enumerable::Enumerator
-#@end
 --- take_while {|element| ... }   -> Array
 
 配列の要素を順に偽になるまでブロックで評価します。
@@ -1805,10 +1787,8 @@ fruits # => ["fig", "pear", "apple"]
    a = [1, 2, 3, 4, 5, 0]
    a.take_while {|i| i < 3 }   # => [1, 2]
 
-#@since 1.9.1
 ブロックを省略した場合は、[[c:Enumerator]] オブジェクトを
 返します。
-#@end
 
 --- to_a       -> Array
 

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -537,6 +537,36 @@ other に配列以外のオブジェクトを指定した場合は nil を返し
   [ "a", "c", 7 ] == [ "a", "c", 7 ]     #=> true
   [ "a", "c", 7 ] == [ "a", "d", "f" ]   #=> false
 
+#@since 2.2.0
+--- any?               -> bool
+--- any? {|item| ... } -> bool
+#@since 2.5.0
+--- any?(pattern)      -> bool
+#@end
+
+すべての要素が偽である場合に false を返します。
+真である要素があれば、ただちに true を返します。
+
+ブロックを伴う場合は、各要素に対してブロックを評価し、すべての結果
+が偽である場合に false を返します。ブロックが真を返した時点
+で、ただちに true を返します。
+
+#@since 2.5.0
+@param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
+#@end
+
+例:
+    p [1, 2, 3].any? {|v| v > 3 }   # => false
+    p [1, 2, 3].any? {|v| v > 1 }   # => true
+    p [].any? {|v| v > 0 }          # => false
+#@since 2.5.0
+    p %w[ant bear cat].any?(/d/)    # => false
+    p [nil, true, 99].any?(Integer) # => true
+    p [nil, true, 99].any?          # => true
+    p [].any?                       # => false
+#@end
+#@end
+
 --- assoc(key)    -> Array | nil
 
 配列の配列を検索して、その 0 番目の要素が key に == で等しい

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -1418,7 +1418,7 @@ nil でない要素の数を返します。
    [ nil, true, 99 ].one?(Integer)                   # => true
    [].one?                                           # => false
 
-@see [[m:Enumerable#none?]]
+@see [[m:Enumerable#one?]]
 #@end
 
 --- pack(template)                      -> String

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -557,6 +557,8 @@ other に配列以外のオブジェクトを指定した場合は nil を返し
     p [5, -1, 7].all? {|v| v > 0 }   # => false
     p [].all? {|v| v > 0 }           # => true
     p %w[ant bear cat].all?(/t/)     # => false
+
+@see [[m:Enumerable#all?]]
 #@end
 
 #@since 2.2.0
@@ -587,6 +589,9 @@ other に配列以外のオブジェクトを指定した場合は nil を返し
     p [nil, true, 99].any?          # => true
     p [].any?                       # => false
 #@end
+
+@see [[m:Enumerable#any?]]
+
 #@end
 
 --- assoc(key)    -> Array | nil
@@ -645,7 +650,9 @@ dup は内容だけをコピーします。
     p [1, 2, 3].map {|n| n * 3 }  # => [3, 6, 9]
 
 #@since 2.6.0
-@see [[m:Hash#to_h]]
+@see [[m:Hash#to_h]], [[m:Enumerable#collect]], [[m:Enumerable#map]]
+#@else
+@see [[m:Enumerable#collect]], [[m:Enumerable#map]]
 #@end
 
 --- collect! {|item| ..}    -> self
@@ -755,6 +762,8 @@ other_arrays の要素を自身の末尾に破壊的に連結します。
    ary.count(2)          # => 2
    ary.count{|x|x%2==0}  # => 3
 
+@see [[m:Enumerable#count]]
+
 --- delete(val)           -> object | nil
 --- delete(val) { ... }   -> object
 
@@ -843,6 +852,8 @@ delete_if は常に self を返しますが、reject! は要素が 1 つ以上�
 
    a = [1, 2, 3, 4, 5, 0]
    a.drop(3)             # => [4, 5, 0]
+
+@see [[m:Enumerable#drop]]
 
 --- drop_while                    -> Enumerator
 --- drop_while {|element| ... }   -> Array
@@ -1383,6 +1394,8 @@ nil でない要素の数を返します。
    [nil,false].none?                                 # => true
    [nil, false, true].none?                          # => false
 
+@see [[m:Enumerable#none?]]
+
 --- one?                -> bool
 --- one?{|obj| ... }    -> bool
 --- one?(pattern)       -> bool
@@ -1404,6 +1417,8 @@ nil でない要素の数を返します。
    [ nil, true, false ].one?                         # => true
    [ nil, true, 99 ].one?(Integer)                   # => true
    [].one?                                           # => false
+
+@see [[m:Enumerable#none?]]
 #@end
 
 --- pack(template)                      -> String
@@ -1534,7 +1549,7 @@ buffer のサイズ(capacity)が足りなければ、packはメモリを確保�
   # 偶数を除外する (奇数を集める)
   [1, 2, 3, 4, 5, 6].reject {|i| i % 2 == 0 }  # => [1, 3, 5]
 
-@see [[m:Array#select]]
+@see [[m:Array#select]], [[m:Enumerable#reject]]
 #@since 2.3.0
 @see [[m:Enumerable#grep_v]]
 #@end
@@ -1778,6 +1793,8 @@ fruits # => ["fig", "pear", "apple"]
    a = [1, 2, 3, 4, 5, 0]
    a.take(3)             # => [1, 2, 3]
 
+@see [[m:Enumerable#take]]
+
 --- take_while                    -> Enumerator
 --- take_while {|element| ... }   -> Array
 
@@ -1789,6 +1806,8 @@ fruits # => ["fig", "pear", "apple"]
 
 ブロックを省略した場合は、[[c:Enumerator]] オブジェクトを
 返します。
+
+@see [[m:Enumerable#take_while]]
 
 --- to_a       -> Array
 

--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -578,6 +578,24 @@ dup は内容だけをコピーします。
     p ary             #=> ["ing"]
     p copy            #=> ["ing"]
 
+--- collect  -> Enumerator
+--- map      -> Enumerator
+--- collect {|item| ... } -> [object]
+--- map {|item| ... }     -> [object]
+
+各要素に対してブロックを評価した結果を全て含む配列を返します。
+
+ブロックを省略した場合、上で説明した繰り返しを実行し、その結果として
+得られる配列を返すような [[c:Enumerator]] オブジェクトを返します。
+
+例:
+    # すべて 3 倍にする
+    p [1, 2, 3].map {|n| n * 3 }  # => [3, 6, 9]
+
+#@since 2.6.0
+@see [[m:Hash#to_h]]
+#@end
+
 --- collect! {|item| ..}    -> self
 --- map! {|item| ..}        -> self
 #@since 1.9.1
@@ -610,9 +628,9 @@ dup は内容だけをコピーします。
     p ary           #=> [1, 1, 1]
 
 #@since 1.9.1
-@see [[m:Enumerable#collect]], [[c:Enumerator]]
+@see [[m:Array#collect]],  [[c:Enumerator]]
 #@else
-@see [[m:Enumerable#collect]], [[c:Enumerable::Enumerator]]
+@see [[m:Array#collect]], [[c:Enumerable::Enumerator]]
 #@end
 
 --- compact     -> Array
@@ -661,6 +679,29 @@ other_arrays の要素を自身の末尾に破壊的に連結します。
 
 @see [[m:Array#+]]
 #@end
+
+--- count                   -> Integer
+--- count(item)             -> Integer
+--- count {|obj| ... }  -> Integer
+
+レシーバの要素数を返します。
+
+引数を指定しない場合は、配列の要素数を返します。
+
+引数を一つ指定した場合は、レシーバの要素のうち引数に一致するものの
+個数をカウントして返します(一致は == で判定します)。
+
+ブロックを指定した場合は、ブロックを評価して真になった要素の個数を
+カウントして返します。
+
+@param item カウント対象となる値。
+
+例:
+
+   ary = [1, 2, 4, 2]
+   ary.count             # => 4
+   ary.count(2)          # => 2
+   ary.count{|x|x%2==0}  # => 3
 
 --- delete(val)           -> object | nil
 --- delete(val) { ... }   -> object
@@ -740,6 +781,35 @@ delete_if は常に self を返しますが、reject! は要素が 1 つ以上�
   e = a.reject!
   e.each{|i| i % 2 == 0}
   p a                    #=> [1, 3, 5]  もとの配列から削除されていることに注意。
+
+--- drop(n)               -> Array
+
+配列の先頭の n 要素を捨てて、
+残りの要素を配列として返します。
+
+@param n 捨てる要素数。
+
+   a = [1, 2, 3, 4, 5, 0]
+   a.drop(3)             # => [4, 5, 0]
+
+#@since 1.9.1
+--- drop_while                    -> Enumerator
+#@else
+--- drop_while                    -> Enumerable::Enumerator
+#@end
+--- drop_while {|element| ... }   -> Array
+
+ブロックを評価して最初に偽となった要素の手前の要素まで捨て、
+残りの要素を配列として返します。
+
+#@since 1.9.1
+ブロックを指定しなかった場合は、[[c:Enumerator]] を返します。
+#@else
+ブロックを指定しなかった場合は、[[c:Enumerable::Enumerator]] を返します。
+#@end
+
+   a = [1, 2, 3, 4, 5, 0]
+   a.drop_while {|i| i < 3 }   # => [3, 4, 5, 0]
 
 --- each {|item| .... }    -> self
 #@since 1.9.1
@@ -1360,6 +1430,32 @@ buffer のサイズ(capacity)が足りなければ、packはメモリを確保�
 
 @see [[m:Array#assoc]]
 
+#@since 1.9.1
+--- reject               -> Enumerator
+#@else
+--- reject               -> Enumerable::Enumerator
+#@end
+--- reject {|item| ... } -> [object]
+
+各要素に対してブロックを評価し、
+その値が偽であった要素を集めた新しい配列を返します。
+条件を反転させた select です。
+
+#@since 1.9.1
+ブロックを省略した場合は、各要素に対しブロックを評価し
+偽になった値の配列を返すような [[c:Enumerator]] を返します。
+#@end
+
+例:
+
+  # 偶数を除外する (奇数を集める)
+  [1, 2, 3, 4, 5, 6].reject {|i| i % 2 == 0 }  # => [1, 3, 5]
+
+@see [[m:Array#select]]
+#@since 2.3.0
+@see [[m:Enumerable#grep_v]]
+#@end
+
 --- replace(another)    -> self
 
 配列の内容を配列 another の内容で置き換えます。
@@ -1588,6 +1684,33 @@ fruits # => ["fig", "pear", "apple"]
 #@end
 
 @see [[m:Enumerable#sort_by]]
+#@end
+
+--- take(n)               -> Array
+
+配列の先頭から n 要素を配列として返します。
+
+@param n 要素数を指定します。
+
+   a = [1, 2, 3, 4, 5, 0]
+   a.take(3)             # => [1, 2, 3]
+
+#@since 1.9.1
+--- take_while                    -> Enumerator
+#@else
+--- take_while                    -> Enumerable::Enumerator
+#@end
+--- take_while {|element| ... }   -> Array
+
+配列の要素を順に偽になるまでブロックで評価します。
+最初に偽になった要素の手前の要素までを配列として返します。
+
+   a = [1, 2, 3, 4, 5, 0]
+   a.take_while {|i| i < 3 }   # => [1, 2]
+
+#@since 1.9.1
+ブロックを省略した場合は、[[c:Enumerator]] オブジェクトを
+返します。
 #@end
 
 --- to_a       -> Array

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -32,6 +32,10 @@
     p %w[ant bear cat].all?(/t/)     # => false
 #@end
 
+#@since 2.6.0
+@see [[m:Array#all?]]
+#@end
+
 --- any?               -> bool
 --- any? {|item| ... } -> bool
 #@since 2.5.0
@@ -58,6 +62,10 @@
     p [nil, true, 99].any?(Integer) # => true
     p [nil, true, 99].any?          # => true
     p [].any?                       # => false
+#@end
+
+#@since 2.2.0
+@see [[m:Array#any?]]
 #@end
 
 #@since 2.6.0
@@ -96,7 +104,9 @@ obj.collect {|item| item } を実行します。
     p [1, 2, 3].map {|n| n * 3 }  # => [3, 6, 9]
 
 #@since 2.6.0
-@see [[m:Hash#to_h]]
+@see [[m:Hash#to_h]], [[m:Array#collect]], [[m:Array#map]]
+#@else
+@see [[m:Array#collect]], [[m:Array#map]]
 #@end
 --- each_with_index(*args)                      -> Enumerator
 --- each_with_index(*args) {|item, index| ... } -> self
@@ -665,7 +675,7 @@ a < b のとき負の整数を、期待しています。
   # 偶数を除外する (奇数を集める)
   [1, 2, 3, 4, 5, 6].reject {|i| i % 2 == 0 }  # => [1, 3, 5]
 
-@see [[m:Enumerable#select]]
+@see [[m:Enumerable#select]], [[m:Array#reject]]
 #@since 2.3.0
 @see [[m:Enumerable#grep_v]]
 #@end
@@ -950,6 +960,7 @@ n 要素ずつ繰り返す [[c:Enumerator]] を返します。
    ary.count(2)          # => 2
    ary.count{|x|x%2==0}  # => 3
 
+@see [[m:Array#count]]
 
 #@since 1.9.1
 --- cycle(n=nil)       -> Enumerator
@@ -993,6 +1004,8 @@ Enumerable オブジェクトの先頭の n 要素を捨てて、
 
    a = [1, 2, 3, 4, 5, 0]
    a.drop(3)             # => [4, 5, 0]
+
+@see [[m:Array#drop]]
 
 #@since 1.9.1
 --- drop_while                    -> Enumerator
@@ -1159,6 +1172,10 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
    [nil,false].none?                                 # => true
    [nil, false, true].none?                          # => false
 
+#@since 2.6.0
+@see [[m:Array#none?]]
+#@end
+
 --- one?                -> bool
 --- one?{|obj| ... }    -> bool
 #@since 2.5.0
@@ -1189,6 +1206,10 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
 #@end
    [].one?                                           # => false
 
+#@since 2.6.0
+@see [[m:Array#one?]]
+#@end
+
 --- take(n)               -> Array
 
 Enumerable オブジェクトの先頭から n 要素を配列として返します。
@@ -1197,6 +1218,8 @@ Enumerable オブジェクトの先頭から n 要素を配列として返しま
 
    a = [1, 2, 3, 4, 5, 0]
    a.take(3)             # => [1, 2, 3]
+
+@see [[m:Array#take]]
 
 #@since 1.9.1
 --- take_while                    -> Enumerator
@@ -1215,6 +1238,8 @@ Enumerable オブジェクトの要素を順に偽になるまでブロックで
 ブロックを省略した場合は、[[c:Enumerator]] オブジェクトを
 返します。
 #@end
+
+@see [[m:Array#take_while]]
 
 #@since 1.9.1
 --- reverse_each -> Enumerator

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -24,12 +24,20 @@
 #@end
 
 例:
+#@since 2.6.0
+    # すべて正の数か？
+    p [5,  6, 7].each.all? {|v| v > 0 }   # => true
+    p [5, -1, 7].each.all? {|v| v > 0 }   # => false
+    p [].each.all? {|v| v > 0 }           # => true
+    p %w[ant bear cat].each.all?(/t/)     # => false
+#@else
     # すべて正の数か？
     p [5,  6, 7].all? {|v| v > 0 }   # => true
     p [5, -1, 7].all? {|v| v > 0 }   # => false
     p [].all? {|v| v > 0 }           # => true
 #@since 2.5.0
     p %w[ant bear cat].all?(/t/)     # => false
+#@end
 #@end
 
 #@since 2.6.0
@@ -54,14 +62,20 @@
 #@end
 
 例:
+#@since 2.2.0
+    p [1, 2, 3].each.any? {|v| v > 3 }   # => false
+    p [1, 2, 3].each.any? {|v| v > 1 }   # => true
+    p [].each.any? {|v| v > 0 }          # => false
+#@else
     p [1, 2, 3].any? {|v| v > 3 }   # => false
     p [1, 2, 3].any? {|v| v > 1 }   # => true
     p [].any? {|v| v > 0 }          # => false
+#@end
 #@since 2.5.0
-    p %w[ant bear cat].any?(/d/)    # => false
-    p [nil, true, 99].any?(Integer) # => true
-    p [nil, true, 99].any?          # => true
-    p [].any?                       # => false
+    p %w[ant bear cat].each.any?(/d/)    # => false
+    p [nil, true, 99].each.any?(Integer) # => true
+    p [nil, true, 99].each.any?          # => true
+    p [].each.any?                       # => false
 #@end
 
 #@since 2.2.0
@@ -101,7 +115,7 @@ obj.collect {|item| item } を実行します。
 
 例:
     # すべて 3 倍にする
-    p [1, 2, 3].map {|n| n * 3 }  # => [3, 6, 9]
+    p [1, 2, 3].each.map {|n| n * 3 }  # => [3, 6, 9]
 
 #@since 2.6.0
 @see [[m:Hash#to_h]], [[m:Array#collect]], [[m:Array#map]]
@@ -673,7 +687,7 @@ a < b のとき負の整数を、期待しています。
 例:
 
   # 偶数を除外する (奇数を集める)
-  [1, 2, 3, 4, 5, 6].reject {|i| i % 2 == 0 }  # => [1, 3, 5]
+  [1, 2, 3, 4, 5, 6].each.reject {|i| i % 2 == 0 }  # => [1, 3, 5]
 
 @see [[m:Enumerable#select]], [[m:Array#reject]]
 #@since 2.3.0
@@ -955,10 +969,10 @@ n 要素ずつ繰り返す [[c:Enumerator]] を返します。
 
 例:
 
-   ary = [1, 2, 4, 2]
-   ary.count             # => 4
-   ary.count(2)          # => 2
-   ary.count{|x|x%2==0}  # => 3
+   enum = [1, 2, 4, 2].each
+   enum.count                  # => 4
+   enum.count(2)               # => 2
+   enum.count{|x|x%2==0}       # => 3
 
 @see [[m:Array#count]]
 
@@ -1002,8 +1016,8 @@ Enumerable オブジェクトの先頭の n 要素を捨てて、
 
 @param n 捨てる要素数。
 
-   a = [1, 2, 3, 4, 5, 0]
-   a.drop(3)             # => [4, 5, 0]
+   e = [1, 2, 3, 4, 5, 0].each
+   e.drop(3)             # => [4, 5, 0]
 
 @see [[m:Array#drop]]
 
@@ -1162,6 +1176,15 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
 @param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
 #@end
 
+#@since 2.6.0
+   %w{ant bear cat}.each.none? {|word| word.length == 5}  # => true
+   %w{ant bear cat}.each.none? {|word| word.length >= 4}  # => false
+   %w{ant bear cat}.each.none?(/d/)                       # => true
+   [].each.none?                                          # => true
+   [nil].each.none?                                       # => true
+   [nil,false].each.none?                                 # => true
+   [nil, false, true].each.none?                          # => false
+#@else
    %w{ant bear cat}.none? {|word| word.length == 5}  # => true
    %w{ant bear cat}.none? {|word| word.length >= 4}  # => false
 #@since 2.5.0
@@ -1171,6 +1194,7 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
    [nil].none?                                       # => true
    [nil,false].none?                                 # => true
    [nil, false, true].none?                          # => false
+#@end
 
 #@since 2.6.0
 @see [[m:Array#none?]]
@@ -1194,6 +1218,15 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
 @param pattern ブロックの代わりに各要素に対して pattern === item を評価します。
 #@end
 
+#@since 2.6.0
+   %w{ant bear cat}.each.one? {|word| word.length == 4}   # => true
+   %w{ant bear cat}.each.one? {|word| word.length > 4}    # => false
+   %w{ant bear cat}.each.one?(/t/)                        # => false
+   [ nil, true, 99 ].each.one?                            # => false
+   [ nil, true, false ].each.one?                         # => true
+   [ nil, true, 99 ].each.one?(Integer)                   # => true
+   [].each.one?                                           # => false
+#@else
    %w{ant bear cat}.one? {|word| word.length == 4}   # => true
    %w{ant bear cat}.one? {|word| word.length > 4}    # => false
 #@since 2.5.0
@@ -1205,6 +1238,7 @@ Enumerable オブジェクトの各要素をブロックに渡して評価し、
    [ nil, true, 99 ].one?(Integer)                   # => true
 #@end
    [].one?                                           # => false
+#@end
 
 #@since 2.6.0
 @see [[m:Array#one?]]
@@ -1216,8 +1250,8 @@ Enumerable オブジェクトの先頭から n 要素を配列として返しま
 
 @param n 要素数を指定します。
 
-   a = [1, 2, 3, 4, 5, 0]
-   a.take(3)             # => [1, 2, 3]
+   e = [1, 2, 3, 4, 5, 0].each
+   e.take(3)             # => [1, 2, 3]
 
 @see [[m:Array#take]]
 
@@ -1231,8 +1265,8 @@ Enumerable オブジェクトの先頭から n 要素を配列として返しま
 Enumerable オブジェクトの要素を順に偽になるまでブロックで評価します。
 最初に偽になった要素の手前の要素までを配列として返します。
 
-   a = [1, 2, 3, 4, 5, 0]
-   a.take_while {|i| i < 3 }   # => [1, 2]
+   e = [1, 2, 3, 4, 5, 0].each
+   e.take_while {|i| i < 3 }   # => [1, 2]
 
 #@since 1.9.1
 ブロックを省略した場合は、[[c:Enumerator]] オブジェクトを


### PR DESCRIPTION
Array のいくつかのメソッドは、最適化のため Enumerable の同名のメソッドをオーバーライドしており、ロジックを継承していないようでした。
`Array#each` を呼び出していないことを明確にしたほうが誤解がないように思うので、これらの Enumerable 以下のメソッドのドキュメントを Array 以下にコピーしてきました。

以下、all-ruby での確認の結果です。

```
$ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-1.8 ./all-ruby -e 'p (Array.instance_methods(false) & %w(all? any? collect count drop drop_while map none? one? reject take take_while).map{|s| s.intern}).sort'
ruby-1.8.0            []
...
ruby-1.8.7-p374       []
ruby-1.9.0-0          [:collect, :map, :reject]
ruby-1.9.0-1          [:collect, :map, :reject]
ruby-1.9.0-2          [:collect, :count, :drop, :drop_while, :map, :reject, :take, :take_while]
...
ruby-2.1.10           [:collect, :count, :drop, :drop_while, :map, :reject, :take, :take_while]
ruby-2.2.0-preview1   [:any?, :collect, :count, :drop, :drop_while, :map, :reject, :take, :take_while]
...
ruby-2.6.0-preview3   [:any?, :collect, :count, :drop, :drop_while, :map, :reject, :take, :take_while]
ruby-2.6.0-rc1        [:all?, :any?, :collect, :count, :drop, :drop_while, :map, :none?, :one?, :reject, :take, :take_while]
...
ruby-3.0.0-preview1   [:all?, :any?, :collect, :count, :drop, :drop_while, :map, :none?, :one?, :reject, :take, :take_while]
```