### PR TITLE
OpenSSL::BNのcmp, ucmpメソッドの説明の加筆修正

### DIFF
--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -230,7 +230,7 @@ odd が真なら、生成される整数は奇数のみとなります。
 @raise OpenSSL::BNError 計算時エラー
 
 --- coerce(other) -> Array
-自身と other が同じクラスになるよう、自身か other を変換し 
+自身と other が同じクラスになるよう、自身か other を変換し
 [other, self] という配列にして返します。
 
 基本的に other が整数のときに、自身を Integer のオブジェクトに
@@ -336,7 +336,7 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
   OpenSSL::BN.new("127").num_bits # => 7
   OpenSSL::BN.new("-127").num_bits # => 7
   OpenSSL::BN.new("128").num_bits # => 8
-  
+
 --- num_bytes -> Integer
 自身を表現するのに使っているバイト数を返します。
 
@@ -379,7 +379,7 @@ checksがnilである場合は OpenSSL が適切な
   # 181 は 「小さな素数」である
   OpenSSL::BN.new("181").prime_fasttest?(nil, true) # => false
   OpenSSL::BN.new("181").prime_fasttest?(nil, false) # => true
-  
+
 @param checks Miller-Robin法の繰り返しの回数
 @param vtrivdiv 真なら小さな素数で割ることでの素数判定を試みます
 @raise OpenSSL::BNError 判定時にエラーが発生

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -175,10 +175,22 @@ odd が真なら、生成される整数は奇数のみとなります。
 
 --- <=>(other) -> -1 | 0 | 1
 --- cmp(other) -> -1 | 0 | 1
-自身と other を比較し、otherのほうが小さければ-1、
-大きければ+1、等しければ 0 を返します。
+自身と other を比較し、自身が小さいときには -1、
+等しいときには 0、大きいときには 1 を返します。
 
-@param other 比較する数
+#@samplecode
+require 'openssl'
+
+OpenSSL::BN.new(5) <=> 5  # =>  0
+
+OpenSSL::BN.new(5) <=> OpenSSL::BN.new(9)  # => -1
+OpenSSL::BN.new(5) <=> OpenSSL::BN.new(5)  # =>  0
+OpenSSL::BN.new(5) <=> OpenSSL::BN.new(-5)  # =>  1
+#@end
+
+@param other 比較する整数
+@raise TypeError 比較できないときに発生します。
+@see [[m:OpenSSL::BN#ucmp]]
 
 --- ==(other) -> bool
 --- ===(other) -> bool
@@ -425,11 +437,23 @@ base で基数を指定します。10,16を指定できます。
 @see [[m:OpenSSL::BN.new]]
 
 --- ucmp(other) -> -1 | 0 | 1
-自身と other の絶対値を比較し、other の絶対値のほうが
-自身の絶対値より小さければ-1、
-大きければ+1、2つの絶対値が等しければ 0 を返します。
+自身と other の絶対値を比較し、自身の絶対値が小さいときには -1、
+等しいときには 0、 大きいときには 1 を返します。
 
-@param other 比較する数
+#@samplecode
+require 'openssl'
+
+OpenSSL::BN.new(-5).ucmp(5)  # =>  0
+
+OpenSSL::BN.new(5).ucmp(OpenSSL::BN.new(-9))  # => -1
+OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(5))  # =>  0
+OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(2))  # =>  1
+#@end
+
+@param other 比較する整数
+@raise TypeError 比較できないときに発生します。
+@see [[m:OpenSSL::BN#cmp]]
+
 --- zero? -> bool
 自身が0である場合に真を返します。
 


### PR DESCRIPTION
## 主にしたこと
- `cmp`(`<=>`), `ucmp`メソッドの説明で、逆になっている部分があったので修正。
- 適当なサンプルコードの追加
- TypeErrorが起きることの追加。 #2183 に対応したものです。

下記のページに対応するものです。
[OpenSSL::BN\#<=> \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aBN/i/=3c=3d=3e.html)
[OpenSSL::BN\#ucmp \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aBN/i/ucmp.html)

## 備忘

以下の例は、全て`TypeError`となりました。

```ruby
require 'openssl'
require 'bigdecimal'

p OpenSSL::BN.new(5).ucmp 5.0  # =>  0
p OpenSSL::BN.new(5).ucmp 5+0i  # =>  0
p OpenSSL::BN.new(5).ucmp 5/1r  # =>  0
p OpenSSL::BN.new(5).ucmp BigDecimal(5)
```
