### PR TITLE
Encodingクラスのaliasesメソッドの利用例修正

### DIFF
--- a/refm/api/src/_builtin/Encoding
+++ b/refm/api/src/_builtin/Encoding
@@ -13,8 +13,8 @@
 
 #@samplecode 例
 p Encoding.aliases
-#=> {"BINARY"=>"ASCII-8BIT", "ASCII"=>"US-ASCII", "ANSI_X3.4-1986"=>"US-ASCII",
-#   "SJIS"=>"Shift_JIS", "eucJP"=>"EUC-JP", "CP932"=>"Windows-31J"}
+#=> {"BINARY"=>"ASCII-8BIT", "ASCII"=>"US-ASCII", "ANSI_X3.4-1968"=>"US-ASCII",
+#   "SJIS"=>"Windows-31J", "eucJP"=>"EUC-JP", "CP932"=>"Windows-31J"}
 #@end
 
 --- compatible?(obj1, obj2) -> Encoding | nil


### PR DESCRIPTION
Encodingクラスのaliasesメソッドの利用例が実態と異なるため修正しました
https://docs.ruby-lang.org/ja/latest/method/Encoding/s/aliases.html

* `ANSI_X3.4-1986` -> `ANSI_X3.4-1968`
* `"SJIS"=>"Shift_JIS"` -> `"SJIS"=>"Windows-31J"`

英語版の方では2.7.0のときに修正が反映されているようです
https://ruby-doc.org/core-2.7.0/Encoding.html#method-c-aliases
https://ruby-doc.org/core-2.6.9/Encoding.html#method-c-aliases
