### PR TITLE
Add string encoding IBM720 alias CP720 since 3.0.0

### DIFF
--- a/refm/api/src/_builtin/Encoding
+++ b/refm/api/src/_builtin/Encoding
@@ -491,6 +491,17 @@ CP437 エンコーディング。
 @see [[url:https://en.wikipedia.org/wiki/Code_page_437]],
      [[m:Encoding::CP869]]
 
+#@since 3.0.0
+--- IBM720 -> Encoding
+--- CP720 -> Encoding
+
+CP720 エンコーディング。
+
+アラビア語を取り扱う 8bit single-byteエンコーディングです。
+
+@see [[url:https://en.wikipedia.org/wiki/Code_page_720]]
+
+#@end
 
 --- IBM737 -> Encoding
 --- CP737 -> Encoding


### PR DESCRIPTION
Ruby 3.0 から追加された `Encoding::CP720` の説明を追加します。

```ruby
irb(main):002:0> RUBY_VERSION
=> "3.0.2"
irb(main):001:0> 'ب'.encode(Encoding::CP720)
=> "\xA0"
```

```ruby
irb(main):001:0> RUBY_VERSION
=> "2.7.4"
irb(main):002:0> 'ب'.encode(Encoding::CP720)
Traceback (most recent call last):
        4: from /Users/mi/.asdf/installs/ruby/2.7.4/bin/irb:23:in `<main>'
        3: from /Users/mi/.asdf/installs/ruby/2.7.4/bin/irb:23:in `load'
        2: from /Users/mi/.asdf/installs/ruby/2.7.4/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        1: from (irb):2
NameError (uninitialized constant Encoding::CP720)
Did you mean?  Encoding::CP1250
```

ref: https://github.com/rurema/doctree/issues/2458
ref: https://bugs.ruby-lang.org/issues/16233
ref: https://en.wikipedia.org/wiki/Code_page_720