### PR TITLE
Remove old branch in Hash

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -8,12 +8,8 @@ include Enumerable
 #@#リテラル-ハッシュ式へのリンクつける
 
   {a => b, ... }   # aはキー、bは値となる
-#@since 1.9.1
   {s: b , ... }    # { :s => b, ... } と同じ。キーがシンボルの場合の省略した書き方
-#@end
-#@since 2.2.0
   {"a+": b , ... } # { :"a+" => b, ... } と同じ。上の表現に空白や記号を含めたい場合
-#@end
 
 キーには任意の種類のオブジェクトを用いることができますが、
 以下の２つのメソッドが適切に定義してある必要があります。
@@ -22,11 +18,7 @@ include Enumerable
 
 破壊的操作によってキーとして与えたオブジェクトの内容が変化し、[[m:Object#hash]] の返す
 値が変わるとハッシュから値が取り出せなくなりますから、
-#@since 1.9.1
 [[c:Array]]、[[c:Hash]]
-#@else
-[[c:Array]]
-#@end
 などのインスタンスはキーに向きません。[[m:Hash#rehash]] を参照。
 
 ただし、 更新不可 ([[m:Object#frozen?]] が true) では無い文字列をキーとして与えた場合は、文字列をコピーし、コピーを更新不可に設定 ([[m:Object#freeze]]) してキーとして
@@ -42,18 +34,12 @@ include Enumerable
 デフォルト値には値形式とブロック形式があります。
 実際にデフォルト値がどのように扱われるかは各メソッドの説明を参照してください。
 
-#@since 1.9.1
 ハッシュに含まれる要素の順序が保持されるようになりました。
 ハッシュにキーが追加された順序で列挙します。
-#@else
-ハッシュに含まれる要素の順序は保持されません。
-列挙する順序は不定です。
-#@end
 
 
 == Class Methods
 
-#@since 1.9.1
 --- try_convert(obj) -> Hash | nil
 
 to_hash メソッドを用いて obj をハッシュに変換しようとします。
@@ -63,7 +49,6 @@ to_hash メソッドを用いて obj をハッシュに変換しようとしま�
 
    Hash.try_convert({1=>2})   # => {1=>2}
    Hash.try_convert("1=>2")   # => nil
-#@end
 
 --- [](other) -> Hash
 
@@ -288,19 +273,13 @@ foo({k: 1}) # => false
 
 self を返します。
 
-#@since 2.0.0
-
 例:
   hash = {}
   p hash.to_hash         # => {}
   p hash.to_hash == hash # => true
 
 @see [[m:Object#to_hash]], [[m:Hash#to_h]]
-#@else
-@see [[m:Object#to_hash]]
-#@end
 
-#@since 2.0.0
 --- to_h -> self | Hash
 #@since 2.6.0
 --- to_h {|key, value| block } -> Hash
@@ -330,7 +309,6 @@ hash.to_h {|key, value| [key.upcase, value-32] } # => {"A"=>65, "B"=>66}
 #@end
 
 @see [[m:Enumerable#map]]
-#@end
 #@end
 
 #@since 2.3.0
@@ -385,11 +363,7 @@ end
 p safe_invert({"a"=>1, "b"=>1, "c"=>3}) # => {1=>["a", "b"], 3=>["c"]}
 #@end
 
-#@since 1.9.1
 @see [[m:Hash#key]]
-#@else
-@see [[m:Hash#index]]
-#@end
 
 --- fetch(key, default = nil) {|key| ... } -> object
 
@@ -401,24 +375,12 @@ fetchはハッシュ自身にデフォルト値が設定されていても単に
 
 @param key 探索するキーを指定します。
 @param default 該当するキーが登録されていない時の返り値を指定します。
-#@since 1.9.1
 @raise  KeyError   引数defaultもブロックも与えられてない時、キーの探索に失敗すると発生します。
-#@else
-@raise  IndexError 引数defaultもブロックも与えられてない時、キーの探索に失敗すると発生します。
-#@end
 
-#@since 1.9.1
   h = {one: nil}
-#@else
-  h = {:one => nil}
-#@end
   p h[:one],h[:two]                        #=> nil,nil これではキーが存在するのか判別できない。
   p h.fetch(:one)                          #=> nil
-#@since 1.9.1
   p h.fetch(:two)                          # エラー key not found (KeyError)
-#@else
-  p h.fetch(:two)                          # エラー key not found (IndexError)
-#@end
   p h.fetch(:two,"error")                  #=> "error"
   p h.fetch(:two){|key|"#{key} not exist"} #=> "two not exist"
   p h.fetch(:two, "error"){|key|           #=> "two not exist"
@@ -426,11 +388,7 @@ fetchはハッシュ自身にデフォルト値が設定されていても単に
     }                                      #  警告が表示される。
   
   h.default = "default"
-#@since 1.9.1
   p h.fetch(:two)                          # エラー key not found (KeyError)
-#@else
-  p h.fetch(:two)                          # エラー key not found (IndexError)
-#@end
 
 @see [[m:Hash#[] ]]
 
@@ -541,7 +499,6 @@ compact は自身から value が nil のもの取り除いた Hash を生成し
 
 #@end
 
-#@since 1.9.1
 --- compare_by_identity -> self
 
 ハッシュのキーの一致判定をオブジェクトの同一性で判定するように変更します。
@@ -578,7 +535,6 @@ selfが変化する破壊的メソッドです。
 
 @see [[m:Hash#compare_by_identity]]
 
-#@end
 --- shift -> [object, object]
 
 ハッシュからキーが追加された順で先頭の要素をひとつ取り除き、
@@ -726,7 +682,6 @@ self と引数 key をブロックに渡して評価し、その結果を返し�
 
 @see [[m:Hash#default]]
 
-#@since 1.9.1
 --- default_proc=(pr)
 
 ハッシュのデフォルト値を返す [[c:Proc]] オブジェクトを
@@ -771,7 +726,6 @@ nil を指定した場合は現在の [[m:Hash#default_proc]] をクリアしま
 
 @see [[m:Hash#default_proc]], [[m:Hash#default]]
 
-#@end
 --- clone -> Hash
 --- dup -> Hash
 
@@ -832,13 +786,8 @@ selfを破壊的に変更したい場合はかわりに[[m:Hash#delete_if]]か[[
 
 @see [[m:Hash#delete_if]],[[m:Hash#delete]],[[m:Enumerable#reject]]
 
-#@since 1.9.1
 --- delete_if -> Enumerator
 --- reject!   -> Enumerator
-#@else
---- delete_if -> Enumerable::Enumerator
---- reject!   -> Enumerable::Enumerator
-#@end
 --- delete_if {|key, value| ... } -> self
 --- reject! {|key, value| ... } -> self|nil
 
@@ -849,11 +798,7 @@ delete_if は常に self を返します。
 reject! は、要素を削除しなかった場合には nil を返し、
 そうでなければ self を返します。
 
-#@until 1.9.1
-ブロックを省略した場合は [[c:Enumerable::Enumerator]] を返します。
-#@else
 ブロックを省略した場合は [[c:Enumerator]] を返します。
-#@end
 
   h = { 2 => "8" ,4 => "6" ,6 => "4" ,8 => "2" }
   
@@ -864,52 +809,18 @@ reject! は、要素を削除しなかった場合には nil を返し、
   p h.reject!{|key, value| key.to_i < value.to_i }   #=> nil
 
 @see [[m:Hash#reject]],[[m:Hash#delete]]
-#@since 1.9.2
 @see [[m:Hash#keep_if]],[[m:Hash#select!]]
-#@end
 
 --- each {|key, value| ... } -> self
 --- each_pair {|key, value| ... } -> self
-#@since 1.9.1
 --- each      -> Enumerator
 --- each_pair -> Enumerator
-#@else
---- each      -> Enumerable::Enumerator
---- each_pair -> Enumerable::Enumerator
-#@end
 
 ハッシュのキーと値を引数としてブロックを評価します。
 
-#@since 1.9.1
 反復の際の評価順序はキーが追加された順です。
-#@else
-反復の際の評価順序は不定です。
-#@end
 ブロック付きの場合 self を、
-#@since 1.9.1
 無しで呼ばれた場合 [[c:Enumerator]] を返します。
-#@else
-無しで呼ばれた場合 [[c:Enumerable::Enumerator]] を返します。
-#@end
-
-#@if( version >= "1.8.0" and version < "1.9.1" )
-each と each_pair ではブロック引数の受渡し方が異なります。
-each は キーと値の配列を１引数で、each_pair は別々に２引数でブロックに値を渡します。
-これによりブロック引数をひとつだけ指定した場合の挙動が異なります。
-ブロック引数を２つ指定するようにすれば同じ挙動になります。
-
-  {:a=>1, :b=>2}.each {|a| p a}
-  #=> [:a, 1]
-      [:b, 2]
-  
-  {:a=>1, :b=>2}.each_pair {|*a| p a} #明示的に配列で受ける
-  #=> [:a, 1]
-      [:b, 2]
-  
-  {:a=>1, :b=>2}.each {|k, v| p [k, v]}  #each_pairでも同じ結果
-  #=> [:a, 1]
-      [:b, 2]
-#@end
 
 each_pair は each のエイリアスです。
 
@@ -925,86 +836,46 @@ each_pair は each のエイリアスです。
   #=> [:a, 1]
       [:b, 2]
   
-#@since 1.9.1
   p({:a=>1, :b=>2}.each_pair)  # => #<Enumerator: {:a=>1, :b=>2}:each_pair>
-#@else
-  p({:a=>1, :b=>2}.each_pair)  # => #<Enumerable::Enumerator:0xbb19e4>
-#@end
 
 @see [[m:Hash#each_key]],[[m:Hash#each_value]]
 
 --- each_key {|key| ... } -> self
-#@since 1.9.1
 --- each_key -> Enumerator
-#@else
---- each_key -> Enumerable::Enumerator
-#@end
 
 ハッシュのキーを引数としてブロックを評価します。
 
-#@since 1.9.1
 反復の際の評価順序はキーが追加された順です。
-#@else
-反復の際の評価順序は不定です。
-#@end
 ブロック付きの場合selfを、
-#@since 1.9.1
 無しで呼ばれた場合[[c:Enumerator]]を返します。
-#@else
-無しで呼ばれた場合[[c:Enumerable::Enumerator]]を返します。
-#@end
 
   {:a=>1, :b=>2}.each_key {|k| p k}
   #=> :a
       :b
        
-#@since 1.9.1
   p({:a=>1, :b=>2}.each_key)  # => #<Enumerator: {:a=>1, :b=>2}:each_key>
-#@else
-  p({:a=>1, :b=>2}.each_key)  #=> #<Enumerable::Enumerator:0xbb19e4>
-#@end
 
 @see [[m:Hash#each_pair]],[[m:Hash#each_value]]
 
 --- each_value {|value| ... } -> self
-#@since 1.9.1
 --- each_value -> Enumerator
-#@else
---- each_value -> Enumerable::Enumerator
-#@end
 
 ハッシュの値を引数としてブロックを評価します。
 
-#@since 1.9.1
 反復の際の評価順序はキーが追加された順です。
-#@else
-反復の際の評価順序は不定です。
-#@end
 ブロック付きの場合selfを、
-#@since 1.9.1
 無しで呼ばれた場合 [[c:Enumerator]] を返します。
-#@else
-無しで呼ばれた場合 [[c:Enumerable::Enumerator]] を返します。
-#@end
 
   {:a=>1, :b=>2}.each_value {|v| p v}
   #=> 1
       2
   
-#@since 1.9.1
   p({:a=>1, :b=>2}.each_value)  # => #<Enumerator: {:a=>1, :b=>2}:each_value>
-#@else
-  p({:a=>1, :b=>2}.each_value)  #=> #<Enumerable::Enumerator:0xbb19e4>
-#@end
 
 @see [[m:Hash#each_pair]],[[m:Hash#each_key]]
 
-#@if (version < "1.9.1")
---- index(val) -> object
-#@else
 --- key(val) -> object
 --- index(val) -> object
-#@end
 
 値 val に対応するキーを返します。対応する要素が存在しない時には
 nil を返します。
@@ -1016,19 +887,11 @@ Hash#index は obsolete です。
 
 @param val 探索に用いる値を指定します。
 
-#@if (version >= "1.9.1")
   h = {:ab => "some" , :cd => "all" , :ef => "all"}
   
   p h.key("some") #=> :ab
   p h.key("all") #=> :cd
   p h.key("at") #=> nil
-#@else
-  h = {:ab => "some" , :cd => "all" , :ef => "all"}
-  
-  p h.index("some") #=> :ab
-  p h.index("all") #=> :cd
-  p h.index("at") #=> nil
-#@end
 
 @see [[m:Hash#invert]]
 
@@ -1416,8 +1279,6 @@ other が self のサブセットである場合に真を返します。
   p a.hash     #=> 329543
 
 
-#@since 1.9.1
-
 --- assoc(key)   ->  Array | nil
 
 ハッシュが key をキーとして持つとき、見つかった要素のキーと値のペア
@@ -1474,8 +1335,6 @@ key が見つからなかった場合は、nil を返します。
 
 @see [[m:Hash#assoc]], [[m:Array#rassoc]]
 
-#@end
-
 --- select                       -> Enumerator
 --- select {|key, value| ... }   -> Hash
 #@since 2.6.0
@@ -1498,24 +1357,13 @@ h.select {|k,v| v < 200}  #=> {"a" => 100}
 
 @see [[m:Hash#select!]], [[m:Hash#reject]]
 
-#@since 1.9.1
 --- to_s     -> String
-#@end
 --- inspect  -> String
 
 ハッシュの内容を人間に読みやすい文字列にして返します。
 
     h = { "c" => 300, "a" => 100, "d" => 400, "c" => 300  }
     h.inspect   # => "{\"a\"=>100, \"c\"=>300, \"d\"=>400}"
-
-#@until 1.9.1
---- to_s     -> String
-
-ハッシュの内容を self.to_a.to_s で文字列化して返します。
-
-    h = { "c" => 300, "a" => 100, "d" => 400, "c" => 300  }
-    h.to_s   # => "a100c300d400"
-#@end
 
 --- sort              -> Array
 --- sort{|a, b| ... } -> Array
@@ -1528,7 +1376,7 @@ h.select {|k,v| v < 200}  #=> {"a" => 100}
   h.sort {|a,b| a[1]<=>b[1]}   #=> [["c", 10], ["a", 20], ["b", 30]]
 
 @see [[m:Array#sort]]
-#@since 1.9.2
+
 --- keep_if -> Enumerator
 --- keep_if {|key, value| ... } -> self
 --- select! -> Enumerator
@@ -1566,7 +1414,7 @@ select! はオブジェクトが変更された場合に self を、
   h2.keep_if { |k, v| true }        # => {0=>"a", 3=>"d", 6=>"g"}
 
 @see [[m:Hash#select]], [[m:Hash#delete_if]], [[m:Hash#reject!]]
-#@end
+
 #@since 2.4.0
 --- transform_values {|value| ... } -> Hash
 --- transform_values                -> Enumerator


### PR DESCRIPTION
Hash の古いバージョン分岐を削除しました。
主に 1.9.1 での分岐の削除です。