### PR TITLE
OpenSSL::BN クラスにコードや説明を追加し、全体的に整理

### DIFF
--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -298,8 +298,17 @@ a # => 128
 変換して [other, 変換後オブジェクト] にして返します。
 それ以外の場合は例外 TypeError を発生させます。
 
+#@samplecode
+require 'openssl'
+p 1.to_bn.coerce(2)  # => [2, 1]
+#@end
+
 @param other 変換の基準となるオブジェクト
 @raise TypeError 変換に失敗した場合に発生します
+
+coerce メソッドの詳細な説明は、[[m:Numeric#coerce]] にあります。
+@see [[m:Numeric#coerce]]
+
 
 --- copy(other) -> self
 other の内容を自身にコピーします。

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -304,6 +304,13 @@ OpenSSL::BN.new("7").mod_exp(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 1
 (self * r) % m == 1 となる r を返します。
 存在しない場合は例外 [[c:OpenSSL::BNError]] が発生します。
 
+#@samplecode
+require 'openssl'
+
+p 3.to_bn.mod_inverse(5) # => 2
+p (3 * 2) % 5            # => 1
+#@end
+
 @param m mod を取る数
 @raise OpenSSL::BNError 計算時エラー
 
@@ -355,6 +362,17 @@ OpenSSL::BN.new("128").num_bits # => 8
 
 --- num_bytes -> Integer
 自身を表現するのに使っているバイト数を返します。
+
+#@samplecode
+require 'openssl'
+
+p 0.to_bn.num_bytes   # => 0
+p 255.to_bn.num_bytes # => 1
+p 256.to_bn.num_bytes # => 2
+
+p  0b111_11111.to_bn.num_bytes # => 1
+p 0b1000_00000.to_bn.num_bytes # => 2
+#@end
 
 --- odd? -> bool
 自身が奇数である場合に真を返します。

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -21,16 +21,17 @@ baseに2を指定すると文字列を big-endian の符号無し整数のバイ
 (最初の4byteはbig-endianでデータ長を表わし、その後にそのデータ長のバイト
 列(big-endian)で数値を表す。最上位ビットが立っていると負数)。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("-241") # => -241
-  OpenSSL::BN.new("ff00",16) # => 65280
-  OpenSSL::BN.new("\x81",2) # => 129
-  OpenSSL::BN.new("\xff\x81",2) # => 65409
-  OpenSSL::BN.new("\x00\x00\x00\x02\x00\x81", 0) # => 129
-  OpenSSL::BN.new("\x00\x00\x00\x02\x80\x81", 0) # => -129
-  OpenSSL::BN.new(1209) # => 1209
+OpenSSL::BN.new("-241") # => -241
+OpenSSL::BN.new("ff00",16) # => 65280
+OpenSSL::BN.new("\x81",2) # => 129
+OpenSSL::BN.new("\xff\x81",2) # => 65409
+OpenSSL::BN.new("\x00\x00\x00\x02\x00\x81", 0) # => 129
+OpenSSL::BN.new("\x00\x00\x00\x02\x80\x81", 0) # => -129
+OpenSSL::BN.new(1209) # => 1209
+#@end
 
 @param str 整数を表す文字列
 @param base 文字列から整数に変換するときの基数
@@ -216,23 +217,25 @@ OpenSSL::BN.new(5) <=> OpenSSL::BN.new(-5)  # =>  1
 --- bit_set?(n) -> bool
 自身の n ビット目が立っているなら真を返します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("129").bit_set?(0) # => true
-  OpenSSL::BN.new("129").bit_set?(1) # => false
+OpenSSL::BN.new("129").bit_set?(0) # => true
+OpenSSL::BN.new("129").bit_set?(1) # => false
+#@end
 
 @param n 調べるビットの位置
 
 --- clear_bit!(n) -> self
 自身の n ビット目を0にします。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  a = OpenSSL::BN.new("129")
-  a.clear_bit!(0)
-  a # => 128
+a = OpenSSL::BN.new("129")
+a.clear_bit!(0)
+a # => 128
+#@end
 
 @param n 0にするビットの位置
 @raise OpenSSL::BNError 計算時エラー
@@ -272,10 +275,11 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 --- mod_add(other, m) -> OpenSSL::BN
 (self + other) % m を返します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("7").mod_add(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 4
+OpenSSL::BN.new("7").mod_add(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 4
+#@end
 
 @param other 和を取る数
 @param m 剰余を取る数
@@ -284,10 +288,11 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 --- mod_exp(other, m) -> OpenSSL::BN
 (self ** other) % m を返します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("7").mod_exp(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 1
+OpenSSL::BN.new("7").mod_exp(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 1
+#@end
 
 @param other 指数
 @param m 剰余を取る数
@@ -305,10 +310,11 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 --- mod_mul(other, m) -> OpenSSL::BN
 (self * other) % m を返します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("7").mod_mul(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 3
+OpenSSL::BN.new("7").mod_mul(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 3
+#@end
 
 @param other 積を取る数
 @param m 剰余を取る数
@@ -323,10 +329,11 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 --- mod_sub(other, m) -> OpenSSL::BN
 (self - other) % m を返します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("27").mod_sub(OpenSSL::BN.new("3"), OpenSSL::BN.new("5")) # => 4
+OpenSSL::BN.new("27").mod_sub(OpenSSL::BN.new("3"), OpenSSL::BN.new("5")) # => 4
+#@end
 
 @param other 引く数
 @param m 剰余を取る数
@@ -338,12 +345,13 @@ n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 
 符号は無視されます。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  OpenSSL::BN.new("127").num_bits # => 7
-  OpenSSL::BN.new("-127").num_bits # => 7
-  OpenSSL::BN.new("128").num_bits # => 8
+OpenSSL::BN.new("127").num_bits # => 7
+OpenSSL::BN.new("-127").num_bits # => 7
+OpenSSL::BN.new("128").num_bits # => 8
+#@end
 
 --- num_bytes -> Integer
 自身を表現するのに使っているバイト数を返します。
@@ -381,12 +389,13 @@ checksで指定した回数だけ繰り返します。
 checksがnilである場合は OpenSSL が適切な
 回数を判断します。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  # 181 は 「小さな素数」である
-  OpenSSL::BN.new("181").prime_fasttest?(nil, true) # => false
-  OpenSSL::BN.new("181").prime_fasttest?(nil, false) # => true
+# 181 は 「小さな素数」である
+OpenSSL::BN.new("181").prime_fasttest?(nil, true) # => false
+OpenSSL::BN.new("181").prime_fasttest?(nil, false) # => true
+#@end
 
 @param checks Miller-Robin法の繰り返しの回数
 @param vtrivdiv 真なら小さな素数で割ることでの素数判定を試みます
@@ -396,12 +405,13 @@ checksがnilである場合は OpenSSL が適切な
 --- set_bit!(n) -> self
 自身の n ビット目を1にします。
 
-例:
-  require 'openssl'
+#@samplecode
+require 'openssl'
 
-  a = OpenSSL::BN.new("128")
-  a.set_bit!(0)
-  a # => 129
+a = OpenSSL::BN.new("128")
+a.set_bit!(0)
+a # => 129
+#@end
 
 @param n 1にするビットの位置
 @raise OpenSSL::BNError 計算時エラー

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -207,7 +207,7 @@ OpenSSL::BN.new(5) <=> OpenSSL::BN.new(-5)  # =>  1
 --- ==(other) -> bool
 --- ===(other) -> bool
 --- eql?(other) -> bool
-自身と other が等しい場合に真を返します。
+自身と other が等しい場合に true を返します。
 
 @param other 比較する数
 
@@ -259,7 +259,7 @@ bn               # => #<OpenSSL::BN 4>
 @see [[m:OpenSSL::BN#>>]]
 
 --- bit_set?(n) -> bool
-自身の n ビット目が立っているなら真を返します。
+自身の n ビット目が立っているなら true を返します。
 
 #@samplecode
 require 'openssl'
@@ -269,6 +269,7 @@ OpenSSL::BN.new("129").bit_set?(1) # => false
 #@end
 
 @param n 調べるビットの位置
+@see   [[m:OpenSSL::set_bit!]]
 
 --- clear_bit!(n) -> self
 自身の n ビット目を0にします。
@@ -283,6 +284,7 @@ a # => 128
 
 @param n 0にするビットの位置
 @raise OpenSSL::BNError 計算時エラー
+@see   [[m:OpenSSL::set_bit!]]
 
 --- coerce(other) -> Array
 自身と other が同じクラスになるよう、自身か other を変換し
@@ -308,10 +310,22 @@ GCD(最大公約数)を返します。
 @raise OpenSSL::BNError 計算時エラー
 
 --- mask_bits!(n) -> self
-自身を下位 n ビットでマスクします。
+自身を下位 n ビットでマスクし、破壊的に変更します。
 
 n が自身のビット数より大きい場合は例外 [[c:OpenSSL::BNError]]
 が発生します。
+
+#@samplecode
+require 'openssl'
+
+bn = 0b1111_1111.to_bn
+
+bn.mask_bits!(8)
+p "%b" % bn      # => "11111111"
+
+bn.mask_bits!(3)
+p "%b" % bn      # =>     "111"
+#@end
 
 @param n マスクするビット数
 @raise OpenSSL::BNError 計算時エラー
@@ -420,14 +434,14 @@ p 0b1000_00000.to_bn.num_bytes # => 2
 #@end
 
 --- odd? -> bool
-自身が奇数である場合に真を返します。
+自身が奇数である場合に true を返します。
 
 --- one? -> bool
-自身が1である場合に真を返します。
+自身が1である場合に true を返します。
 
 --- prime? -> bool
 --- prime?(checks) -> bool
-自身が素数であるなら真を返します。
+自身が素数であるなら true を返します。
 
 Miller-Rabin 法により確率的に判定します。
 checkで指定した回数だけ繰り返します。
@@ -439,7 +453,7 @@ checkで指定した回数だけ繰り返します。
 @see [[m:OpenSSL::BN#prime_fasttest?]]
 
 --- prime_fasttest?(checks=nil, vtrivdiv=true) -> bool
-自身が素数であるなら真を返します。
+自身が素数であるなら true を返します。
 
 vtrivdiv が真である場合には、 Miller-Rabin 法での
 判定の前に小さな素数で割ることで素数か否かを
@@ -478,6 +492,7 @@ a # => 129
 
 @param n 1にするビットの位置
 @raise OpenSSL::BNError 計算時エラー
+@see   [[m:OpenSSL::clear_bit!]], [[m:OpenSSL::bit_set?]]
 
 --- sqr -> OpenSSL::BN
 自身の2乗を計算します。
@@ -566,7 +581,7 @@ OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(2))  # =>  1
 @see [[m:OpenSSL::BN#cmp]]
 
 --- zero? -> bool
-自身が0である場合に真を返します。
+自身が 0 である場合に true を返します。
 
 = class OpenSSL::BNError < OpenSSL::OpenSSLError
 [[c:OpenSSL::BN]] 関連のエラーを表す例外です。

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -598,6 +598,18 @@ OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(2))  # =>  1
 @raise TypeError 比較できないときに発生します。
 @see [[m:OpenSSL::BN#cmp]]
 
+#@since 2.5.0
+--- negative? -> bool
+自身が負である場合に true を返します。Ruby 2.5, OpenSSL 2.1.0 から利用できます。
+
+#@samplecode
+require 'openssl'
+p 15.to_bn.negative?    # => false
+p  0.to_bn.negative?    # => false
+p (-5).to_bn.negative?  # => treu
+#@end
+#@end
+
 --- zero? -> bool
 自身が 0 である場合に true を返します。
 

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -606,7 +606,7 @@ OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(2))  # =>  1
 require 'openssl'
 p 15.to_bn.negative?    # => false
 p  0.to_bn.negative?    # => false
-p (-5).to_bn.negative?  # => treu
+p (-5).to_bn.negative?  # => true
 #@end
 #@end
 

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -11,15 +11,15 @@ OpenSSL内で利用される多倍長整数クラスです。
 
 文字列を多倍長整数オブジェクト([[c:OpenSSL::BN]])を生成します。
 
-base によって変換の基数を決めることができます。
-10, 16 が利用可能です。
+base で、変換方法(基数)を指定します。
+デフォルトは 10 で、他に 16, 2, 0 を指定できます。
 
-baseに2を指定すると文字列を big-endian の符号無し整数のバイナリ列とみなして
-変換します。
-
-また、base に 0 を指定すると、MPIのフォーマットから変換します。
-(最初の4byteはbig-endianでデータ長を表わし、その後にそのデータ長のバイト
-列(big-endian)で数値を表す。最上位ビットが立っていると負数)。
+  10  引数の文字列を 10進数とみなして、変換します。
+  16  引数の文字列を 16進数とみなして、変換します。
+   2  引数の文字列を big-endian の符号無し整数のバイナリ列とみなして、変換します。
+   0  引数の文字列を MPI形式の文字列(バイト列)とみなして、変換します。
+      (最初の4byteはbig-endianでデータ長を表わし、その後にそのデータ長のバイト
+       列(big-endian)で数値を表す。最上位ビットが立っていると負数)。
 
 #@samplecode
 require 'openssl'
@@ -37,7 +37,10 @@ OpenSSL::BN.new(1209) # => 1209
 @param base 文字列から整数に変換するときの基数
 @raise OpenSSL::BNError 変換に失敗した場合に発生します
 
-@see [[m:Integer#to_bn]]
+反対に、[[c:OpenSSL::BN]] クラスのオブジェクトを文字列にするには、
+[[m:OpenSSL::BN#to_s]] を用います。
+
+@see [[m:OpenSSL::BN#to_s]]
 
 --- new(bn) -> OpenSSL::BN
 
@@ -51,6 +54,7 @@ OpenSSL::BN.new(1209) # => 1209
 ([[c:OpenSSL::BN]])を生成します。
 
 @param integer 整数オブジェクト
+@see [[m:Integer#to_bn]]
 
 --- generate_prime(bits, safe=true, add=nil, rem=nil) -> OpenSSL::BN
 ランダム(疑似乱数的)な bits ビットの素数を返します。
@@ -545,6 +549,11 @@ p 6.to_bn.to_s(0) # => "\x00\x00\x00\x01\x06"
 p 7.to_bn.to_s(0) # => "\x00\x00\x00\x01\a"
 #@end
 
+反対に、文字列から [[c:OpenSSL::BN]] クラスのインスタンスを作るには
+[[m:OpenSSL::BN.new]] を用います。
+
+@see [[m:OpenSSL::BN.new]]
+
 
 --- pretty_print(pp)
 
@@ -615,4 +624,4 @@ class Integer
 end
 #@end
 
-@see [[m:OpenSSL::BN.new]]
+@see [[m:OpenSSL::BN.new]], [[m:OpenSSL::BN#to_i]]

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -30,9 +30,7 @@ baseに2を指定すると文字列を big-endian の符号無し整数のバイ
   OpenSSL::BN.new("\xff\x81",2) # => 65409
   OpenSSL::BN.new("\x00\x00\x00\x02\x00\x81", 0) # => 129
   OpenSSL::BN.new("\x00\x00\x00\x02\x80\x81", 0) # => -129
-#@since 2.1.0
   OpenSSL::BN.new(1209) # => 1209
-#@end
 
 @param str 整数を表す文字列
 @param base 文字列から整数に変換するときの基数
@@ -44,14 +42,12 @@ baseに2を指定すると文字列を big-endian の符号無し整数のバイ
 
 @param bn 複製する [[c:OpenSSL::BN]] オブジェクト
 
-#@since 2.1.0
 --- new(integer) -> OpenSSL::BN
 
 整数オブジェクト([[c:Integer]])から多倍長整数オブジェクト
 ([[c:OpenSSL::BN]])を生成します。
 
 @param integer 整数オブジェクト
-#@end
 
 --- generate_prime(bits, safe=true, add=nil, rem=nil) -> OpenSSL::BN
 ランダム(疑似乱数的)な bits ビットの素数を返します。

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -453,14 +453,55 @@ a # => 129
 --- to_s(base=10) -> String
 自身を表す文字列を返します。
 
-base で基数を指定します。10,16を指定できます。
-2を指定すると自身の絶対値を big-endian の符号無し整数のバイナリ列に
-変換します。
-0を指定した場合には MPI 形式の文字列(バイト列)に変換します。
+base で、変換方法(基数)を指定します。
+デフォルトは 10 で、他に 16, 2, 0 を指定できます。
 
-@param base 文字列変換の基数
+  10  10進数の表記
+  16  16進数の表記
+   2  big-endianの符号無し整数のバイナリ列
+   0  MPI形式の文字列(バイト列)
+
+@param base 文字列への変換方法(基数)
 @raise OpenSSL::BNError 変換に失敗した場合に発生します
-@see [[m:OpenSSL::BN.new]]
+
+#@samplecode
+require 'openssl'
+
+p 10.to_bn.to_s   # =>  "10"
+p (-5).to_bn.to_s # =>  "-5"
+
+p 0.to_bn.to_s(16)  # =>   "0"
+p 9.to_bn.to_s(16)  # =>  "09"
+p 10.to_bn.to_s(16) # =>  "0A"
+p 16.to_bn.to_s(16) # =>  "10"
+p 26.to_bn.to_s(16) # =>  "1A"
+p 256.to_bn.to_s(16) # => "0100"
+
+p 0.to_bn.to_s(2) # => ""
+p 6.to_bn.to_s(2) # => "\x06"
+p 7.to_bn.to_s(2) # => "\a"
+
+p 0.to_bn.to_s(0) # => "\x00\x00\x00\x00"
+p 6.to_bn.to_s(0) # => "\x00\x00\x00\x01\x06"
+p 7.to_bn.to_s(0) # => "\x00\x00\x00\x01\a"
+#@end
+
+
+--- pretty_print(pp)
+
+[[m:Kernel.#pp]] でオブジェクトの内容を出力するときに、内部で呼ばれるメソッドです。
+
+#@samplecode
+#@until 2.5.0
+require 'pp'
+#@end
+require 'openssl'
+
+pp 5.to_bn     #=> #<OpenSSL::BN 5>
+pp (-5).to_bn  #=> #<OpenSSL::BN -5>
+#@end
+
+@param pp [[c:PP]] クラスのインスタンスオブジェクト
 
 --- ucmp(other) -> -1 | 0 | 1
 自身と other の絶対値を比較し、自身の絶対値が小さいときには -1、

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -3,7 +3,7 @@ include Comparable
 
 OpenSSL内で利用される多倍長整数クラスです。
 
-通常多倍長整数を利用するには [[c:Bignum]] を用いてください。
+通常多倍長整数を利用するには [[c:Integer]] を用いてください。
 
 == Class Methods
 

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -142,35 +142,48 @@ odd が真なら、生成される整数は奇数のみとなります。
 
 @param other かける数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_mul]]
+
 --- **(other) -> OpenSSL::BN
 自身の other 乗を返します。
 
 @param other 指数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_exp]]
 
 --- +(other) -> OpenSSL::BN
 自身と other の和を返します。
 
 @param other 足す整数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_add]]
 
 --- -(other) -> OpenSSL::BN
 自身から other を引いた値を返します。
 
 @param other 引く整数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_sub]]
 
 --- /(other) -> [OpenSSL::BN, OpenSSL::BN]
 自身を other で割った商と余りを配列で返します。
 
 @param other 除数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_inverse]]
 
 --- <<(other) -> OpenSSL::BN
 自身を other ビット左シフトした値を返します。
 
+#@samplecode
+bn = 1.to_bn
+pp bn << 1    # => #<OpenSSL::BN 2>
+pp bn         # => #<OpenSSL::BN 1>
+#@end
+
 @param other シフトするビット数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#lshift!]]
 
 --- <=>(other) -> -1 | 0 | 1
 --- cmp(other) -> -1 | 0 | 1
@@ -201,20 +214,49 @@ OpenSSL::BN.new(5) <=> OpenSSL::BN.new(-5)  # =>  1
 --- >>(other) -> OpenSSL::BN
 自身を other ビット右シフトした値を返します。
 
+#@samplecode
+require 'openssl'
+
+bn = 2.to_bn
+bn >> 1    # => #<OpenSSL::BN 1>
+bn         # => #<OpenSSL::BN 2>
+#@end
+
 @param other シフトするビット数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#rshift!]]
 
 --- lshift!(n) -> self
 自身を n ビット左シフトします。
+[[m:OpenSSL::BN#<<]]と異なり、破壊的メソッドです。
+
+#@samplecode
+require 'openssl'
+
+bn = 1.to_bn
+bn.lshift!(2)   # => #<OpenSSL::BN 4>
+bn              # => #<OpenSSL::BN 4>
+#@end
 
 @param n シフトするビット数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#<<]]
 
 --- rshift!(n) -> self
 自身を n ビット右シフトします。
+[[m:OpenSSL::BN#>>]と異なり、破壊的メソッドです。
+
+#@samplecode
+require 'openssl'
+
+bn = 8.to_bn
+bn.rshift!(1)    # => #<OpenSSL::BN 4>
+bn               # => #<OpenSSL::BN 4>
+#@end
 
 @param n シフトするビット数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#>>]]
 
 --- bit_set?(n) -> bool
 自身の n ビット目が立っているなら真を返します。
@@ -334,6 +376,7 @@ OpenSSL::BN.new("7").mod_mul(OpenSSL::BN.new("3"), OpenSSL::BN.new("6")) # => 3
 
 @param m mod を取る数
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#sqr]]
 
 --- mod_sub(other, m) -> OpenSSL::BN
 (self - other) % m を返します。
@@ -440,6 +483,7 @@ a # => 129
 自身の2乗を計算します。
 
 @raise OpenSSL::BNError 計算時エラー
+@see [[m:OpenSSL::BN#mod_sqr]]
 
 --- to_bn -> self
 自分自身を返します。

--- a/refm/api/src/openssl/BN
+++ b/refm/api/src/openssl/BN
@@ -37,6 +37,8 @@ OpenSSL::BN.new(1209) # => 1209
 @param base 文字列から整数に変換するときの基数
 @raise OpenSSL::BNError 変換に失敗した場合に発生します
 
+@see [[m:Integer#to_bn]]
+
 --- new(bn) -> OpenSSL::BN
 
 [[c:OpenSSL::BN]] を複製して返します。
@@ -484,10 +486,33 @@ OpenSSL::BN.new(-5).ucmp(OpenSSL::BN.new(2))  # =>  1
 = class OpenSSL::BNError < OpenSSL::OpenSSLError
 [[c:OpenSSL::BN]] 関連のエラーを表す例外です。
 
+
 = reopen Integer
 == Instance Methods
+
 --- to_bn -> OpenSSL::BN
+
 Integer を同じ数を表す [[c:OpenSSL::BN]] のオブジェクトに
 変換します。
 
-現在のバージョンでは正しく実装されていません。
+#@samplecode
+#@until 2.5.0
+require 'pp'
+#@end
+require 'openssl'
+
+pp 5.to_bn     #=> #<OpenSSL::BN 5>
+pp (-5).to_bn  #=> #<OpenSSL::BN -5>
+#@end
+
+なお、実装は、以下のようになっています。
+
+#@samplecode
+class Integer
+  def to_bn
+    OpenSSL::BN::new(self)
+  end
+end
+#@end
+
+@see [[m:OpenSSL::BN.new]]


### PR DESCRIPTION
[class OpenSSL::BN \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/class/OpenSSL=3a=3aBN.html)
上記のページに対する編集です。

以下のようなことをしました。
- 2.3以前の統合前の`Bignum`という単語が残っていたため、`Integer`に変更。
- 既存のコードに`#@samplecode` ~ `#@end`を追加し、シンタックスハイライト&COPYボタンを追加。
- `#@since 2.1.0`の分岐を削除。`OpenSSL::BN.new`で、`Integer`を引数に取る例のところ。
- いくつかのサンプルコードのないところに、サンプルコードを追加。
- `<<`と`lshift!`, `>>`と`rshift!`に参照を追加し、違いを説明。
- 返り値が`bool`で「真を返す」となっていたところを、「true を返す」に変更。
- `OpenSSL::BN#pretty_print`を追加。 
  `OpenSSL::BN`に対する`p`メソッドでの出力はわかりにくいので、`pp`メソッドの説明も書きました。