### PR TITLE
Fix 404 link to ObjectSpace's methods

### DIFF
--- a/refm/api/src/objspace.rd
+++ b/refm/api/src/objspace.rd
@@ -179,7 +179,7 @@ obj が ObjectSpace::InternalObjectWrapper オブジェクトであった場合�
 
 オブジェクト割り当てのトレースを開始します。
 
-@see [[m:ObjectSpace#trace_object_allocations_stop]]
+@see [[m:ObjectSpace.#trace_object_allocations_stop]]
 
 --- trace_object_allocations_stop -> nil
 
@@ -187,7 +187,7 @@ obj が ObjectSpace::InternalObjectWrapper オブジェクトであった場合�
 
 トレースを終了する為には、[[m:ObjectSpace.#trace_object_allocations_start]]を呼んだ回数分だけこのメソッドを呼ぶ必要があります。
 
-@see [[m:ObjectSpace#trace_object_allocations_start]]
+@see [[m:ObjectSpace.#trace_object_allocations_start]]
 
 --- allocation_sourcefile(object) -> String
 
@@ -205,8 +205,8 @@ puts "file:#{ObjectSpace::allocation_sourcefile(obj)}"   # => file:test.rb
 ObjectSpace::trace_object_allocations_stop
 #@end
 
-@see [[m:ObjectSpace#trace_object_allocations_start]],
-     [[m:ObjectSpace#trace_object_allocations_stop]]
+@see [[m:ObjectSpace.#trace_object_allocations_start]],
+     [[m:ObjectSpace.#trace_object_allocations_stop]]
 
 --- allocation_sourceline(object) -> Integer
 
@@ -224,8 +224,8 @@ puts "line:#{ObjectSpace::allocation_sourceline(obj)}"  # => line:4
 ObjectSpace::trace_object_allocations_stop
 #@end
 
-@see [[m:ObjectSpace#trace_object_allocations_start]],
-     [[m:ObjectSpace#trace_object_allocations_stop]]
+@see [[m:ObjectSpace.#trace_object_allocations_start]],
+     [[m:ObjectSpace.#trace_object_allocations_stop]]
 
 --- trace_object_allocations { ... }
 

--- a/refm/doc/news/2_0_0.rd
+++ b/refm/doc/news/2_0_0.rd
@@ -270,7 +270,7 @@
     * 追加: [[m:Net::IMAP.default_imaps_port]]
 
   * [[lib:objspace]]
-    * 追加: [[m:ObjectSpace.reachable_objects_from]]
+    * 追加: [[m:ObjectSpace.#reachable_objects_from]]
 
   * [[lib:openssl]]
     * Consistently raise an error when trying to encode nil values. All instances

--- a/refm/doc/news/2_1_0.rd
+++ b/refm/doc/news/2_1_0.rd
@@ -182,18 +182,18 @@
     * 追加: [[m:Net::SMTP#rset]] RSET コマンドに対応している
 
   * [[lib:objspace]]
-    * 追加: [[m:ObjectSpace.trace_object_allocations]]
-    * 追加: [[m:ObjectSpace.trace_object_allocations_start]]
-    * 追加: [[m:ObjectSpace.trace_object_allocations_stop]]
-    * 追加: [[m:ObjectSpace.trace_object_allocations_clear]]
-    * 追加: [[m:ObjectSpace.allocation_sourcefile]]
-    * 追加: [[m:ObjectSpace.allocation_sourceline]]
-    * 追加: [[m:ObjectSpace.allocation_class_path]]
-    * 追加: [[m:ObjectSpace.allocation_method_id]]
-    * 追加: [[m:ObjectSpace.allocation_generation]]
-    * 追加: [[m:ObjectSpace.reachable_objects_from_root]]
-    * 追加: [[m:ObjectSpace.dump]]
-    * 追加: [[m:ObjectSpace.dump_all]]
+    * 追加: [[m:ObjectSpace.#trace_object_allocations]]
+    * 追加: [[m:ObjectSpace.#trace_object_allocations_start]]
+    * 追加: [[m:ObjectSpace.#trace_object_allocations_stop]]
+    * 追加: [[m:ObjectSpace.#trace_object_allocations_clear]]
+    * 追加: [[m:ObjectSpace.#allocation_sourcefile]]
+    * 追加: [[m:ObjectSpace.#allocation_sourceline]]
+    * 追加: [[m:ObjectSpace.#allocation_class_path]]
+    * 追加: [[m:ObjectSpace.#allocation_method_id]]
+    * 追加: [[m:ObjectSpace.#allocation_generation]]
+    * 追加: [[m:ObjectSpace.#reachable_objects_from_root]]
+    * 追加: [[m:ObjectSpace.#dump]]
+    * 追加: [[m:ObjectSpace.#dump_all]]
 
   * OpenSSL::BN
     * 拡張: [[m:OpenSSL::BN.new]] Fixnum や Bignum を引数として取れるようになりました。

--- a/refm/doc/news/2_3_0.rd
+++ b/refm/doc/news/2_3_0.rd
@@ -221,10 +221,10 @@
     * nkf 2.1.4 をマージしました。
 
   * [[c:ObjectSpace]] ([[lib:objspace]])
-    * [[m:ObjectSpace.count_symbols]] を追加。
-    * [[m:ObjectSpace.count_imemo_objects]] を追加。
-    * [[m:ObjectSpace.internal_class_of]] を追加。
-    * [[m:ObjectSpace.internal_super_of]] を追加。
+    * [[m:ObjectSpace.#count_symbols]] を追加。
+    * [[m:ObjectSpace.#count_imemo_objects]] を追加。
+    * [[m:ObjectSpace.#internal_class_of]] を追加。
+    * [[m:ObjectSpace.#internal_super_of]] を追加。
 
   * [[c:OpenSSL]]
     * [[m:OpenSSL::SSL::SSLSocket#accept_nonblock]] と


### PR DESCRIPTION
ObjectSpaceのメソッドへのリンクがリンク切れになっていたのを修正します。


ObjectSpaceのメソッドはすべてモジュール関数ですが、リンクの記法がクラスメソッドやインスタンスメソッドになっていたため、リンク切れになっていました。

修正対象は、`git grep -F 'm:ObjectSpace'` して探しました。これに引っかかるリンクはすべて修正済みです :heavy_check_mark: 


なお、NEWSに書かれている一部のメソッド(`ObjectSpace.count_symbols`など)はそもそもドキュメントが書かれていないので、このPRで修正しても依然として404のままです。これは別のPRでドキュメントを追加すると良さそうです。

Thanks! @mame 