### PR TITLE
NEWS for Ruby 2.5.0にリンクを追加

### DIFF
--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -155,11 +155,11 @@
 
   * [[lib:bigdecimal]]
     * BigDecimal 1.3.4 に更新
-    * BigDecimal::VERSION を追加
+    * [[m:BigDecimal::VERSION]] を追加
     * 非推奨(1.4.0で削除予定)
       * BigDecimal.new
       * BigDecimal.ver
-    * BigDecimal#clone と [[m:BigDecimal#dup]] は新しいインスタンスを作らなくなりました。selfを返します。
+    * [[m:BigDecimal#clone]] と [[m:BigDecimal#dup]] は新しいインスタンスを作らなくなりました。selfを返します。
 
   * [[lib:coverage]]
     * ブランチカバレッジとメソッドカバレッジの計測をサポートしました [[feature:13901]]
@@ -211,8 +211,8 @@ Coverage.result
 //}
     * 例えば [Object, :foo, 1, 0, 7, 3] は Object#foo は1行目の0桁目から7行目の3桁目までで定義されている、と読みます。
       上記の例では Object#foo は2回実行されています。
-    * Note: 互換性のため、Coverage.startにオプションを与えない場合は、ラインカバレッジのみを計測します。
-      また Coverage.result も旧フォーマットを返します。
+    * Note: 互換性のため、[[m:Coverage.start]]にオプションを与えない場合は、ラインカバレッジのみを計測します。
+      また [[m:Coverage.result]] も旧フォーマットを返します。
 #@samplecode
 Coverage.result
 #=> { "/path/to/file.rb"=> [1, 2, 0, nil, ...] }
@@ -371,13 +371,13 @@ Coverage.result
       * webrick
       * zlib
 
-  * Logger
+  * [[c:Logger]]
     * Logger.new("| command") は意図せず、コマンドを実行していましたが、禁止されました。
       Logger#initialize の引数は仕様としてファイル名としてのみ扱うようになりました。
       [[bug:14212]]
 
-  * Net::HTTP
-    * Net::HTTP#start の第3引数のデフォルト値を :ENV にしました。 [[bug:13351]]
+  * [[c:Net::HTTP]]
+    * [[m:Net::HTTP#start]] の第3引数のデフォルト値を :ENV にしました。 [[bug:13351]]
       これを避けるには明示的に nil を与えてください。
 
   * mathn.rb
@@ -395,20 +395,20 @@ Coverage.result
 
 === 実装の改善
 
-  * (これは「ユーザーに見える機能の変更」ではないが) Hashクラスのhashメソッドのアルゴリズムを SipHash13 にしました
+  * (これは「ユーザーに見える機能の変更」ではないが) [[c:Hash]]クラスのhashメソッドのアルゴリズムを SipHash13 にしました
     [[feature:13017]]
 
-  * SecureRandom が OpenSSL の提供する乱数ソースよりもOSの提供する乱数ソースを優先するようにしました [[bug:9569]]
+  * [[c:SecureRandom]] が [[c:OpenSSL]] の提供する乱数ソースよりもOSの提供する乱数ソースを優先するようにしました [[bug:9569]]
 
-  * Mutex をより小さくより速く書き直しました [[feature:13517]]
+  * [[c:Mutex]] をより小さくより速く書き直しました [[feature:13517]]
 
   * lazy Proc allocation というテクニックでブロックをメソッドの引数として渡したときの性能が向上しました
     [[feature:14045]]
 
-  * TracePointのためにtrace命令の変わりに命令の動的書き換えを使用するようにしました
+  * [[c:TracePoint]]のためにtrace命令の変わりに命令の動的書き換えを使用するようにしました
     [[feature:14104]]
 
-  * ERB がテンプレートから生成するコードはRuby 2.4 よりも2倍速くなりました
+  * [[c:ERB]] がテンプレートから生成するコードはRuby 2.4 よりも2倍速くなりました
 
 === その他の変更
 

--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -264,7 +264,7 @@ Coverage.result
   * [[lib:pathname]]
     * [[m:Pathname#glob]] を追加 [[feature:7360]]
 
-  * Psych
+  * [[lib:psych]]
     * Psych 3.0.2 に更新しました
       * Convert fallback option to a keyword argument
         [[url:https://github.com/ruby/psych/pull/342]]

--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -159,7 +159,7 @@
     * 非推奨(1.4.0で削除予定)
       * BigDecimal.new
       * BigDecimal.ver
-    * BigDecimal#clone と #dup は新しいインスタンスを作らなくなりました。selfを返します。
+    * BigDecimal#clone と [[m:BigDecimal#dup]] は新しいインスタンスを作らなくなりました。selfを返します。
 
   * [[lib:coverage]]
     * ブランチカバレッジとメソッドカバレッジの計測をサポートしました [[feature:13901]]

--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -165,11 +165,11 @@
     * ブランチカバレッジとメソッドカバレッジの計測をサポートしました [[feature:13901]]
       この新機能と一緒にテストスイートを実行すると、テストによって実行された条件分岐やメソッドについて知ることができます。
       テストスイートのカバレッジをより厳密に評価することができます。
-      [[m:Coverage.start]]に与えるオプションによって計測する対象を指定することができます。
+      [[m:Coverage.start]] に与えるオプションによって計測する対象を指定することができます。
 #@samplecode
 Coverage.start(lines: true, branches: true, methods: true)
 #@end
-    * Rubyで書かれたファイルをいくつか読み込んでから、[[m:Coverage.result]]を使って結果を取得することができます。
+    * Rubyで書かれたファイルをいくつか読み込んでから、[[m:Coverage.result]] を使って結果を取得することができます。
 #@samplecode
 Coverage.result
 #=> { "/path/to/file.rb"=>
@@ -211,7 +211,7 @@ Coverage.result
 //}
     * 例えば [Object, :foo, 1, 0, 7, 3] は Object#foo は1行目の0桁目から7行目の3桁目までで定義されている、と読みます。
       上記の例では Object#foo は2回実行されています。
-    * Note: 互換性のため、[[m:Coverage.start]]にオプションを与えない場合は、ラインカバレッジのみを計測します。
+    * Note: 互換性のため、[[m:Coverage.start]] にオプションを与えない場合は、ラインカバレッジのみを計測します。
       また [[m:Coverage.result]] も旧フォーマットを返します。
 #@samplecode
 Coverage.result

--- a/refm/doc/news/2_5_0.rd
+++ b/refm/doc/news/2_5_0.rd
@@ -330,7 +330,7 @@ Coverage.result
     * RubyGem としてリリース [[feature:13173]]
     * 意図しない振舞いを避けるため [[m:Kernel.#open]] を使用するのをやめました [[misc:14216]]
 
-  * [[lib:zlip]]
+  * [[lib:zlib]]
     * [[m:Zlib::GzipWriter#write]] は複数の引数を受け取れるようになりました
 
 === 互換性 (機能追加とバグ修正以外)


### PR DESCRIPTION
## 概要

NEWS for Ruby 2.5.0のページで、説明のクラスやメソッドのテキストをリンクにしました。

## 変更箇所

リンクの変更箇所を確認した時のスクリーンショットです。

### bigdecimal

`BigDecimal::VERSION` と `BigDecimal#clone` と `BigDecimal#dup` をリンクにしました。

![image](https://user-images.githubusercontent.com/645970/146200033-113647f7-7209-409d-90a0-6498abe44d50.png)

### coverage

`Coverage.start` と `Coverage.result` をリンクにしました。

![image](https://user-images.githubusercontent.com/645970/146199317-bfca920f-00e0-4311-9ff3-8fe9c5ba0cac.png)

### zlib

リンクのテキストを `zlip` から `zlib` に変更しました。

![image](https://user-images.githubusercontent.com/645970/146198326-a0b77e16-8df3-4aa8-b8b8-39a702d668a5.png)

### psych

標準ライブラリの項目で他はライブラリ名のリンクでしたので、クラス名の `Psych` から `psych` のリンクにしました。

![image](https://user-images.githubusercontent.com/645970/146198057-66cabd15-da5f-4921-9d26-988a9a97d175.png)

### 標準添付ライブラリの互換性(機能追加とバグ修正を除く)

`Logger` と `Net::HTTP` と `Net::HTTP#start` をリンクにしました。

![image](https://user-images.githubusercontent.com/645970/146198673-aa787f6e-3905-4db9-9e56-9a26318eda56.png)

### 実装の改善

`Hash` と `SecureRandom` と `OpenSSL` と `TracePoint` と `ERB` をリンクにしました。

![image](https://user-images.githubusercontent.com/645970/146198922-75695cf8-314d-4ea7-85a5-4e318efdd4b4.png)

ご確認よろしくお願いします。
