### PR TITLE
optparse ライブラリのサンプルコードにハイライトを追加

### DIFF
--- a/refm/api/src/optparse.rd
+++ b/refm/api/src/optparse.rd
@@ -69,7 +69,6 @@ opt で置き換えます。そうでない場合は先頭に opt を追加し�
 
 @return 文字列を返します。
 
-#@since 1.9.1
 --- set_backtrace(array) -> [String]
 
 自身に array で指定したバックトレースを設定します。
@@ -91,7 +90,6 @@ array で指定されたバックトレースから optparse ライブラリに�
 
 @return array を返します。
 
-#@end
 
 = class OptionParser::AmbiguousOption < OptionParser::ParseError
 

--- a/refm/api/src/optparse/Arguable
+++ b/refm/api/src/optparse/Arguable
@@ -29,16 +29,16 @@ OptionParser::Arguable を [[m:Object#extend]] します。
 が発生した場合は、全て rescue し、エラーメッセージを出力し、
 nil を返します。
 
-例:
+#@samplecode
+require 'optparse'
 
- require 'optparse'
- 
- o = nil
- ARGV.options{|opt|
-   opt.on('-a'){ o = true }
-   opt.parse!
- }
- p o                         #=> true
+o = nil
+ARGV.options{|opt|
+  opt.on('-a'){ o = true }
+  opt.parse!
+}
+p o                         #=> true
+#@end
 
 --- order!               -> [String]
 --- order!{|s| ... }     -> [String]
@@ -50,14 +50,14 @@ nil を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスの例外になります。
 
-例:
+#@samplecode
+require 'optparse'
 
-  require 'optparse'
-  
-  o = nil
-  ARGV.options.on('-a'){ o = true }
-  ARGV.order!
-  p o                                #=> true
+o = nil
+ARGV.options.on('-a'){ o = true }
+ARGV.order!
+p o                                #=> true
+#@end
 
 --- permute!             -> [String]
 
@@ -68,14 +68,14 @@ nil を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスの例外になります。
 
-例:
+#@samplecode
+require 'optparse'
 
-  require 'optparse'
-  
-  o = nil
-  ARGV.options.on('-a'){ o = true }
-  ARGV.permute!
-  p o                                #=> true
+o = nil
+ARGV.options.on('-a'){ o = true }
+ARGV.permute!
+p o                                #=> true
+#@end
 
 --- parse!               -> [String]
 
@@ -86,14 +86,14 @@ nil を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスの例外になります。
 
-例:
+#@samplecode
+require 'optparse'
 
-  require 'optparse'
-  
-  o = nil
-  ARGV.options.on('-a'){ o = true }
-  ARGV.parse!
-  p o                                #=> true
+o = nil
+ARGV.options.on('-a'){ o = true }
+ARGV.parse!
+p o                                #=> true
+#@end
 
 --- getopts(short_opt, *long_opt)    -> Hash
 
@@ -114,14 +114,12 @@ nil を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスの例外になります。
 
-例:
-
- # t.rb の内容
- require 'optparse'
- params = ARGV.getopts("ab:", "foo", "bar:", "bufsize:1024")
- p params
+#@samplecode t.rb
+require 'optparse'
+params = ARGV.getopts("ab:", "foo", "bar:", "bufsize:1024")
+p params
+#@end
 
  # 実行結果
  $ ruby t.rb -b 1 --foo  --bar xxx -- -a
  {"bufsize"=>"1024", "a"=>false, "b"=>"1", "foo"=>true, "bar"=>"xxx"}  # "a"=>false であることに注意。
-

--- a/refm/api/src/optparse/OptionParser
+++ b/refm/api/src/optparse/OptionParser
@@ -144,11 +144,7 @@ parse(opts2) # => unsupported argument type: Time (ArgumentError)
 
 @param argv パースしたい配列を指定します。
 
-#@since 1.9.1
 @param opts 引数を文字列で指定します。
-#@else
-@param opts 引数を文字列で指定します。[[m:Kernel#getopts]] を参照して下さい。
-#@end
 
 @raise OptionParser::ParseError パースに失敗した場合、発生します。
                                 実際は OptionParser::ParseError のサブク
@@ -1178,10 +1174,6 @@ p config          # => {:lib=>"lib1"}
 --- getopts(argv, *opts)   -> Hash
 --- getopts(*opts)         -> Hash
 
-#@until 1.9.1
-[[lib:getopts]] 相当の機能を提供します。
-getopts と違って、グローバル変数を定義しません。
-#@end
 引数をパースした結果を、Hash として返します。
 
 配列 argv を与えた場合、argv をパースします。そうでない場合は、
@@ -1198,11 +1190,7 @@ params = opt.getopts(ARGV, "ab:", "foo", "bar:")
 
 @param argv パースしたい配列を指定します。
 
-#@since 1.9.1
 @param opts 引数を文字列で指定します。
-#@else
-@param opts 引数を文字列で指定します。[[m:Kernel#getopts]] を参照して下さい。
-#@end
 
 @raise OptionParser::ParseError パースに失敗した場合、発生します。
                                 実際は OptionParser::ParseError のサブク

--- a/refm/api/src/optparse/OptionParser
+++ b/refm/api/src/optparse/OptionParser
@@ -12,11 +12,13 @@
 
 というような流れになります。
 
-  require "optparse"
-  ProgramConfig = Hash.new
-  opts = OptionParser.new
-  opts.on("-a"){|v| ProgramConfig[:a] = true } # オプション「-a」がコマンドラインで指定されていた場合の動作。
-  opts.parse!(ARGV)                            # 実際にコマンドラインの parse を行う。
+#@samplecode
+require "optparse"
+ProgramConfig = Hash.new
+opts = OptionParser.new
+opts.on("-a"){|v| ProgramConfig[:a] = true } # オプション「-a」がコマンドラインで指定されていた場合の動作。
+opts.parse!(ARGV)                            # 実際にコマンドラインの parse を行う。
+#@end
 
 === デフォルトで利用可能なオプション
 
@@ -47,14 +49,16 @@ OptionParser オブジェクトを生成して返します。
 ブロックが与えられた場合、生成した OptionParser オブジェクトを引数としてブロックを評
 価します。つまり、以下のような書き方が可能です。
 
-  require 'optparse'
-  OptionParser.new do |opt|
+#@samplecode
+require 'optparse'
+OptionParser.new do |opt|
 
-    opt.on('-a') {|v| p v }
-    opt.on('-b') {|v| p v }
+  opt.on('-a') {|v| p v }
+  opt.on('-b') {|v| p v }
 
-    opt.parse!(ARGV)
-  end
+  opt.parse!(ARGV)
+end
+#@end
 
 @param banner ヘルプ(サマリ)の最初の部分に表示される、アプリケーションの説明などを文字列で与えます。
 
@@ -73,24 +77,26 @@ OptionParser オブジェクトを生成して返します。
 コマンドラインのオプションに与えられた引数は、この accept で登録したブロックで
 klass のインスタンスに変換されてから、OptionParser#on メソッドで登録したブロックに渡されます。
 
-  require "optparse"
-  require "time"
+#@samplecode
+require "optparse"
+require "time"
 
-  OptionParser.accept(Time) do |s,|
-    begin
-      Time.parse(s) if s
-    rescue
-      raise OptionParser::InvalidArgument, s
-    end
+OptionParser.accept(Time) do |s,|
+  begin
+    Time.parse(s) if s
+  rescue
+    raise OptionParser::InvalidArgument, s
   end
+end
 
-  opts = OptionParser.new
+opts = OptionParser.new
 
-  opts.on("-t", "--time [TIME]", Time) do |time|
-    p time.class #=> Time
-  end
+opts.on("-t", "--time [TIME]", Time) do |time|
+  p time.class #=> Time
+end
 
-  opts.parse!(ARGV)
+opts.parse!(ARGV)
+#@end
 
 いくつかのクラスに対しては変換用のブロックがデフォルトで登録されて
 います。[[m:OptionParser#on]] を参照して下さい。
@@ -535,25 +541,26 @@ opts.to_a # => ["Usage: test [options]", "    -i, --init\n", "    -u, --update\n
 
 @param sep サマリの区切りを文字列で指定します。
 
-例:
-       require 'optparse'
-       opts = OptionParser.new
-       opts.banner = "Usage: example.rb [options]"
+#@samplecode
+require 'optparse'
+opts = OptionParser.new
+opts.banner = "Usage: example.rb [options]"
 
-       opts.separator ""
-       opts.separator "Specific options:"
+opts.separator ""
+opts.separator "Specific options:"
 
-       opts.on("-r", "--require LIBRARY") do |lib|
-               options.library << lib
-       end
+opts.on("-r", "--require LIBRARY") do |lib|
+        options.library << lib
+end
 
-       opts.separator ""
-       opts.separator "Common options:"
+opts.separator ""
+opts.separator "Common options:"
 
-       opts.on_tail("-h", "--help", "Show this message") do
-         puts opts
-         exit
-       end
+opts.on_tail("-h", "--help", "Show this message") do
+  puts opts
+  exit
+end
+#@end
 
 --- on(short, desc = "") {|v| ... }        -> self
 --- on(long, desc = "") {|v| ... }         -> self
@@ -723,16 +730,17 @@ OptionParser.accept や OptionParser#accept によって、受け付け
 @param rest 可能な引数を列挙した配列やハッシュを与えます。文字列を与えた場合は、
             サマリに表示されるオプションの説明と見なします。
 
-例:
-  opts.on("--protocol VALUE", [:http, :ftp, :https]){|w|
-    p w
-  }
-  # ruby command --protocol=http #=> :http
+#@samplecode
+opts.on("--protocol VALUE", [:http, :ftp, :https]){|w|
+  p w
+}
+# ruby command --protocol=http #=> :http
 
-  opts.on("-c", "--charset VALUE", {"jis" => "iso-2022-jp", "sjis" => "shift_jis"}){|w|
-    p w
-  }
-  # ruby command --charset=jis #=> "iso-2022-jp"
+opts.on("-c", "--charset VALUE", {"jis" => "iso-2022-jp", "sjis" => "shift_jis"}){|w|
+  p w
+}
+# ruby command --charset=jis #=> "iso-2022-jp"
+#@end
 
 --- on_head(*arg, &block) -> self
 
@@ -842,18 +850,18 @@ argv からオプションを取り除いたものを返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスになります。
 
-例:
-  $ cat opt.rb
-  require 'optparse'
-  opt = OptionParser.new
+#@samplecode opt.rb
+require 'optparse'
+opt = OptionParser.new
 
-  opt.on('-a [VAL]') {|v| p :a }
-  opt.on('-b') {|v| p :b }
+opt.on('-a [VAL]') {|v| p :a }
+opt.on('-b') {|v| p :b }
 
-  opt.order(ARGV)
-  p ARGV
-
-  $ ruby opt2.rb -a foo somefile -b
+opt.order(ARGV)
+p ARGV
+#@end
+↓
+  $ ruby opt.rb -a foo somefile -b
   :a
   ["-a", "foo", "somefile", "-b"]
 
@@ -889,18 +897,18 @@ argv を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスになります。
 
-例:
-  $ cat opt.rb
-  require 'optparse'
-  opt = OptionParser.new
+#@samplecode opt.rb
+require 'optparse'
+opt = OptionParser.new
 
-  opt.on('-a [VAL]') {|v| p :a }
-  opt.on('-b') {|v| p :b }
+opt.on('-a [VAL]') {|v| p :a }
+opt.on('-b') {|v| p :b }
 
-  opt.order!(ARGV)
-  p ARGV
-
-  $ ruby opt2.rb -a foo somefile -b
+opt.order!(ARGV)
+p ARGV
+#@end
+↓
+  $ ruby opt.rb -a foo somefile -b
   :a
   ["somefile", "-b"]
 
@@ -934,19 +942,18 @@ argv からオプションを取り除いたものを返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスになります。
 
-例:
+#@samplecode opt.rb
+require 'optparse'
+opt = OptionParser.new
 
-  $ cat opt.rb
-  require 'optparse'
-  opt = OptionParser.new
+opt.on('-a [VAL]') {|v| p :a }
+opt.on('-b ') {|v| p :b }
 
-  opt.on('-a [VAL]') {|v| p :a }
-  opt.on('-b ') {|v| p :b }
-
-  opt.permute!(ARGV)
-  p ARGV
-
-  $ ruby opt2.rb -a foo somefile -b
+opt.permute!(ARGV)
+p ARGV
+#@end
+↓
+  $ ruby opt.rb -a foo somefile -b
   :a
   :b
   ["somefile"]
@@ -977,19 +984,18 @@ argv を返します。
                                 実際は OptionParser::ParseError のサブク
                                 ラスになります。
 
-例:
+#@samplecode opt.rb
+require 'optparse'
+opt = OptionParser.new
 
-  $ cat opt.rb
-  require 'optparse'
-  opt = OptionParser.new
+opt.on('-a [VAL]') {|v| p :a }
+opt.on('-b ') {|v| p :b }
 
-  opt.on('-a [VAL]') {|v| p :a }
-  opt.on('-b ') {|v| p :b }
-
-  opt.permute!(ARGV)
-  p ARGV
-
-  $ ruby opt2.rb -a foo somefile -b
+opt.permute!(ARGV)
+p ARGV
+#@end
+↓
+  $ ruby opt.rb -a foo somefile -b
   :a
   :b
   ["somefile"]
@@ -1181,12 +1187,14 @@ getopts と違って、グローバル変数を定義しません。
 配列 argv を与えた場合、argv をパースします。そうでない場合は、
 default_argv をパースします。
 
- opt = OptionParser.new
- params = opt.getopts(ARGV, "ab:", "foo", "bar:")
- # params["a"] = true   # -a
- # params["b"] = "1"    # -b1
- # params["foo"] = true  # --foo
- # params["bar"] = "x"  # --bar x
+#@samplecode
+opt = OptionParser.new
+params = opt.getopts(ARGV, "ab:", "foo", "bar:")
+# params["a"] = true   # -a
+# params["b"] = "1"    # -b1
+# params["foo"] = true  # --foo
+# params["bar"] = "x"  # --bar x
+#@end
 
 @param argv パースしたい配列を指定します。
 

--- a/refm/api/src/optparse/date.rd
+++ b/refm/api/src/optparse/date.rd
@@ -5,12 +5,14 @@ require optparse
 オプションの引数はそれぞれのクラスのインスタンスに変換されてから、
 [[m:OptionParser#on]] のブロックに渡されます。
 
- require 'optparse/date'
- opts = OptionParser.new
- 
- opts.on("-d DATE", Date){|d|
-   p d.to_s #=> 2000-01-01
- }
- opts.parse!
- 
- # ruby command -d 2000/1/1
+#@samplecode
+require 'optparse/date'
+opts = OptionParser.new
+
+opts.on("-d DATE", Date){|d|
+  p d.to_s #=> 2000-01-01
+}
+opts.parse!
+
+# ruby command -d 2000/1/1
+#@end

--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -38,11 +38,7 @@ optparse を使う場合、基本的には
 れた時の処理をブロックで記述します。ブロックの引数にはオプションが指定
 されたことを示す true が渡されます([[ref:optionarg]]の項も参照)。
 
-#@since 1.9.1
 [[m:Enumerator#each]] などと違い、[[m:OptionParser#on]]
-#@else
-[[m:Enumerable::Enumerator#each]] などと違い、[[m:OptionParser#on]]
-#@end
 メソッドが呼ばれた時点ではブロックは実行されません。あくまで登録される
 だけです。[[m:OptionParser#parse]] が呼ばれた時に、コマンドラインにオプ
 ションが指定されていれば実行されます。

--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -321,8 +321,8 @@ parser.on('-i') { puts "-i" }
 parser.on('-o') { puts '-o' }
 
 subparsers = Hash.new {|h,k|
-$stderr.puts "no such subcommand: #{k}"
-exit 1
+  $stderr.puts "no such subcommand: #{k}"
+  exit 1
 }
 subparsers['add'] = OptionParser.new.on('-i') { puts "add -i" }
 subparsers['del'] = OptionParser.new.on('-i') { puts "del -i" }

--- a/refm/api/src/optparse/optparse-tut
+++ b/refm/api/src/optparse/optparse-tut
@@ -20,15 +20,17 @@ optparse を使う場合、基本的には
 
 以下はオプション -a, -b を受け付けるコマンドを作成する例です。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a') {|v| p v }
-        opt.on('-b') {|v| p v }
+opt.on('-a') {|v| p v }
+opt.on('-b') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby sample.rb -a foo bar -b baz
         # => true
              true
@@ -55,17 +57,19 @@ optparse を使う場合、基本的には
 [[m:OptionParser#parse!]] では、ARGV からオプションが取り除かれます。
 これを避けるには [[m:OptionParser#parse]] を使います。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a') {|v| p v }
-        opt.on('-b') {|v| p v }
+opt.on('-a') {|v| p v }
+opt.on('-b') {|v| p v }
 
-        # parse() の場合、ARGVは変更されない。
-        # オプションを取り除いた結果は argv に設定される。
-        argv = opt.parse(ARGV)
+# parse() の場合、ARGVは変更されない。
+# オプションを取り除いた結果は argv に設定される。
+argv = opt.parse(ARGV)
 
-        p argv
+p argv
+#@end
 
 定義していないオプションを指定すると例外
 [[c:OptionParser::InvalidOption]] が発生します。
@@ -86,18 +90,20 @@ optparse を使う場合、基本的には
 後の処理の方で、オプションによる条件判断を加えるには、
 他のコンテナに格納します。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        params = {}
+params = {}
 
-        opt.on('-a') {|v| params[:a] = v }
-        opt.on('-b') {|v| params[:b] = v }
+opt.on('-a') {|v| params[:a] = v }
+opt.on('-b') {|v| params[:b] = v }
 
-        opt.parse!(ARGV)
-        p ARGV
-        p params
-
+opt.parse!(ARGV)
+p ARGV
+p params
+#@end
+↓
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]
              {:a=>true, :b=>true}
@@ -110,18 +116,20 @@ optparse を使う場合、基本的には
 ロングオプションの値を、ショートオプションのみの場合はショートオプションの値から、
 先頭の "-" を除いてシンボル化した値が使用されます。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        params = {}
+params = {}
 
-        opt.on('-a') {|v| v }
-        opt.on('-b', '--bbb') {|v| v }
+opt.on('-a') {|v| v }
+opt.on('-b', '--bbb') {|v| v }
 
-        opt.parse!(ARGV, into: params) # intoオプションにハッシュを渡す
-        p ARGV
-        p params
-
+opt.parse!(ARGV, into: params) # intoオプションにハッシュを渡す
+p ARGV
+p params
+#@end
+↓
         ruby sample.rb -a foo bar -b baz
         # => ["foo", "bar", "baz"]
              {:a=>true, :bbb=>true}
@@ -133,14 +141,16 @@ optparse を使う場合、基本的には
 [[m:OptionParser#on]] メソッドのオプション定義で末尾に何かを書くと、そ
 のオプションは引数を受け付けることの指定となります。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a VAL') {|v| p v }         # <- " VAL" を追加
-        opt.on('-b') {|v| p v }
+opt.on('-a VAL') {|v| p v }         # <- " VAL" を追加
+opt.on('-b') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
+opt.parse!(ARGV)
+p ARGV
+#@end
 
         ruby sample.rb -a foo bar -b baz
 
@@ -162,15 +172,17 @@ optparse を使う場合、基本的には
 
 オプションの引数が必須でないことを示すには、" [" を付けます。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a [VAL]') {|v| p v }          # <- [VAL] を追加
-        opt.on('-b') {|v| p v }
+opt.on('-a [VAL]') {|v| p v }          # <- [VAL] を追加
+opt.on('-b') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby sample.rb -a
 
         # => nil
@@ -187,15 +199,17 @@ optparse を使う場合、基本的には
 
 ロングオプションは [[m:OptionParser#on]] の引数に '--'で始まるオプションを指定します。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a', '--foo') {|v| p v }
-        opt.on('--bar') {|v| p v }
+opt.on('-a', '--foo') {|v| p v }
+opt.on('--bar') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby sample.rb -a foo bar --bar baz
         # => true
              true
@@ -203,15 +217,17 @@ optparse を使う場合、基本的には
 
 --[no-]...などとすることで、否定型のオプションを指定することができます。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode sample.rb
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a', '--foo') {|v| p v }
-        opt.on('--[no-]bar') {|v| p v }
+opt.on('-a', '--foo') {|v| p v }
+opt.on('--[no-]bar') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby sample.rb -a foo bar --bar baz --no-bar
         # => true
              true
@@ -221,23 +237,27 @@ optparse を使う場合、基本的には
 オプションに対する引数も指定できます。ショートオプションと同じだが、
 GNUの慣習にあわせて
 
-        opt.on('-a', '--foo=VAL') {|v| p v }
-        opt.on('--[no-]bar[=VAL]') {|v| p v }
+#@samplecode
+opt.on('-a', '--foo=VAL') {|v| p v }
+opt.on('--[no-]bar[=VAL]') {|v| p v }
+#@end
 
 と "=" を使うのが良いと思われます。
 
 オプションを指定する時は、どのオプションか一意に決まる長さまで指定す
 れば良いです。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a', '--foo') {|v| p v }
-        opt.on('--[no-]bar') {|v| p v }
+opt.on('-a', '--foo') {|v| p v }
+opt.on('--[no-]bar') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby sample.rb --fo
 
 この例では、--fo は、--foo を指定したのと同じになります。この例なら --f
@@ -257,26 +277,30 @@ GNUの慣習にあわせて
 (優先度は低いが VERSION 定数も参照します。Ruby のバージョンを示す VERSION
 定数が ruby 1.8 までは定義されているので注意)
 
-        require 'optparse'
-        opt = OptionParser.new
-        Version = "1.2.3"       # opt.version = "1.2.3"
-        opt.parse!(ARGV)
-
+#@samplecode
+require 'optparse'
+opt = OptionParser.new
+Version = "1.2.3"       # opt.version = "1.2.3"
+opt.parse!(ARGV)
+#@end
+↓
         ruby ./sample.rb --version
         # => sample 1.2.3
 
 [[m:OptionParser#on]] の引数にそのオプションの説明を加えると --help の
 出力に反映されます。
 
-        require 'optparse'
-        opt = OptionParser.new
+#@samplecode
+require 'optparse'
+opt = OptionParser.new
 
-        opt.on('-a', 'description of -a') {|v| p v }
-        opt.on('-b', 'description of -b') {|v| p v }
+opt.on('-a', 'description of -a') {|v| p v }
+opt.on('-b', 'description of -b') {|v| p v }
 
-        opt.parse!(ARGV)
-        p ARGV
-
+opt.parse!(ARGV)
+p ARGV
+#@end
+↓
         ruby ./sample.rb --help
         # => Usage: sample [options]
                 -a                               description of -a
@@ -286,25 +310,27 @@ GNUの慣習にあわせて
 ====[a:subcmd] サブコマンド
 以下は cvs や svn のようにサブコマンドを解釈する例です。
 
-    #! /usr/bin/ruby
-    # contributed by Minero Aoki.
+#@samplecode subcom.rb
+#! /usr/bin/ruby
+# contributed by Minero Aoki.
 
-    require 'optparse'
+require 'optparse'
 
-    parser = OptionParser.new
-    parser.on('-i') { puts "-i" }
-    parser.on('-o') { puts '-o' }
+parser = OptionParser.new
+parser.on('-i') { puts "-i" }
+parser.on('-o') { puts '-o' }
 
-    subparsers = Hash.new {|h,k|
-      $stderr.puts "no such subcommand: #{k}"
-      exit 1
-    }
-    subparsers['add'] = OptionParser.new.on('-i') { puts "add -i" }
-    subparsers['del'] = OptionParser.new.on('-i') { puts "del -i" }
-    subparsers['list'] = OptionParser.new.on('-i') { puts "list -i" }
+subparsers = Hash.new {|h,k|
+$stderr.puts "no such subcommand: #{k}"
+exit 1
+}
+subparsers['add'] = OptionParser.new.on('-i') { puts "add -i" }
+subparsers['del'] = OptionParser.new.on('-i') { puts "del -i" }
+subparsers['list'] = OptionParser.new.on('-i') { puts "list -i" }
 
-    parser.order!(ARGV)
-    subparsers[ARGV.shift].parse!(ARGV) unless ARGV.empty?
+parser.order!(ARGV)
+subparsers[ARGV.shift].parse!(ARGV) unless ARGV.empty?
+#@end
 
 実行すると以下のようになります。
 
@@ -322,10 +348,12 @@ GNUの慣習にあわせて
 optparse を require すると ARGV に [[c:OptionParser::Arguable]] の機能
 が加わります。以下の書き方ができるようになります。
 [[m:OptionParser::Arguable#getopts]] はオプションを保持した Hash を返します。
-  # sample.rb の内容
-  require 'optparse'
-  params = ARGV.getopts("a:b:", "foo", "bar:")
-  p params
+
+#@samplecode sample.rb
+require 'optparse'
+params = ARGV.getopts("a:b:", "foo", "bar:")
+p params
+#@end
 この sample.rb を実行すると
   $ ruby sample.rb -a 1 --foo --bar xxx
   {"a"=>"1", "b"=>nil, "foo"=>true, "bar"=>"xxx"}

--- a/refm/api/src/optparse/shellwords.rd
+++ b/refm/api/src/optparse/shellwords.rd
@@ -5,12 +5,14 @@ require optparse
 オプションの引数は [[m:Shellwords.#shellwords]] によって配列に変換されてから、
 [[m:OptionParser#on]] のブロックに渡されます。
 
- require 'optparse/shellwords'
- opts = OptionParser.new
- 
- opts.on("-s VAL", Shellwords){|a|
-   p a #=> ["hoge", "foo", "bar"]
- }
- opts.parse!
- 
- # ruby command -s hoge\ foo\ bar
+#@samplecode
+require 'optparse/shellwords'
+opts = OptionParser.new
+
+opts.on("-s VAL", Shellwords){|a|
+  p a #=> ["hoge", "foo", "bar"]
+}
+opts.parse!
+
+# ruby command -s hoge\ foo\ bar
+#@end

--- a/refm/api/src/optparse/time.rd
+++ b/refm/api/src/optparse/time.rd
@@ -5,12 +5,14 @@ require optparse
 オプションの引数は [[c:Time]] クラスのインスタンスに変換されてから、
 [[m:OptionParser#on]] のブロックに渡されます。
 
- require 'optparse/time'
- opts = OptionParser.new
- 
- opts.on("-t TIME", Time){|t|
-   p t #=> Sat, Jan 01 2000 00:00:00 +0900
- }
- opts.parse!
- 
- # ruby command -t '2000/01/01 00:00'
+#@samplecode
+require 'optparse/time'
+opts = OptionParser.new
+
+opts.on("-t TIME", Time){|t|
+  p t #=> Sat, Jan 01 2000 00:00:00 +0900
+}
+opts.parse!
+
+# ruby command -t '2000/01/01 00:00'
+#@end

--- a/refm/api/src/optparse/uri.rd
+++ b/refm/api/src/optparse/uri.rd
@@ -5,12 +5,14 @@ require optparse
 オプションの引数は [[c:URI]] クラスのインスタンスに変換されてから、
 [[m:OptionParser#on]] のブロックに渡されます。
 
- require 'optparse/uri'
- opts = OptionParser.new
+#@samplecode
+require 'optparse/uri'
+opts = OptionParser.new
 
- opts.on("-u URI", URI){|u|
-   p u #=> #<URI::HTTP:0x201267d4 URL:http://www.example.com>
- }
- opts.parse!
- 
- # ruby command -u http://www.example.com
+opts.on("-u URI", URI){|u|
+  p u #=> #<URI::HTTP:0x201267d4 URL:http://www.example.com>
+}
+opts.parse!
+
+# ruby command -u http://www.example.com
+#@end


### PR DESCRIPTION
optpase ライブラリのサンプルコードに `#@samplecode ~ #@end` を追加してハイライトされるようにしました。