### PR TITLE
Add NoMatchingPatternError since 2.7.0

### DIFF
--- a/refm/api/src/_builtin.rd
+++ b/refm/api/src/_builtin.rd
@@ -74,6 +74,9 @@ require を書かなくても使うことができます。
 #@include(thread/Mutex)
 #@include(_builtin/NameError)
 #@include(_builtin/NilClass)
+#@since 2.7.0
+#@include(_builtin/NoMatchingPatternError)
+#@end
 #@include(_builtin/NoMemoryError)
 #@include(_builtin/NoMethodError)
 #@include(_builtin/NotImplementedError)

--- a/refm/api/src/_builtin/NoMatchingPatternError
+++ b/refm/api/src/_builtin/NoMatchingPatternError
@@ -1,0 +1,9 @@
+#@since 2.7.0
+#@since 3.0
+= class NoMatchingPatternError < StandardError
+#@else
+= class NoMatchingPatternError < RuntimeError
+#@end
+
+パターンマッチでどの条件にも一致せず、else節もない場合に発生します。
+#@end


### PR DESCRIPTION
and superclass changed at https://github.com/ruby/ruby/commit/31b17a14abf9686a0a9b6777c6b47285f510b66a