### PR TITLE
Symbolの比較する系のメソッドの返り値と説明を更新

### DIFF
--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -113,16 +113,16 @@ Ruby によって GC されます。すなわち、ある使わなくなった
   def number
     'make_3'
   end
-  
+
   p Symbol.all_symbols.select{|sym|sym.to_s.include? 'make'}
   #=> [:make_1, :make_2]
-  
+
   re  = #確実に生成されるように代入操作を行う
   :make_1,
   :'make_2',
   :"#{number}",
   'make_4'.intern
-  
+
   p Symbol.all_symbols.select{|sym|sym.to_s.include? 'make'}
   #=> [:make_1, :make_2, :make_3, :make_4]
 
@@ -148,7 +148,7 @@ self を返します。
 
   p :foo.id2name  # => "foo"
   p :foo.id2name.intern == :foo  # => true
-  
+
 @see [[m:String#intern]]
 #@since 3.0
 @see [[m:Symbol#name]]

--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -242,21 +242,25 @@ self の先頭が prefixes のいずれかであるとき true を返します�
 
 @see [[m:String#succ]]
 
---- <=>(other) -> -1 | 0 | 1
+--- <=>(other) -> -1 | 0 | 1 | nil
 
 self と other のシンボルに対応する文字列を ASCII コード順で比較して、
-self が大きい時には正の整数、等しい時には 0、小さい時には負の整数を返し
-ます。
+self が小さい時には -1、等しい時には 0、大きい時には 1 を返します。
+
+other がシンボルではなく比較できない時には nil を返します。
 
 @param other 比較対象のシンボルを指定します。
 
-  p :aaa <=> :xxx  # => -1
-  p :aaa <=> :aaa  # => 0
-  p :xxx <=> :aaa  # => 1
+#@samplecode
+p :aaa <=> :xxx  # => -1
+p :aaa <=> :aaa  # => 0
+p :xxx <=> :aaa  # => 1
+p :foo <=> "foo" # => nil
+#@end
 
-@see [[m:String#<=>]]
+@see [[m:String#<=>]], [[m:String#casecmp]]
 
---- casecmp(other) -> -1 | 0 | 1
+--- casecmp(other) -> -1 | 0 | 1 | nil
 
 [[m:Symbol#<=>]] と同様にシンボルに対応する文字列の順序を比較しますが、
 アルファベットの大文字小文字の違いを無視します。
@@ -268,17 +272,22 @@ Unicode 全体ではなく、A-Z/a-z だけです。
 
 @param other 比較対象のシンボルを指定します。
 
-  :aBcDeF.casecmp(:abcde)     #=> 1
-  :aBcDeF.casecmp(:abcdef)    #=> 0
-  :aBcDeF.casecmp(:abcdefg)   #=> -1
-  :abcdef.casecmp(:ABCDEF)    #=> 0
-  :"\u{e4 f6 fc}".casecmp(:"\u{c4 d6 dc}") #=> 1
+#@samplecode
+:aBcDeF.casecmp(:abcde)     #=> 1
+:aBcDeF.casecmp(:abcdef)    #=> 0
+:aBcDeF.casecmp(:abcdefg)   #=> -1
+:abcdef.casecmp(:ABCDEF)    #=> 0
+:"\u{e4 f6 fc}".casecmp(:"\u{c4 d6 dc}") #=> 1
+#@end
 
-nil は文字列のエンコーディングが非互換の時に返されます。
+other がシンボルではない場合や、文字列のエンコーディングが非互換の場合は、nil を返します。
 
-  "\u{e4 f6 fc}".encode("ISO-8859-1").to_sym.casecmp(:"\u{c4 d6 dc}")   #=> nil
+#@samplecode
+:foo.casecmp("foo")   #=> nil
+"\u{e4 f6 fc}".encode("ISO-8859-1").to_sym.casecmp(:"\u{c4 d6 dc}")   #=> nil
+#@end
 
-@see [[m:String#casecmp]]
+@see [[m:String#casecmp]], [[m:Symbol#<=>]], [[m:Symbol#casecmp?]]
 
 #@since 2.4.0
 --- casecmp?(other) -> bool | nil
@@ -288,17 +297,22 @@ nil は文字列のエンコーディングが非互換の時に返されます�
 
 @param other 比較対象のシンボルを指定します。
 
-  :abcdef.casecmp?(:abcde)     #=> false
-  :aBcDeF.casecmp?(:abcdef)    #=> true
-  :abcdef.casecmp?(:abcdefg)   #=> false
-  :abcdef.casecmp?(:ABCDEF)    #=> true
-  :"\u{e4 f6 fc}".casecmp?(:"\u{c4 d6 dc}") #=> true
+#@samplecode
+:abcdef.casecmp?(:abcde)     #=> false
+:aBcDeF.casecmp?(:abcdef)    #=> true
+:abcdef.casecmp?(:abcdefg)   #=> false
+:abcdef.casecmp?(:ABCDEF)    #=> true
+:"\u{e4 f6 fc}".casecmp?(:"\u{c4 d6 dc}") #=> true
+#@end
 
-nil は文字列のエンコーディングが非互換の時に返されます。
+other がシンボルではない場合や、文字列のエンコーディングが非互換の場合は、nil を返します。
 
-  "\u{e4 f6 fc}".encode("ISO-8859-1").to_sym.casecmp?(:"\u{c4 d6 dc}")   #=> nil
+#@samplecode
+:foo.casecmp?("foo")   #=> nil
+"\u{e4 f6 fc}".encode("ISO-8859-1").to_sym.casecmp?(:"\u{c4 d6 dc}")   #=> nil
+#@end
 
-@see [[m:String#casecmp?]]
+@see [[m:String#casecmp?]], [[m:Symbol#casecmp]]
 #@end
 
 --- =~(other) -> Integer | nil

--- a/refm/api/src/_builtin/Symbol
+++ b/refm/api/src/_builtin/Symbol
@@ -258,7 +258,7 @@ p :xxx <=> :aaa  # => 1
 p :foo <=> "foo" # => nil
 #@end
 
-@see [[m:String#<=>]], [[m:String#casecmp]]
+@see [[m:String#<=>]], [[m:Symbol#casecmp]]
 
 --- casecmp(other) -> -1 | 0 | 1 | nil
 


### PR DESCRIPTION
# PRの主な内容

`<=>`, `casecmp`, `casecmp?`について、返り値と説明を更新しました。

- `<=>`, `casecmp`の返り値に`nil`がなかったので追加。#2183 に対応したものです。
- `<=>`, `casecmp`, `casecmp?`の`nil`が返る条件について、追記・修正。
   説明は、英語版に寄せています。
- 各メソッドに`nil`となるサンプルコードの追加。
- シンタックスハイライトが効くように、`#@samplecode`を適用。
- 各メソッドに似てるメソッドの参照を追加。

下記のページに対するものです。
[Symbol\#<=> \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/Symbol/i/=3c=3d=3e.html)
[Symbol\#casecmp \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/Symbol/i/casecmp.html)
[Symbol\#casecmp? \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/Symbol/i/casecmp=3f.html)

# 備考

最初のコミットで行末の意味のない空白を削除してます。