### PR TITLE
Symbol#to_proc returns a lambda Proc since 3.0.0

### DIFF
--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -174,6 +174,13 @@ self に対応する Proc オブジェクトを返します。
 Proc#callの第一引数をレシーバとして、 self という名前のメソッドを
 残りの引数を渡して呼びだします。
 
+#@since 3.0.0
+生成される Proc オブジェクトは lambda です。
+#@samplecode
+:object_id.to_proc.lambda? # => true
+#@end
+#@end
+
 #@samplecode 明示的に呼ぶ例
 :to_i.to_proc["ff", 16]  # => 255 ← "ff".to_i(16)と同じ
 #@end


### PR DESCRIPTION
Symbol#to_proc で生成する Proc が lambda となるようになりました。

```
❯ RBENV_VERSION=2.7.2 irb
irb(main):001:0> :object_id.to_proc.lambda?
=> false

❯ RBENV_VERSION=3.0.0 irb
irb(main):001:0> :object_id.to_proc.lambda?
=> true
```

ref: https://bugs.ruby-lang.org/issues/16260
#2458 