### PR TITLE
IO#fsyncとIO#fdatasyncのreturnを修正

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1121,7 +1121,7 @@ File.open("testfile") do |f|
 end
 #@end
 
---- fsync    -> 0 | nil
+--- fsync    -> 0
 
 書き込み用の IO に対して、システムコール [[man:fsync(2)]]
 を実行します。[[m:IO#flush]] を行ったあと、(OSレベルで)まだディスクに
@@ -2353,7 +2353,7 @@ IO の各コードポイントに対して繰り返しブロックを呼びだ�
 
 @see [[m:IO#each_codepoint]]
 #@end
---- fdatasync -> 0 | nil
+--- fdatasync -> 0
 
 IO のすべてのバッファされているデータを直ちにディスクに書き込みます。
 


### PR DESCRIPTION
RDoc の https://github.com/ruby/ruby/commit/6ad8cf70713e6ae91a8218d4e0034ebbc1983c69 の修正に含まれていて、
最初の
https://github.com/ruby/ruby/commit/eb9708f38671aa6446a89acc755f3341f5cb59b6#diff-92194f057884b3287a3a6bf84e6e3b2bf433a556b68562799252a091744e7854R459
から not reached で nil を返す可能性はなく、
https://github.com/ruby/ruby/commit/8e8ae2a9c53d58a59bc680c6d05c453ac866db8c#diff-92194f057884b3287a3a6bf84e6e3b2bf433a556b68562799252a091744e7854L1313
で return Qnil も完全に消えているため、バージョン分岐なし。