### PR TITLE
Struct::Tms -> Process::Tms

### DIFF
--- a/refm/api/src/_builtin.rd
+++ b/refm/api/src/_builtin.rd
@@ -88,6 +88,7 @@ require を書かなくても使うことができます。
 #@include(_builtin/Process__GID)
 #@include(_builtin/Process__Status)
 #@include(_builtin/Process__Sys)
+#@include(_builtin/Process__Tms)
 #@include(_builtin/Process__UID)
 #@since 2.3.0
 #@include(thread/Queue)
@@ -117,7 +118,6 @@ require を書かなくても使うことができます。
 #@include(_builtin/StopIteration)
 #@include(_builtin/String)
 #@include(_builtin/Struct)
-#@include(_builtin/Struct__Tms)
 #@include(_builtin/Symbol)
 #@include(_builtin/SyntaxError)
 #@include(_builtin/SystemCallError)

--- a/refm/api/src/_builtin/Process
+++ b/refm/api/src/_builtin/Process
@@ -550,15 +550,15 @@ Errno::EACCES となった場合には無視して実行を続けます。
 @see [[man:getsid(2)]]
 #@end
 
---- times    -> Struct::Tms
+--- times    -> Process::Tms
 
 自身のプロセスとその子プロセスが消費したユーザ/システム CPU 時間の積算を
-[[c:Struct::Tms]] オブジェクトで返します。
+[[c:Process::Tms]] オブジェクトで返します。
 時間の単位は秒で、浮動小数点数で与えられます。
 
 @raise NotImplementedError メソッドが現在のプラットフォームで実装されていない場合に発生します。
 
-@see [[c:Struct::Tms]] 
+@see [[c:Process::Tms]]
 
 --- wait    -> Integer
 --- wait2   -> [Integer, Process::Status]

--- a/refm/api/src/_builtin/Process__Tms
+++ b/refm/api/src/_builtin/Process__Tms
@@ -1,4 +1,4 @@
-= class Struct::Tms < Struct
+= class Process::Tms < Struct
 
 [[m:Process.#times]] の返り値を表現する構造体です。
 
@@ -37,5 +37,3 @@ Windows 上では常に 0 を返します。
 
 --- utime=(n)
 ユーザー CPU 時間をセットします。
-
-

--- a/refm/api/src/benchmark.rd
+++ b/refm/api/src/benchmark.rd
@@ -6,13 +6,6 @@ category Development
 
 ベンチマークを取るためのモジュールです。
 
-#@# == Class Methods
-#@# 
-#@# --- times -> Struct::Tms
-#@# 
-#@# [[m:Process.#times]] を呼び出しています。
-
-
 == Module Functions
 
 --- measure(label = "") { ... }  -> Benchmark::Tms


### PR DESCRIPTION
Deleted at https://github.com/ruby/ruby/commit/fee2913d0af894492542cc0ed5e45dbf00e8f8df since 3.0.

`Process.times` returns `Process::Tms` instead of `Struct::Tms` since 2.1.0.

```
% docker run -it --rm ghcr.io/ruby/all-ruby env ALL_RUBY_SINCE=ruby-1.8 ./all-ruby -e 'p Process.times.class'
ruby-1.8.0            Struct::Tms
...
ruby-2.1.0-preview1   Struct::Tms
ruby-2.1.0-preview2   Process::Tms
...
ruby-3.0.0-rc1        Process::Tms
```

`Benchmark.times` removed since 1.9.3.

```
% docker run -it --rm ghcr.io/ruby/all-ruby env ALL_RUBY_SINCE=ruby-1.8 ./all-ruby -r benchmark -e 'p Benchmark.times.class'
ruby-1.8.0            Struct::Tms
...
ruby-1.9.2-p330       Struct::Tms
ruby-1.9.3-preview1   -e:1:in `<main>': undefined method `times' for Benchmark:Module (NoMethodError)
                  exit 1
...
ruby-3.0.0-rc1        -e:1:in `<main>': undefined method `times' for Benchmark:Module (NoMethodError)
                  exit 1
```