### PR TITLE
Update description around removed `Hash#index` since Ruby 3.0+

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -938,15 +938,19 @@ p({:a=>1, :b=>2}.each_value)  # => #<Enumerator: {:a=>1, :b=>2}:each_value>
 @see [[m:Hash#each_pair]],[[m:Hash#each_key]]
 
 --- key(val) -> object
+#@until 3.0
 --- index(val) -> object
+#@end
 
 値 val に対応するキーを返します。対応する要素が存在しない時には
 nil を返します。
 
 該当するキーが複数存在する場合、どのキーを返すかは不定です。
 
+#@until 3.0
 Hash#index は obsolete です。
 使用すると警告メッセージが表示されます。
+#@end
 
 @param val 探索に用いる値を指定します。
 


### PR DESCRIPTION
ref: https://github.com/ruby/ruby/commit/547c71dec47561571b4862dda0395fb0b08d6c1c
現状のリストには挙がっていませんが、 https://github.com/rurema/doctree/issues/2458 の一環と言うことになるのでしょうか。

```console
❯ ruby -v -e '{}.index(0)'
ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]
-e:1: warning: Hash#index is deprecated; use Hash#key instead

❯ ruby -v -e '{}.index(0)'
ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
-e:1:in `<main>': undefined method `index' for {}:Hash (NoMethodError)
```

Before this PR
---

<img width="544" alt="Before-Hash-2 7 0" src="https://user-images.githubusercontent.com/1180335/169526986-ff0e1e59-1006-459c-a2b9-36139700f79e.png">
<img width="563" alt="Before-Hash-3 0" src="https://user-images.githubusercontent.com/1180335/169527001-105782ff-3a0a-4f9c-a42b-bc6fda56d05a.png">

After this PR
---

<img width="556" alt="After-Hash-2 7 0" src="https://user-images.githubusercontent.com/1180335/169526721-4c95ca00-2f23-407e-9438-4a123b5a7d23.png">
<img width="569" alt="After-Hash-3 0" src="https://user-images.githubusercontent.com/1180335/169526726-d4ffc92a-5ce3-4337-9620-47b7d3baaf2d.png">
