### PR TITLE
Typo 「満たん」 -> 「満タン」に修正 

### DIFF
--- a/refm/api/src/thread/ConditionVariable
+++ b/refm/api/src/thread/ConditionVariable
@@ -47,7 +47,7 @@ alias ConditionVariable
     }
 
 以下は [[ruby-list:14445]] で紹介されている例です。@q が空になった場合、
-あるいは満たんになった場合に Condition Variable を使って wait しています。
+あるいは満タンになった場合に Condition Variable を使って wait しています。
 
   require 'thread'
 


### PR DESCRIPTION
満タンの"タン"とはタンクの略らしいのでカタカナで表記する方がいいと思いました。
[参考url](https://dictionary.goo.ne.jp/word/%E6%BA%80%E3%82%BF%E3%83%B3/)