### PR TITLE
Change return value of Module#alias_method

### DIFF
--- a/refm/api/src/_builtin/Module.alias_method
+++ b/refm/api/src/_builtin/Module.alias_method
@@ -32,6 +32,8 @@ alias との違いは以下の通りです。
 
 #@since 3.0.0
 @return メソッド名を表す Symbol を返します。
+#@else
+@return self を返します。
 #@end
 
 @see [[ref:d:spec/def#alias]]

--- a/refm/api/src/_builtin/Module.alias_method
+++ b/refm/api/src/_builtin/Module.alias_method
@@ -1,6 +1,19 @@
+#@since 3.0.0
+--- alias_method(new, original) -> Symbol
+#@else
 --- alias_method(new, original) -> self
+#@end
 
 メソッドの別名を定義します。
+
+#@since 3.0.0
+#@samplecode 例
+module Kernel
+  alias_method :hoge, :puts # => :hoge
+  alias_method "foo", :puts # => :foo
+end
+#@end
+#@end
 
 alias との違いは以下の通りです。
 
@@ -12,6 +25,10 @@ alias との違いは以下の通りです。
 @param new 新しいメソッド名。[[c:String]] または [[c:Symbol]] で指定します。
 
 @param original 元のメソッド名。[[c:String]] または [[c:Symbol]] で指定します。
+
+#@since 3.0.0
+@return メソッド名を表す Symbol を返します。
+#@end
 
 @see [[ref:d:spec/def#alias]]
 

--- a/refm/api/src/_builtin/Module.alias_method
+++ b/refm/api/src/_builtin/Module.alias_method
@@ -6,11 +6,15 @@
 
 メソッドの別名を定義します。
 
-#@since 3.0.0
 #@samplecode 例
+#@since 3.0.0
 module Kernel
   alias_method :hoge, :puts # => :hoge
   alias_method "foo", :puts # => :foo
+end
+#@else
+module Kernel
+  alias_method :hoge, :puts # => Kernel
 end
 #@end
 #@end

--- a/refm/api/src/_builtin/Module.alias_method
+++ b/refm/api/src/_builtin/Module.alias_method
@@ -31,7 +31,7 @@ alias との違いは以下の通りです。
 @param original 元のメソッド名。[[c:String]] または [[c:Symbol]] で指定します。
 
 #@since 3.0.0
-@return メソッド名を表す Symbol を返します。
+@return 作成したエイリアスのメソッド名を表す [[c:Symbol]] を返します。
 #@else
 @return self を返します。
 #@end


### PR DESCRIPTION
Ruby 3.0 で `Module#alias_method` の戻り値が変わったのでドキュメントに追加しました。

#### 参照

* [[Feature #17314] Provide a way to declare visibility of attributes defined by attr* methods in a single expression](https://bugs.ruby-lang.org/issues/17314)
* https://github.com/rurema/doctree/issues/2458