### PR TITLE
File::Stat#world_readable?とworld_writable?の記述を日本語化した

### DIFF
--- a/refm/api/src/_builtin/File__Stat
+++ b/refm/api/src/_builtin/File__Stat
@@ -466,10 +466,10 @@ stickyビットが立っている時に真を返します。
 #@# bc-rdoc: detected missing name: world_readable?
 --- world_readable? -> Integer | nil
 
-If stat is readable by others, returns an integer representing
-the file permission bits of stat. Returns nil otherwise. The
-meaning of the bits is platform dependent; on Unix systems, see
-stat(2).
+全てのユーザから読めるならば、そのファイルのパーミッションを表す
+整数を返します。そうでない場合は nil を返します。
+
+整数の意味はプラットフォームに依存します。
 
    m = File.stat("/etc/passwd").world_readable?  # => 420
    sprintf("%o", m)                              # => "644"
@@ -477,10 +477,10 @@ stat(2).
 #@# bc-rdoc: detected missing name: world_writable?
 --- world_writable? -> Integer | nil
 
-If stat is writable by others, returns an integer representing
-the file permission bits of stat. Returns nil otherwise. The
-meaning of the bits is platform dependent; on Unix systems, see
-stat(2).
+全てのユーザから書き込めるならば、そのファイルのパーミッションを表す
+整数を返します。そうでない場合は nil を返します。
+
+整数の意味はプラットフォームに依存します。
 
    m = File.stat("/tmp").world_writable?         # => 511
    sprintf("%o", m)                              # => "777"

--- a/refm/api/src/_builtin/File__Stat
+++ b/refm/api/src/_builtin/File__Stat
@@ -463,7 +463,6 @@ stickyビットが立っている時に真を返します。
   #...
 
 #@since 1.9.1
-#@# bc-rdoc: detected missing name: world_readable?
 --- world_readable? -> Integer | nil
 
 全てのユーザから読めるならば、そのファイルのパーミッションを表す
@@ -474,7 +473,6 @@ stickyビットが立っている時に真を返します。
    m = File.stat("/etc/passwd").world_readable?  # => 420
    sprintf("%o", m)                              # => "644"
 
-#@# bc-rdoc: detected missing name: world_writable?
 --- world_writable? -> Integer | nil
 
 全てのユーザから書き込めるならば、そのファイルのパーミッションを表す


### PR DESCRIPTION
File::Stat#world_readable?とworld_writable?の記述を日本語化しました。

書きぶりはFileTestの[world_readable?](https://docs.ruby-lang.org/ja/3.0.0/method/FileTest/m/world_readable=3f.html)と[world_readable?](https://docs.ruby-lang.org/ja/3.0.0/method/FileTest/m/world_writable=3f.html)をそれぞれ参考にしています。
