### PR TITLE
Add resolve_feature_path since 2.6.0

### DIFF
--- a/refm/api/src/_builtin/RubyVM
+++ b/refm/api/src/_builtin/RubyVM
@@ -32,6 +32,19 @@ Ruby の 内部情報へのアクセス手段を提供するクラスです。
 #@#
 #@# VM_COLLECT_USAGE_DETAILS を有効にしてコンパイルした時のみ有効
 
+#@since 2.6.0
+#@until 2.7.0
+--- resolve_feature_path
+require を呼んだときに読み込まれるファイルを特定します。
+このメソッドはRuby 2.7 で $LOAD_PATH の特異メソッドに移動しました。
+
+#@samplecode
+p p RubyVM.resolve_feature_path('set')
+# => [:rb, "/build-all-ruby/2.6.0/lib/ruby/2.6.0/set.rb"]
+#@end
+#@end
+#@end
+
 == Constants
 
 --- OPTS -> [String]

--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -378,8 +378,6 @@ Rubyライブラリをロードするときの検索パスです。
 コンパイル時に指定したデフォルト値
 をこの順番で含みます。
 
-#@# 1.6.5 から以下のように変更されている
-#@# 1.6.4 以前の値は書かなくていいよね……
 以下に典型的な UNIX システム上でのロードパスを示します。
 
   -I で指定したパス
@@ -390,7 +388,6 @@ Rubyライブラリをロードするときの検索パスです。
   /usr/local/lib/ruby/VERSION                  標準ライブラリ
   /usr/local/lib/ruby/VERSION/ARCH             標準、システム依存、拡張ライブラリ
 
-#@#((-デフォルトの順序は 1.6.5 から変更されました-))
 上記表中の VERSION は Ruby のバージョンを表す文字列で、
 「1.6」や「1.8」です。
 ARCH はハードウェアと OS を表す文字列で、
@@ -423,6 +420,16 @@ require 'foo' を実行すると、
   $ ruby -e 'puts $:'
 
 とします。
+
+#@since 2.7.0
+$LOAD_PATH の特異メソッドとして resolve_feature_path が定義されています。
+require を呼んだときに読み込まれるファイルを特定できます。
+
+#@samplecode
+p $LOAD_PATH.resolve_feature_path('set')
+# => [:rb, "/build-all-ruby/2.7.0/lib/ruby/2.7.0/set.rb"]
+#@end
+#@end
 
 この変数はグローバルスコープです。
 


### PR DESCRIPTION
ref https://github.com/rurema/doctree/issues/2071

Ruby 2.6 で `RubyVM` の、 Ruby 2.7 より `$LOAD_PATH` の特異メソッドとなった `resolve_feature_path` を追加しました。  https://bugs.ruby-lang.org/issues/15903
特殊変数の特異メソッドということでどこに書くか悩みましたが、 `$LOAD_PATH` の説明の中に書いてしまうことにしました。

<s> Ruby 2.6 では `RubyVM.resolve_feature_path` が使えましたが、Ruby 2.6 はもうすぐ EOL なことと使用頻度が少なそうなことから追加していません。必要そうであれば追加します。 </s>
追加しました。

## 質問
`refm/api/src/_builtin/specialvars` の HTML を出力する方法が分からず確認できていません。
お手数ですが、確認するためのコマンドを教えていただきたいです 🙏 

以下のコマンドは試しました。
- `bitclust htmlfile --force refm/api/src/_builtin/specialvars --ruby=2.7.0 > /tmp/tmp.html`
  - `method_signature': undefined method `index_id' for nil:NilClass (NoMethodError)` で出力失敗
- `bitclust server --database=db-3.0.0 --debug`
  - サーバは起動しましたが、 http://localhost:10080/  http://localhost:10080/view/ にアクセスしても `This site can’t be reachedThe webpage at http://localhost:10080/ might be temporarily down or it may have moved permanently to a new web address. ERR_UNSAFE_PORT` とブラウザに表示され繋がらなかったです。

```
❯ bitclust htmlfile --force refm/api/src/_builtin/specialvars --ruby 2.7.0 > /tmp/tmp.html                                                        
/Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:387:in `method_signature': undefined method `index_id' for nil:NilClass (NoMethodError)
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:114:in `block in entry_chunk'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/lineinput.rb:129:in `while_match'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:113:in `entry_chunk'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:81:in `library_file'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:42:in `block in compile'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:73:in `setup'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/rdcompiler.rb:41:in `compile'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/screen.rb:453:in `compile_rd'
        from doc.erb:48:in `doc_template'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/screen.rb:328:in `run_template'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/screen.rb:682:in `body'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/subcommands/htmlfile_command.rb:74:in `exec'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/runner.rb:141:in `_run'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/lib/bitclust/runner.rb:33:in `run'
        from /Users/mi/.asdf/installs/ruby/3.0.3/lib/ruby/gems/3.0.0/gems/bitclust-core-1.3.0/bin/bitclust:14:in `<top (required)>'
        from /Users/mi/.asdf/installs/ruby/3.0.3/bin/bitclust:25:in `load'
        from /Users/mi/.asdf/installs/ruby/3.0.3/bin/bitclust:25:in `<main>'
```

