### PR TITLE
Drop Hash#sort since Ruby 1.9

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -1365,6 +1365,7 @@ h.select {|k,v| v < 200}  #=> {"a" => 100}
     h = { "c" => 300, "a" => 100, "d" => 400, "c" => 300  }
     h.inspect   # => "{\"a\"=>100, \"c\"=>300, \"d\"=>400}"
 
+#@if (version < "1.9.0")
 --- sort              -> Array
 --- sort{|a, b| ... } -> Array
 
@@ -1376,6 +1377,7 @@ h.select {|k,v| v < 200}  #=> {"a" => 100}
   h.sort {|a,b| a[1]<=>b[1]}   #=> [["c", 10], ["a", 20], ["b", 30]]
 
 @see [[m:Array#sort]]
+#@end
 
 --- keep_if -> Enumerator
 --- keep_if {|key, value| ... } -> self

--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -1365,20 +1365,6 @@ h.select {|k,v| v < 200}  #=> {"a" => 100}
     h = { "c" => 300, "a" => 100, "d" => 400, "c" => 300  }
     h.inspect   # => "{\"a\"=>100, \"c\"=>300, \"d\"=>400}"
 
-#@if (version < "1.9.0")
---- sort              -> Array
---- sort{|a, b| ... } -> Array
-
-ハッシュを [key, value] を要素とする配列の配列に変換して，それをソー
-トした配列を返します。
-
-  h = { "a" => 20, "b" => 30, "c" => 10  }
-  h.sort                       #=> [["a", 20], ["b", 30], ["c", 10]]
-  h.sort {|a,b| a[1]<=>b[1]}   #=> [["c", 10], ["a", 20], ["b", 30]]
-
-@see [[m:Array#sort]]
-#@end
-
 --- keep_if -> Enumerator
 --- keep_if {|key, value| ... } -> self
 --- select! -> Enumerator


### PR DESCRIPTION
```console
$ ruby -v -e 'p({}.method(:sort).owner)'
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
Enumerable
```

```console
root@5766e318ff5a:/usr/src# ruby -v -e 'p({}.method(:sort).owner)'
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
Enumerable
```

https://github.com/ruby/ruby/blob/ruby_1_8_7/hash.c#L1268-L1290
https://github.com/ruby/ruby/blob/ruby_1_9_1/hash.c

今の https://github.com/ruby/ruby にあるブランチからちょっと追ってみた限りですが、 1.9 系から Hash#sort が落とされたのかな？ という感じに見えました。
https://github.com/ruby/ruby/commit/0bc84af1f97e2ecf9a32042b4ef974935c3bd9c1#diff-2894a90fd17590e4f7afd08dfd8505526d5283e09fea645cc7a7d4873936bdff この commit ですかね。

---

ちょっと大きくなりすぎちゃって邪魔かな？とも思うんですが、一応変更前後のスクリーンショットを貼っておきます。
自分が気をつけて確認した部分は、 

`Ruby 3.0 で Hash#sort の記述が 「Enumerableから継承しているメソッド」 の section に移った`

という点になります。

Before
---

from https://docs.ruby-lang.org/ja/3.0.0/class/Hash.html

![docs ruby-lang org_ja_3 0 0_class_Hash html](https://user-images.githubusercontent.com/1180335/111856991-ec145f80-8971-11eb-807d-aad2f93586d0.png)

After
---

from `bundle exec rake`

![_private_tmp_html_3 0_class_Hash html](https://user-images.githubusercontent.com/1180335/111856989-e61e7e80-8971-11eb-9f09-d3a05f2e0316.png)


