### PR TITLE
Psych のサンプルコードのハイライトを追加

### DIFF
--- a/refm/api/src/psych.rd
+++ b/refm/api/src/psych.rd
@@ -14,13 +14,15 @@ Psych を用いると YAML のパースと出力ができます。
 
 === 基本的な使いかた
 
-  require 'psych'
-  # YAML のテキストをパースする
-  Psych.load("--- foo") # => "foo"
+#@samplecode
+require 'psych'
+# YAML のテキストをパースする
+Psych.load("--- foo") # => "foo"
 
-  # YAML のデータを出力
-  Psych.dump("foo")     # => "--- foo\n...\n"
-  { :a => 'b'}.to_yaml  # => "---\n:a: b\n"
+# YAML のデータを出力
+Psych.dump("foo")     # => "--- foo\n...\n"
+{ :a => 'b'}.to_yaml  # => "---\n:a: b\n"
+#@end
 
 基本的な使い方はこれだけです。簡単な用事は
 [[m:Psych.load]]、[[m:Psych.dump]] で片付きます。
@@ -182,19 +184,21 @@ Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 そのクラスが追加されます。例えば Date クラスを許可するには
 以下のように書いてください:
 
-  Psych.safe_load(yaml, [Date])
+#@samplecode
+Psych.safe_load(yaml, [Date])
+#@end
 
 すると上のクラス一覧に加えて Date クラスが読み込まれます。
 
 エイリアスは aliases パラメーターを変更することで明示的に許可できます。
 
-例:
-
-  x = []
-  x << x
-  yaml = Psych.dump x
-  Psych.safe_load yaml               # => 例外発生
-  Psych.safe_load yaml, [], [], true # => エイリアスが読み込まれる
+#@samplecode 例
+x = []
+x << x
+yaml = Psych.dump x
+Psych.safe_load yaml               # => 例外発生
+Psych.safe_load yaml, [], [], true # => エイリアスが読み込まれる
+#@end
 
 yaml にホワイトリストにないクラスが含まれていた場合は、
 Psych::DisallowedClass 例外が発生します。
@@ -244,16 +248,16 @@ AST については [[c:Psych::Nodes]] を参照してください。
 @raise Psych::SyntaxError YAMLドキュメントに文法エラーが発見されたときに発生します
 @see [[m:Psych.load]]
 
-=== 例
+#@samplecode 例
+Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Document:...>
 
-  Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Document:...>
-
-  begin
-    Psych.parse("--- `", "file.txt")
-  rescue Psych::SyntaxError => ex
-    p ex.file    # => 'file.txt'
-    p ex.message # => "(file.txt): found character that cannot start any token while scanning for the next token at line 1 column 5"
-  end
+begin
+  Psych.parse("--- `", "file.txt")
+rescue Psych::SyntaxError => ex
+  p ex.file    # => 'file.txt'
+  p ex.message # => "(file.txt): found character that cannot start any token while scanning for the next token at line 1 column 5"
+end
+#@end
 
 --- parse_file(filename) -> Psych::Nodes::Document
 filename で指定したファイルをパースして YAML の AST を返します。
@@ -281,8 +285,9 @@ yaml が 複数の YAML ドキュメントを含む場合を取り扱うこと�
 
 @see [[c:Psych::Nodes]]
 
-=== 例
-  Psych.parse_stream("---\n - a\n - b") # => #<Psych::Nodes::Stream:0x00>
+#@samplecode 例
+Psych.parse_stream("---\n - a\n - b") # => #<Psych::Nodes::Stream:0x00>
+#@end
 
 --- dump(o, options = {}) -> String
 --- dump(o, io, options = {}) -> ()
@@ -301,27 +306,28 @@ options で出力に関するオプションを以下の指定できます。
 @param io 出力先
 @param options 出力オプション
 
-=== 例
+#@samplecode 例
+# Dump an array, get back a YAML string
+Psych.dump(['a', 'b'])  # => "---\n- a\n- b\n"
 
-  # Dump an array, get back a YAML string
-  Psych.dump(['a', 'b'])  # => "---\n- a\n- b\n"
+# Dump an array to an IO object
+Psych.dump(['a', 'b'], StringIO.new)  # => #<StringIO:0x000001009d0890>
 
-  # Dump an array to an IO object
-  Psych.dump(['a', 'b'], StringIO.new)  # => #<StringIO:0x000001009d0890>
+# Dump an array with indentation set
+Psych.dump(['a', ['b']], :indentation => 3) # => "---\n- a\n-  - b\n"
 
-  # Dump an array with indentation set
-  Psych.dump(['a', ['b']], :indentation => 3) # => "---\n- a\n-  - b\n"
-
-  # Dump an array to an IO with indentation set
-  Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
+# Dump an array to an IO with indentation set
+Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
+#@end
 
 --- dump_stream(*objects) -> String
 オブジェクト列を YAML ドキュメント列に変換します。
 
 @param objects 変換対象のオブジェクト列
 
-=== 例
-  Psych.dump_stream("foo\n  ", {}) # => "--- ! \"foo\\n  \"\n--- {}\n"
+#@samplecode 例
+Psych.dump_stream("foo\n  ", {}) # => "--- ! \"foo\\n  \"\n--- {}\n"
+#@end
 
 --- to_json(o) -> String
 Ruby のオブジェクト o を JSON の文字列に変換します。
@@ -335,14 +341,19 @@ Ruby のオブジェクトに変換します。
 
 ブロックなしの場合はオブジェクトの配列を返します。
 
-  Psych.load_stream("--- foo\n...\n--- bar\n...") # => ['foo', 'bar']
+#@samplecode 例
+Psych.load_stream("--- foo\n...\n--- bar\n...") # => ['foo', 'bar']
+#@end
 
 ブロックありの場合は各オブジェクト引数としてそのブロックを呼び出します。
-  list = []
-  Psych.load_stream("--- foo\n...\n--- bar\n...") do |ruby|
-    list << ruby
-  end
-  list # => ['foo', 'bar']
+
+#@samplecode 例
+list = []
+Psych.load_stream("--- foo\n...\n--- bar\n...") do |ruby|
+  list << ruby
+end
+list # => ['foo', 'bar']
+#@end
 
 filename はパース中に発生した例外のメッセージに用います。
 


### PR DESCRIPTION
Psych のサンプルコードに  `#@samplecode ~ #@end` を追加してハイライトされるようにしました。
NOTE: この PR では [Psych::Nodes](https://docs.ruby-lang.org/ja/latest/class/Psych=3a=3aNodes.html) などは未対応です。