### PR TITLE
Benchmark.#bm,benchmark の返り値更新

### DIFF
--- a/refm/api/src/benchmark.rd
+++ b/refm/api/src/benchmark.rd
@@ -33,7 +33,7 @@ Benchmark::Tms オブジェクトには to_s が定義されているので、
 
 
 
---- bm(label_width = 0, *labels) {|rep| ... } -> bool
+--- bm(label_width = 0, *labels) {|rep| ... } -> [Benchmark::Tms]
 
 [[m:Benchmark.#benchmark]] メソッドの引数を簡略化したものです。
 
@@ -41,8 +41,6 @@ Benchmark::Tms オブジェクトには to_s が定義されているので、
 
 @param label_width ラベルの幅を指定します。
 @param labels     ブロックが [[c:Benchmark::Tms]] オブジェクトの配列を返す場合に指定します。
-
-@return STDIN.sync の値を返すだけなので返り値に意味はありません。
 
 例:
 
@@ -137,7 +135,7 @@ Benchmark::Tms オブジェクトには to_s が定義されているので、
   sort!  12.959000   0.010000  12.969000 ( 13.793000)
   sort   12.007000   0.000000  12.007000 ( 12.791000)
 
---- benchmark(caption = "", label_width = nil, fmtstr = nil, *labels){|rep| ...} -> bool
+--- benchmark(caption = "", label_width = nil, fmtstr = nil, *labels){|rep| ...} -> [Benchmark::Tms]
 
 [[c:Benchmark::Report]] オブジェクトを生成し、それを引数として与えられたブロックを実行します。
 
@@ -154,9 +152,6 @@ Benchmark::Tms オブジェクトには to_s が定義されているので、
                    この引数を省略すると [[m:Benchmark::FMTSTR]] が使用されます。
 #@end
 @param labels  ブロックが [[c:Benchmark::Tms]] オブジェクトの配列を返す場合に指定します。
-
-@return STDIN.sync の値を返すだけなので返り値に意味はありません。
-
 
 === フォーマット文字列
 


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/4870feb31a6625dcbf8817ccf16294bb3f3737e1#diff-630499446570a9b1bd6b6efc1534eb42bf50e875f3dbe81282ee535433b4f158R178
の変更で ruby-1.9.3-preview1 から返り値が修正されているため。

(ruby-jp slack の `#performance` で指摘があって調べた結果の反映になります。)

他の `[Benchmark::Tms]` を返すメソッドでは `@return` の説明を書いていなかったので、単純に削っています。