### PR TITLE
irb: Remove e2mmap dependency and lib/irb/slex.rb since 2.7

### DIFF
--- a/refm/api/src/LIBRARIES
+++ b/refm/api/src/LIBRARIES
@@ -98,7 +98,9 @@ irb/notifier
 irb/output-method
 irb/ruby-lex
 irb/ruby-token
+#@until 2.7.0
 irb/slex
+#@end
 irb/version
 irb/workspace
 irb/ws-for-case-2

--- a/refm/api/src/irb.rd
+++ b/refm/api/src/irb.rd
@@ -2,7 +2,9 @@
 
 category Development
 
+#@until 2.7.0
 require e2mmap
+#@end
 require irb/init
 require irb/context
 require irb/extend-command

--- a/refm/api/src/irb/notifier.rd
+++ b/refm/api/src/irb/notifier.rd
@@ -1,4 +1,6 @@
+#@until 2.7.0
 require e2mmap
+#@end
 require irb/output-method
 
 ライブラリ内部で使用します。

--- a/refm/api/src/irb/output-method.rd
+++ b/refm/api/src/irb/output-method.rd
@@ -1,4 +1,6 @@
+#@until 2.7.0
 require e2mmap
+#@end
 
 irb が出力を扱うためのサブライブラリです。
 

--- a/refm/api/src/irb/ruby-lex.rd
+++ b/refm/api/src/irb/ruby-lex.rd
@@ -1,5 +1,7 @@
+#@until 2.7.0
 require e2mmap
 require irb/slex
+#@end
 require irb/ruby-token
 
 Ruby のソースコードを字句解析するためのサブライブラリです。

--- a/refm/api/src/irb/slex.rd
+++ b/refm/api/src/irb/slex.rd
@@ -1,3 +1,4 @@
+#@until 2.7.0
 require e2mmap
 require irb/notifier
 
@@ -5,3 +6,4 @@ Ruby のソースコードを字句解析するためのサブライブラリで
 [[lib:irb/ruby-lex]] から使用されます。
 
 このライブラリで定義されているメソッドはユーザが直接使用するものではありません。
+#@end


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/51ea1abb5f2ed70387dda28a5d0d9ee817367d61
https://github.com/ruby/ruby/commit/efbca15116d4aea1588c6ba4ef0eb72c3c55c1db