### PR TITLE
StringScanner のサンプルコードにハイライトを追加

### DIFF
--- a/refm/api/src/strscan.rd
+++ b/refm/api/src/strscan.rd
@@ -7,89 +7,93 @@ strscan は 文字列を高速にスキャンするためのライブラリで�
 StringScanner は文字列スキャナクラスです。
 簡単に高速なスキャナを記述できます。
 
-    require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-    s = StringScanner.new('This is an example string')
-    s.eos?            #=> false
+s = StringScanner.new('This is an example string')
+s.eos?            #=> false
 
-    p s.scan(/\w+/)   #=> "This"
-    p s.scan(/\w+/)   #=> nil
-    p s.scan(/\s+/)   #=> " "
-    p s.scan(/\s+/)   #=> nil
-    p s.scan(/\w+/)   #=> "is"
-    s.eos?            #=> false
+p s.scan(/\w+/)   #=> "This"
+p s.scan(/\w+/)   #=> nil
+p s.scan(/\s+/)   #=> " "
+p s.scan(/\s+/)   #=> nil
+p s.scan(/\w+/)   #=> "is"
+s.eos?            #=> false
 
-    p s.scan(/\s+/)   #=> " "
-    p s.scan(/\w+/)   #=> "an"
-    p s.scan(/\s+/)   #=> " "
-    p s.scan(/\w+/)   #=> "example"
-    p s.scan(/\s+/)   #=> " "
-    p s.scan(/\w+/)   #=> "string"
-    s.eos?            #=> true
+p s.scan(/\s+/)   #=> " "
+p s.scan(/\w+/)   #=> "an"
+p s.scan(/\s+/)   #=> " "
+p s.scan(/\w+/)   #=> "example"
+p s.scan(/\s+/)   #=> " "
+p s.scan(/\w+/)   #=> "string"
+s.eos?            #=> true
 
-    p s.scan(/\s+/)   #=> nil
-    p s.scan(/\w+/)   #=> nil
+p s.scan(/\s+/)   #=> nil
+p s.scan(/\w+/)   #=> nil
+#@end
 
 StringScanner オブジェクトはスキャンする文字列と「スキャンポインタ」のセットです。
 スキャンポインタとはスキャンしおわったところを示すインデックスのことです。
 オブジェクト作成直後にはスキャンポインタは文字列先頭にあり、
 その地点でのみマッチを試します。マッチしたらその後ろにポインタを進めます。
 
-    require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-    ## a string and a scan pointer   ("_" = scan pointer)
+## a string and a scan pointer   ("_" = scan pointer)
 
