### PR TITLE
Fix return type of `File.size?`

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -900,7 +900,7 @@ File.umask         # => 6
 
 @param path パスを表す文字列か IO オブジェクトを指定します。
 
---- size?(path)    -> bool
+--- size?(path)    -> Integer | nil
 
 [[m:FileTest.#size?]] と同じです。
 


### PR DESCRIPTION
関連: https://github.com/ruby/ruby/commit/48145282969230ba4a7c8cc7a6aedfd1263900c4