### PR TITLE
Add --backtrace-limit=num

### DIFF
--- a/refm/doc/spec/rubycmd.rd
+++ b/refm/doc/spec/rubycmd.rd
@@ -59,7 +59,8 @@ Rubyインタプリタは以下のコマンドラインオプションを受け�
 
   バックトレースの最大行数を指定します。
 
-#@samplecode test.rb
+//emlist{
+# test.rb
 def f6 = raise
 def f5 = f6
 def f4 = f5
@@ -67,7 +68,7 @@ def f3 = f4
 def f2 = f3
 def f1 = f2
 f1
-#@end
+//}
 
 //emlist{
 % ruby --backtrace-limit=3 test.rb

--- a/refm/doc/spec/rubycmd.rd
+++ b/refm/doc/spec/rubycmd.rd
@@ -54,6 +54,31 @@ Rubyインタプリタは以下のコマンドラインオプションを受け�
   が実行されます。`-n'か`-p'オプションが同時に指定されない限り,
   このオプションは意味を持ちません。
 
+#@since 3.0.0
+: --backtrace-limit=num
+
+  バックトレースの最大行数を指定します。
+
+#@samplecode test.rb
+def f6 = raise
+def f5 = f6
+def f4 = f5
+def f3 = f4
+def f2 = f3
+def f1 = f2
+f1
+#@end
+
+//emlist{
+% ruby --backtrace-limit=3 test.rb
+test.rb:1:in `f6': unhandled exception
+  from test.rb:2:in `f5'
+  from test.rb:3:in `f4'
+  from test.rb:4:in `f3'
+   ... 3 levels...
+//}
+#@end
+
 : -C directory
 
   スクリプト実行前に指定されたディレクトリに移動します。


### PR DESCRIPTION
--backtrace-limit オプションを追加しました。

[Feature \#8661: Add option to print backtrace in reverse order \(stack frames first and error last\) \- CommonRuby \- Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/8661)

ref: #2458