### PR TITLE
Improve an example of Array#count comparison

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -802,7 +802,7 @@ a.concat(a, a)                    #=> [1, 2, 1, 2, 1, 2]
 @param item カウント対象となる値。
 
 #@samplecode 例
-ary = [1, 2, 4, 2]
+ary = [1, 2, 4, 2.0]
 ary.count             # => 4
 ary.count(2)          # => 2
 ary.count{|x|x%2==0}  # => 3


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/f46bbb2e99b8c1df6a62756967b40de36039916b
と同様に Float が混ざった例に変更