### PR TITLE
String#=~ の返り値の型を修正

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -450,7 +450,7 @@ p str    # => "foo!!!"
 #@end
 #@end
 
---- =~(other) -> Integer
+--- =~(other) -> Integer | nil
 
 正規表現 other とのマッチを行います。
 マッチが成功すればマッチした位置のインデックスを、そうでなければ nil を返します。


### PR DESCRIPTION
[String#=~ (Ruby 3.0.0 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/3.0.0/method/String/i/=3d=7e.html)
において，`String#=~` の返り値が `Integer` となっていますが，マッチしなかった場合は `nil` を返します。