### PR TITLE
Add return value of Module#attr Module#attr_accessor Module#attr_reader Module#attr_writer

### DIFF
--- a/refm/api/src/_builtin/Module.attr
+++ b/refm/api/src/_builtin/Module.attr
@@ -74,7 +74,7 @@ end
 #@end
 
 #@since 3.0.0
---- attr_reader -> [Symbol]
+--- attr_reader(*name) -> [Symbol]
 #@else
 --- attr_reader(*name) -> nil
 #@end
@@ -103,7 +103,7 @@ end
 #@end
 
 #@since 3.0.0
---- attr_writer -> [Symbol]
+--- attr_writer(*name) -> [Symbol]
 #@else
 --- attr_writer(*name) -> nil
 #@end

--- a/refm/api/src/_builtin/Module.attr
+++ b/refm/api/src/_builtin/Module.attr
@@ -36,7 +36,9 @@ end
 第 2 引数 に true か false を指定する方法は非推奨です。
 
 @param name [[c:String]] または [[c:Symbol]] で指定します。
+#@since 3.0.0
 @return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
+#@end
 
 #@since 3.0.0
 --- attr_accessor(*name) -> [Symbol]
@@ -67,7 +69,9 @@ end
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+#@since 3.0.0
 @return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
+#@end
 
 #@since 3.0.0
 --- attr_reader -> [Symbol]
@@ -94,7 +98,9 @@ end
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+#@since 3.0.0
 @return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
+#@end
 
 #@since 3.0.0
 --- attr_writer -> [Symbol]
@@ -121,4 +127,6 @@ end
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+#@since 3.0.0
 @return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
+#@end

--- a/refm/api/src/_builtin/Module.attr
+++ b/refm/api/src/_builtin/Module.attr
@@ -1,8 +1,24 @@
+#@since 3.0.0
+--- attr(*name) -> [Symbol]
+--- attr(name, true) -> [Symbol]
+--- attr(name, false) -> [Symbol]
+#@else
 --- attr(*name) -> nil
 --- attr(name, true) -> nil
 --- attr(name, false) -> nil
+#@end
 
 インスタンス変数読み取りのためのインスタンスメソッド name を定義します。
+
+#@since 3.0.0
+#@samplecode 例
+class User
+  attr :name # => [:name]
+  # 複数の名前を渡すこともできる
+  attr :id, :age # => [:id, :age]
+end
+#@end
+#@end
 
 このメソッドで定義されるアクセスメソッドの定義は次の通りです。
 
@@ -20,12 +36,27 @@
 第 2 引数 に true か false を指定する方法は非推奨です。
 
 @param name [[c:String]] または [[c:Symbol]] で指定します。
+@return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
 
+#@since 3.0.0
+--- attr_accessor(*name) -> [Symbol]
+#@else
 --- attr_accessor(*name) -> nil
+#@end
 
 インスタンス変数 name に対する読み取りメソッドと書き込みメソッドの両方を
 定義します。
 
+#@since 3.0.0
+#@samplecode 例
+class User
+  attr_accessor :name # => [:name, :name=]
+  # 複数の名前を渡すこともできる
+  attr_accessor :id, :age # => [:id, :id=, :age, :age=]
+end
+#@end
+#@end
+
 このメソッドで定義されるメソッドの定義は以下の通りです。
 
   def name
@@ -36,11 +67,26 @@
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+@return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
 
+#@since 3.0.0
+--- attr_reader -> [Symbol]
+#@else
 --- attr_reader(*name) -> nil
+#@end
 
 インスタンス変数 name の読み取りメソッドを定義します。
 
+#@since 3.0.0
+#@samplecode 例
+class User
+  attr_reader :name # => [:name]
+  # 複数の名前を渡すこともできる
+  attr_reader :id, :age # => [:id, :age]
+end
+#@end
+#@end
+
 このメソッドで定義されるメソッドの定義は以下の通りです。
 
   def name
@@ -48,10 +94,25 @@
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+@return 定義されたメソッド名を [[c:Symbol]] の配列で返します。
 
+#@since 3.0.0
+--- attr_writer -> [Symbol]
+#@else
 --- attr_writer(*name) -> nil
+#@end
 
 インスタンス変数 name への書き込みメソッド (name=) を定義します。
+
+#@since 3.0.0
+#@samplecode 例
+class User
+  attr_writer :name # => [:name=]
+  # 複数の名前を渡すこともできる
+  attr_writer :id, :age # => [:id=, :age=]
+end
+#@end
+#@end
 
 このメソッドで定義されるメソッドの定義は以下の通りです。
 
@@ -60,3 +121,4 @@
   end
 
 @param name [[c:String]] または [[c:Symbol]] を 1 つ以上指定します。
+@return 定義されたメソッド名を [[c:Symbol]] の配列で返します。


### PR DESCRIPTION
Ruby 3.0 で `Module#attr` `Module#attr_accessor` `Module#attr_reader` `Module#attr_writer` の戻り値が変更されたのでそのドキュメントを追加しました。

#### 参照

* [[Feature #17314] Provide a way to declare visibility of attributes defined by attr* methods in a single expression](https://bugs.ruby-lang.org/issues/17314)
* https://github.com/rurema/doctree/issues/2458