### PR TITLE
Translate "NEWS for Ruby 3.0.0" (ja)

### DIFF
--- a/refm/doc/news/3_0_0.rd
+++ b/refm/doc/news/3_0_0.rd
@@ -8,12 +8,11 @@
 
 == 言語仕様の変更
 
-  * Keyword arguments are now separated from positional arguments.
-    Code that resulted in deprecation warnings in Ruby 2.7 will now
-    result in ArgumentError or different behavior. [[feature:14183]]
-  * Procs accepting a single rest argument and keywords are no longer
-    subject to autosplatting.  This now matches the behavior of Procs
-    accepting a single rest argument and no keywords.
+  * キーワード引数が位置引数から分離されるようになります。
+    Ruby 2.7 では非推奨の警告を表示していましたが、ArgumentError を出力するか、異なる振る舞いをします。
+    [[feature:14183]]
+  * 単一の rest 引数とキーワードを受け入れる Proc は、autosplat の対象ではなくなりました。
+    これは、単一の rest 引数を受け入れキーワードを受け入れない Procs の振る舞いと一致するようになっています。
     [[feature:16166]]
 
 #@samplecode
@@ -28,7 +27,7 @@ pr.call([1, {a: 1}])
 # 3.0 => [[[1, {:a=>1}]], {}]
 #@end
 
-  * Arguments forwarding (`...`) now supports leading arguments.
+  * 引数委譲（`...`）は、先頭の引数をサポートするようになりました。
     [[feature:16378]]
 
 //emlist{
@@ -37,11 +36,11 @@ def method_missing(meth, ...)
 end
 //}
 
-    * Pattern matching (`case/in`) is no longer experimental. [[feature:17260]]
-    * One-line pattern matching is redesigned.  [EXPERIMENTAL]
-        * `=>` is added. It can be used like a rightward assignment.
+    * パターンマッチ（`case/in`）が正式機能となりました。 [[feature:17260]]
+    * 一行パターンマッチが実験的に再設計されました。
+        * `=>` が導入されました。右代入のように使用できます。
           [[feature:17260]]
-      * `in` is changed to return `true` or `false`. [[feature:17371]]
+      * `in` は `true` もしくは `false` を返すように変更されています。 [[feature:17371]]
 
 //emlist{
 0 => a
@@ -59,7 +58,7 @@ p b #=> 0
 0 in 1 #=> raise NoMatchingPatternError
 //}
 
-  * Find-pattern is added.  [EXPERIMENTAL]
+  * Find パターンが実験的に導入されています。
     [[feature:16828]]
 
 //emlist{
@@ -72,61 +71,56 @@ in [*pre, String => x, String => y, *post]
 end
 //}
 
-  * Endless method definition is added.  [EXPERIMENTAL]
+  * end のないメソッド定義が実験的に導入されました。
     [[feature:16746]]
 
 //emlist{
 def square(x) = x * x
 //}
 
-  * Interpolated String literals are no longer frozen when
-    `# frozen-string-literal: true` is used. [[feature:17104]]
-  * Magic comment `shareable_constant_value` added to freeze constants.
-    See {Magic Comments}[rdoc-ref:doc/syntax/comments.rdoc@Magic+Comments] for more details.
+  * `# frozen-string-literal: true` が使用されている場合、式典会を含む文字列リテラルは freeze されなくなりました。
+    [[feature:17104]]
+  * マジックコメント `shareable_constant_value` が freeze 定数に導入されました。
+    詳細は {Magic Comments}[rdoc-ref:doc/syntax/comments.rdoc@Magic+Comments] を参照してください。
     [[feature:17273]]
-  * A {static analysis}[rdoc-label:label-Static+analysis] foundation is
-    introduced.
-      * {RBS}[rdoc-label:label-RBS] is introduced. It is a type definition
-        language for Ruby programs.
-      * {TypeProf}[rdoc-label:label-TypeProf] is experimentally bundled. It is a
-        type analysis tool for Ruby programs.
-  * Deprecation warnings are no longer shown by default (since Ruby 2.7.2).
-    Turn them on with `-W:deprecated` (or with `-w` to show other warnings too).
+  * {静的解析}[rdoc-label:label-Static+analysis]基盤が導入されました。
+      * {RBS}[rdoc-label:label-RBS] が導入されました。
+        RBS は Ruby プログラムのための型定義言語です。
+      * {TypeProf}[rdoc-label:label-TypeProf] が実験的にバンドルされました。
+        TypeProf は Ruby プログラムのための型解析ツールです。
+  * 非推奨に関する警告がデフォルトで非表示になりました（Ruby 2.7.2 から導入されています）。
+    `-W:deprecated` を指定すると表示されるようになります（もしくは、`-w` を指定すると異なる警告が表示されます）。
     [[feature:16345]]