-    s = StringScanner.new('This is an example string')
-    _This is an example string     s.eos? = false
-    s.scan(/\w+/)
-    This_ is an example string     s.eos? = false
-    s.scan(/\s+/)
-    This _is an example string     s.eos? = false
-    s.scan(/\w+/)
-    This is_ an example string     s.eos? = false
-    s.scan(/\s+/)
-    This is _an example string     s.eos? = false
-    s.scan(/\w+/)
-    This is an_ example string     s.eos? = false
-    s.scan(/\s+/)
-    This is an _example string     s.eos? = false
-    s.scan(/\w+/)
-    This is an example_ string     s.eos? = false
-    s.scan(/\s+/)
-    This is an example _string     s.eos? = false
-    s.scan(/\w+/)
-    This is an example string_     s.eos? = true
+s = StringScanner.new('This is an example string')
+# _This is an example string     s.eos? = false
+s.scan(/\w+/)
+# This_ is an example string     s.eos? = false
+s.scan(/\s+/)
+# This _is an example string     s.eos? = false
+s.scan(/\w+/)
+# This is_ an example string     s.eos? = false
+s.scan(/\s+/)
+# This is _an example string     s.eos? = false
+s.scan(/\w+/)
+# This is an_ example string     s.eos? = false
+s.scan(/\s+/)
+# This is an _example string     s.eos? = false
+s.scan(/\w+/)
+# This is an example_ string     s.eos? = false
+s.scan(/\s+/)
+# This is an example _string     s.eos? = false
+s.scan(/\w+/)
+# This is an example string_     s.eos? = true
+#@end
 
 
 現在のスキャンポインタがさす地点以外でもマッチしたい場合は、[[m:StringScanner#scan_until]]など
 を使ってください。
 
-例: scan, scan_until の動作の違い
+#@samplecode 例: scan, scan_until の動作の違い
+require 'strscan'
 
-  require 'strscan'
+def case1
+  s = StringScanner.new('test string')
+  p s.scan(/t/)       #=> "t"
+  p s.scan(/\w+/)     #=> "est"
+  p s.scan(/string/)  #=> nil
+  p s.scan(/\s+/)     #=> " "
+  p s.scan(/string/)  #=> "string"
+end
 
-  def case1
-    s = StringScanner.new('test string')
-    p s.scan(/t/)       #=> "t"
-    p s.scan(/\w+/)     #=> "est"
-    p s.scan(/string/)  #=> nil
-    p s.scan(/\s+/)     #=> " "
-    p s.scan(/string/)  #=> "string"
-  end
-  
-  def case2
-    s = StringScanner.new('test string')
-    p s.scan_until(/t/)       #=> "t"
-    p s.scan_until(/\w+/)     #=> "est"
-    p s.scan_until(/string/)  #=> " string"
-    p s.scan_until(/\s+/)     #=> nil
-    p s.scan_until(/string/)  #=> nil
-  end
-  
-  p "case1"
-  case1
-  p "case2"
-  case2
+def case2
+  s = StringScanner.new('test string')
+  p s.scan_until(/t/)       #=> "t"
+  p s.scan_until(/\w+/)     #=> "est"
+  p s.scan_until(/string/)  #=> " string"
+  p s.scan_until(/\s+/)     #=> nil
+  p s.scan_until(/string/)  #=> nil
+end
+
+p "case1"
+case1
+p "case2"
+case2
+#@end
 
 スキャンポインタの位置は文字単位でなくバイト単位となります。
 
@@ -119,15 +123,16 @@ StringScanner は $~ $& $1 $2 …… などの正規表現関連変数を
            引数の文字列は複製も freeze もされず、そのまま使います。
 #@end
 
-使用例
-    require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-    s = StringScanner.new('This is an example string')
-    s.eos?            #=> false
+s = StringScanner.new('This is an example string')
+s.eos?            #=> false
 
-    p s.scan(/\w+/)   #=> "This"
-    p s.scan(/\w+/)   #=> nil
-    p s.scan(/\s+/)   #=> " "
+p s.scan(/\w+/)   #=> "This"
+p s.scan(/\w+/)   #=> nil
+p s.scan(/\s+/)   #=> " "
+#@end
 
 ---  must_C_version -> self
 このメソッドは後方互換性のために定義されています。
@@ -144,25 +149,27 @@ StringScanner は $~ $& $1 $2 …… などの正規表現関連変数を
            返します。
 
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan(/\w(\w)(\w*)/) # => "test"
-      s[0]                  # => "test"
-      s[1]                  # => "e"
-      s[2]                  # => "st"
-      s.scan(/\w+/)         # => nil
-      s[0]                  # => nil
-      s[1]                  # => nil
-      s[2]                  # => nil
-      s.scan(/\s+/)         # => " "
-      s[0]                  # => " "
-      s[1]                  # => nil
-      s[2]                  # => nil
-      s.scan(/\w(\w)(\w*)/) # => "string"
-      s[0]                  # => "string"
-      s[1]                  # => "t"
-      s[2]                  # => "ring"
+s = StringScanner.new('test string')
+s.scan(/\w(\w)(\w*)/) # => "test"
+s[0]                  # => "test"
+s[1]                  # => "e"
+s[2]                  # => "st"
+s.scan(/\w+/)         # => nil
+s[0]                  # => nil
+s[1]                  # => nil
+s[2]                  # => nil
+s.scan(/\s+/)         # => " "
+s[0]                  # => " "
+s[1]                  # => nil
+s[2]                  # => nil
+s.scan(/\w(\w)(\w*)/) # => "string"
+s[0]                  # => "string"
+s[1]                  # => "t"
+s[2]                  # => "ring"
+#@end
 
 #@if (version >= "1.8.1")
 --- <<(str) -> self
@@ -175,27 +182,30 @@ selfを返します。
 
 @param str 操作対象の文字列に対し str を破壊的に連結します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test') # => #<StringScanner 0/4 @ "test">
-      s.match(/\w(\w*)/)            # => "test"
-      s[0]                          # => "test"
-      s[1]                          # => "est"
-      s << ' string'                # => #<StringScanner 4/11 "test" @ " stri...">
-      s[0]                          # => "test"
-      s[1]                          # => "est"
-      s.match(/\s+/)                # => " "
-      s.match(/\w+/)                # => "string"
+s = StringScanner.new('test') # => #<StringScanner 0/4 @ "test">
+s.match(/\w(\w*)/)            # => "test"
+s[0]                          # => "test"
+s[1]                          # => "est"
+s << ' string'                # => #<StringScanner 4/11 "test" @ " stri...">
+s[0]                          # => "test"
+s[1]                          # => "est"
+s.match(/\s+/)                # => " "
+s.match(/\w+/)                # => "string"
+#@end
 
 この操作は StringScanner.new に渡した文字列にも影響することがあります。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      str = 'test'
-      s = StringScanner.new(str) # => #<StringScanner 0/4 @ "test">
-      s << ' string'             # => #<StringScanner 0/11 @ "test ...">
-      str                        # => "test string"
+str = 'test'
+s = StringScanner.new(str) # => #<StringScanner 0/4 @ "test">
+s << ' string'             # => #<StringScanner 0/11 @ "test ...">
+str                        # => "test string"
+#@end
 #@end
 
 #@if (version >= "1.8.1")
@@ -207,17 +217,18 @@ selfを返します。
 行頭の定義は、文字列先頭かまたは \n の直後を指していることです。
 文字列末尾は必ずしも行頭ではありません。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new("test\nstring")
-      s.bol?        # => true
-      s.scan(/\w+/)
-      s.bol?        # => false
-      s.scan(/\n/)
-      s.bol?        # => true
-      s.scan(/\w+/)
-      s.bol?        # => false
+s = StringScanner.new("test\nstring")
+s.bol?        # => true
+s.scan(/\w+/)
+s.bol?        # => false
+s.scan(/\n/)
+s.bol?        # => true
+s.scan(/\w+/)
+s.bol?        # => false
+#@end
 #@end
 
 --- check(regexp) -> String | nil
@@ -229,15 +240,16 @@ selfを返します。
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.check(/\w+/) # => "test"
-      s.pos          # => 0
-      s.matched      # => "test"
-      s.check(/\s+/) # => nil
-      s.matched      # => nil
+s = StringScanner.new('test string')
+s.check(/\w+/) # => "test"
+s.pos          # => 0
+s.matched      # => "test"
+s.check(/\s+/) # => nil
+s.matched      # => nil
+#@end
 
 --- check_until(regexp) -> String | nil
 regexp が一致するまで文字列をスキャンします。
@@ -248,29 +260,31 @@ regexp が一致するまで文字列をスキャンします。
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.check_until(/str/) # => "test str"
-      s.matched            # => "str"
-      s.pos                # => 0
-      s.pre_match          # => "test "
+s = StringScanner.new('test string')
+s.check_until(/str/) # => "test str"
+s.matched            # => "str"
+s.pos                # => 0
+s.pre_match          # => "test "
+#@end
 
 --- eos? -> bool
 --- empty? -> bool
 スキャンポインタが文字列の末尾を指しているなら true を、
 末尾以外を指しているなら false を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.eos?        # => false
-      s.scan(/\w+/)
-      s.scan(/\s+/)
-      s.scan(/\w+/)
-      s.eos?        # => true
+s = StringScanner.new('test string')
+s.eos?        # => false
+s.scan(/\w+/)
+s.scan(/\s+/)
+s.scan(/\w+/)
+s.eos?        # => true
+#@end
 
 [[m:StringScanner#empty?]] は将来のバージョンで削除される予定です。
 代わりに [[m:StringScanner#eos?]] を使ってください。
@@ -289,15 +303,16 @@ regexp が一致するまで文字列をスキャンします。
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.exist?(/s/) # => 3
-      s.exist?(//)  # => 0
-      s.scan(/\w+/) # => "test"
-      s.exist?(/s/) # => 2
-      s.exist?(/e/) # => nil
+s = StringScanner.new('test string')
+s.exist?(/s/) # => 3
+s.exist?(//)  # => 0
+s.scan(/\w+/) # => "test"
+s.exist?(/s/) # => 2
+s.exist?(/e/) # => nil
+#@end
 #@end
 
 --- getch -> String | nil
@@ -308,30 +323,32 @@ regexp が一致するまで文字列をスキャンします。
 #@since 1.9.1
 一文字の定義は、与えた文字列のエンコードに依存します。
 
-使用例
-  require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-  utf8 = "\u{308B 3073 3044}"
-  s = StringScanner.new(utf8.encode("UTF-8")) 
-  p s.getch                         # => "る"
-  p s.getch                         # => "び"
-  p s.getch                         # => "い"
-  p s.getch                         # => nil
+utf8 = "\u{308B 3073 3044}"
+s = StringScanner.new(utf8.encode("UTF-8")) 
+p s.getch                         # => "る"
+p s.getch                         # => "び"
+p s.getch                         # => "い"
+p s.getch                         # => nil
+#@end
 
 #@else
 一文字の定義は $KCODE に依存します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
-      $KCODE = 'n'                    # 単なるバイト列として認識されます
-      s.getch                         # => "\244"
-      s.getch                         # => "\353"
-      $KCODE = "e"                    # EUC-JPの文字列として認識されます
-      s.getch                         # => "び"
-      s.getch                         # => "い"
-      s.getch                         # => nil
+s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
+$KCODE = 'n'                    # 単なるバイト列として認識されます
+s.getch                         # => "\244"
+s.getch                         # => "\353"
+$KCODE = "e"                    # EUC-JPの文字列として認識されます
+s.getch                         # => "び"
+s.getch                         # => "い"
+s.getch                         # => nil
+#@end
 #@end
 
 
@@ -346,18 +363,19 @@ regexp が一致するまで文字列をスキャンします。
 [[m:StringScanner#getbyte]] は将来のバージョンで削除される予定です。
 代わりに [[m:StringScanner#get_byte]] を使ってください。
 
-使用例
-  require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-  utf8 = "\u{308B 3073 3044}"
-  s = StringScanner.new(utf8.encode("EUC-JP"))
-  p s.get_byte       #=> "\xA4"
-  p s.get_byte       #=> "\xEB"
-  p s.get_byte       #=> "\xA4"
-  p s.get_byte       #=> "\xD3"
-  p s.get_byte       #=> "\xA4"
-  p s.get_byte       #=> "\xA4"
-  p s.get_byte       #=> nil   
+utf8 = "\u{308B 3073 3044}"
+s = StringScanner.new(utf8.encode("EUC-JP"))
+p s.get_byte       #=> "\xA4"
+p s.get_byte       #=> "\xEB"
+p s.get_byte       #=> "\xA4"
+p s.get_byte       #=> "\xD3"
+p s.get_byte       #=> "\xA4"
+p s.get_byte       #=> "\xA4"
+p s.get_byte       #=> nil   
+#@end
 
 #@else
 $KCODE に関らず 1 バイトスキャンして文字列で返します。
@@ -367,19 +385,20 @@ $KCODE に関らず 1 バイトスキャンして文字列で返します。
 [[m:StringScanner#getbyte]] は将来のバージョンで削除される予定です。
 代わりに [[m:StringScanner#get_byte]] を使ってください。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
-      $KCODE = 'n'                    # 単なるバイト列として認識されます
-      s.get_byte                      # => "\244"
-      s.get_byte                      # => "\353"
-      $KCODE = 'e'                    # やはり単なるバイト列として認識されます
-      s.get_byte                      # => "\244"
-      s.get_byte                      # => "\323"
-      s.get_byte                      # => "\244"
-      s.get_byte                      # => "\244"
-      s.get_byte                      # => nil
+s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
+$KCODE = 'n'                    # 単なるバイト列として認識されます
+s.get_byte                      # => "\244"
+s.get_byte                      # => "\353"
+$KCODE = 'e'                    # やはり単なるバイト列として認識されます
+s.get_byte                      # => "\244"
+s.get_byte                      # => "\323"
+s.get_byte                      # => "\244"
+s.get_byte                      # => "\244"
+s.get_byte                      # => nil
+#@end
 
 #@end
 
@@ -393,17 +412,18 @@ StringScannerオブジェクトを表す文字列を返します。
     * スキャン対象の文字列の長さ。
     * スキャンポインタの前後にある文字。上記実行例の @ がスキャンポインタを表します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.inspect                            # => "#<StringScanner 0/11 @ \"test ...\">"
-      s.scan(/\w+/)                        # => "test"
-      s.inspect                            # => "#<StringScanner 4/11 \"test\" @ \" stri...\">"
-      s.scan(/\s+/)                        # => " "
-      s.inspect                            # => "#<StringScanner 5/11 \"test \" @ \"strin...\">"
-      s.scan(/\w+/)                        # => "string"
-      s.inspect                            # => "#<StringScanner fin>"
+s = StringScanner.new('test string')
+s.inspect                            # => "#<StringScanner 0/11 @ \"test ...\">"
+s.scan(/\w+/)                        # => "test"
+s.inspect                            # => "#<StringScanner 4/11 \"test\" @ \" stri...\">"
+s.scan(/\s+/)                        # => " "
+s.inspect                            # => "#<StringScanner 5/11 \"test \" @ \"strin...\">"
+s.scan(/\w+/)                        # => "string"
+s.inspect                            # => "#<StringScanner fin>"
+#@end
 
 
 --- match?(regexp) -> Integer | nil
@@ -414,65 +434,70 @@ StringScannerオブジェクトを表す文字列を返します。
 
 マッチしたサイズは文字単位でなくバイト単位となります。
 
+#@samplecode
 #@since 1.9.1
-  require 'strscan'
-  def case1(encode)
-    utf8 = "\u{308B 3073 3044}"
-    s = StringScanner.new(utf8.encode(encode))
-    s.match?(/#{"\u{308B}".encode(encode)}/)
-  end
+require 'strscan'
+def case1(encode)
+  utf8 = "\u{308B 3073 3044}"
+  s = StringScanner.new(utf8.encode(encode))
+  s.match?(/#{"\u{308B}".encode(encode)}/)
+end
 
-  p case1("EUC-JP")     #=> 2
+p case1("EUC-JP")     #=> 2
 #@else
 
-  require 'strscan'
-  s = StringScanner.new("るびい") # 文字コードはUTF-8とします
-  puts s.string      #=> るびい
-  puts s.match?(/る/)  #=> 3
+require 'strscan'
+s = StringScanner.new("るびい") # 文字コードはUTF-8とします
+puts s.string      #=> るびい
+puts s.match?(/る/)  #=> 3
 
+#@end
 #@end
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-        require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-        s = StringScanner.new('test string')
-        p s.match?(/\w+/)   #=> 4
-        p s.match?(/\w+/)   #=> 4
-        p s.match?(/\s+/)   #=> nil
+s = StringScanner.new('test string')
+p s.match?(/\w+/)   #=> 4
+p s.match?(/\w+/)   #=> 4
+p s.match?(/\s+/)   #=> nil
+#@end
 
 --- matched -> String | nil
 前回マッチした部分文字列を返します。
 前回のマッチに失敗していると nil を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.matched     # => nil
-      s.scan(/\w+/) # => "test"
-      s.matched     # => "test"
-      s.scan(/\w+/) # => nil
-      s.matched     # => nil
-      s.scan(/\s+/) # => " "
-      s.matched     # => " "
+s = StringScanner.new('test string')
+s.matched     # => nil
+s.scan(/\w+/) # => "test"
+s.matched     # => "test"
+s.scan(/\w+/) # => nil
+s.matched     # => nil
+s.scan(/\s+/) # => " "
+s.matched     # => " "
+#@end
 
 --- matched? -> bool
 前回のマッチが成功していたら true を、
 失敗していたら false を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.matched?    # => false
-      s.scan(/\w+/) # => "test"
-      s.matched?    # => true
-      s.scan(/\w+/) # => nil
-      s.matched?    # => false
-      s.scan(/\s+/) # => " "
-      s.matched?    # => true
+s = StringScanner.new('test string')
+s.matched?    # => false
+s.scan(/\w+/) # => "test"
+s.matched?    # => true
+s.scan(/\w+/) # => nil
+s.matched?    # => false
+s.scan(/\s+/) # => " "
+s.matched?    # => true
+#@end
 
 --- matched_size -> Integer | nil
 前回マッチした部分文字列の長さを返します。
@@ -480,50 +505,54 @@ StringScannerオブジェクトを表す文字列を返します。
 
 マッチしたサイズは文字単位でなくバイト単位となります。
 
+#@samplecode
 #@since 1.9.1
-  require 'strscan'
+require 'strscan'
 
-  def run(encode)
-    utf8 = "\u{308B 3073 3044}" # るびい
-    s = StringScanner.new(utf8.encode(encode))
-    s.scan(/#{"\u{308B}".encode(encode)}/)
-    s.matched_size
-  end
+def run(encode)
+  utf8 = "\u{308B 3073 3044}" # るびい
+  s = StringScanner.new(utf8.encode(encode))
+  s.scan(/#{"\u{308B}".encode(encode)}/)
+  s.matched_size
+end
 
-  p run("UTF-8")     #=> 3
-  p run("EUC-JP")    #=> 2
-  p run("Shift_Jis") #=> 2
+p run("UTF-8")     #=> 3
+p run("EUC-JP")    #=> 2
+p run("Shift_Jis") #=> 2
 
 #@else
 
- require 'strscan'
+require 'strscan'
 
- s = StringScanner.new("るびい") # 文字コードはUTF-8とします
- puts s.string       #=> るびい
- puts s.scan(/る/)   #=> る
- p s.matched_size    #=> 3
+s = StringScanner.new("るびい") # 文字コードはUTF-8とします
+puts s.string       #=> るびい
+puts s.scan(/る/)   #=> る
+p s.matched_size    #=> 3
 
 #@end
+#@end
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.matched_size # => nil
-      s.scan(/\w+/)  # => "test"
-      s.matched_size # => 4
-      s.scan(/\w+/)  # => nil
-      s.matched_size # => nil
+s = StringScanner.new('test string')
+s.matched_size # => nil
+s.scan(/\w+/)  # => "test"
+s.matched_size # => 4
+s.scan(/\w+/)  # => nil
+s.matched_size # => nil
+#@end
 
 
 --- peek(bytes) -> String
 --- peep(bytes) -> String
 スキャンポインタから長さ bytes バイト分だけ文字列を返します。
 
-動作例:
-      require 'strscan'
-      s = StringScanner.new('test string')
-      s.peek(4)   # => "test"
+#@samplecode 例
+require 'strscan'
+s = StringScanner.new('test string')
+s.peek(4)   # => "test"
+#@end
 
 また、このメソッドを実行してもスキャンポインタは移動しません。
 
@@ -537,47 +566,49 @@ StringScannerオブジェクトを表す文字列を返します。
 
 @raise ArgumentError bytes に負数を与えると発生します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      p s.peek(4)     # => "test"
-      p s.peek(20)    # => "test string"
-      p s.peek(0)     # => ""
-      begin
-        s.peek(-1)   
-      rescue ArgumentError => err
-        puts err # negative string size (or size too big)
-      end
-      p s.scan(/\w+/) # => "test"
-      p s.scan(/\s+/) # => " "
-      p s.scan(/\w+/) # => "string"
-      p s.peek(4)     # => ""
+s = StringScanner.new('test string')
+p s.peek(4)     # => "test"
+p s.peek(20)    # => "test string"
+p s.peek(0)     # => ""
+begin
+s.peek(-1)   
+rescue ArgumentError => err
+puts err # negative string size (or size too big)
+end
+p s.scan(/\w+/) # => "test"
+p s.scan(/\s+/) # => " "
+p s.scan(/\w+/) # => "string"
+p s.peek(4)     # => ""
 
-      # このメソッドを実行してもスキャンポインタは移動しません。
+# このメソッドを実行してもスキャンポインタは移動しません。
 
-      s = StringScanner.new('test string')
-      p s.peek(4)     # => "test"
-      p s.peek(4)     # => "test"
-      p s.scan(/\w+/) # => "test"
-      p s.peek(4)     # => " str"
-      p s.peek(4)     # => " str"
+s = StringScanner.new('test string')
+p s.peek(4)     # => "test"
+p s.peek(4)     # => "test"
+p s.scan(/\w+/) # => "test"
+p s.peek(4)     # => " str"
+p s.peek(4)     # => " str"
+#@end
 
 --- pointer -> Integer
 --- pos -> Integer
 現在のスキャンポインタのインデックスを返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.pos         # => 0
-      s.scan(/\w+/) # => "test"
-      s.pos         # => 4
-      s.scan(/\w+/) # => nil
-      s.pos         # => 4
-      s.scan(/\s+/) # => " "
-      s.pos         # => 5
+s = StringScanner.new('test string')
+s.pos         # => 0
+s.scan(/\w+/) # => "test"
+s.pos         # => 4
+s.scan(/\w+/) # => nil
+s.pos         # => 4
+s.scan(/\s+/) # => " "
+s.pos         # => 5
+#@end
 
 #@since 2.0.0
 @see [[m:StringScanner#charpos]]
@@ -586,15 +617,15 @@ StringScannerオブジェクトを表す文字列を返します。
 
 現在のスキャンポインタのインデックスを文字単位で返します。
 
-使用例
+#@samplecode 例
+require 'strscan'
 
-  require 'strscan'
-
-  s = StringScanner.new("abcädeföghi")
-  s.charpos           # => 0
-  s.scan_until(/ä/)   # => "abcä"
-  s.pos               # => 5
-  s.charpos           # => 4
+s = StringScanner.new("abcädeföghi")
+s.charpos           # => 0
+s.scan_until(/ä/)   # => "abcä"
+s.pos               # => 5
+s.charpos           # => 4
+#@end
 
 @see [[m:StringScanner#pos]]
 #@end
@@ -609,23 +640,24 @@ StringScannerオブジェクトを表す文字列を返します。
 
 @return n を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      p s.scan(/\w+/) # => "test"
-      p s.pos = 1     # => 1
-      p s.scan(/\w+/) # => "est"
-      p s.pos = 7     # => 7
-      p s.scan(/\w+/) # => "ring"
+s = StringScanner.new('test string')
+p s.scan(/\w+/) # => "test"
+p s.pos = 1     # => 1
+p s.scan(/\w+/) # => "est"
+p s.pos = 7     # => 7
+p s.scan(/\w+/) # => "ring"
 
-      begin
-        s.pos = 20    
-      rescue RangeError => err
-        puts err #=> index out of range
-      end
-      p s.pos = -4    # => -4
-      p s.scan(/\w+/) # => "ring"
+begin
+s.pos = 20    
+rescue RangeError => err
+puts err #=> index out of range
+end
+p s.pos = -4    # => -4
+p s.scan(/\w+/) # => "ring"
+#@end
 
 #@if (version <= "1.8.0")
 このメソッドはマッチ記録を捨てます。
@@ -636,40 +668,44 @@ StringScannerオブジェクトを表す文字列を返します。
 部分文字列を返します。前回のマッチが失敗していると常に nil を
 返します。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.post_match  # => nil
-      s.scan(/\w+/) # => "test"
-      s.post_match  # => " string"
-      s.scan(/\w+/) # => nil
-      s.post_match  # => nil
-      s.scan(/\s+/) # => " "
-      s.post_match  # => "string"
-      s.scan(/\w+/) # => "string"
-      s.post_match  # => ""
-      s.scan(/\w+/) # => nil
-      s.post_match  # => nil
+s = StringScanner.new('test string')
+s.post_match  # => nil
+s.scan(/\w+/) # => "test"
+s.post_match  # => " string"
+s.scan(/\w+/) # => nil
+s.post_match  # => nil
+s.scan(/\s+/) # => " "
+s.post_match  # => "string"
+s.scan(/\w+/) # => "string"
+s.post_match  # => ""
+s.scan(/\w+/) # => nil
+s.post_match  # => nil
+#@end
 
 --- pre_match -> String | nil
 前回マッチを行った文字列のうち、マッチしたところよりも前の
 部分文字列を返します。前回のマッチが失敗していると常に nil を
 返します。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.pre_match   # => nil
-      s.scan(/\w+/) # => "test"
-      s.pre_match   # => ""
-      s.scan(/\w+/) # => nil
-      s.pre_match   # => nil
-      s.scan(/\s+/) # => " "
-      s.pre_match   # => "test"
-      s.scan(/\w+/) # => "string"
-      s.pre_match   # => "test "
-      s.scan(/\w+/) # => nil
-      s.pre_match   # => nil
+s = StringScanner.new('test string')
+s.pre_match   # => nil
+s.scan(/\w+/) # => "test"
+s.pre_match   # => ""
+s.scan(/\w+/) # => nil
+s.pre_match   # => nil
+s.scan(/\s+/) # => " "
+s.pre_match   # => "test"
+s.scan(/\w+/) # => "string"
+s.pre_match   # => "test "
+s.scan(/\w+/) # => nil
+s.pre_match   # => nil
+#@end
 
 --- reset -> self
 スキャンポインタを文字列の先頭 (インデックス 0) に戻し、
@@ -679,17 +715,19 @@ pos = 0と同じ動作です。
 
 @return self を返します。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan(/\w+/) # => "test"
-      s.matched     # => "test"
-      s.pos         # => 4
-      s[0]          # => "test"
-      s.reset
-      s.matched     # => nil
-      s[0]          # => nil
-      s.pos         # => 0
+s = StringScanner.new('test string')
+s.scan(/\w+/) # => "test"
+s.matched     # => "test"
+s.pos         # => 4
+s[0]          # => "test"
+s.reset
+s.matched     # => nil
+s[0]          # => nil
+s.pos         # => 0
+#@end
 
 --- rest -> String
 文字列の残り (rest) を返します。
@@ -697,16 +735,18 @@ pos = 0と同じ動作です。
 
 スキャンポインタが文字列の末尾を指していたら空文字列 ("") を返します。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.rest         # => "test string"
-      s.scan(/\w+/)  # => "test"
-      s.rest         # => " string"
-      s.scan(/\s+/)  # => " "
-      s.rest         # => "string"
-      s.scan(/\w+/)  # => "string"
-      s.rest         # => ""
+s = StringScanner.new('test string')
+s.rest         # => "test string"
+s.scan(/\w+/)  # => "test"
+s.rest         # => " string"
+s.scan(/\s+/)  # => " "
+s.rest         # => "string"
+s.scan(/\w+/)  # => "string"
+s.rest         # => ""
+#@end
 
 --- rest? -> bool
 文字列が残っているならば trueを、
@@ -717,17 +757,18 @@ pos = 0と同じ動作です。
 [[m:StringScanner#rest?]] は将来のバージョンで削除される予定です。
 代わりに [[m:StringScanner#eos?]] を使ってください。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      p s.eos?        # => false
-      p s.rest?       # => true
-      s.scan(/\w+/)
-      s.scan(/\s+/)
-      s.scan(/\w+/)
-      p s.eos?        # => true
-      p s.rest?       # => false
+s = StringScanner.new('test string')
+p s.eos?        # => false
+p s.rest?       # => true
+s.scan(/\w+/)
+s.scan(/\s+/)
+s.scan(/\w+/)
+p s.eos?        # => true
+p s.rest?       # => false
+#@end
 
 --- rest_size -> Integer
 --- restsize -> Integer
@@ -737,12 +778,13 @@ stringscanner.rest.size と同じです。
 [[m:StringScanner#restsize]] は将来のバージョンで削除される予定です。
 代わりに[[m:StringScanner#rest_size]] を使ってください。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      p s.rest_size # => 11
-      p s.rest.size # => 11
+s = StringScanner.new('test string')
+p s.rest_size # => 11
+p s.rest.size # => 11
+#@end
 
 --- scan(regexp) -> String | nil
 スキャンポインタの地点だけで regexp と文字列のマッチを試します。
@@ -751,15 +793,16 @@ stringscanner.rest.size と同じです。
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-        require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-        s = StringScanner.new('test string')
-        p s.scan(/\w+/)   #=> "test"
-        p s.scan(/\w+/)   #=> nil
-        p s.scan(/\s+/)   #=> " "
-        p s.scan(/\w+/)   #=> "string"
-        p s.scan(/./)     #=> nil
+s = StringScanner.new('test string')
+p s.scan(/\w+/)   #=> "test"
+p s.scan(/\w+/)   #=> nil
+p s.scan(/\s+/)   #=> " "
+p s.scan(/\w+/)   #=> "string"
+p s.scan(/./)     #=> nil
+#@end
 
 --- scan_full(regexp, s, f) -> object
 スキャンポインタの位置から regexp と文字列のマッチを試します。
@@ -789,15 +832,16 @@ stringscanner.rest.size と同じです。
 @param f true ならばマッチした部分文字列を返します。
          false ならばマッチした部分文字列の長さを返します。
 
-使用例
-  require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-  s = StringScanner.new('test string')
-  p s.scan_full(/\w+/, true, true)     #=> "test"
-  p s.scan_full(/\s+/, false, true)    #=> " "
-  p s.scan_full(/\s+/, true, false)    #=> 1
-  p s.scan_full(/\w+/, false, false)   #=> 6
-  p s.scan_full(/\w+/, true, true)     #=> "string"
+s = StringScanner.new('test string')
+p s.scan_full(/\w+/, true, true)     #=> "test"
+p s.scan_full(/\s+/, false, true)    #=> " "
+p s.scan_full(/\s+/, true, false)    #=> 1
+p s.scan_full(/\w+/, false, false)   #=> 6
+p s.scan_full(/\w+/, true, true)     #=> "string"
+#@end
 
 @see [[m:StringScanner#scan]] [[m:StringScanner#skip]] [[m:StringScanner#check]]  [[m:StringScanner#match?]] 
 
@@ -809,14 +853,15 @@ regexp で指定された正規表現とマッチするまで文字列をスキ�
 
 @param regexp マッチに用いる正規表現を指定します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan_until(/str/) # => "test str"
-      s.matched           # => "str"
-      s.pos               # => 8
-      s.pre_match         # => "test "
+s = StringScanner.new('test string')
+s.scan_until(/str/) # => "test str"
+s.matched           # => "str"
+s.pos               # => 8
+s.pre_match         # => "test "
+#@end
 
 --- search_full(regexp, s, f) -> object
 regexp で指定された正規表現とマッチするまで文字列をスキャンします。
@@ -846,14 +891,14 @@ regexp で指定された正規表現とマッチするまで文字列をスキ�
 @param f true ならばマッチした部分文字列を返します。
          false ならばマッチした部分文字列の長さを返します。
 
-使用例
+#@samplecode 例
+require 'strscan'
 
-  require 'strscan'
-
-  s = StringScanner.new('test string')   
-  p s.search_full(/t/, true, true)       #=> "t"
-  p s.search_full(/str/, false, true)    #=> "est str"
-  p s.search_full(/string/, true, true)  #=> "est string"
+s = StringScanner.new('test string')   
+p s.search_full(/t/, true, true)       #=> "t"
+p s.search_full(/str/, false, true)    #=> "est str"
+p s.search_full(/string/, true, true)  #=> "est string"
+#@end
 
 
 @see [[m:StringScanner#scan_until]] [[m:StringScanner#skip_until]] [[m:StringScanner#check_until]] [[m:StringScanner#exist?]]
@@ -865,15 +910,16 @@ regexp で指定された正規表現とマッチするまで文字列をスキ�
 
 @param regexp マッチに使用する正規表現を指定します。
 
-使用例
-        require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-        s = StringScanner.new('test string')
-        p s.skip(/\w+/)   #=> 4
-        p s.skip(/\w+/)   #=> nil
-        p s.skip(/\s+/)   #=> 1
-        p s.skip(/\w+/)   #=> 6
-        p s.skip(/./)     #=> nil
+s = StringScanner.new('test string')
+p s.skip(/\w+/)   #=> 4
+p s.skip(/\w+/)   #=> nil
+p s.skip(/\s+/)   #=> 1
+p s.skip(/\w+/)   #=> 6
+p s.skip(/./)     #=> nil
+#@end
 
 --- skip_until(regexp) -> Integer | nil
 regexp が一致するまで文字列をスキャンします。
@@ -883,40 +929,46 @@ regexp が一致するまで文字列をスキャンします。
 
 @param regexp マッチに使用する正規表現を指定します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan_until(/str/) # => 8
-      s.matched           # => "str"
-      s.pos               # => 8
-      s.pre_match         # => "test "
+s = StringScanner.new('test string')
+s.scan_until(/str/) # => 8
+s.matched           # => "str"
+s.pos               # => 8
+s.pre_match         # => "test "
+#@end
 
 --- string -> String
 スキャン対象にしている文字列を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.string # => "test string"
+s = StringScanner.new('test string')
+s.string # => "test string"
+#@end
 
 #@if (version <= "1.8.0")
 #@#Ruby 1.8.0 では
 返り値は freeze されています。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.string.frozen? # => true
+s = StringScanner.new('test string')
+s.string.frozen? # => true
+#@end
 #@else
 #@#Ruby 1.8.1 以降では
 返り値は freeze されていません。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.string.frozen? # => false
+s = StringScanner.new('test string')
+s.string.frozen? # => false
+#@end
 #@end
 
 なお、このメソッドは StringScanner.new に渡した
@@ -934,13 +986,15 @@ regexp が一致するまで文字列をスキャンします。
 この操作がスキャン対象の文字列を変更することも保証されません。
 この仕様に依存したコードを書かないでください。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      str = 'test string'
-      s = StringScanner.new(str)
-      s.string.replace("0123")
-      s.scan(/\w+/)     # => "0123" (将来は "test" が返る可能性あり)
-      str               # => "0123" (将来は "test string" が返る可能性あり)
+str = 'test string'
+s = StringScanner.new(str)
+s.string.replace("0123")
+s.scan(/\w+/)     # => "0123" (将来は "test" が返る可能性あり)
+str               # => "0123" (将来は "test string" が返る可能性あり)
+#@end
 
 --- string=(str)
 スキャン対象の文字列を str に変更して、マッチ記録を捨てます。
@@ -949,13 +1003,14 @@ regexp が一致するまで文字列をスキャンします。
 
 @return str を返します。
 
-使用例
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      str = '0123'
-      s = StringScanner.new('test string')
-      s.string = str     # => "0123"
-      s.scan(/\w+/)      # => "0123"
+str = '0123'
+s = StringScanner.new('test string')
+s.string = str     # => "0123"
+s.scan(/\w+/)      # => "0123"
+#@end
 
 --- terminate -> self
 --- clear -> self
@@ -965,17 +1020,19 @@ regexp が一致するまで文字列をスキャンします。
 
 pos = self.string.size と同じ動作です。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan(/\w+/) # => "test"
-      s.matched     # => "test"
-      s.pos         # => 4
-      s[0]          # => "test"
-      s.terminate
-      s.matched     # => nil
-      s[0]          # => nil
-      s.pos         # => 11
+s = StringScanner.new('test string')
+s.scan(/\w+/) # => "test"
+s.matched     # => "test"
+s.pos         # => 4
+s[0]          # => "test"
+s.terminate
+s.matched     # => nil
+s[0]          # => nil
+s.pos         # => 11
+#@end
 
 [[m:StringScanner#clear]] は将来のバージョンで削除される予定です。
 代わりに [[m:StringScanner#terminate]] を使ってください。
@@ -983,12 +1040,14 @@ pos = self.string.size と同じ動作です。
 --- unscan -> self
 スキャンポインタを前回のマッチの前の位置に戻します。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      s = StringScanner.new('test string')
-      s.scan(/\w+/) # => "test"
-      s.unscan
-      s.scan(/\w+/) # => "test"
+s = StringScanner.new('test string')
+s.scan(/\w+/) # => "test"
+s.unscan
+s.scan(/\w+/) # => "test"
+#@end
 
 
 @return selfを返します。
@@ -1001,38 +1060,40 @@ pos = self.string.size と同じ動作です。
 @raise StringScanner::Error 2 回分以上戻そうとした時や、
                             まだマッチを一度も行っていない時、
                             前回のマッチが失敗していた時に発生します。
-使用例
-      require 'strscan'
 
-      s = StringScanner.new('test string')
-      begin
-        # マッチを一度も行っていないので、例外が発生する。
-        s.unscan
-      rescue StringScanner::Error => err
-        puts err
-        # 出力例
-        #=> unscan failed: previous match had failed
-      end
-      p s.scan(/\w+/) # => "test"
-      s.unscan
-      begin
-        # 二回以上戻そうとしたので、例外が発生する。
-        s.unscan
-      rescue StringScanner::Error => err
-        puts err
-        # 出力例
-        #=> unscan failed: previous match had failed
-      end
-      p s.scan(/\w+/) # => "test"
-      p s.scan(/\w+/) # => nil
-      begin
-        # 前回のマッチが失敗しているので、例外が発生する。
-        s.unscan
-      rescue => err
-        puts err
-        # 出力例
-        #=> unscan failed: previous match had failed
-      end
+#@samplecode 例
+require 'strscan'
+
+s = StringScanner.new('test string')
+begin
+  # マッチを一度も行っていないので、例外が発生する。
+  s.unscan
+rescue StringScanner::Error => err
+  puts err
+  # 出力例
+  #=> unscan failed: previous match had failed
+end
+p s.scan(/\w+/) # => "test"
+s.unscan
+begin
+  # 二回以上戻そうとしたので、例外が発生する。
+  s.unscan
+rescue StringScanner::Error => err
+  puts err
+  # 出力例
+  #=> unscan failed: previous match had failed
+end
+p s.scan(/\w+/) # => "test"
+p s.scan(/\w+/) # => nil
+begin
+  # 前回のマッチが失敗しているので、例外が発生する。
+  s.unscan
+rescue => err
+  puts err
+  # 出力例
+  #=> unscan failed: previous match had failed
+end
+#@end
 
 
 #@# bc-rdoc: detected missing name: matchedsize
@@ -1051,10 +1112,12 @@ pos = self.string.size と同じ動作です。
 [[c:StringScanner]] クラスのバージョンを文字列で返します。
 この文字列は [[m:Object#freeze]] されています。
 
-      require 'strscan'
+#@samplecode 例
+require 'strscan'
 
-      StringScanner::Version           # => "0.7.0"
-      StringScanner::Version.frozen?   # => true
+StringScanner::Version           # => "0.7.0"
+StringScanner::Version.frozen?   # => true
+#@end
 
 --- Id -> String
 

--- a/refm/api/src/strscan.rd
+++ b/refm/api/src/strscan.rd
@@ -97,10 +97,12 @@ case2
 
 スキャンポインタの位置は文字単位でなくバイト単位となります。
 
-      # vim:set fileencoding=euc-jp:
-      require 'strscan'
-      s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
-      p s.exist?(/び/) #=> 4
+#@samplecode 例:
+# 次の行以降の内容を EUC-JP として保存して試してください
+require 'strscan'
+s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
+p s.exist?(/び/) #=> 4
+#@end
 
 StringScanner は $~ $& $1 $2 …… などの正規表現関連変数を
 セットしません。代わりに [[m:StringScanner#[] ]], [[m:StringScanner#matched?]] などの

--- a/refm/api/src/strscan.rd
+++ b/refm/api/src/strscan.rd
@@ -99,6 +99,7 @@ case2
 
 #@samplecode 例:
 # 次の行以降の内容を EUC-JP として保存して試してください
+# vim:set fileencoding=euc-jp:
 require 'strscan'
 s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
 p s.exist?(/び/) #=> 4


### PR DESCRIPTION
StringScanner のサンプルコードに `#@samplecode ~ #@end` を追加してハイライトされるようにしました。
~~また、以下のサンプルコードにも `#@samplecode ~ #@end` を追加しようとしたんですが `bitclust` でエラーになってしまったので一旦ここでは対応していません。~~
追記：コメントで説明することで対応しました。

```ruby
# vim:set fileencoding=euc-jp:
require 'strscan'
s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
p s.exist?(/び/) #=> 4
```

```shell
$ bitclust htmlfile strscan.rd --target=StringScanner
-:3:23 invalid multibyte char (EUC-JP)
# vim:set fileencoding=euc-jp:
require 'strscan'
s = StringScanner.new("るびい") # 文字コードはEUC-JPとします
p s.exist?(/び/) #=> 4
 (BitClust::SyntaxHighlighter::CompileError)
$
```