### PR TITLE
Array#keep_ifなどの修正・改善

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -861,24 +861,15 @@ p array             #=> [0, 1, 3, 4]
 
 --- delete_if {|x| ... }    -> self
 --- reject! {|x| ... }      -> self | nil
-#@since 1.9.1
 --- delete_if               -> Enumerator
 --- reject!                 -> Enumerator
-#@else
---- delete_if               -> Enumerable::Enumerator
---- reject!                 -> Enumerable::Enumerator
-#@end
 
 要素を順番にブロックに渡して評価し、その結果が真になった要素をすべて削除します。
 delete_if は常に self を返しますが、reject! は要素が 1 つ以上削除されれば self を、
 1 つも削除されなければ nil を返します。
 
 ブロックが与えられなかった場合は、自身と reject! から生成した
-#@since 1.9.1
 [[c:Enumerator]] オブジェクトを返します。
-#@else
-[[c:Enumerable::Enumerator]] オブジェクトを返します。
-#@end
 返された Enumerator オブジェクトの each メソッドには、
 もとの配列に対して副作用があることに注意してください。
 
@@ -892,6 +883,8 @@ e = a.reject!
 e.each{|i| i % 2 == 0}
 p a                    #=> [1, 3, 5]  もとの配列から削除されていることに注意。
 #@end
+
+@see [[m:Array#select!]], [[m:Array#keep_if]]
 
 --- drop(n)               -> Array
 
@@ -2500,7 +2493,7 @@ a.repeated_permutation(0).to_a  #=> [[]] # one permutation of length 0
 --- keep_if {|item| ... } -> self
 --- keep_if -> Enumerator
 
-ブロックが false を返した要素を削除します。
+ブロックが真を返した要素を残し、偽を返した要素を自身から削除します。
 
 #@samplecode 例
 a = %w{ a b c d e f }
@@ -2508,8 +2501,8 @@ a.keep_if {|v| v =~ /[aeiou]/}   # => ["a", "e"]
 a # => ["a", "e"]
 #@end
 
-[[m:Array#select!]] と同様に自身を上書きしますが、削除する要素がなかっ
-た場合には修正を行いません。
+keep_if は常に self を返しますが、[[m:Array#select!]] は要素が 1 つ以上削除されれば self を、
+1 つも削除されなければ nil を返します。
 
 #@samplecode 例
 a = %w{ a b c d e f }
@@ -2520,7 +2513,8 @@ a # => ["a", "b", "c", "d", "e", "f"]
 ブロックが与えられなかった場合は、自身と keep_if から生成した
 [[c:Enumerator]] オブジェクトを返します。
 
-@see [[m:Array#select!]]
+@see [[m:Array#select!]], [[m:Array#delete_if]]
+
 --- select    -> Enumerator
 #@since 2.6.0
 --- filter    -> Enumerator
@@ -2541,6 +2535,7 @@ a # => ["a", "b", "c", "d", "e", "f"]
 #@end
 @see [[m:Enumerable#select]]
 @see [[m:Array#select!]]
+
 --- select! {|item| block } -> self | nil
 --- select! -> Enumerator
 #@since 2.6.0
@@ -2548,7 +2543,7 @@ a # => ["a", "b", "c", "d", "e", "f"]
 --- filter! -> Enumerator
 #@end
 
-ブロックが false を返した要素を自身から削除します。
+ブロックが真を返した要素を残し、偽を返した要素を自身から削除します。
 変更があった場合は self を、
 変更がなかった場合には nil を返します。
 
@@ -2561,7 +2556,8 @@ a # => ["a", "b", "c", "d", "e", "f"]
 ブロックが与えられなかった場合は、自身と select! から生成した
 [[c:Enumerator]] オブジェクトを返します。
 
-@see [[m:Array#keep_if]]
+@see [[m:Array#keep_if]], [[m:Array#reject!]]
+
 --- rotate(cnt = 1) -> Array
 
 cnt で指定したインデックスの要素が先頭になる配列を新しく作成します。


### PR DESCRIPTION
fix #2640 

keep_if, select!, delete_ifの項目について、修正などをしました。

・keep_ifとselect!の違いを修正。
・説明を改善。
・古いRubyバージョンの条件分岐を削除。
・メソッドの参照の追加。

以下の文面は、`reject!`と`delete_if`の文章を参考にしました。
「keep_if は常に self を返しますが、[[m:Array#select!]] は要素が 1 つ以上削除されれば self を、
1 つも削除されなければ nil を返します。」

よろしくお願いします!