-  * `$SAFE` and `$KCODE` are now normal global variables with no special behavior.
-    C-API methods related to `$SAFE` have been removed.
+  * `$SAFE` と `$KCODE` は特別扱いせずただのグローバル変数になりました。
+    `$SAFE` に関係した C API メソッドは削除されました。
     [[feature:16131]] [[feature:17136]]
-  * yield in singleton class definitions in methods is now a SyntaxError
-    instead of a warning. yield in a class definition outside of a method
-    is now a SyntaxError instead of a LocalJumpError.  [[feature:15575]]
-  * When a class variable is overtaken by the same definition in an
-    ancestor class/module, a RuntimeError is now raised (previously,
-    it only issued a warning in verbose mode).  Additionally, accessing a
-    class variable from the toplevel scope is now a RuntimeError.
+  * メソッド内のシングルトンクラス定義中の yield は警告ではなく SyntaxError になりました。
+    メソッド外のクラス定義中の yield は LocalJumpError ではなく SyntaxError になりました。
+    [[feature:15575]]
+  * スーパークラス/スーパーモジュールでクラス変数を再定義した場合、RuntimeError が浮揚されるようになりました
+    （今までは verbose モードでのみ警告を出していました）。
+    さらにトップレベルでクラス変数にアクセスすると RuntimeError になりました。
     [[bug:14541]]
-  * Assigning to a numbered parameter is now a SyntaxError instead of
-    a warning.
+  * Numbered parameter への代入が警告ではなく SyntaxError になりました。
 
-== Command line options
+== コマンドラインオプション
 
-=== `--help` option
+=== `--help` オプション
 
-When the environment variable `RUBY_PAGER` or `PAGER` is present and has
-a non-empty value, and the standard input and output are tty, the `--help`
-option shows the help message via the pager designated by the value.
+環境変数 `RUBY_PAGER` または `PAGER` が空ではない文字列を指定され、標準入出力が tty である場合、`--help` オプションはページャーとしてヘルプメッセージを表示するようになりました。
 [[feature:16754]]
 
-=== `--backtrace-limit` option
+=== `--backtrace-limit` オプション
 
-The `--backtrace-limit` option limits the maximum length of a backtrace.
+`--backtrace-limit` オプションはバックトレースの最大行数を指定できるようになりました。
 [[feature:8661]]
 
-== Core classes updates
+== 組み込みクラスの更新
 
-Outstanding ones only.
+注目すべきもののみ記載します。
 
   * Array
-    * The following methods now return Array instances instead of subclass instances when called on subclass instances: [[bug:6087]]
+    * 以下のメソッドは、サブクラスインスタンスで呼び出された場合、配列インスタンスを返すようになりました: [[bug:6087]]
       * Array#drop
       * Array#drop_while
       * Array#flatten
@@ -136,7 +130,7 @@ Outstanding ones only.
       * Array#take_while
       * Array#uniq
       * Array#*
-    * Can be sliced with Enumerator::ArithmeticSequence
+    * Enumerator::ArithmeticSequence でスライスできます。
 
 #@samplecode
 dirty_data = ['--', 'data1', '--', 'data2', '--', 'data3']
@@ -145,41 +139,44 @@ dirty_data[(1..).step(2)] # take each second element
 #@end
 
   * Binding
-    * Binding#eval when called with one argument will use `"(eval)"` for `__FILE__` and `1` for `__LINE__` in the evaluated code. [[bug:4352]] [[bug:17419]]
+    * 1 引数で呼び出された Binding#eval は、コード評価時に `__FILE__` では `"(eval)"` を、`__LINE__` では `1` を使うようになります。[[bug:4352]] [[bug:17419]]
   * ConditionVariable
-    * ConditionVariable#wait may now invoke the `block`/`unblock` scheduler hooks in a non-blocking context. [[feature:16786]]
+    * ConditionVariable#wait はノンブロッキングコンテキストで `block`/`unblock` スケジューラーフックを呼び出せるようになりました。[[feature:16786]]
   * Dir
-    * Dir.glob and Dir.[] now sort the results by default, and accept the `sort:` keyword option.  [[feature:8709]]
+    * Dir.glob および Dir.[] は出力結果をデフォルトでソートするようになりました。[[feature:8709]]
   * ENV
-    * ENV.except has been added, which returns a hash excluding the given keys and their values.  [[feature:15822]]
-    * Windows: Read ENV names and values as UTF-8 encoded Strings [[feature:12650]]
+    * ENV.except が導入されました。与えられたキーとそれらの値を除外したハッシュを返すようになりました。[[feature:15822]]
+    * Windows: ENV の名前を値を UTF-8 でエンコードされた文字列として読み取ります。[[feature:12650]]
   * Encoding
-    * Added new encoding IBM720.  [[feature:16233]]
-    * Changed default for Encoding.default_external to UTF-8 on Windows [[feature:16604]]
+    * 新しく IBM720 というエンコーディングが導入されました。[[feature:16233]]
+    * Windows では UTF-8 形式の Encoding.default_external がデフォルトになりました。[[feature:16604]]
   * Fiber
