### PR TITLE
Gem::Requirement クラスの加筆・整理

### DIFF
--- a/refm/api/src/rubygems/requirement.rd
+++ b/refm/api/src/rubygems/requirement.rd
@@ -10,11 +10,32 @@ Gem の必要条件を扱うクラスです。
 
 このクラスのインスタンスには複数の必要条件を含めることができます。
 
+[[c::Gem::Dependency]] の内部で使われています。
+
 == Constants
 
 --- OPS -> Hash
 
-比較演算子と対応する処理を格納したハッシュです。
+比較演算子と対応する処理を格納したハッシュです。次の内容と等価です。
+
+#@samplecode
+OPS = { #:nodoc:
+  "="  =>  lambda {|v, r| v == r },
+  "!=" =>  lambda {|v, r| v != r },
+  ">"  =>  lambda {|v, r| v >  r },
+  "<"  =>  lambda {|v, r| v <  r },
+  ">=" =>  lambda {|v, r| v >= r },
+  "<=" =>  lambda {|v, r| v <= r },
+  "~>" =>  lambda {|v, r| v >= r && v.release < r.bump },
+}.freeze
+#@end
+
+次のように、[[c:Gem::Version]] どうしを比較します。
+
+#@samplecode
+p Gem::Requirement::OPS["="].call(Gem::Version.new('3.1'), Gem::Version.new('3.0'))   # => false
+p Gem::Requirement::OPS["~>"].call(Gem::Version.new('3.1'), Gem::Version.new('3.0'))  # => true
+#@end
 
 
 == Singleton Methods
@@ -28,12 +49,21 @@ Gem の必要条件を扱うクラスです。
 
 @return 上記以外の値を input に指定するとデフォルト値を返します。
 
+#@samplecode
+p Gem::Requirement.create("~> 3.2.1")
+# => #<Gem::Requirement:0x000000000096a578 @requirements=[["~>", #<Gem::Version "3.2.1">]]>
+#@end
+
 @see [[m:Gem::Requirement.new]], [[m:Gem::Requirement.default]]
 
 --- default -> Gem::Requirement
 
 ゼロ以上 ( '>= 0' ) を指定して作成された [[c:Gem::Requirement]] のインスタンスを返します。
 
+#@samplecode
+p Gem::Requirement.default
+# => #<Gem::Requirement:0x0000000000a1d7b8 @requirements=[[">=", #<Gem::Version "0">]]>
+#@end
 
 --- new(requirements) -> Gem::Requirement
 
@@ -41,13 +71,35 @@ Gem の必要条件を扱うクラスです。
 
 @param requirements 文字列か配列か [[c:Gem::Version]] のインスタンスを指定します。
 
