### PR TITLE
Remove Random::DEFAULT since 3.2

### DIFF
--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -1,4 +1,3 @@
-#@since 1.9.2
 = class Random < Object
 
 MT19937に基づく擬似乱数生成器を提供するクラスです。
@@ -388,7 +387,6 @@ Random.rand(10) # => 4
 [[m:Random.rand]] や [[m:Kernel.#rand]] などで使用されます。
 
 @see [[m:Random.srand]], [[m:Kernel.#srand]]
-#@end
 #@end
 #@end
 #@end

--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -87,7 +87,11 @@ Random.rand(10.0)  #=> 1.9151945037889229  (0.0 以上 10.0 未満の実数)
 rand(10.0)         #=> 6                   (rand(10) と同じ)
 #@end
 
+#@since 3.2
+@see [[m:Random.srand]], [[m:Random#rand]]
+#@else
 @see [[m:Random.srand]], [[m:Random#rand]], [[m:Random::DEFAULT]]
+#@end
 #@else
 --- rand(max = 0) -> Integer | Float
 
@@ -112,10 +116,10 @@ rand(10.0)         #=> 6                   (rand(10) と同じ)
 
 #@#noexample 詳しくは Kernel.#srand を参照
 
-#@since 1.9.3
-@see [[m:Kernel.#rand]], [[m:Random::DEFAULT]]
-#@else
+#@since 3.2
 @see [[m:Kernel.#rand]]
+#@else
+@see [[m:Kernel.#rand]], [[m:Random::DEFAULT]]
 #@end
 #@since 2.6.0
 --- bytes(size) -> String

--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -365,6 +365,7 @@ C言語レベルで定義されている構造体MTの静的変数default_rand�
 #@since 1.9.3
 == Constants
 
+#@until 3.2
 #@since 3.0.0
 --- DEFAULT -> Class
 #@else
@@ -387,6 +388,7 @@ Random.rand(10) # => 4
 [[m:Random.rand]] や [[m:Kernel.#rand]] などで使用されます。
 
 @see [[m:Random.srand]], [[m:Kernel.#srand]]
+#@end
 #@end
 #@end
 #@end

--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -366,15 +366,15 @@ C言語レベルで定義されている構造体MTの静的変数default_rand�
 == Constants
 
 #@until 3.2
-#@since 3.0.0
+#@since 3.0
 --- DEFAULT -> Class
 #@else
 --- DEFAULT -> Random
 #@end
 
-Ruby 3.0.0 から非推奨です。代わりに Random クラスオブジェクトを擬似乱数生成器として使用してください。
+Ruby 3.0 から非推奨です。代わりに Random クラスオブジェクトを擬似乱数生成器として使用してください。
 
-#@since 3.0.0
+#@since 3.0
 
 また、 Random::DEFAULT は Random クラスオブジェクトが返ります。
 


### PR DESCRIPTION
Random::DEFAULT を until 3.2 でくくって、リンク切れになるところを対応しました。
また、3.0.0 になっていたところの一部を 3.0 に変更しました。