-    * Fiber.new(blocking: true/false) allows you to create non-blocking execution contexts. [[feature:16786]]
-    * Fiber#blocking? tells whether the fiber is non-blocking. [[feature:16786]]
-    * Fiber#backtrace and Fiber#backtrace_locations provide per-fiber backtrace. [[feature:16815]]
-    * The limitation of Fiber#transfer is relaxed. [[bug:17221]]
+    * Fiber.new(blocking: true/false) は、ノンブロッキング実行コンテキストを生成することを許可するようになりました。[[feature:16786]]
+    * Fiber#blocking? は fiber がノンブロッキングであるかどうかを知らせてくれます。[[feature:16786]]
+    * Fiber#backtrace および Fiber#backtrace_locations は fiber ごとのバックトレースを提供するようになりました。[[feature:16815]]
+    * Fiber#transfer の制限が緩和されるようになりました。[[bug:17221]]
   * GC
-    * GC.auto_compact= and GC.auto_compact have been added to control when compaction runs.  Setting `auto_compact=` to `true` will cause compaction to occur during major collections.  At the moment, compaction adds significant overhead to major collections, so please test first!  [[feature:17176]]
+    * コンパクションが実行されるタイミングを制御するために GC.auto_compact= および GC.auto_compact が導入されました。
+      `auto_compact=` を `true` に設定すると、主要なコレクション中にコンパクションが発生します。
+      現時点では、コンパクションによって主要なコレクションにかなりのオーバーヘッドが追加されます。よって、まず最初にテストを実行してください！
+      [[feature:17176]]
   * Hash
-    * Hash#transform_keys and Hash#transform_keys! now accept a hash that maps keys to new keys.  [[feature:16274]]
-    * Hash#except has been added, which returns a hash excluding the given keys and their values.  [[feature:15822]]
+    * Hash#transform_keys および Hash#transform_keys! はキーを新しいキーにマッピングするハッシュを受け入れるようになりました。[[feature:16274]]
+    * Hash#except が導入されました。与えられたキーとそれらの値を除外したハッシュを返すようになりました。[[feature:15822]]
   * IO
-    * IO#nonblock? now defaults to `true`. [[feature:16786]]
-    * IO#wait_readable, IO#wait_writable, IO#read, IO#write and other related methods (e.g. IO#puts, IO#gets) may invoke the scheduler hook `#io_wait(io, events, timeout)` in a non-blocking execution context. [[feature:16786]]
+    * IO#nonblock? のデフォルト値が `true` になりました。[[feature:16786]]
+    * IO#wait_readable, IO#wait_writable, IO#read, IO#write およびその他関連するメソッド（例 IO#puts, IO#gets）は、ノンブロッキング実行コンテキストでスケジューラフック `#io_wait(io, events, timeout)` を呼び出せるようになりました。[[feature:16786]]
   * Kernel
-    * Kernel#clone when called with the `freeze: false` keyword will call `#initialize_clone` with the `freeze: false` keyword. [[bug:14266]]
-    * Kernel#clone when called with the `freeze: true` keyword will call `#initialize_clone` with the `freeze: true` keyword, and will return a frozen copy even if the receiver is unfrozen. [[feature:16175]]
-    * Kernel#eval when called with two arguments will use `"(eval)"` for `__FILE__` and `1` for `__LINE__` in the evaluated code. [[bug:4352]]
-    * Kernel#lambda now warns if called without a literal block. [[feature:15973]]
-    * Kernel.sleep invokes the scheduler hook `#kernel_sleep(...)` in a non-blocking execution context. [[feature:16786]]
+    * キーワード引数 `freeze: false` で呼び出された Kernel#clone は、キーワード引数 `freeze: false` で `#initialize_clone` を呼び出すようになります。[[bug:14266]]
+    * キーワード引数 `freeze: true` で呼び出された Kernel#clone は、キーワード引数 `freeze: true` で `#initialize_clone` を呼び出すようになります。そして、Kernel#clone は、レシーバが freeze されていない場合、freeze して複製を返すようになります。[[feature:16175]]
+    * 2 引数で呼び出された場合の Kernel#eval は、コード評価時に `__FILE__` では `"(eval)"` を、`__LINE__` では `1` を使うようになります。[[bug:4352]]
+    * Kernel#lambda は、リテラルブロックなしで呼び出された場合、警告を出すようになりました。[[feature:15973]]
+    * Kernel.sleep はノンブロッキング実行コンテキストでスケジューラフック `#kernel_sleep(...)` を呼び出せるようになりました。[[feature:16786]]
   * Module
