### PR TITLE
GC.auto_compact / GC.auto_compact= の説明を追加

### DIFF
--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -185,9 +185,10 @@ oldmalloc_increase_bytes と呼ばれる。この2つの性質は以下のよう
 #@since 3.0.0
 --- auto_compact -> bool
 
-[[m:GC.auto_compact=]] に設定されている値を返します。
+auto compaction が有効化どうかを返します。
 
-@return [[m:GC.auto_compact=]] に設定されている値を返します。
+@return auto compaction が有効な場合 true を返します。
+        そうでなければ false を返します。
 
 @see [[m:GC.auto_compact=]]
 

--- a/refm/api/src/_builtin/GC
+++ b/refm/api/src/_builtin/GC
@@ -182,6 +182,32 @@ oldmalloc_increase_bytes と呼ばれる。この2つの性質は以下のよう
 
 == Singleton Methods
 
+#@since 3.0.0
+--- auto_compact -> bool
+
+[[m:GC.auto_compact=]] に設定されている値を返します。
+
+@return [[m:GC.auto_compact=]] に設定されている値を返します。
+
+@see [[m:GC.auto_compact=]]
+
+--- auto_compact=(bool)
+
+[[m:GC.compact]] をフルGCで行うかどうかを制御します。
+
+true を設定するとフルGCのタイミングででヒープをコンパクションします。
+
+この機能を有効にするとフルGCのパフォーマンスが低下します。
+
+デフォルトは false です。
+
+詳細は[[feature:17176]]を参照してください。
+
+@param bool フルGCでコンパクションするかどうかを true か false で設定します。
+
+@see [[m:GC.compact]] [[m:GC.auto_compact]]
+#@end
+
 --- disable -> bool
 
 ガーベージコレクトを禁止します。


### PR DESCRIPTION
Ruby 3.0 で追加された `GC.auto_compact / GC.auto_compact=` の説明を追加しました

#### 参照

* [[Feature #17176] GC.auto_compact / GC.auto_compact=(flag)](https://bugs.ruby-lang.org/issues/17176)
* https://docs.ruby-lang.org/en/3.0.0/GC.html#method-c-auto_compact-3D
* https://github.com/rurema/doctree/issues/2458