### PR TITLE
Ruby 2.7 で Time#inspect の出力が変わったので対応

### DIFF
--- a/refm/api/src/_builtin/Time
+++ b/refm/api/src/_builtin/Time
@@ -896,6 +896,25 @@ p t.strftime("%Y-%m-%d %H:%M:%S UTC")  # => "2000-01-01 18:04:05 UTC"
 
 戻り値の文字エンコーディングは [[m:Encoding::US_ASCII]] です。
 
+#@since 2.7.0
+--- inspect     -> String
+
+時刻を文字列に変換した結果を返します。
+
+[[m:Time#to_s]] とは異なりナノ秒まで含めて返します。
+
+#@samplecode
+t = Time.now
+t.inspect                             #=> "2012-11-10 18:16:12.261257655 +0100"
+t.strftime "%Y-%m-%d %H:%M:%S.%N %z"  #=> "2012-11-10 18:16:12.261257655 +0100"
+
+t.utc.inspect                          #=> "2012-11-10 17:16:12.261257655 UTC"
+t.strftime "%Y-%m-%d %H:%M:%S.%N UTC"  #=> "2012-11-10 17:16:12.261257655 UTC"
+#@end
+
+戻り値の文字エンコーディングは [[m:Encoding::US_ASCII]] です。
+#@end
+
 --- hash -> Integer
 
 self のハッシュ値を返します。


### PR DESCRIPTION
Ruby 2.7 から `Time#inspect` でナノ秒まで含めるようになったのでそのドキュメントを追加しました。

* 参照：https://github.com/rurema/doctree/issues/2071