-    * Module#include and Module#prepend now affect classes and modules that have already included or prepended the receiver, mirroring the behavior if the arguments were included in the receiver before the other modules and classes included or prepended the receiver. [[feature:9573]]
-    * Module#public, Module#protected, Module#private, Module#public_class_method, Module#private_class_method, toplevel "private" and "public" methods now accept single array argument with a list of method names. [[feature:17314]]
-    * Module#attr_accessor, Module#attr_reader, Module#attr_writer and Module#attr methods now return an array of defined method names as symbols. [[feature:17314]]
-    * Module#alias_method now returns the defined alias as a symbol. [[feature:17314]]
+    * Module#include および Module#prepend はレシーバが include されている、もしくは、prepend されているクラスとモジュールに影響を与えるようになります。そして、他のモジュールやクラスが include される、もしくは、prepend される前に、引数がレシーバー include されるような振る舞いをミラーリングします。[[feature:9573]]
+    * Module#public, Module#protected, Module#private, Module#public_class_method, Module#private_class_method, およびトップレベルな "private"/"public" メソッドが、メソッド名一覧で単一の配列引数を受け取れるようになりました。[[feature:17314]]
+    * Module#attr_accessor, Module#attr_reader, Module#attr_writer および Module#attr メソッドは、定義されたメソッドのシンボルの配列を返すようになりました。[[feature:17314]]
+    * Module#alias_method は、定義されたシンボルのエイリアスを返すようになりました。[[feature:17314]]
 
 #@samplecode
 class C; end
@@ -191,18 +188,21 @@ p C.ancestors #=> [C, M1, M2, Object, Kernel, BasicObject]
 #@end
 
   * Mutex
-    * `Mutex` is now acquired per-`Fiber` instead of per-`Thread`. This change should be compatible for essentially all usages and avoids blocking when using a scheduler. [[feature:16792]]
+    * `Mutex` は、`Thread` ごとではなく `Fiber` ごとに取得されるようになりました。
+      この変更は、基本的に全てのユースケースで互換性がありべきで、スケジューラーを使用する際のブロッキングを回避する必要があります。
+      [[feature:16792]]
   * Proc
     * Proc#== and Proc#eql? are now defined and will return true for separate Proc instances if the procs were created from the same block. [[feature:14267]]
+    * Proc#== および Proc#eql? は、Procs が同じブロックから作成される場合、Proc インスタンスと分離して true を返すように定義されました。[[feature:14267]]
   * Queue / SizedQueue
-    * Queue#pop, SizedQueue#push and related methods may now invoke the `block`/`unblock` scheduler hooks in a non-blocking context. [[feature:16786]]
+    * Queue#pop, SizedQueue#push および関連したメソッドは、ノンブロッキングコンテキストで `block`/`unblock` スケジューラーフックを呼び出せるようになりました。[[feature:16786]]
   * Ractor
-    * New class added to enable parallel execution. See rdoc-ref:ractor.md for more details.
+    * 並列処理を可能にする新しいクラスが追加されました。詳細は {Ractor}[rdoc-ref:ractor.md] を参照してください。
   * Random
-    * `Random::DEFAULT` now refers to the `Random` class instead of being a `Random` instance, so it can work with `Ractor`. [[feature:17322]]
-    * `Random::DEFAULT` is deprecated since its value is now confusing and it is no longer global, use `Kernel.rand`/`Random.rand` directly, or create a `Random` instance with `Random.new` instead. [[feature:17351]]
+    * `Random::DEFAULT` は `Random` インスタンスではなく `Random` クラスから参照されるようになりました。よって、`Ractor` で機能します。[[feature:17322]]
+    * `Random::DEFAULT` は、その値がわかりにくくグローバルではなくなったため、非推奨になりました。`Kernel.rand`/`Random.rand` を直接使用するか、代わりに `Random.new` を使用して `Random` インスタンスを生成してください。[[feature:17351]]
   * String
-    * The following methods now return or yield String instances instead of subclass instances when called on subclass instances: [[bug:10845]]
+    * 以下のメソッドは、サブクラスインスタンスで呼び出された場合、文字列インスタンスを返すようになりました: [[bug:10845]]
       * String#*
       * String#capitalize
       * String#center
@@ -237,108 +237,109 @@ p C.ancestors #=> [C, M1, M2, Object, Kernel, BasicObject]
       * String#tr_s
       * String#upcase
   * Symbol
-    * Symbol#to_proc now returns a lambda Proc.  [[feature:16260]]
-    * Symbol#name has been added, which returns the name of the symbol if it is named.  The returned string is frozen.  [[feature:16150]]
+    * Symbol#to_proc は lambda となる Proc を返すようになりました。[[feature:16260]]
+    * Symbol#name が導入されました。 シンボルの名前がある場合は、その名前を返します。返された文字列は freeze です。[[feature:16150]]
   * Fiber
