### PR TITLE
Add an exception description for `File.dirname`

### DIFF
--- a/refm/api/src/_builtin/File
+++ b/refm/api/src/_builtin/File
@@ -237,6 +237,8 @@ File.dirname("/home/gumby/work/ruby.rb", 4) # => "/"
 @param filename ファイル名を表す文字列を指定します。
 #@since 3.1
 @param level 末尾からいくつ取り除くかを指定します。
+
+@raise ArgumentError level が負の場合に発生します。
 #@end
 
 @see [[m:File.basename]], [[m:File.extname]]


### PR DESCRIPTION
Ruby 3.1 で追加された `File.dirname` の `level` 引数に負の値を渡した場合の例外について追記します。

```ruby
File.dirname('path/to/foo.rb', -1) #=> negative level: -1 (ArgumentError)
```