### PR TITLE
3.0.0でクラス変数の挙動が変更されたため説明を更新

### DIFF
--- a/refm/doc/spec/variables.rd
+++ b/refm/doc/spec/variables.rd
@@ -193,7 +193,7 @@ _ですが、組み込み変数の一部には
  end
 
  class Bar
-   p @@v       #=> RuntimeError になります。
+   p @@v       #=> RuntimeError (class variable @@v of Bar is overtaken by Foo)
  end
 
 #@end

--- a/refm/doc/spec/variables.rd
+++ b/refm/doc/spec/variables.rd
@@ -137,11 +137,11 @@ _ですが、組み込み変数の一部には
 
  class Foo
  end
- 
+
  class Bar < Foo
    @@v = :bar
  end
- 
+
  class Foo
    @@v = :foo
  end
@@ -156,23 +156,44 @@ _ですが、組み込み変数の一部には
 
 #@end
 
-#@since 1.9.0
+#@until 3.0.0
 親クラスに、子クラスで既に定義されている同名のクラス変数を追加した場合には、
 子クラスのクラス変数が上書きされます。
 
  class Foo
  end
- 
+
  class Bar < Foo
    @@v = :bar
  end
- 
+
  class Foo
    @@v = :foo
  end
 
  class Bar
    p @@v       #=> :foo
+ end
+
+#@end
+
+#@since 3.0.0
+親クラスに、子クラスで既に定義されている同名のクラス変数を追加した場合、
+子クラスが、そのクラス変数を参照した際に例外 [[c:RuntimeError]] が発生します。
+
+ class Foo
+ end
+
+ class Bar < Foo
+   @@v = :bar
+ end
+
+ class Foo
+   @@v = :foo
+ end
+
+ class Bar
+   p @@v       #=> RuntimeError になります。
  end
 
 #@end
@@ -189,16 +210,16 @@ _ですが、組み込み変数の一部には
    class << Foo
      p @@a       #=> :a
    end
-   
+
    def Foo.a1
      p @@a
    end
  end
 
- Foo.a1          #=> :a              
- 
+ Foo.a1          #=> :a
+
  def Foo.a2
-   p @@a 
+   p @@a
  end
  Foo.a2          #=> NameError になります。
 


### PR DESCRIPTION
# PR の概要
3.0.0にて、子クラスで定義されているクラス変数を親クラスで再定義した場合に、子クラスがそのクラス変数を参照すると例外が発生するように変更されました。

下記のスクリーンショットの「修正前」にあるように、上記の挙動について言及されていなかったため、説明文とサンプルコードを更新しました。

（加えて、不要な空白を削除しました）

# スクリーンショット
## 修正前

![Screen Shot 2021-06-20 at 16 40 21](https://user-images.githubusercontent.com/51867807/122666272-3ca48e80-d1e7-11eb-9504-0b2c26818470.png)

## 修正後

![Screen Shot 2021-06-20 at 16 41 55](https://user-images.githubusercontent.com/51867807/122666275-429a6f80-d1e7-11eb-9a82-bf15ac43aa67.png)

# 参考
- 上記の挙動変更のチケット: https://bugs.ruby-lang.org/issues/14541
- https://github.com/rurema/doctree/issues/2458


<details>
<summary>手元でリファレンスマニュアルに記載されているサンプルコードを実行した時のログ</summary>

環境: Ruby 3.0.0

```ruby
irb(main):001:1* class Foo
irb(main):002:0> end
=> nil
irb(main):003:1* class Bar < Foo
irb(main):004:1*   @@v = :bar
irb(main):005:0> end
=> :bar
irb(main):006:1* class Foo
irb(main):007:1*   @@v = :foo
irb(main):008:0> end
=> :foo
irb(main):009:1* class Bar
irb(main):010:1*   p @@v
irb(main):011:1* end
Traceback (most recent call last):
        5: from /Users/koheitakahashi/.rbenv/versions/3.0.0/bin/irb:23:in `<main>'
        4: from /Users/koheitakahashi/.rbenv/versions/3.0.0/bin/irb:23:in `load'
        3: from /Users/koheitakahashi/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/irb-1.3.0/exe/irb:11:in `<top (required)>'
        2: from (irb):9:in `<main>'
        1: from (irb):10:in `<class:Bar>'
RuntimeError (class variable @@v of Bar is overtaken by Foo)

```

</details>