-    * Introduce Fiber.set_scheduler for intercepting blocking operations and Fiber.scheduler for accessing the current scheduler. See rdoc-ref:fiber.md for more details about what operations are supported and how to implement the scheduler hooks. [[feature:16786]]
-    * Fiber.blocking? tells whether the current execution context is blocking. [[feature:16786]]
-    * Thread#join invokes the scheduler hooks `block`/`unblock` in a non-blocking execution context. [[feature:16786]]
-  * Thread
-    * Thread.ignore_deadlock accessor has been added for disabling the default deadlock detection, allowing the use of signal handlers to break deadlock. [[bug:13768]]
+    * ブロッキングオペレーションをインターセプトするための Fiber.set_scheduler、および現在のスケジューラーにアクセスするための Fiber.scheduler が導入されました。
+      詳細は {Fiber}[rdoc-ref:fiber.md] のサポートされているオペレーションとスケジューラーフックの実装方法を参照してください。[[feature:16786]]
+    * Fiber.blocking? は、現在の実行コンテキストがブロックされているかどうかを知らせてくれます。[[feature:16786]]
+    * Thread#join はノンブロッキングコンテキストで `block`/`unblock` スケジューラーフックを呼び出せるようになりました。 [[feature:16786]]
+    * デフォルトのデッドロック検出を無効にするために Thread.ignore_deadlock アクセッサが導入されました。
+      また、シグナルハンドラーを使用してデッドロックを解除できるようになりました。[[bug:13768]]
   * Warning
-    * Warning#warn now supports a category keyword argument. [[feature:17122]]
+    * Warning#warn は category キーワード引数をサポートするようになりました。[[feature:17122]]
 
-== Stdlib updates
+== 標準添付ライブラリの更新
 
-Outstanding ones only.
+注目すべきもののみ記載します。
 
   * BigDecimal
-    * Update to BigDecimal 3.0.0
-    * This version is Ractor compatible.
+    * BigDecimal 3.0.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Bundler
-    * Update to Bundler 2.2.3
+    * Bundler 2.2.3 に更新されました。
   * CGI
-    * Update to 0.2.0
-    * This version is Ractor compatible.
+    * 0.2.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * CSV
-    * Update to CSV 3.1.9
+    * CSV 3.1.9 に更新されました。
   * Date
-    * Update to Date 3.1.1
-    * This version is Ractor compatible.
+    * Date 3.1.1 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Digest
-    * Update to Digest 3.0.0
-    * This version is Ractor compatible.
+    * Digest 3.0.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Etc
-    * Update to Etc 1.2.0
-    * This version is Ractor compatible.
+    * Etc 1.2.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Fiddle
-    * Update to Fiddle 1.0.5
+    * Fiddle 1.0.5 に更新されました。
   * IRB
-    * Update to IRB 1.2.6
+    * IRB 1.2.6 に更新されました。
   * JSON
-    * Update to JSON 2.5.0
-    * This version is Ractor compatible.
+    * JSON 2.5.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Set
-    * Update to set 1.0.0
-    * SortedSet has been removed for dependency and performance reasons.
-    * Set#join is added as a shorthand for `.to_a.join`.
-    * Set#<=> is added.
+    * set 1.0.0 に更新されました。
+    * SortedSet は依存関係とパフォーマンス上の理由から削除されました。
+    * Set#join が、`.to_a.join` の省略形として導入されました。
+    * Set#<=> が導入されました。
   * Socket
-    * Add :connect_timeout to TCPSocket.new [[feature:17187]]
+    * TCPSocket.new に :connect_timeout が導入されました。[[feature:17187]]
   * Net::HTTP
-    * Net::HTTP#verify_hostname= and Net::HTTP#verify_hostname have been added to skip hostname verification.  [[feature:16555]]
-    * Net::HTTP.get, Net::HTTP.get_response, and Net::HTTP.get_print can take the request headers as a Hash in the second argument when the first argument is a URI.  [[feature:16686]]
+    * Net::HTTP#verify_hostname= および Net::HTTP#verify_hostname が、ホスト名の検証をスキップするために導入されました。[[feature:16555]]
+    * Net::HTTP.get, Net::HTTP.get_response, および Net::HTTP.get_print は、最初の引数が URI の場合、2 番目の引数でリクエストヘッダーをハッシュとして受け取れるようになりました。[[feature:16686]]
   * Net::SMTP
-    * Add SNI support.
-    * Net::SMTP.start arguments are keyword arguments.
-    * TLS should not check the host name by default.
+    * SNI サポートが導入されました。
+    * Net::SMTP.start 引数がキーワード引数になりました。
+    * TLS はデフォルトでホスト名をチェックしなくなりました。
   * OpenStruct
-    * Initialization is no longer lazy. [[bug:12136]]
-    * Builtin methods can now be overridden safely. [[bug:15409]]
-    * Implementation uses only methods ending with `!`.
-    * Ractor compatible.
-    * Improved support for YAML. [[bug:8382]]
-    * Use officially discouraged. Read OpenStruct@Caveats section.
+    * 初期化はもはや lazy ではありません。[[bug:12136]]
+    * 組み込みメソッドは安全に上書き可能になりました。[[bug:15409]]
+    * 実装では、 `!` で終わるメソッドでのみ使用されます。
+    * Ractor 互換
+    * YAML をサポートするよう改善されています。[[bug:8382]]
+    * オフィシャルな採用は推奨しません。OpenStruct@Caveats セクションを参照してください。
   * Pathname
