### PR TITLE
Dir.glob("*", File::FNM_DOTMATCH) does not return ".." since Ruby 3.1.0

### DIFF
--- a/refm/api/src/_builtin/Dir
+++ b/refm/api/src/_builtin/Dir
@@ -41,7 +41,7 @@ include Enumerable
 
 #@samplecode
 Dir.glob("*")                      #=> ["bar", "foo"]
-Dir.glob("*", File::FNM_DOTMATCH)  #=> [".", "..", "bar", "foo"]
+Dir.glob("*", File::FNM_DOTMATCH)  #=> [".", "bar", "foo"]
 #@end
 
 #@since 2.5.0

--- a/refm/api/src/_builtin/Dir
+++ b/refm/api/src/_builtin/Dir
@@ -41,7 +41,11 @@ include Enumerable
 
 #@samplecode
 Dir.glob("*")                      #=> ["bar", "foo"]
+#@since 3.1.0
 Dir.glob("*", File::FNM_DOTMATCH)  #=> [".", "bar", "foo"]
+#@else
+Dir.glob("*", File::FNM_DOTMATCH)  #=> [".", "..", "bar", "foo"]
+#@end
 #@end
 
 #@since 2.5.0


### PR DESCRIPTION
Related to:

- [Bug \#17280: Dir\.glob with FNM\_DOTMATCH matches "\.\." and "\." and results in duplicated entries \- Ruby master \- Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/17280)
- [Bug \#18436: Fix Pathname dot directory globbing \- Ruby master \- Ruby Issue Tracking System](https://bugs.ruby-lang.org/issues/18436)