### PR TITLE
Fix typo in refm/api/src/_builtin/Hash

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -384,7 +384,7 @@ fetchはハッシュ自身にデフォルト値が設定されていても単に
   p h.fetch(:two,"error")                  #=> "error"
   p h.fetch(:two){|key|"#{key} not exist"} #=> "two not exist"
   p h.fetch(:two, "error"){|key|           #=> "two not exist"
-      "#{key} not exit"                    #  warning: block supersedes default value argument
+      "#{key} not exist"                   #  warning: block supersedes default value argument
     }                                      #  警告が表示される。
   
   h.default = "default"


### PR DESCRIPTION
コメントとして添えられている戻り値 `"two not exist"` に合わせる形での修正を提案します。