### PR TITLE
リンク先をFiddle::Closure::BlockCallerに修正

### DIFF
--- a/refm/api/src/fiddle/1.9/fiddle.rd
+++ b/refm/api/src/fiddle/1.9/fiddle.rd
@@ -244,7 +244,7 @@ new でオブジェクトを生成することで利用します。
   }.new(TYPE_INT, [TYPE_VOIDP, TYPE_VOIDP])
 
 単に Ruby のブロックを C の(コールバック)関数に変換したい場合は
-[[c:Fiddle::BlockClosure]] を使うほうが簡単です。
+[[c:Fiddle::Closure::BlockCaller]] を使うほうが簡単です。
 
 == Class Methods
 --- new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
@@ -295,7 +295,7 @@ Ruby のブロックを C の関数ポインタとして表現するためのク
   p s # =>  "()07Uabcqx"
 
 == Class Methods
---- new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::BlockClosure
+--- new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
 
 Ruby のブロックを呼び出す Fiddle::Closure オブジェクトを返します。
 

--- a/refm/api/src/fiddle/2.0/Fiddle__Function
+++ b/refm/api/src/fiddle/2.0/Fiddle__Function
@@ -141,7 +141,7 @@ new でオブジェクトを生成することで利用します。
   }.new(TYPE_INT, [TYPE_VOIDP, TYPE_VOIDP])
 
 単に Ruby のブロックを C の(コールバック)関数に変換したい場合は
-[[c:Fiddle::BlockClosure]] を使うほうが簡単です。
+[[c:Fiddle::Closure::BlockCaller]] を使うほうが簡単です。
 
 == Class Methods
 --- new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure

--- a/refm/api/src/fiddle/2.0/Fiddle__Function
+++ b/refm/api/src/fiddle/2.0/Fiddle__Function
@@ -192,7 +192,7 @@ Ruby のブロックを C の関数ポインタとして表現するためのク
   p s # =>  "()07Uabcqx"
 
 == Class Methods
---- new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::BlockClosure
+--- new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
 
 Ruby のブロックを呼び出す Fiddle::Closure オブジェクトを返します。
 


### PR DESCRIPTION
class Fiddle::Closure ページ内の 
https://docs.ruby-lang.org/ja/latest/class/Fiddle=3a=3aClosure.html

> 単に Ruby のブロックを C の(コールバック)関数に変換したい場合は Fiddle::BlockClosure を使うほうが簡単です。 

という文中の `Fiddle::BlockClosure` ですが、そのような名前のクラスは存在しないようです。
Fiddle::Closure::BlockCallerの誤りだと思われるので、修正しました。