### PR TITLE
CSV::Tableの説明・サンプルコードの追加等

### DIFF
--- a/refm/api/src/csv/CSV__Table
+++ b/refm/api/src/csv/CSV__Table
@@ -403,11 +403,12 @@ table.headers # => ["header1", "header2"]
 
 モードとサイズを US-ASCII な文字列で返します。
 
-例:
-  require 'csv'
-  csv = CSV.new("a,b,c\n1,2,3", headers: true)
-  table = csv.read
-  table.inspect # => "#<CSV::Table mode:col_or_row row_count:2>"
+#@samplecode
+require 'csv'
+csv = CSV.new("a,b,c\n1,2,3", headers: true)
+table = csv.read
+table.inspect # => "#<CSV::Table mode:col_or_row row_count:2>"
+#@end
 
 
 --- length -> Integer
@@ -440,11 +441,13 @@ table.mode    # => :col
 @param rows [[c:CSV::Row]] のインスタンスか配列を指定します。
 
 以下と同じです。
-  require 'csv'
-  csv = CSV.new("a,b,c\n,1,2,3", headers: true)
-  table = csv.read
-  rows = [[4, 5, 6], [7, 8, 9]]
-  rows.each{|row| table << row }
+#@samplecode
+require 'csv'
+csv = CSV.new("a,b,c\n,1,2,3", headers: true)
+table = csv.read
+rows = [[4, 5, 6], [7, 8, 9]]
+rows.each{|row| table << row }
+#@end
 
 --- to_a -> [Array]
 
@@ -471,12 +474,13 @@ CSV の文字列に変換して返します。
 デフォルトでは、ヘッダを出力します。オプションに :write_headers =>
 false を指定するとヘッダを出力しません。
 
-例:
-  require 'csv'
-  csv = CSV.new("a,b,c\n,1,2,3", headers: true)
-  table = csv.read
-  table.to_csv                       # => "a,b,c\n1,2,3\n"
-  table.to_csv(write_headers: false) # => "1,2,3\n"
+#@samplecode
+require 'csv'
+csv = CSV.new("a,b,c\n1,2,3", headers: true)
+table = csv.read
+table.to_csv                       # => "a,b,c\n1,2,3\n"
+table.to_csv(write_headers: false) # => "1,2,3\n"
+#@end
 
 --- values_at(indices_or_headers) -> Array
 

--- a/refm/api/src/csv/CSV__Table
+++ b/refm/api/src/csv/CSV__Table
@@ -406,9 +406,9 @@ table.each { |column_name, values| print column_name, values, "\n" }
 require 'csv'
 csv = CSV.new("a,b\n", headers: true)
 table = csv.read
-table.empty?     # => true
+p table.empty?     # => true
 table << [1, 2]
