### PR TITLE
Fix documentation for Module#ruby2_keywords

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -2048,7 +2048,7 @@ self が [[m:Module#prepend]] されたときに対象のクラスまたはモ�
 #@end
 
 #@since 2.7.0
---- ruby2_keywords(method_name, ...)    -> self
+--- ruby2_keywords(method_name, ...)    -> nil
 
 For the given method names, marks the method as passing keywords through
 a normal argument splat.  This should only be called on methods that


### PR DESCRIPTION
It returns nil, not self.

https://github.com/ruby/ruby/commit/49d3830f44031174ad450a0ea1cdcdf0eabf9d0e