### PR TITLE
Proxy is singleton method of Net::HTTP

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -354,14 +354,14 @@ address が nil のときは Net::HTTP クラスをそのまま返します。
 
 例1: [[m:Net::HTTP.new]] を使う
   require 'net/http'
-  proxy_class = Net::HTTP::Proxy('proxy.example.com', 8080)
+  proxy_class = Net::HTTP.Proxy('proxy.example.com', 8080)
   http = proxy_class.new('www.example.org')
   http.start {|h|
     h.get('/ja/') # proxy.example.com 経由で接続します。
   }
 例2: [[m:Net::HTTP.start]] を使う
   require 'net/http'
-  proxy_class = Net::HTTP::Proxy('proxy.example.com', 8080)
+  proxy_class = Net::HTTP.Proxy('proxy.example.com', 8080)
   proxy_class.start('www.example.org') {|h|
     h.get('/ja/') # proxy.example.com 経由で接続します。
   }


### PR DESCRIPTION
ProxyはNet::HTTPの特異メソッドですので呼び出し方が異なるような気がしています。

ref. https://github.com/ruby/net-http/blob/master/lib/net/http.rb#L1095