### PR TITLE
Update Time.new with zone

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -283,30 +283,48 @@ p Time.local(2000, 1, 1) # => 2000-01-01 00:00:00 +0900
 p Time.now # => 2009-06-24 12:39:54 +0900
 #@end
 
---- new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, utc_offset = nil)    -> Time
+--- new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, zone = nil)    -> Time
+#@since 3.1
+--- new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, in: nil)       -> Time
+#@end
 
 引数で指定した地方時の Time オブジェクトを返します。
 
 mon day hour min sec に nil を指定した場合の値は、その引数がとり得る最小の値です。
-utc_offset に nil を指定した場合の値は、現在のタイムゾーンに従います。
+#@since 3.1
+zone と in に nil を指定した場合の値は、現在のタイムゾーンに従います。
+#@else
+zone に nil を指定した場合の値は、現在のタイムゾーンに従います。
+#@end
 
 @param year 年を整数か文字列で指定します。例えば 1998 年に対して 1998 を指定します。
 
 @param mon 1(1月)から 12(12月)の範囲の整数または文字列で指定します。
            英語の月名("Jan", "Feb", ... などの省略名。大文字小文字の違いは無視します)も指定できます。
 
-@param  day 日を 1 から 31 までの整数か文字列で指定します。
+@param day 日を 1 から 31 までの整数か文字列で指定します。
 
-@param  hour 時を 0 から 23 までの整数か文字列で指定します。
+@param hour 時を 0 から 23 までの整数か文字列で指定します。
 
-@param  min 分を 0 から 59 までの整数か文字列で指定します。
+@param min 分を 0 から 59 までの整数か文字列で指定します。
 
-@param  sec 秒を 0 から 60 までの整数か文字列で指定します。(60はうるう秒)
+@param sec 秒を 0 から 60 までの整数か文字列で指定します。(60はうるう秒)
 
-@param  utc_offset 協定世界時との時差を、秒を単位とする整数か、
-                   "+HH:MM" "-HH:MM" 形式の文字列で指定します。
+@param zone 協定世界時との時差を、秒を単位とする整数か、
+#@since 2.7.0
+            "UTC" かミリタリータイムゾーンの文字列または
+#@end
+            "+HH:MM" "-HH:MM" 形式の文字列で指定します。
+#@since 3.1
+@param in 協定世界時との時差を、秒を単位とする整数か、
+          "UTC" かミリタリータイムゾーンの文字列または
+          "+HH:MM" "-HH:MM" 形式の文字列で指定します。
+#@end
 
 @raise ArgumentError 与えられた引数が無効である場合に発生します。
+#@since 3.1
+@raise ArgumentError zone と in を同時に指定した場合に発生します。
+#@end
 
 #@samplecode
 p Time.new(2008, 6, 21, 13, 30, 0, "+09:00") # => 2008-06-21 13:30:00 +0900


### PR DESCRIPTION
- [Keyword argument for timezone in Time.new](https://bugs.ruby-lang.org/issues/17485)
- 空白文字調整
- (rdoc にあわせて) utc_offset を zone に変更して 2.7.0 から Time.at の in: と同様に "UTC" や "Z" などに対応していることを追加。
- 3.1 からの in: 対応追加