### PR TITLE
Net::HTTPの使用例でNet::HTTP.getを使用するように修正

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -9,12 +9,12 @@ category Network
 
 例1: GET して 表示するだけ
   require 'net/http'
-  Net::HTTP.get_print 'www.example.com', '/index.html'
+  print Net::HTTP.get('www.example.com', '/index.html')
 
 例2: [[c:URI]] を使う
   require 'net/http'
   require 'uri'
-  Net::HTTP.get_print URI.parse('http://www.example.com/index.html')
+  print Net::HTTP.get(URI.parse('http://www.example.com/index.html'))
 
 例3: より汎用的な例
 


### PR DESCRIPTION
Net::HTTPのページの頭に書かれている使用例では`Net::HTTP.get_print`を使った例が出てきますが、
`Net::HTTP.get`を使った例は出てきません。
このため、単にページをGETするだけでも`Net::HTTP.start`を使った初期化を行う必要があると誤解されているケースが
あるのではないかと思いました。（私もそうだったのですが）

`Net::HTTP.get_print`は`print Net::HTTP.get`とほぼ等価で後者のほうが応用が効くので、
`Net::HTTP.get`を使うように書き換えてはどうでしょうか。