### PR TITLE
OpenSSL::Cipher#decrypt は 引数なしで使えることを明示

### DIFF
--- a/refm/api/src/openssl/Cipher
+++ b/refm/api/src/openssl/Cipher
@@ -151,6 +151,7 @@ pass と iv が渡された場合、これらを用いて鍵を生成し、暗�
 @param iv IV文字列
 @raise OpenSSL::Cipher::CipherError 準備に失敗した場合に発生します
 
+--- decrypt -> self
 --- decrypt(pass, iv = nil) -> self
 復号化の準備をします。
 


### PR DESCRIPTION
OpenSSL::Cipher#encrypt の記載と同様、引数なしで使えることを明示したいです。

すでに同じページ内で `pass と iv が渡された場合、これらを用いて鍵を生成し、暗号オブジェクトに鍵と IV を設定します。このやりかたは非標準的であるため利用すべきではありません。` と説明のある通り、このように利用するのが好ましいはずです。