### PR TITLE
正規表現の\Rは文字クラスの中では使用できないことを追記

### DIFF
--- a/refm/doc/spec/regexp19
+++ b/refm/doc/spec/regexp19
@@ -248,6 +248,11 @@ d, a, u の3つのオプションがあります。
   /\w/.match("e\u{0308}") # => #<MatchData "e">
   $&.codepoints # => [101]
 
+ただし、\R は文字クラスの中では使用できません。
+
+  /\R/.match("\r\n") # => #<MatchData "\r\n">
+  /[\R]/.match("\r\n") # => nil
+
 #@end
 
 


### PR DESCRIPTION
正規表現の `\R` は文字クラスの中では使用できないので、そのことを明記しました。

```
/\R/.match("\r\n") # => #<MatchData "\r\n">
/[\R]/.match("\r\n") # => nil
```

https://github.com/kkos/oniguruma/blob/d484916f3ca2b6bbc81accba63054625dfe26b6b/doc/RE.ja#L83-L84
