### PR TITLE
NEWS for Ruby 2.5.0のSocketをBasicSocketに変更

### DIFF
--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -335,7 +335,7 @@ Coverage.result
 
 === 互換性 (機能追加とバグ修正以外)
 
-  * [[c:Socket]]
+  * [[c:BasicSocket]]
     * [[m:BasicSocket#read_nonblock]] と [[m:BasicSocket#write_nonblock]] で
       副作用として O_NONBLOCK フラグをセットするのをやめました(Linux のみ)
       [[feature:13362]]


### PR DESCRIPTION
NEWS for Ruby 2.5.0の `Socket` を `BasicSocket` に変更しました。
以下のPRに関する変更です。

https://github.com/ruby/ruby/pull/5236