### PR TITLE
Delete deprecated IO like methods since 3.0

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -298,13 +298,14 @@ ARGF の現在位置から 1 バイトずつ読み込み、それを整数とし
 
 @see [[m:IO#each_byte]]
 
+#@until 3.0
 --- bytes { |byte| ... } -> self
 --- bytes                -> Enumerator
 
 このメソッドは obsolete です。
 代わりに [[m:ARGF.class#each_byte]] を使用してください。
 使用すると警告メッセージが表示されます。
-
+#@end
 --- each_char { |c| ... } -> self
 --- each_char             -> Enumerator
 
@@ -343,13 +344,14 @@ ARGF の現在位置から 1 バイトずつ読み込み、それを整数とし
 
 @see [[m:IO#each_char]], [[m:IO#chars]]
 
+#@until 3.0
 --- chars { |c| ... } -> self
 --- chars             -> Enumerator
 
 このメソッドは obsolete です。
 代わりに [[m:ARGF.class#each_char]] を使用してください。
 使用すると警告メッセージが表示されます。
-
+#@end
 --- each_codepoint { |c| ... }   -> self
 --- each_codepoint               -> Enumerator
 
@@ -368,6 +370,7 @@ self の各コードポイントに対して繰り返しブロックを呼びだ
   ARGF.each_codepoint                  # => #<Enumerator: ARGF:each_codepoint>
   ARGF.each_codepoint{|e|print e, ","} # => 108,105,110,101,49,10,108,105,110,101,50,10,
 
+#@until 3.0
 #@# 2.0 から追加のメソッドだが IO#codepoints と揃えたと思われる。
 --- codepoints { |c| ... }       -> self
 --- codepoints                   -> Enumerator
@@ -375,7 +378,7 @@ self の各コードポイントに対して繰り返しブロックを呼びだ
 このメソッドは obsolete です。
 代わりに [[m:ARGF.class#each_codepoint]] を使用してください。
 使用すると警告メッセージが表示されます。
-
+#@end
 --- eof  -> bool
 --- eof? -> bool
 
@@ -609,6 +612,7 @@ ARGFが現在開いているファイルの[[c:File]]、または[[c:IO]]オブ�
 
 @see [[m:ARGF.class#file]], [[m:ARGF.class#to_write_io]]
 
+#@until 3.0
 --- lines(rs = $/) { |line| ... }   -> self
 --- lines(limit) { |line| ... }     -> self
 --- lines(rs, limit) { |line| ... } -> self
@@ -621,7 +625,7 @@ ARGFが現在開いているファイルの[[c:File]]、または[[c:IO]]オブ�
 使用すると警告メッセージが表示されます。
 
 @see [[m:$/]], [[m:ARGF.class#each_line]]
-
+#@end
 --- getbyte   -> Integer | nil
 
 self から 1 バイト(0..255)を読み込み整数として返します。

--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -30,7 +30,9 @@ IO の読み込みメソッドは2種類存在します。
  * [[m:IO.foreach]]
  * [[m:IO.readlines]]
  * [[m:IO#each_line]]
+#@until 3.0
  * [[m:IO#lines]]
+#@end
  * [[m:IO#gets]]
  * [[m:IO#getc]]
  * [[m:IO#ungetc]]
@@ -1042,6 +1044,7 @@ File.open("testfile") do |io|
 end
 #@end
 
+#@until 3.0
 --- bytes {|ch| ... }        -> self
 --- bytes                    -> Enumerator
 
@@ -1061,7 +1064,7 @@ IO の現在位置から 1 バイトずつ読み込み、それを整数とし�
 #@#noexample obsolete
 
 @see [[m:IO#each_byte]]
-
+#@end
 --- eof     -> bool
 --- eof?    -> bool
 
@@ -2038,6 +2041,7 @@ end
 File.read("testfile")     # => "\u0000\u0000\u0000ABCDEF"
 #@end
 #@end
+#@until 3.0
 --- lines(rs = $/) {|line| ... }        -> self
 --- lines(limit) {|line| ... }          -> self
 --- lines(rs, limit) {|line| ... }      -> self
@@ -2071,7 +2075,7 @@ limit で最大読み込みバイト数を指定します。ただしマルチ�
 #@#noexample obsolete
 
 @see [[m:$/]], [[m:IO#each_line]]
-
+#@end
 --- getbyte   -> Integer | nil
 
 IO から1バイトを読み込み整数として返します。
@@ -2116,6 +2120,7 @@ self は読み込み用にオープンされていなければなりません。
   f = File.new("testfile")
   f.each_char {|c| print c, ' ' }   #=> #<File:testfile>
 
+#@until 3.0
 --- chars{|c| ... }         -> self
 --- chars                   -> Enumerator
 
@@ -2135,7 +2140,7 @@ self は読み込み用にオープンされていなければなりません。
 #@#noexample obsolete
 
 @see [[m:IO#each_char]]
-
+#@end
 --- ungetbyte(c) -> nil
 
 指定したバイト列を書き戻します。
@@ -2329,6 +2334,7 @@ end
 # 12354
 #@end
 
+#@until 3.0
 --- codepoints{|c| ... }         -> self
 --- codepoints                   -> Enumerator
 
@@ -2346,7 +2352,7 @@ IO の各コードポイントに対して繰り返しブロックを呼びだ�
 #@#noexample obsolete
 
 @see [[m:IO#each_codepoint]]
-
+#@end
 --- fdatasync -> 0 | nil
 
 IO のすべてのバッファされているデータを直ちにディスクに書き込みます。

--- a/refm/api/src/stringio.rd
+++ b/refm/api/src/stringio.rd
@@ -153,15 +153,11 @@ close された StringIO に読み書き等が行われると IOError が発生�
 
 --- each(rs = $/){|line| ... }       -> self
 --- each_line(rs = $/){|line| ... }  -> self
---- lines(rs = $/){|line| ... }      -> self
-#@since 1.9.1
 --- each(rs = $/)       -> Enumerator
 --- each_line(rs = $/)  -> Enumerator
+#@until 3.0
+--- lines(rs = $/){|line| ... }      -> self
 --- lines(rs = $/)      -> Enumerator
-#@else
---- each(rs = $/)       -> Enumerable::Enumerator
---- each_line(rs = $/)  -> Enumerable::Enumerator
---- lines(rs = $/)      -> Enumerable::Enumerator
 #@end
 
 自身から 1 行ずつ読み込み、それを引数として与えられたブロックを実行します。
@@ -179,15 +175,13 @@ close された StringIO に読み書き等が行われると IOError が発生�
   "foo\n"
 
 @see [[m:$/]]
+@see [[m:IO#each_line]]
 
 --- each_byte{|ch| ... }    -> self
---- bytes{|ch| ... }        -> self
-#@since 1.9.1
 --- each_byte -> Enumerator
+#@until 3.0
+--- bytes{|ch| ... }        -> self
 --- bytes     -> Enumerator
-#@else
---- each_byte -> Enumerable::Enumerator
---- bytes     -> Enumerable::Enumerator
 #@end
 
 自身から 1 バイトずつ読み込み、整数 ch に変換し、それを引数として与えられたブロックを実行します。
@@ -203,6 +197,8 @@ close された StringIO に読み書き等が行われると IOError が発生�
   111
   103
   101
+
+@see [[m:IO#each_byte]]
 
 --- eof    -> bool
 --- eof?   -> bool
@@ -676,21 +672,14 @@ nil を返します。
 
 
 --- each_char{|c| ... } -> self
---- chars{|c| ... }     -> self
-#@since 1.9.1
 --- each_char           -> Enumerator
+#@until 3.0
+--- chars{|c| ... }     -> self
 --- chars               -> Enumerator
-#@else
---- each_char           -> Enumerable::Enumerator
---- chars               -> Enumerable::Enumerator
 #@end
 自身に含まれる文字を一文字ずつブロックに渡して評価します。
 
 自身は読み込み用にオープンされていなければなりません。
-
-#@until 1.9.1
-また、マルチバイト文字列を使用する場合は [[m:$KCODE]] を適切に設定してください。
-#@end
 
 @raise IOError 自身が読み込み用にオープンされていない場合に発生します。
 
@@ -737,15 +726,14 @@ nil を返します。
 
 現在の内部エンコーディングを返します。
 
-#@since 1.9.2
---- codepoints{|codepoint| ... } -> self
---- codepoints -> Enumerator
 --- each_codepoint{|codepoint| ... } -> self
 --- each_codepoint -> Enumerator
+#@until 3.0
+--- codepoints{|codepoint| ... } -> self
+--- codepoints -> Enumerator
+#@end
 
 自身の各コードポイントに対して繰り返します。
 
 @see [[m:IO#each_codepoint]]
-
-#@end
 #@end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/43b95bafd57d04c8fb401d3a9b52aca3f5b4b0be
で削除されたメソッド対応