### PR TITLE
Remove `Data` since 3.0.0

### DIFF
--- a/refm/api/src/_builtin.rd
+++ b/refm/api/src/_builtin.rd
@@ -21,7 +21,9 @@ require を書かなくても使うことができます。
 #@since 2.3.0
 #@include(thread/ConditionVariable)
 #@end
+#@until 3.0.0
 #@include(_builtin/Data)
+#@end
 #@include(_builtin/Dir)
 #@include(_builtin/ENV)
 #@include(_builtin/EOFError)

--- a/refm/api/src/_builtin/Data
+++ b/refm/api/src/_builtin/Data
@@ -1,8 +1,6 @@
 = class Data < Object
 
-このクラスは Ruby 2.5 から deprecated です。
-Fixnum や Bignum が Integer に統合されたように、将来 Object に統合されて
-Ruby スクリプトレベルでは見えなくなる予定です。
+このクラスは Ruby 3.0 で削除されました。
 
 拡張ライブラリを書く時に new が定義されているとまずい場合が
 あるため、[[c:Object]] から new と allocate を undef したクラスです。


### PR DESCRIPTION
`Data` クラスは Ruby 3.0 で削除されたため、3.0以降はリンクしないようにしました。
`Data` クラス自体の説明は残しています。

ref: https://github.com/ruby/ruby/commit/c30f03d32833f38fedf41ecb08f1ade9c6657fef
ref: #2458