### PR TITLE
[Add] String#length に16進数表記文字とUnicodeコードポイントの具体例を追加 && 戻り値コメントのインデント統一

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1802,10 +1802,12 @@ p "foo".intern.to_s == "foo"   # => true
 文字列の文字数を返します。バイト数を知りたいときは bytesize メソッドを使ってください。
 
 #@samplecode 例
-"test".length   # => 4
-"test".size     # => 4
-"テスト".length   # => 3
-"テスト".size     # => 3
+"test".length          # => 4
+"test".size            # => 4
+"テスト".length         # => 3
+"テスト".size           # => 3
+"\x80\u3042".length    # => 2
+"\x80\u3042".size      # => 2
 #@end
 
 @see [[m:String#bytesize]]


### PR DESCRIPTION
[本家](https://docs.ruby-lang.org/en/3.0.0/String.html#method-i-length)に、16進数表記文字とUnicodeコードポイントの具体例があったので追加しました。


また、16進数表記文字やUnicodeコードポイント等がこのような文字の塊で1文字とカウントされることは、初心者やるりまを読み始めた人は知らないと思います。るりまに記載しておけば、読者を「自分が何を分かっていないかを知らない」状態から「自分が何を分かっていないかを知っている」状態へ持っていけると思います。

初めてのPRです。
至らない所があれば、ご指摘をお願いいたします。
