### PR TITLE
Ruby 3.0 で open-uri の Kernel.#open への再定義が削除されたので対応した

### DIFF
--- a/refm/api/src/open-uri.rd
+++ b/refm/api/src/open-uri.rd
@@ -99,6 +99,7 @@ URI オブジェクトは直接読み込むことができます。
   str = uri.read
   p str.base_uri
 
+#@until 3.0.0
 = redefine Kernel
 
 == Module Functions
@@ -154,6 +155,8 @@ Ruby2.7以降、open-uriにより拡張されたKernel.openでURLを開くとき
   puts sio.read
 
 @see [[m:OpenURI.open_uri]], [[m:URI.open]]
+
+#@end
 
 = module OpenURI
 http/ftp に簡単にアクセスするためのモジュールです。
@@ -359,19 +362,32 @@ include OpenURI::OpenRead
 Last-Modified ヘッダがない場合は nil を返します。
 
 例:
-  require 'open-uri'
-  p open('http://www.rubyist.net/').last_modified
-  #=> Thu Feb 26 16:54:58 +0900 2004
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URI.open('http://www.rubyist.net/').last_modified
+#=> Thu Feb 26 16:54:58 +0900 2004
+#@else
+require 'open-uri'
+p open('http://www.rubyist.net/').last_modified
+#=> Thu Feb 26 16:54:58 +0900 2004
+#@end
+#@end
 
 --- content_type    -> String
 
 対象となるリソースの Content-Type を文字列の配列で返します。Content-Type ヘッダの情報が使われます。
 Content-Type ヘッダがない場合は、"application/octet-stream" を返します。
 
-例:
-
-  require 'open-uri'
-  p open('http://www.ruby-lang.org/').content_type  #=> "text/html"
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URI.open('http://www.ruby-lang.org/').content_type  #=> "text/html"
+#@else
+require 'open-uri'
+p open('http://www.ruby-lang.org/').content_type  #=> "text/html"
+#@end
+#@end
 
 --- charset       -> String | nil
 --- charset{ ... }  -> String
@@ -383,13 +399,21 @@ Content-Type ヘッダがない場合は、nil を返します。ただし、ブ
 その結果を返します。また対象となる URI のスキームが HTTP であり、自身のタイプが text である場合は、
 [[RFC:2616]] 3.7.1 で定められているとおり、文字列 "iso-8859-1" を返します。
 
-例:
-
-  require 'open-uri'
-  open("http://www.ruby-lang.org/en") {|f|
-    p f.content_type  # => "text/html"
-    p f.charset       # => "iso-8859-1"
-  }
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+URI.open("http://www.ruby-lang.org/en") {|f|
+  p f.content_type  # => "text/html"
+  p f.charset       # => "iso-8859-1"
+}
+#@else
+require 'open-uri'
+open("http://www.ruby-lang.org/en") {|f|
+  p f.content_type  # => "text/html"
+  p f.charset       # => "iso-8859-1"
+}
+#@end
+#@end
 
 --- content_encoding    -> [String]
 
@@ -398,40 +422,68 @@ Content-Encoding ヘッダがない場合は、空の配列を返します。
 
 例:
 
-  require 'open-uri'
-  p open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URI.open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
+#@else
+require 'open-uri'
+p open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
+#@end
+#@end
 
 --- status    -> [String]
 
 対象となるリソースのステータスコードと reason phrase を文字列の配列として返します。
 
-例:
-  require 'open-uri'
-  p open('http://example.com/').status  #=> ["200", "OK"]
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URI.open('http://example.com/').status  #=> ["200", "OK"]
+#@else
+require 'open-uri'
+p open('http://example.com/').status  #=> ["200", "OK"]
+#@end
+#@end
 
 --- base_uri    -> URI
 
 リソースの実際の URI を URI オブジェクトとして返します。
 リダイレクトされた場合は、リダイレクトされた後のデータが存在する URI を返します。
 
-例:
-
-  require 'open-uri'
-  p open('http://www.ruby-lang.org/').base_uri
-  #=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URL.open('http://www.ruby-lang.org/').base_uri
+#=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+#@else
+require 'open-uri'
+p open('http://www.ruby-lang.org/').base_uri
+#=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+#@end
+#@end
 
 --- meta    -> Hash
 
 ヘッダを収録したハッシュを返します。
 
-例:
-
-  require 'open-uri'
-  p open('http://example.com/').meta
-  #=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
-       "content-type"=>"text/html;charset=utf-8",
-       "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
-       "transfer-encoding"=>"chunked"}
+#@samplecode 例
+#@since 2.7.0
+require 'open-uri'
+p URL.open('http://example.com/').meta
+#=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
+#    "content-type"=>"text/html;charset=utf-8",
+#    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
+#    "transfer-encoding"=>"chunked"}
+#@else
+require 'open-uri'
+p open('http://example.com/').meta
+#=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
+#    "content-type"=>"text/html;charset=utf-8",
+#    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
+#    "transfer-encoding"=>"chunked"}
+#@end
+#@end
 
 = class OpenURI::HTTPError < StandardError
 

--- a/refm/api/src/open-uri.rd
+++ b/refm/api/src/open-uri.rd
@@ -126,7 +126,9 @@ name.open(*rest, &block) のように name の open メソッドが呼ばれま�
 Ruby2.7以降、open-uriにより拡張されたKernel.openでURLを開くときにwarningが表示されるようになりました。
 
   require 'open-uri'
