### PR TITLE
Add ENV.clone and ENV.dup

### DIFF
--- a/refm/api/src/_builtin/ENV
+++ b/refm/api/src/_builtin/ENV
@@ -424,3 +424,28 @@ ENV.except("TERM","HOME") #=> {"LANG"=>"en_US.UTF-8"}
 
 @see [[m:Hash#except]], [[m:ENV.slice]]
 #@end
+--- clone(freeze: true) -> object
+ENV オブジェクトの複製を作成して返します。
+
+ENV は OS のプロセス全体で共有される環境変数を操作するラッパーオブジェクトなので、複製は有用ではありません。
+そのため、3.1 からは複製で環境変数を操作するときに deprecated 警告がでます。
+
+テスト実行中に環境変数を退避する用途には [[m:ENV.to_h]] を使用してください。
+
+#@samplecode
+saved_env = ENV.to_h
+# (テストなど)
+ENV.replace(saved_env)
+#@end
+
+@see [[m:Object#clone]]
+#@since 3.1.0
+@see [[m:ENV.dup]]
+--- dup -> ()
+[[c:TypeError]]を発生させます。
+
+3.0 以前では Object.new と同様の ENV とは無関係の有用ではないオブジェクトを返していたため、3.1 からは例外が発生するようになりました。
+詳細は[[m:ENV.clone]]を参照してください。
+
+@see [[m:ENV.clone]]
+#@end


### PR DESCRIPTION
Ruby 3.1 で `ENV.clone` と `ENV.dup` が追加されて挙動が変更されたため、ドキュメントの追加です。
`ENV.dup` は操作しようとするとエラーになるため誤用の可能性は低い(けど存在する)のですが、 `ENV.clone` は誤用されている可能性が高い(し、多数存在する)ので、3.0 以前にも追加しています。

https://bugs.ruby-lang.org/issues/17767
https://github.com/ruby/ruby/pull/4557
https://blog.n-z.jp/blog/2021-06-12-ruby-env.html