-table.empty?     # => false
+p table.empty?     # => false
 #@end
 
 @see [[m:Array#empty?]]
@@ -435,7 +435,7 @@ table.headers # => ["header1", "header2"]
 require 'csv'
 csv = CSV.new("a,b,c\n1,2,3", headers: true)
 table = csv.read
-table.inspect # => "#<CSV::Table mode:col_or_row row_count:2>"
+p table.inspect # => "#<CSV::Table mode:col_or_row row_count:2>"
 #@end
 
 
@@ -490,7 +490,7 @@ rows = [
 ]
 
 table.push(*rows)
-puts table[0..2]
+p table[0..2]
 # => [#<CSV::Row "a":"1" "b":"2" "c":"3">, #<CSV::Row "a":4 "b":5 "c":6>, #<CSV::Row "a":7 "b":8 "c":9>]
 #@end
 
@@ -525,8 +525,8 @@ false を指定するとヘッダを出力しません。
 require 'csv'
 csv = CSV.new("a,b,c\n1,2,3", headers: true)
 table = csv.read
-table.to_csv                       # => "a,b,c\n1,2,3\n"
-table.to_csv(write_headers: false) # => "1,2,3\n"
+p table.to_csv                       # => "a,b,c\n1,2,3\n"
+p table.to_csv(write_headers: false) # => "1,2,3\n"
 #@end
 
 --- values_at(indices_or_headers) -> Array

--- a/refm/api/src/csv/CSV__Table
+++ b/refm/api/src/csv/CSV__Table
@@ -88,7 +88,9 @@ table2 << CSV::Row.new(["header1", "header2"], ["row3_1", "row3_2"])
 table1 == table2 # => false
 #@end
 
---- [](index_or_header) -> object
+--- [](index) -> CSV::Row | [String] | nil
+--- [](range) -> [CSV::Row]| [Array] | nil
+--- [](header) -> [String] | [nil]
 
 ミックスモードでは、このメソッドは引数に行番号を指定すれば行単位で動作
 し、ヘッダの名前を指定すれば列単位で動作します。
@@ -97,10 +99,10 @@ table1 == table2 # => false
 モードになります。また [[m:CSV::Table#by_row!]] を呼び出すとロウモード
 になります。
 
-@param index_or_header 行番号かヘッダの名前を指定します。
-
-@return 値の配列を返します。この配列を変更しても元のデータには何の影響
-        もありません。
+@param index ミックスモード・ロウモードでは、取得したい行の行番号を整数で指定します。
+             カラムモードでは、取得したい列の列番号を整数で指定します。
+@param range 取得したい範囲を整数の範囲で指定します。
+@param header 取得したい列のヘッダを文字列で指定します。ロウモードでは使用できません。
 
 #@samplecode 例
 require "csv"
@@ -108,11 +110,28 @@ require "csv"
 row1 = CSV::Row.new(["header1", "header2"], ["row1_1", "row1_2"])
 row2 = CSV::Row.new(["header1", "header2"], ["row2_1", "row2_2"])
 table = CSV::Table.new([row1, row2])
-table[0] # => #<CSV::Row "header1":"row1_1" "header2":"row1_2">
-table[1] # => #<CSV::Row "header1":"row2_1" "header2":"row2_2">
+
+# ミックスモード
+p table.mode       # => :col_or_row
+p table[0]         # => #<CSV::Row "header1":"row1_1" "header2":"row1_2">
+p table[1]         # => #<CSV::Row "header1":"row2_1" "header2":"row2_2">
+p table["header2"] # => ["row1_2", "row2_2"]
+p table[0..1]      # => [#<CSV::Row "header1":"row1_1" "header2":"row1_2">, #<CSV::Row "header1":"row2_1" "header2":"row2_2">]
+
+# カラムモード
 table.by_col!
-table[0] # => ["row1_1", "row2_1"]
-table[1] # => ["row1_2", "row2_2"]
+p table.mode       # => :col
+p table[0]         # => ["row1_1", "row2_1"]
+p table[1]         # => ["row1_2", "row2_2"]
+p table["header2"] # => ["row1_2", "row2_2"]
+p table[0..1]      # => [["row1_1", "row1_2"], ["row2_1", "row2_2"]]
+
+# ロウモード
+table.by_row!
+p table.mode       # => :row
+p table[0]         # => #<CSV::Row "header1":"row1_1" "header2":"row1_2">
+p table[1]         # => #<CSV::Row "header1":"row2_1" "header2":"row2_2">
+p table[0..1]      # => [#<CSV::Row "header1":"row1_1" "header2":"row1_2">, #<CSV::Row "header1":"row2_1" "header2":"row2_2">]
 #@end
 
 --- []=(index_or_header, value)
@@ -379,9 +398,18 @@ table.each { |column_name, values| print column_name, values, "\n" }
 
 --- empty? -> bool
 
-[[m:Array#empty?]] に委譲します。
+ヘッダーを除いて、データがないときに true を返します。
 
-#@#noexample Array#empty? の例を参照
+[[m:Array#empty?]] に委譲しています。
+
+#@samplecode
+require 'csv'
+csv = CSV.new("a,b\n", headers: true)
+table = csv.read
+table.empty?     # => true
+table << [1, 2]
+table.empty?     # => false
+#@end
 
 @see [[m:Array#empty?]]
 
@@ -414,9 +442,16 @@ table.inspect # => "#<CSV::Table mode:col_or_row row_count:2>"
 --- length -> Integer
 --- size -> Integer
 
-[[m:Array#length]], [[m:Array#size]] に委譲します。
+(ヘッダを除く)行数を返します。
 
-#@#noexample Array#length, Array#size の例を参照
+[[m:Array#length]], [[m:Array#size]] に委譲しています。
+
+#@samplecode
+require 'csv'
+csv = CSV.new("a,b,c\n1,2,3", headers: true)
+table = csv.read
+p table.size  # => 1
+#@end
 
 @see [[m:Array#length]], [[m:Array#size]]
 
@@ -438,16 +473,28 @@ table.mode    # => :col
 
 複数の行を追加するためのショートカットです。
 
-@param rows [[c:CSV::Row]] のインスタンスか配列を指定します。
-
 以下と同じです。
 #@samplecode
-require 'csv'
-csv = CSV.new("a,b,c\n,1,2,3", headers: true)
-table = csv.read
-rows = [[4, 5, 6], [7, 8, 9]]
-rows.each{|row| table << row }
+rows.each {|row| self << row }
 #@end
+
+@param rows [[c:CSV::Row]] のインスタンスか配列を指定します。
+
+#@samplecode 例
+require 'csv'
+csv = CSV.new("a,b,c\n1,2,3", headers: true)
+table = csv.read
+rows = [
+  CSV::Row.new(table.headers, [4, 5, 6]),
+  [7, 8, 9]
+]
+
+table.push(*rows)
+puts table[0..2]
+# => [#<CSV::Row "a":"1" "b":"2" "c":"3">, #<CSV::Row "a":4 "b":5 "c":6>, #<CSV::Row "a":7 "b":8 "c":9>]
+#@end
+
+@see [[m:CSV::Table#<<]]
 
 --- to_a -> [Array]
 


### PR DESCRIPTION
全体的にCSV::Tableの説明などを加えました。

例えば、`empty?`は、`Array#empty?`に委譲しているという説明のみで済ませられていましたが、
ヘッダーを除くことは必ずしも自明ではないため、説明やサンプルコードがあった方がいいと思います。