### PR TITLE
Prime.eachの冗長なeachを削除

### DIFF
--- a/refm/api/src/prime.rd
+++ b/refm/api/src/prime.rd
@@ -140,10 +140,10 @@ Prime.instance.prime_division と同じです。
 
 #@samplecode 例
 require 'prime'
-Prime.each(6).each{|prime| prime }  # => 5
-Prime.each(7).each{|prime| prime }  # => 7
-Prime.each(10).each{|prime| prime } # => 7
-Prime.each(11).each{|prime| prime } # => 11
+Prime.each(6){|prime| prime }  # => 5
+Prime.each(7){|prime| prime }  # => 7
+Prime.each(10){|prime| prime } # => 7
+Prime.each(11){|prime| prime } # => 11
 #@end
 
 #@samplecode 例: 30以下の双子素数


### PR DESCRIPTION
すぐ下にPrime.eachのブロックを渡さない例として双子素数の例がありますし、
変に冗長に見えたのでeachを削除しブロックを使ったコード例になるよう修正したものです。

下記のページに対するものです。
[Prime\#each \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/Prime/i/each.html)