-    * Ractor compatible.
+    * Ractor 互換
   * Psych
-    * Update to Psych 3.3.0
-    * This version is Ractor compatible.
+    * Psych 3.3.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * Reline
-    * Update to Reline 0.1.5
+    * Reline 0.1.5 に更新されました。
   * RubyGems
-    * Update to RubyGems 3.2.3
+    * RubyGems 3.2.3 に更新されました。
   * StringIO
-    * Update to StringIO 3.0.0
-    * This version is Ractor compatible.
+    * StringIO 3.0.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
   * StringScanner
-    * Update to StringScanner 3.0.0
-    * This version is Ractor compatible.
+    * StringScanner 3.0.0 に更新されました。
+    * このバージョンは Ractor と互換性があります。
 
-== Compatibility issues
+== 互換性
 
-Excluding feature bug fixes.
+機能追加とバグ修正は除いています。
 
-  * Regexp literals and all Range objects are frozen. [[feature:8948]] [[feature:16377]] [[feature:15504]]
+  * 正規表現リテラルとすべての Range オブジェクトは freeze されるようになりました。[[feature:8948]] [[feature:16377]] [[feature:15504]]
 
 #@samplecode
 /foo/.frozen? #=> true
 (42...).frozen? # => true
 #@end
 
-  * EXPERIMENTAL: Hash#each consistently yields a 2-element array. [[bug:12706]]
-    * Now `{ a: 1 }.each(&->(k, v) { })` raises an ArgumentError due to lambda's arity check.
-  * When writing to STDOUT redirected to a closed pipe, no broken pipe error message will be shown now.  [[feature:14413]]
-  * `TRUE`/`FALSE`/`NIL` constants are no longer defined.
-  * Integer#zero? overrides Numeric#zero? for optimization.  [[misc:16961]]
-  * Enumerable#grep and Enumerable#grep_v when passed a Regexp and no block no longer modify Regexp.last_match. [[bug:17030]]
-  * Requiring 'open-uri' no longer redefines `Kernel#open`. Call `URI.open` directly or `use URI#open` instead. [[misc:15893]]
-  * SortedSet has been removed for dependency and performance reasons.
+  * EXPERIMENTAL: Hash#each  が常に 2 要素配列を yield するようになりました。[[bug:12706]]
+    * `{ a: 1 }.each(&->(k, v) { })` は lambda のアリティチェックが要因で、ArgumentError を浮揚するようになりました。
+  * パイプがクローズされた後に標準出力へ出力しようとしても、EPIPE 例外を浮揚しないようになりました。[[feature:14413]]
+  * `TRUE`/`FALSE`/`NIL` 各定数が定義されないようになりました。
+  * Integer#zero? は最適化のために Numeric#zero? をオーバーライドするようになりました。[[misc:16961]]
+  * Enumerable#grep および Enumerable#grep_v は、正規表現が渡され、かつ、ブロックがない場合、Regexp.last_match を変更しなくなりました。[[bug:17030]]
+  * 'open-uri' を要求しても `Kernel#open` は再定義されなくなりました。代わりに `URI.open` を直接呼び出すか `URI#open` を使用してください。[[misc:15893]]
+  * 依存関係とパフォーマンス上の理由から、SortedSet が削除されました。
 
-== Stdlib compatibility issues
+== 標準添付ライブラリの互換性
 
   * Default gems
-    * The following libraries are promoted to default gems from stdlib.
+    * 以下のライブラリが新たに default gems になりました。
       * English
       * abbrev
       * base64
@@ -366,7 +367,7 @@ Excluding feature bug fixes.
       * tsort
       * un
       * weakref
-    * The following extensions are promoted to default gems from stdlib.
+    * 以下の拡張機能が新たに default gems になりました。
       * digest
       * io-nonblock
       * io-wait
@@ -375,65 +376,75 @@ Excluding feature bug fixes.
       * syslog
       * win32ole
   * Bundled gems
-    * net-telnet and xmlrpc have been removed from the bundled gems. If you are interested in maintaining them, please comment on your plan to https://github.com/ruby/xmlrpc or https://github.com/ruby/net-telnet.
-  * SDBM has been removed from the Ruby standard library. [[bug:8446]]
-    * The issues of sdbm will be handled at https://github.com/ruby/sdbm
-  * WEBrick has been removed from the Ruby standard library. [[feature:17303]]
-    * The issues of WEBrick will be handled at https://github.com/ruby/webrick
+    * net-telnet および xmlrpc は、バンドルされた gem から削除されました。
+      これらを保守したい場合は、https://github.com/ruby/xmlrpc もしくは https://github.com/ruby/net-telnet にあなたのプランをコメントしてください。
+  * SDBM は Ruby 表示ん添付ライブラリから削除されました。[[bug:8446]]
+    * sdbm の課題は、https://github.com/ruby/sdbm で処理される予定です。
+  * WEBrick は Ruby 標準添付ライブラリから削除されました。[[feature:17303]]
+    * WEBrick の課題は、https://github.com/ruby/webrick で処理される予定です。
 
