### PR TITLE
Thread#group does not return nil

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -678,10 +678,9 @@ ensure 節を実行せずにスレッドの実行を終了させます。
 @see [[m:Thread#exit]], [[m:Kernel.#exit]], [[m:Kernel.#exit!]]
 #@end
 
---- group    -> ThreadGroup | nil
+--- group    -> ThreadGroup
 
 スレッドが属している [[c:ThreadGroup]] オブジェクトを返します。
-死んでいるスレッドは nil を返します。
 
     p Thread.current.group == ThreadGroup::Default
     # => true


### PR DESCRIPTION
when thread is dead since 1.9.0-1.

```
% docker run -it --rm ghcr.io/ruby/all-ruby env ALL_RUBY_SINCE=ruby-1.8 ./all-ruby -e 'th=Thread.start{};Thread.pass;p th.group.class'
ruby-1.8.0            NilClass
...
ruby-1.9.0-0          NilClass
ruby-1.9.0-1          ThreadGroup
...
ruby-3.0.0            ThreadGroup
```

see also
https://github.com/ruby/ruby/commit/fc83b4896e9d7de084b203b133b84c1209c6ad88
https://bugs.ruby-lang.org/issues/17505