### PR TITLE
Use URI#read instead of Kernel.#open

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -692,7 +692,7 @@ require 'open-uri'
 require 'json'
 
 construct_url(arguments).
-  yield_self {|url| open(url).read }.
+  yield_self {|url| URI(url).read }.
   yield_self {|response| JSON.parse(response) }
 #@end
 


### PR DESCRIPTION
ref: https://github.com/ruby/ruby/pull/4039

`Kernel.#open`の代わりに`URI#read`を使うようにします。
`Kernel.#open`でURIをオープンする機能が2.7からdeprecatedになって3.0から削除されたためです。


`URI.open`を使っていないのは、`URI.open`だとopenしたIOをcloseしないためです。
![210110165110](https://user-images.githubusercontent.com/4361134/104117357-12ab8e00-5364-11eb-9b54-df1bd88ad853.png)
https://ruby-jp.slack.com/archives/CM964FVAB/p1610120174336000


2.7より古いバージョンでは`Kernel.#open`でもURIをオープンできますが、将来的に使えなくなるものをドキュメントに書いておく必要もないと思うので、バージョンによる分岐は入れていません。
また、`URI#read`は古いRubyでも使えます(少なくともRuby 1.9からあります)。


なお、open-uri自体のドキュメントには依然として`Kernel.#open`が再定義されるように書かれていますが、このPRではそこには手を付けていません。別PRで対応すると良いかなと思っています。


`open-uri`でgrepして、この修正箇所以外には`open-uri`自体のページと、NEWSにしか使われていないことを確認済みです。
また、`open`でgrepした結果もざっと眺めました。こちらはなんとなく見ただけなので、もしかしたら漏れがあるかもしれません。