+#@samplecode
+p Gem::Requirement.new("~> 3.2.1")
+# => #<Gem::Requirement:0x000000000096a578 @requirements=[["~>", #<Gem::Version "3.2.1">]]>
+#@end
+
 @see [[m:Gem::Requirement#parse]], [[m:Gem::Requirement.create]]
+
+--- parse(obj) -> Array
+
+バージョンの必要上件をパースして比較演算子とバージョンを要素とする二要素の配列を返します。
+
+@param obj 必要上件を表す文字列または [[c:Gem::Version]] のインスタンスを指定します。
+@return 比較演算子と [[c:Gem::Version]] のインスタンスを要素とする二要素の配列を返します。
+@raise ArgumentError obj に不正なオブジェクトを指定すると発生します。
+
+#@samplecode
+p Gem::Requirement.parse("~> 3.2.1") # => ["~>", #<Gem::Version "3.2.1">]
+#@end
 
 == Public Instance Methods
 
-#@#--- as_list -> [String]
-#@# nodoc
-#@#必要条件を文字列の配列で返します。
+--- as_list -> [String]
+
+必要条件を文字列の配列で返します。
+
+#@samplecode
+req = Gem::Requirement.new("< 5.0", ">= 1.9")
+p req.as_list  # => ["< 5.0", ">= 1.9"]
+#@end
 
 #@#--- marshal_dump -> Array
 #@# nodoc
@@ -57,16 +109,6 @@ Gem の必要条件を扱うクラスです。
 #@# nodoc
 #@#必要条件をロードします。
 
---- parse(obj) -> Array
-
-バージョンの必要上件をパースして比較演算子とバージョンを要素とする二要素の配列を返します。
-
-@param obj 必要上件を表す文字列または [[c:Gem::Version]] のインスタンスを指定します。
-
-@return 比較演算子と [[c:Gem::Version]] のインスタンスを要素とする二要素の配列を返します。
-
-@raise ArgumentError obj に不正なオブジェクトを指定すると発生します。
-
 #@#--- requirements -> Array
 #@# nodoc
 #@#自身に含まれる必要条件の配列を返します。
@@ -75,12 +117,94 @@ Gem の必要条件を扱うクラスです。
 
 
 --- satisfied_by?(version) -> bool
+--- ===(version) -> bool
+--- =~(version) -> bool
 
-引数 version が自身に含まれる全ての必要条件を満たす場合に真を返します。
-そうでなければ偽を返します。
+引数 version が自身に含まれる全ての必要条件を満たす場合に true を返します。
+そうでなければ、false を返します。
 
 @param version [[c:Gem::Version]] のインスタンスを指定します。
 
+#@samplecode
+req = Gem::Requirement.new("~> 3.2.1")
 
-#@#--- to_s -> String
-#@# nodoc
+p req.satisfied_by?(Gem::Version.new('3.2.9'))  # => true
+p req.satisfied_by?(Gem::Version.new('3.3.0'))  # => false
+#@end
+
+--- specific? -> bool
+
+条件に上限のある指定で、最新のバージョンにマッチしない可能性のある場合は、true を返します。
+
+#@samplecode
+p Gem::Requirement.new(">= 3").specific?  # => false
+p Gem::Requirement.new("~> 3").specific?  # => true
+p Gem::Requirement.new("=  3").specific?  # => true
+#@end
+
+--- exact? -> bool
+
+条件がちょうどのバージョンが指定されている場合は、true を返します。
+
+#@samplecode
+p Gem::Requirement.new("= 3").exact?          # => true
+p Gem::Requirement.new("= 3", "= 3").exact?   # => true
+p Gem::Requirement.new("= 3", "= 5").exact?   # => false
+p Gem::Requirement.new("= 3", ">= 3").exact?  # => false
+p Gem::Requirement.new(">= 3").exact?         # => false
+#@end
+
+--- none? -> bool
+
+自身が条件を持たない場合は、true を返します。
+
+#@samplecode
+req = Gem::Requirement.new(">= 0")
+p req.none?  # => true
+#@end
+
+--- concat(requirements) -> Array
+
+新しい条件(配列)を自身の条件に破壊的に加えます。
+
+@param requirements 条件の配列を指定します。
+
+#@samplecode
+req = Gem::Requirement.new("< 5.0")
+req.concat(["= 1.9"])
+puts req  # => < 5.0, = 1.9
+#@end
+
+--- prerelease? -> bool
+
+何らかのバージョンがプレリリースのものであれば、true を返します。
+
+#@samplecode
+p Gem::Requirement.new("< 5.0").prerelease?   # => false
+p Gem::Requirement.new("< 5.0a").prerelease?  # => true
+#@end
+
+--- to_s -> String
+
+条件を表す文字列を返します。
+
+#@samplecode
+req = Gem::Requirement.new(["< 5.0", ">= 1.9"])
+p req.to_s # => "< 5.0, >= 1.9"
+#@end
+
+--- pretty_print(pp) -> String
+
+わかりやすい形で、条件を表す文字列を返します。
+pp メソッドで出力する際に、内部で用いられます。
+
+@param PP [[c::PP]] オブジェクトを指定します。
+
+#@samplecode
+#@until 2.5.0
+require 'pp'
+
+#@end
+req = Gem::Requirement.new(["< 5.0", ">= 1.9"])
+pp req # => Gem::Requirement.new(["< 5.0", ">= 1.9"])
+#@end

--- a/refm/api/src/rubygems/requirement.rd
+++ b/refm/api/src/rubygems/requirement.rd
@@ -50,8 +50,8 @@ p Gem::Requirement::OPS["~>"].call(Gem::Version.new('3.1'), Gem::Version.new('3.
 @return 上記以外の値を input に指定するとデフォルト値を返します。
 
 #@samplecode
-p Gem::Requirement.create("~> 3.2.1")
-# => #<Gem::Requirement:0x000000000096a578 @requirements=[["~>", #<Gem::Version "3.2.1">]]>
+pp Gem::Requirement.create("~> 3.2.1")
+# => Gem::Requirement.new(["~> 3.2.1"])
 #@end
 
 @see [[m:Gem::Requirement.new]], [[m:Gem::Requirement.default]]
@@ -61,8 +61,8 @@ p Gem::Requirement.create("~> 3.2.1")
 ゼロ以上 ( '>= 0' ) を指定して作成された [[c:Gem::Requirement]] のインスタンスを返します。
 
 #@samplecode
-p Gem::Requirement.default
-# => #<Gem::Requirement:0x0000000000a1d7b8 @requirements=[[">=", #<Gem::Version "0">]]>
+pp Gem::Requirement.default
+# => Gem::Requirement.new([">= 0"])
 #@end
 
 --- new(requirements) -> Gem::Requirement
@@ -72,8 +72,8 @@ p Gem::Requirement.default
 @param requirements 文字列か配列か [[c:Gem::Version]] のインスタンスを指定します。
 
 #@samplecode
-p Gem::Requirement.new("~> 3.2.1")
-# => #<Gem::Requirement:0x000000000096a578 @requirements=[["~>", #<Gem::Version "3.2.1">]]>
+pp Gem::Requirement.new("~> 3.2.1")
+# => Gem::Requirement.new(["~> 3.2.1"])
 #@end
 
 @see [[m:Gem::Requirement#parse]], [[m:Gem::Requirement.create]]

--- a/refm/api/src/rubygems/requirement.rd
+++ b/refm/api/src/rubygems/requirement.rd
@@ -16,9 +16,6 @@ Gem の必要条件を扱うクラスです。
 
 比較演算子と対応する処理を格納したハッシュです。
 
---- OP_RE
-
-比較演算子のいずれかにマッチする正規表現です。
 
 == Singleton Methods
 
@@ -47,9 +44,6 @@ Gem の必要条件を扱うクラスです。
 @see [[m:Gem::Requirement#parse]], [[m:Gem::Requirement.create]]
 
 == Public Instance Methods
-
-#@#--- <=>(other) -> Integer
-#@# nodoc
 
 #@#--- as_list -> [String]
 #@# nodoc

--- a/refm/api/src/rubygems/requirement.rd
+++ b/refm/api/src/rubygems/requirement.rd
@@ -63,10 +63,6 @@ Gem の必要条件を扱うクラスです。
 #@# nodoc
 #@#必要条件をロードします。
 
---- normalize -> nil
-
-self を正規化します。
-
 --- parse(obj) -> Array
 
 バージョンの必要上件をパースして比較演算子とバージョンを要素とする二要素の配列を返します。
@@ -91,22 +87,6 @@ self を正規化します。
 
 @param version [[c:Gem::Version]] のインスタンスを指定します。
 
-@see [[m:Gem::Requirement#satisfy?]]
-
---- satisfy?(op, version, required_version) -> bool
-
-version op required_version を満たす場合に真を返します。
-そうでなければ偽を返します。
-
-@param op 比較演算子 (<, <=, =, =>, >, !=, ~>) を文字列で指定します。
-
-@param version  外部から与えられるバージョンを [[c:Gem::Version]] のインスタンスで指定します。
-
-@param required_version 満たすべき条件を示すバージョンを指定します。
-
-@see [[m:Gem::Requirement#satisfied_by?]]
 
 #@#--- to_s -> String
 #@# nodoc
-
-


### PR DESCRIPTION
[class Gem::Requirement \(Ruby 3\.0\.0 リファレンスマニュアル\)](https://docs.ruby-lang.org/ja/latest/class/Gem=3a=3aRequirement.html)
上記クラスに対するPRです。

だいぶ古そうなメソッドなどを削除して、いくつかのメソッドを加筆しました。