### PR TITLE
Add IPAddr#prefix and IPAddr#prefix= since 2.5.0

### DIFF
--- a/refm/api/src/ipaddr.rd
+++ b/refm/api/src/ipaddr.rd
@@ -193,6 +193,21 @@ IPv4 互換でも IPv4 組み込みでもないなら self を返します。
   p IPAddr.new("0000:0000:0000:0000:0000:ffff:c0a8:0001").native
       # => #<IPAddr: IPv4:192.168.0.1/255.255.255.255>
 
+#@since 2.5.0
+--- prefix -> Integer
+
+プリフィックス長をビット数で返します。
+
+--- prefix=(prefixlen)
+
+プリフィックス長を prefixlen に設定します。
+
+@param prefixlen 設定したいプリフィックス長をビット数で指定します。
+
+@raise IPAddr::InvalidPrefixError 引数 prefixlen に整数以外のオブジェクトを指定した場合に発生します。
+
+#@end
+
 --- reverse -> String
 
 DNS 逆引きのための文字列を返します。


### PR DESCRIPTION
`IPAddr#prefix` と `IPAddr#prefix=` の説明が見当たらなかったので追加しました。

Dockerの `ruby:2.5.0` イメージなどで調べた限りでは、2.5.0 から利用可能でしたので、since 2.5.0 としました。

https://github.com/ruby/ruby/commit/c2db917b3db09e3738529d5a45315b77d12ae4c3