### PR TITLE
Fix return value of `class` in irb

### DIFF
--- a/refm/api/src/irb.rd
+++ b/refm/api/src/irb.rd
@@ -32,7 +32,7 @@ irb コマンドを実行すると、以下のようなプロンプトが表れ�
   irb(main):004:2>     print 1
   irb(main):005:2>   end
   irb(main):006:1> end
-  nil
+  :foo
   irb(main):007:0>
 
 また irb コマンドは [[lib:readline]] ライブラリにも対応しています。


### PR DESCRIPTION
`class` の戻り値は最後に評価した式の結果（この場合は `def foo` の戻り値）になるので修正しました。