### PR TITLE
Update Integer#chr description

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -66,24 +66,31 @@ Math.sqrt(10**46).floor  #=>  99999999999999991611392 (!)
 --- chr -> String
 --- chr(encoding) -> String
 
-与えられたエンコーディング encoding において self を文字コードと見た時、それに対応する一文字からなる文字列を返します。
+self を文字コードとして見た時に、引数で与えたエンコーディング encoding に対応する文字を返します。
+
+#@samplecode
+p 65.chr
+# => "A"
+p 12354.chr
+# => `chr': 12354 out of char range (RangeError)
+
+p 12354.chr(Encoding::UTF_8)
+# => "あ"
+p 12354.chr(Encoding::EUC_JP)
+# => RangeError: invalid codepoint 0x3042 in EUC-JP
+#@end
+
 引数無しで呼ばれた場合は self を US-ASCII、ASCII-8BIT、デフォルト内部エンコーディングの順で優先的に解釈します。
 
-  p 65.chr # => "A"
-  p 0x79.chr.encoding # => #<Encoding:US_ASCII>
-  p 0x80.chr.encoding # => #<Encoding:ASCII_8BIT>
-  p 12354.chr Encoding::UTF_8 # => "あ"
-  p 12354.chr Encoding::EUC_JP
-  # => RangeError: invalid codepoint 0x3042 in EUC-JP
-  p 12354.chr Encoding::ASCII_8BIT
-  # => RangeError: 12354 out of char range
-  p (2**32).chr
-  # => RangeError: bignum out of char range
+#@samplecode
+p 0x79.chr.encoding # => #<Encoding:US_ASCII>
+p 0x80.chr.encoding # => #<Encoding:ASCII_8BIT>
+#@end
 
 @param encoding エンコーディングを表すオブジェクト。Encoding::UTF_8、'shift_jis' など。
 @return     一文字からなる文字列
 @raise RangeError self を与えられたエンコーディングで正しく解釈できない場合に発生します。
-@see [[m:String#ord]]
+@see [[m:String#ord]] [[m:Encoding#default_internal]]
 #@end
 
 #@since 2.4.0


### PR DESCRIPTION
- サンプルコードの順番と説明文を整理しました。
- (2**32)はInteger#chrに渡すことはないと思い、サンプルコードから削除しました。
- デフォルト内部エンコーディングに関係があるため、Encoding#default_internalへのリンクを追加しました。

## 変更前
![image](https://user-images.githubusercontent.com/52617472/113419932-5feb4900-9403-11eb-83a9-c3c7d2381ff9.png)

## 変更後
![image](https://user-images.githubusercontent.com/52617472/113419890-4fd36980-9403-11eb-8bff-f555998bd535.png)
