### PR TITLE
Struct::Group#nameと#name=()の説明を修正

### DIFF
--- a/refm/api/src/etc.rd
+++ b/refm/api/src/etc.rd
@@ -484,12 +484,12 @@ alias Etc::Group
 
 --- name -> String
 
-グループ名を設定します。
+グループ名を返します。
 
 
 --- name=(name)
 
-グループ名を返します。
+グループ名を設定します。
 
 --- passwd -> String
 


### PR DESCRIPTION
Struct::Group#nameと#name=()の説明が逆になっていたため、修正しました。
Closes #2592