### PR TITLE
`MatchData#offset(name)` の説明を追加

### DIFF
--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -152,6 +152,34 @@ n 番目の部分文字列のオフセットの配列 [start, end] を返
 
 @see [[m:MatchData#begin]], [[m:MatchData#end]]
 
+--- offset(name) -> [Integer]
+
+name という名前付きグループに対応する部分文字列のオフセットの配列 [start, end] を返
+します。
+
+#@samplecode 例
+[ self.begin(name), self.end(name) ]
+#@end
+
+と同じです。nameの名前付きグループにマッチした部分文字列がなければ
+[nil, nil] を返します。
+
+@param name 名前(シンボルか文字列)
+
+@raise IndexError 正規表現中で定義されていない name を指定した場合に発生します。
+
+#@samplecode 例
+/(?<year>\d{4})年(?<month>\d{1,2})月(?:(?<day>\d{1,2})日)?/ =~ "2021年1月"
+p $~.offset('year')    # => [0, 4]
+p $~.offset(:year)     # => [0, 4]
+p $~.offset('month')   # => [5, 6]
+p $~.offset(:month)    # => [5, 6]
+p $~.offset('day')     # => [nil, nil]
+p $~.offset('century') # => `offset': undefined group name reference: century (IndexError)
+#@end
+
+@see [[m:MatchData#begin]], [[m:MatchData#end]]
+
 --- post_match -> String
 
 マッチした部分より後ろの文字列を返します([[m:$']]と同じ)。


### PR DESCRIPTION
`MatchData` のインスタンスメソッド `#offset(n)` (n: Integer) の説明は載っていますが、 `#offset(name)` (name: String or Symbol) の方の説明はまだ載っていなかったので、追加します。

https://ruby-doc.org/core-3.0.0/MatchData.html#method-i-offset の方では軽く触れられています。