### PR TITLE
Resolv::DNSにnameserver_portの説明とサンプルコードを追加

### DIFF
--- a/refm/api/src/resolv.rd
+++ b/refm/api/src/resolv.rd
@@ -270,10 +270,15 @@ resolv_conf が文字列の場合は /etc/resolv.conf と
 resolv_conf がハッシュの場合は、:nameserver, :search, :ndots
 というキーが利用可能です。
 それぞれの意味は [[man:resolv.conf(5)]] を参照してください。
+また、:nameserver_portでアドレスとポートを指定できます。
 
 #@samplecode
 require "resolv"
 Resolv::DNS.new(:nameserver => ['210.251.121.21'],
+                :search => ['ruby-lang.org'],
+                :ndots => 1)
+
+Resolv::DNS.new(:nameserver_port => [['8.8.8.8', 53], ['8.8.4.4', 53]],
                 :search => ['ruby-lang.org'],
                 :ndots => 1)
 #@end


### PR DESCRIPTION
Resolv::DNSを使う際に、ポート番号を指定する方法の説明とサンプルコードがなかったので追記しました。

説明およびサンプルコードの内容は https://github.com/ruby/ruby/blob/46291a29fbb92a6e04aa1b8555efb30cca2ab6dc/lib/resolv.rb#L304-L327 を参考にしました。