### PR TITLE
Object#public_send の説明を #send に合わせる形でブロック付きの用法を加える

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1024,9 +1024,12 @@ p Foo.new.send(methods[3])      # => "baz"
 @see [[m:Object#public_send]], [[m:BasicObject#__send__]], [[m:Object#method]], [[m:Kernel.#eval]], [[c:Proc]], [[c:Method]]
 
 --- public_send(name, *args) -> object
+--- public_send(name, *args) { .... } -> object
 
 オブジェクトの public メソッド name を args を引数にして呼び出し、メソッ
 ドの実行結果を返します。
+
+ブロック付きで呼ばれたときはブロックもそのまま引き渡します。
 
 #@samplecode
 1.public_send(:+, 2)  # => 3


### PR DESCRIPTION
`Object#send` にはブロック付きの用法とそれに関する記述があるのですが `Object#public_send` には無かったので、`public_send` を `send` に合わせる形でブロック付きの用法と記述を加えました。

（`send` には書いてあるのに `public_send` には書いていなかったので、「あれ？もしかして `public_send` はブロック非対応？」と思ってしまいました。）

補足：「昔はブロック非対応だったのかも」と思って 1.9.0 で確認しましたが、昔からブロックに対応していました。