### PR TITLE
Add :connect_timeout to TCPSocket.new since 3.0

### DIFF
--- a/refm/api/src/socket/TCPSocket
+++ b/refm/api/src/socket/TCPSocket
@@ -24,8 +24,13 @@
 
 == Class Methods
 
+#@since 3.0
+--- open(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
+--- new(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
+#@else
 --- open(host, service, local_host=nil, local_service=nil) -> TCPSocket
 --- new(host, service, local_host=nil, local_service=nil) -> TCPSocket
+#@end
 
 host で指定したホストの service で指定したポートと接続したソケッ
 トを返します。host はホスト名、またはインターネットアドレスを
@@ -41,7 +46,12 @@ host で指定したホストの service で指定したポートと接続した
 @param service        /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
 @param local_host     ホスト名、またはインターネットアドレスを示す文字列を指定します。
 @param local_service  /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
-
+#@since 3.0
+#@# getaddrinfo_a(3) が入らなかったので、3.0 では resolv_timeout は指定しても無視される。
+#@# https://github.com/ruby/ruby/commit/c6b37cb169f190bac46c76a643350ee4ffc3dfca
+#@#@param resolv_timeout 名前解決のタイムアウトを秒数で指定します。
+@param connect_timeout タイムアウトを秒数で指定します。
+#@end
 --- gethostbyname(host) -> Array
 
 ホスト名または IP アドレス (整数または"127.0.0.1"


### PR DESCRIPTION
`resolv_timeout` は `getaddrinfo_a` が fork との組み合わせで問題があって revert された影響で無視される状態になっているので、ドキュメントからは省略しています。(rdoc の方からも削除されました。3.1 で再チャレンジの予定なので、一部の実装は残っているようです。)