### PR TITLE
proc without block

### DIFF
--- a/refm/api/src/_builtin/Proc
+++ b/refm/api/src/_builtin/Proc
@@ -24,13 +24,28 @@ Proc がローカル変数のスコープを保持していることは以下の
 
 == Class Methods
 
+#@until 3.0
 --- new -> Proc
+#@end
 --- new { ... } -> Proc
 
 ブロックをコンテキストとともにオブジェクト化して返します。
 
+#@until 3.0
+ブロックを指定しない場合、Ruby 2.7 では
+[[m:$VERBOSE]] = true のときには警告メッセージ
+「warning: Capturing the given block using Proc.new is deprecated; use `&block` instead」
+が出力され、Ruby 3.0 では
+[[c:ArgumentError]] (tried to create Proc object without a block)
+が発生します。
+
 ブロックを指定しなければ、このメソッドを呼び出したメソッドが
 ブロックを伴うときに、それを Proc オブジェクトとして生成して返します。
+
+ただし、ブロックを指定しない呼び出しは推奨されていません。呼び出し元のメソッドで指定されたブロック
+を得たい場合は明示的に & 引数でうけるべきです。
+
+@raise ArgumentError スタック上にブロックがないのにブロックを省略した呼び出しを行ったときに発生します。
 
   def foo
     pr = Proc.new
@@ -57,6 +72,18 @@ Proc がローカル変数のスコープを保持していることは以下の
   # => -:2:in `new': tried to create Proc object without a block (ArgumentError)
           from -:2:in `foo'
           from -:4:in `<main>'
+#@else
+@raise ArgumentError ブロックを省略した呼び出しを行ったときに発生します。
+
+#@samplecode
+pr = Proc.new {|arg| p arg }
+pr.call(1) # => 1
+#@end
+
+#@samplecode
+Proc.new # => -e:1:in `new': tried to create Proc object without a block (ArgumentError)
+#@end
+#@end
 
 Proc.new は、Proc#initialize が定義されていれば
 オブジェクトの初期化のためにこれを呼び出します。このことを

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -2418,12 +2418,17 @@ bind によらずに特定のオブジェクトのコンテキストで expr を
 
 --- proc { ... } -> Proc
 --- lambda { ... } -> Proc
+#@until 3.0
 --- proc -> Proc
+#@end
+#@until 2.7
 --- lambda -> Proc
+#@end
 
 与えられたブロックから手続きオブジェクト ([[c:Proc]] のインスタンス)
 を生成して返します。[[m:Proc.new]] に近い働きをします。
 
+#@until 3.0
 ブロックが指定されなければ、呼び出し元のメソッドで指定されたブロック
 を手続きオブジェクトとして返します。呼び出し元のメソッドがブロックなし
 で呼ばれると [[c:ArgumentError]] 例外が発生します。
@@ -2431,7 +2436,23 @@ bind によらずに特定のオブジェクトのコンテキストで expr を
 ただし、ブロックを指定しない呼び出しは推奨されていません。呼び出し元のメソッドで指定されたブロック
 を得たい場合は明示的に & 引数でうけるべきです。
 
+ブロックを指定しない lambda は Ruby 2.6 までは警告メッセージ
+「warning: tried to create Proc object without a block」
+が出力され、Ruby 2.7 では
+[[c:ArgumentError]] (tried to create Proc object without a block)
+が発生します。
+
+ブロックを指定しない proc は、Ruby 2.7 では
+[[m:$VERBOSE]] = true のときには警告メッセージ
+「warning: Capturing the given block using Proc.new is deprecated; use `&block` instead」
+が出力され、Ruby 3.0 では
+[[c:ArgumentError]] (tried to create Proc object without a block)
+が発生します。
+
 @raise ArgumentError スタック上にブロックがないのにブロックを省略した呼び出しを行ったときに発生します。
+#@else
+@raise ArgumentError ブロックを省略した呼び出しを行ったときに発生します。
+#@end
 
   def foo &block
     lambda(&block)


### PR DESCRIPTION
`Proc.new` や `proc` が 2.7 で `$VERBOSE=true` で警告が出るようになり、3.0 で例外になったのに対応。
`lambda` は 2.6 まで無条件で警告がでていて、2.7 から例外。