### PR TITLE
`require irb`が不要になった変更は今は"実験的"ではないので、説明から"実験的"という表記を削除

### DIFF
--- a/refm/api/src/_builtin/Binding
+++ b/refm/api/src/_builtin/Binding
@@ -150,7 +150,7 @@ binding.eval("self")
 --- irb -> object
 REPLのセッションを開始します。
 
-2.5.0 からは require 'irb' せずに直接 binding.irb を呼び出しても使えるようになりました。(実験的)
+2.5.0 からは require 'irb' せずに直接 binding.irb を呼び出しても使えるようになりました。
 
 @see [[lib:irb]]
 #@end


### PR DESCRIPTION
#2582 への対応です。
変更内容、理由は表題の通りです。