-  open("http://www.ruby-lang.org/")
+  open("http://www.ruby-lang.org/") {|f|
+    # ...
+  }
   #=> warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
 #@end
 
@@ -149,10 +151,11 @@ Ruby2.7以降、open-uriにより拡張されたKernel.openでURLを開くとき
 例:
 
   require 'open-uri'
-  sio = open('http://www.example.com')
-  p sio.is_a?(OpenURI::Meta) # => true
-  p sio.content_type
-  puts sio.read
+  sio = open('http://www.example.com') { |sio|
+    p sio.is_a?(OpenURI::Meta) # => true
+    p sio.content_type
+    puts sio.read
+  }
 
 @see [[m:OpenURI.open_uri]], [[m:URI.open]]
 
@@ -365,12 +368,16 @@ Last-Modified ヘッダがない場合は nil を返します。
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URI.open('http://www.rubyist.net/').last_modified
-#=> Thu Feb 26 16:54:58 +0900 2004
+URI.open('http://www.rubyist.net/') {|f|
+  p f.last_modified
+  #=> Thu Feb 26 16:54:58 +0900 2004
+}
 #@else
 require 'open-uri'
-p open('http://www.rubyist.net/').last_modified
-#=> Thu Feb 26 16:54:58 +0900 2004
+open('http://www.rubyist.net/') {|f|
+  p f.last_modified
+  #=> Thu Feb 26 16:54:58 +0900 2004
+}
 #@end
 #@end
 
@@ -382,10 +389,14 @@ Content-Type ヘッダがない場合は、"application/octet-stream" を返し�
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URI.open('http://www.ruby-lang.org/').content_type  #=> "text/html"
+URI.open('http://www.ruby-lang.org/') {|f|
+  p f.content_type  #=> "text/html"
+}
 #@else
 require 'open-uri'
-p open('http://www.ruby-lang.org/').content_type  #=> "text/html"
+open('http://www.ruby-lang.org/') {|f|
+  p f.content_type  #=> "text/html"
+}
 #@end
 #@end
 
@@ -425,10 +436,14 @@ Content-Encoding ヘッダがない場合は、空の配列を返します。
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URI.open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
+URI.open('http://example.com/f.tar.gz') {|f|
+  p f.content_encoding  #=> ["x-gzip"]
+}
 #@else
 require 'open-uri'
-p open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
+open('http://example.com/f.tar.gz') {|f|
+  p f.content_encoding  #=> ["x-gzip"]
+}
 #@end
 #@end
 
@@ -439,10 +454,14 @@ p open('http://example.com/f.tar.gz').content_encoding  #=> ["x-gzip"]
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URI.open('http://example.com/').status  #=> ["200", "OK"]
+URI.open('http://example.com/') {|f|
+  p f.status  #=> ["200", "OK"]
+}
 #@else
 require 'open-uri'
-p open('http://example.com/').status  #=> ["200", "OK"]
+open('http://example.com/') {|f|
+  p f.status  #=> ["200", "OK"]
+}
 #@end
 #@end
 
@@ -454,12 +473,16 @@ p open('http://example.com/').status  #=> ["200", "OK"]
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URL.open('http://www.ruby-lang.org/').base_uri
-#=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+URL.open('http://www.ruby-lang.org/') {|f|
+  p f.base_uri
+  #=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+}
 #@else
 require 'open-uri'
-p open('http://www.ruby-lang.org/').base_uri
-#=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+open('http://www.ruby-lang.org/') {|f|
+  p f.base_uri
+  #=> #<URI::HTTP:0xb7043aa0 URL:http://www.ruby-lang.org/en/>
+}
 #@end
 #@end
 
@@ -470,18 +493,22 @@ p open('http://www.ruby-lang.org/').base_uri
 #@samplecode 例
 #@since 2.7.0
 require 'open-uri'
-p URL.open('http://example.com/').meta
-#=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
-#    "content-type"=>"text/html;charset=utf-8",
-#    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
-#    "transfer-encoding"=>"chunked"}
+URL.open('http://example.com/') {|f|
+  p f.meta
+  #=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
+  #    "content-type"=>"text/html;charset=utf-8",
+  #    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
+  #    "transfer-encoding"=>"chunked"}
+}
 #@else
 require 'open-uri'
-p open('http://example.com/').meta
-#=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
-#    "content-type"=>"text/html;charset=utf-8",
-#    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
-#    "transfer-encoding"=>"chunked"}
+open('http://example.com/') {|f|
+  p f.meta
+  #=> {"date"=>"Sun, 04 May 2008 11:26:40 GMT",
+  #    "content-type"=>"text/html;charset=utf-8",
+  #    "server"=>"Apache/2.0.54 (Debian GNU/Linux) mod_ssl/2.0.54 OpenSSL/0.9.7e",
+  #    "transfer-encoding"=>"chunked"}
+}
 #@end
 #@end
 


### PR DESCRIPTION
open-uri の Kernel.#open への再定義は Ruby 2.7 で警告が出るようになり、Ruby 3.0 で削除されました。
ドキュメントでも Ruby 2.7 以降では Kernel.#open ではなくて URI.open を参照するように変更しました。
また Ruby 3.0 以降では Kernel.#open への再定義のドキュメントも削除しました。

NOTE: `redefine Kernel` に対する動作確認が手元でできなかったのでそちらは未確認になります。それ以外は `bitclust htmlfile` で確認済みです。

#### 参照

* [[Misc #15893] open-uri: URI.open status](https://bugs.ruby-lang.org/issues/15893)
* https://github.com/rurema/doctree/issues/2458