### PR TITLE
Random#rand が nil を返すケースは存在しない

### DIFF
--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -65,7 +65,7 @@ Random.raw_seed(8)  #=> "\x78\x41\xBA\xAF\x7D\xEA\xD8\xEA"
 #@since 1.9.3
 --- rand -> Float
 --- rand(max) -> Integer | Float
---- rand(range) -> Integer | Float | nil
+--- rand(range) -> Integer | Float
 
 擬似乱数を発生させます。
 
@@ -214,7 +214,6 @@ max が正の整数なら整数を、正の実数なら実数を返します。
 
 三番目の形式では range で指定された範囲の値を返します。
 range の始端と終端が共に整数の場合は整数を、少なくとも片方が実数の場合は実数を返します。
-range に含まれる数が無い場合は nil を返します。
 rangeが終端を含まない(つまり ... で生成した場合)には終端の値は乱数の範囲から除かれます。
 range.end - range.begin が整数を返す場合は range.begin + self.rand((range.end - range.begin) + e)
 の値を返します(e は終端を含む場合は1、含まない場合は0です)。

--- a/refm/api/src/_builtin/Random
+++ b/refm/api/src/_builtin/Random
@@ -81,6 +81,7 @@ Random.raw_seed(8)  #=> "\x78\x41\xBA\xAF\x7D\xEA\xD8\xEA"
              range の境界は数値でなければなりません。
 
 @raise Errno::EDOM rand(1..Float::INFINITY) などのように範囲に問題があるときに発生します。
+@raise ArgumentError 引数の数が0または1では無い時、引数に負の数値を与えた時や (1..0) のような値が存在しない範囲を渡した時に発生します。
 
 #@samplecode 例
 srand 1234 # 乱数の種を設定する。
@@ -202,7 +203,7 @@ p r1 == r3 # => true
 #@end
 --- rand -> Float
 --- rand(max) -> Integer | Float
---- rand(range) -> Integer | Float | nil
+--- rand(range) -> Integer | Float
 
 一様な擬似乱数を発生させます。
 
@@ -228,7 +229,8 @@ range.end - range.begin が実数を返す場合も同様です。
              range.end - range.begin は数値である必要があり、
              range.begin + 数値 が適切な値を返す必要があります。
 
-@raise ArgumentError 引数の数が0または1では無い時、引数に負の数値を与えた時に発生します。
+@raise Errno::EDOM rand(1..Float::INFINITY) などのように範囲に問題があるときに発生します。
+@raise ArgumentError 引数の数が0または1では無い時、引数に負の数値を与えた時や (1..0) のような値が存在しない範囲を渡した時などに発生します。
 
 #@samplecode 例
 # Kernel.#rand とほぼ同様の使い勝手


### PR DESCRIPTION
Random#rand は `(1..0)` のような Range オブジェクトを指定したときに例外を送出するため `nil` を返却するケースは存在しないと思われる。

おそらく Kernel#rand の記述をそのままコピーしてきたことで誤った記述となっていた?

(Ruby 3.1.0 で確認)
```
Kernel.rand(1..0)
=> nil

Random.new.rand(1..0)
=>  `rand': invalid argument - 1..0 (ArgumentError)
```