### PR TITLE
Regexp literals and all Range objects are frozen since 3.0

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -106,6 +106,16 @@ range.first     # => 1
 range.first = 1 # => NoMethodError
 #@end
 
+#@since 3.0.0
+また、Ruby 3.0.0 からすべての Range オブジェクトは freeze されるようになりました。
+#@samplecode
+p (1..10).frozen?
+# => true
+p Range.new(1, 10).frozen?
+# => true
+#@end
+#@end
+
 == Class Methods
 
 --- new(first, last, exclude_end = false) -> Range

--- a/refm/api/src/_builtin/Regexp
+++ b/refm/api/src/_builtin/Regexp
@@ -13,6 +13,18 @@ Regexp.new(string) を使って正規表現オブジェクトを動的に生成�
   p rp1 =~ str           # => 0
   p Regexp.last_match[0] # => "this is regexp"
 
+#@since 3.0.0
+Ruby 3.0.0 から正規表現リテラルは freeze されるようになりました。
+#@samplecode
+p /abc/.frozen?
+# => true
+p /a#{42}bc/.frozen?
+# => true
+p Regexp.new('abc').frozen?
+# => false
+#@end
+#@end
+
 [[d:spec/regexp]] や [[ref:d:spec/literal#regexp]] も参照してください。
 
 == Class Methods


### PR DESCRIPTION
Ruby 3.0.0 から正規表現リテラルとすべてのRangeオブジェクトはfreezeされるようになりました。

[ruby/NEWS\.md at v3\_0\_0 · ruby/ruby](https://github.com/ruby/ruby/blob/v3_0_0/NEWS.md#compatibility-issues)

ref: #2458 