### PR TITLE
Drop a C-API `rb_compile_bug`

### DIFF
--- a/refm/capi/src/error.c.rd
+++ b/refm/capi/src/error.c.rd
@@ -17,8 +17,3 @@ fmt とその後の引数は printf と同じ形式でエラーメッセージ�
 
 この関数は Ruby 2.3.0 から deprecated です。公開関数ですが内部利用のみを想
 定しています。外部のライブラリで使用すべきではありません。
-
---- void rb_compile_bug(const char *file, int line, const char *fmt, ...)
-
-この関数は Ruby 2.3.0 から deprecated です。公開関数ですが内部利用のみを想
-定しています。外部のライブラリで使用すべきではありません。


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/912948c7f5cd91e93b9ae17d72e213f4ebd22bd1 で削除されたみたいです。

<img width="1253" alt="スクリーンショット 2021-03-28 1 12 21" src="https://user-images.githubusercontent.com/1180335/112726816-aacc1300-8f62-11eb-8353-57d9935b92da.png">

を見る限り、既に EOL の 2.4 でもこの commit が入っていそうなので

https://github.com/rurema/doctree/blob/42497176d7ec17640cbb2c470b8c63348e7c2ff7/CONTRIBUTING.md#%E5%90%84%E3%83%90%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%81%AE%E5%AF%BE%E5%BF%9C%E6%96%B9%E9%87%9D

>それ以前: 対応しない(outdatedな記述は消してもよい)
例: 2.1がEOLになったとき、2.0.x で追加されたけど、2.1.x 以降で消えた機能については消してもよい。

これに当たるのかな？と思って削ってみました。

<img width="596" alt="スクリーンショット 2021-03-28 1 08 49" src="https://user-images.githubusercontent.com/1180335/112726785-94be5280-8f62-11eb-99f9-f06bb066b5f7.png">
<img width="498" alt="スクリーンショット 2021-03-28 1 09 00" src="https://user-images.githubusercontent.com/1180335/112726789-9720ac80-8f62-11eb-86d9-8496445f4cdc.png">
<img width="662" alt="スクリーンショット 2021-03-28 1 09 08" src="https://user-images.githubusercontent.com/1180335/112726791-97b94300-8f62-11eb-8847-c0566fa8c627.png">
<img width="807" alt="スクリーンショット 2021-03-28 1 09 16" src="https://user-images.githubusercontent.com/1180335/112726793-9851d980-8f62-11eb-9bd2-20ee72f5206d.png">