-== C API updates
+== C API の更新
 
-  * C API functions related to `$SAFE` have been removed. [[feature:16131]]
-  * C API header file `ruby/ruby.h` was split. [[url:https://github.com/ruby/ruby/pull/2991]] This should have no impact on extension libraries, but users might experience slow compilations.
+  * `$SAFE` に関連する C API 関数は削除されました。[[feature:16131]]
+  * `ruby/ruby.h` は分割されました。[[url:https://github.com/ruby/ruby/pull/2991]]
+    これは拡張ライブラリに影響はないはずです。しかし、コンパイルが遅くなる可能性があります。
   * Memory view interface [EXPERIMENTAL]
-    * The memory view interface is a C-API set to exchange a raw memory area, such as a numeric array or a bitmap image, between extension libraries. The extension libraries can share also the metadata of the memory area that consists of the shape, the element format, and so on. Using these kinds of metadata, the extension libraries can share even a multidimensional array appropriately. This feature is designed by referring to Python's buffer protocol. [[feature:13767]] [[feature:14722]]
-  * Ractor related C APIs are introduced (experimental) in "include/ruby/ractor.h".
+    * メモリビューインタフェースは、数値配列やビットマップ画像などの生のメモリ領域を、拡張ライブラリ間で交換するための C API セットです。
+      拡張ライブラリは、形状や要素フォーマットなどで構成されたメモリ領域のメタデータも共有できます。
+      これらのメタデータを使用して、拡張ライブラリは多次元配列でさえ適切に共有できます。
+      この機能は、Python のバッファプロトコルを参考にして設計されています。
+      [[feature:13767]] [[feature:14722]]
+  * "include/ruby/ractor.h" に C API 関連の Ractor が実験的に導入されました。
 
-== Implementation improvements
+== 実装の改善
 
-  * New method cache mechanism for Ractor. [[feature:16614]]
-    * Inline method caches pointed from ISeq can be accessed by multiple Ractors in parallel and synchronization is needed even for method caches. However, such synchronization can be overhead so introducing new inline method cache mechanisms, (1) Disposable inline method cache (2) per-Class method cache and (3) new invalidation mechanism. (1) can avoid per-method call synchronization because it only uses atomic operations. See the ticket for more details.
-  * The number of hashes allocated when using a keyword splat in a method call has been reduced to a maximum of 1, and passing a keyword splat to a method that accepts specific keywords does not allocate a hash.
-  * `super` is optimized when the same type of method is called in the previous call if it's not refinements or an attr reader or writer.
+  * Ractor のためにメソッドキャッシュが刷新されました。[[feature:16614]]
+    * ISeq からポイントされたインラインメソッドキャッシュは、複数の Ractor から並行してアクセスでき、メソッドキャッシュの場合でも同期が必要です。
+      しかしながら、このような同期はオーバーヘッドになる可能性があるため、(1) 使い捨てできる (2) クラスごとにキャッシュできる (3) 新規の無効化する機構を新しいインラインキャッシュメソッドに導入しました。
+      (1) はアトミックな処理を使用するのみなので、メソッドごとに呼び出す同期を回避できます。
+      詳細はチケットを参照してください。
+  * メソッド呼び出しでキーワード引数を使用するときに割り当てられるハッシュの数が最大 1 に減り、特定のキーワードを受け取るメソッドにキーワード引数を渡してもハッシュを割り当てなくなりました。
+  * `super` は、refinements, attr_reader, attr_writer ではない場合、前回と同じ型のメソッドが呼び出されたときに最適化されます。
 
 === JIT
 
-  * Performance improvements of JIT-ed code
-    * Microarchitectural optimizations
-        * Native functions shared by multiple methods are deduplicated on JIT compaction.
-        * Decrease code size of hot paths by some optimizations and partitioning cold paths.
-    * Instance variables
-        * Eliminate some redundant checks.
-        * Skip checking a class and a object multiple times in a method when possible.
-        * Optimize accesses in some core classes like Hash and their subclasses.
-    * Method inlining support for some C methods
+  * JIT-ed コードのパフォーマンス改善
+    * マイクロアーキテクチャの最適化
+        * 複数のメソッドによって共有されるネイティブ関数は、JIT コンパクションで重複排除されます。
+        * いくつかの最適化とコールドパスの分割により、ホットパスのコードサイズを減らしています。
+    * インスタンス変数
+        * いくつかの冗長なチェックを削除しています。
+        * 可能であれば、メソッド内のクラスとオブジェクトの複数回チェックをスキップしています。
+        * Hash やそのサブクラスの一部のコアクラスでアクセスを最適化しています。
+    * 一部の C メソッドのサポートをインライン化するメソッド
         * `Kernel`: `#class`, `#frozen?`
         * `Integer`: `#-@`, `#~`, `#abs`, `#bit_length`, `#even?`, `#integer?`, `#magnitude`, `#odd?`, `#ord`, `#to_i`, `#to_int`, `#zero?`
-        * `Struct`: reader methods for 10th or later members
-    * Constant references are inlined.
-    * Always generate appropriate code for `==`, `nil?`, and `!` calls depending on a receiver class.
-    * Reduce the number of PC accesses on branches and method returns.
-    * Optimize C method calls a little.
-  * Compilation process improvements
-    * It does not keep temporary files in /tmp anymore.
-    * Throttle GC and compaction of JIT-ed code.
-    * Avoid GC-ing JIT-ed code when not necessary.
-    * GC-ing JIT-ed code is executed in a background thread.
-    * Reduce the number of locks between Ruby and JIT threads.
+        * `Struct`: 10 番目以降のメンバー用リーダーメソッド
+    * 定数の参照がインライン化されました。
+    * レシーバクラスの `==`, `nil?`, および `!` には常に適切なコードを生成するようになりました。
+    * 分岐やメソッドからのリターンでの PC アクセス回数が削減されました。
+    * C メソッド呼び出しが少し最適化されました。
+  * コンパイルプロセスの改善
+    * /tmp ディレクトリに一時ファイルを保持しなくなりました。
+    * GC と JIT-ed なコードのコンパクションが抑制されるようになりました。
+    * 必要ではない場合、GC-ing で JIT-ed コードは回避されるようになりました。
+    * GC-ing で JIT-ed コードはバックグランドスレッドで実行されるようになりました。
+    * Ruby と JIT スレッド間でのロックの回数が削減されました。
 
-== Static analysis
+== 静的解析
 
 === RBS
 
-  * RBS is a new language for type definition of Ruby programs. It allows writing types of classes and modules with advanced types including union types, overloading, generics, and _interface types_ for duck typing.
-  * Ruby ships with type definitions for core/stdlib classes.
-  * `rbs` gem is bundled to load and process RBS files.
+  * RBS は Ruby プログラムのための新しい型定義言語です。
+    共用体型、オーバーロード、ジェネリクス、およびダックタイピングのような _インタフェース型_ を含む進化した型のクラスやモジュールを記述できるようになりました。
+  * Ruby は core/stdlib クラスの型定義を同梱しています。
+  * `rbs` gem は RBS ファイルをロードして処理するためにバンドルされています。
 
 === TypeProf
 
-  * TypeProf is a type analysis tool for Ruby code based on abstract interpretation.
-    * It reads non-annotated Ruby code, tries inferring its type signature, and prints the analysis result in RBS format.
-    * Though it supports only a subset of the Ruby language yet, we will continuously improve the coverage of language features, analysis performance, and usability.
+  * TypeProf はu抽象解釈に基づいた Ruby コード用の型解析ツールです。
+    * 型注釈のない Ruby コードを読み取り、その型シグネチャを推測しようと試み、そして RBS フォーマットで分析結果を出力します。
+    * まだ Ruby 言語のサブセットしかサポートしていませんが、言語機能のカバレッジ、分析パフォーマンス、およびユーザビリティを継続的に改善する予定です。
 
 #@samplecode
 # test.rb
@@ -456,9 +467,9 @@ class Object
 end
 //}
 
-== Miscellaneous changes
+== その他の変更
 
-  * Methods using `ruby2_keywords` will no longer keep empty keyword splats, those are now removed just as they are for methods not using `ruby2_keywords`.
-  * When an exception is caught in the default handler, the error message and backtrace are printed in order from the innermost. [[feature:8661]]
-  * Accessing an uninitialized instance variable no longer emits a warning in verbose mode. [[feature:17055]]
+  * `ruby2_keywords` を使用するメソッドは、空のキーワード引数を保持しなくなります。これらは `ruby2_keywords` を使用しないメソッドの場合と同様に削除されるようになりました。
+  * デフォルトのハンドラーで例外がキャッチされた場合、エラーメッセージとバックトレースが最も深い順に出力されるようになりました。[[feature:8661]]
+  * 初期化されていないインスタンス変数にアクセスしても、冗長モードで警告が表示されなくなりました。[[feature:17055]]
 #@end


### PR DESCRIPTION
* Translate [https://github.com/ruby/ruby/blob/ruby_3_0/NEWS.md](https://github.com/ruby/ruby/blob/ruby_3_0/NEWS.md) to ja.
* ただし、ローカル環境での動作確認方法が分からなかったので、動作未確認