### PR TITLE
各 VERSION 定数のシグネチャ表記は String に統一する

### DIFF
--- a/refm/api/src/forwardable.rd
+++ b/refm/api/src/forwardable.rd
@@ -147,7 +147,7 @@ def_delegator は def_instance_delegator の別名になります。
 
 == Constants
 
---- FORWARDABLE_VERSION -> "1.1.0"
+--- FORWARDABLE_VERSION -> String
 
 [[lib:forwardable]] ライブラリのバージョンを返します。
 #@end

--- a/refm/api/src/syslog/logger.rd
+++ b/refm/api/src/syslog/logger.rd
@@ -254,7 +254,7 @@ call メソッドは文字列を返す必要があります。
 
 == Constants
 
---- VERSION -> '2.0'
+--- VERSION -> String
 
 [[c:Syslog::Logger]] のバージョンを表す文字列です。
 

--- a/refm/api/src/yaml/constants.rd
+++ b/refm/api/src/yaml/constants.rd
@@ -8,11 +8,11 @@ YAML 関連の定数のためのサブライブラリです。
 
 == Constants
 
---- VERSION -> "0.60"
+--- VERSION -> String
 
 このライブラリのバージョンを文字列で返します。
 
---- SUPPORTED_YAML_VERSIONS -> ["1.0"]
+--- SUPPORTED_YAML_VERSIONS -> [String]
 
 サポートする YAML のバージョンを文字列の配列で返します。
 

--- a/refm/api/src/yaml/dbm.rd
+++ b/refm/api/src/yaml/dbm.rd
@@ -18,7 +18,7 @@ require dbm
 
 == Constants
 
---- VERSION -> "0.1"
+--- VERSION -> String
 
 [[lib:yaml/dbm]] のバージョンを文字列で返します。
 
@@ -196,4 +196,3 @@ keys に対応する値を配列に格納して返します。
 対応するキーが見つからなかった要素には nil が格納されます。
 
 @param keys キーを文字列で指定します。複数指定することができます。
-


### PR DESCRIPTION
Fixed https://github.com/rurema/doctree/issues/2397

上記の Solution の方針のとおり該当定数のシグネチャ表記では
具体的なリテラル値ではなく、値の型である String を記載するよう
に変えました。

`webrick` も実行例だったので対象から外しています。

念のため最新のソースコードで上記 Issue に記載されていたのと同じ
方法で grep した結果も掲載しておきます。

```
$ git grep -E 'VERSION.+[0-9]+[.][0-9]+' refm/
refm/api/src/etc.rd:242:Etc.confstr(Etc::CS_GNU_LIBC_VERSION) # => "glibc 2.18"
refm/api/src/etc.rd:243:Etc.confstr(Etc::CS_GNU_LIBPTHREAD_VERSION) # => "NPTL 2.18"
refm/api/src/forwardable.rd:150:--- FORWARDABLE_VERSION -> "1.1.0"
refm/api/src/syslog/logger.rd:257:--- VERSION -> '2.0'
refm/api/src/webrick.rd:72: p WEBrick::VERSION   #=> "1.3.1"
refm/api/src/yaml/constants.rd:11:--- VERSION -> "0.60"
refm/api/src/yaml/constants.rd:15:--- SUPPORTED_YAML_VERSIONS -> ["1.0"]
refm/api/src/yaml/dbm.rd:21:--- VERSION -> "0.1"
```