### PR TITLE
Fix a broken link in the doc of `Integer`

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -70,7 +70,7 @@ p 0x80.chr.encoding # => #<Encoding:ASCII_8BIT>
 @param encoding エンコーディングを表すオブジェクト。Encoding::UTF_8、'shift_jis' など。
 @return     一文字からなる文字列
 @raise RangeError self を与えられたエンコーディングで正しく解釈できない場合に発生します。
-@see [[m:String#ord]] [[m:Encoding#default_internal]]
+@see [[m:String#ord]] [[m:Encoding.default_internal]]
 
 --- digits -> [Integer]
 --- digits(base) -> [Integer]


### PR DESCRIPTION
`Encoding.default_internal` へのパーマリンク指定が間違っていたため、リンク先が 404 Not Found になっていました。

この PR はリンク先を以下のように更新します。

```diff
- https://docs.ruby-lang.org/ja/latest/method/Encoding/i/default_internal.html
+ https://docs.ruby-lang.org/ja/latest/method/Encoding/s/default_internal.html
```