### PR TITLE
set_form_data例の区切り文字を&に変更ではなく、削除

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -60,7 +60,7 @@ puts res.body
 url = URI.parse('http://www.example.com/todo.cgi')
 req = Net::HTTP::Post.new(url.path)
 req.basic_auth 'jack', 'pass'
-req.set_form_data({'from'=>'2005-01-01', 'to'=>'2005-03-31'}, ';')
+req.set_form_data({'from'=>'2005-01-01', 'to'=>'2005-03-31'}, '&')
 res = Net::HTTP.new(url.host, url.port).start {|http| http.request(req) }
 case res
 when Net::HTTPSuccess, Net::HTTPRedirection

--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -60,7 +60,7 @@ puts res.body
 url = URI.parse('http://www.example.com/todo.cgi')
 req = Net::HTTP::Post.new(url.path)
 req.basic_auth 'jack', 'pass'
-req.set_form_data({'from'=>'2005-01-01', 'to'=>'2005-03-31'}, '&')
+req.set_form_data({'from'=>'2005-01-01', 'to'=>'2005-03-31'})
 res = Net::HTTP.new(url.host, url.port).start {|http| http.request(req) }
 case res
 when Net::HTTPSuccess, Net::HTTPRedirection


### PR DESCRIPTION
179行目に以下のように書いてあるにもかかわらず、

> しかし、実際には `;' を解釈しないCGIやサーバもまだまだ見受けられるためこのリファレンスマニュアルでは例として `&' を用いました。

set_form_dataの例では `;` が使われていました。
2022年現在でも `;` に対応していないサービスが多く（たとえばSlack API）、このページからコードをコピペしてリクエストが失敗したときにその原因がわかりにくいため、 `&` にしておくべきではないかと思います。