### PR TITLE
Fix broken links

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -2043,7 +2043,7 @@ refinements 機能の詳細については以下を参照してください。
 
  * [[url:https://magazine.rubyist.net/articles/0041/0041-200Special-refinement.html]]
 #@since 2.1.0
- * [[url:https://docs.ruby-lang.org/en/master/doc/syntax/refinements_rdoc.html]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html]]
 #@else
  * [[url:https://docs.ruby-lang.org/en/2.0.0/syntax/refinements_rdoc.html]]
 #@end
@@ -2212,7 +2212,7 @@ C.singleton_class.singleton_class?  # => true
 
 有効にした拡張の有効範囲については以下を参照してください。
 
- * [[url:https://docs.ruby-lang.org/en/master/doc/syntax/refinements_rdoc.html#label-Scope]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html#label-Scope]]
 
 @param module 有効にするモジュールを指定します。
 

--- a/refm/api/src/_builtin/main
+++ b/refm/api/src/_builtin/main
@@ -132,7 +132,7 @@ hypot(3, 4)  # => 5.0
 有効にした拡張の有効範囲については以下を参照してください。
 
 #@since 2.1.0
- * [[url:https://docs.ruby-lang.org/en/master/doc/syntax/refinements_rdoc.html#label-Scope]]
+ * [[url:https://docs.ruby-lang.org/en/master/syntax/refinements_rdoc.html#label-Scope]]
 #@else
  * [[url:https://docs.ruby-lang.org/en/2.0.0/syntax/refinements_rdoc.html#label-Scope]]
 #@end


### PR DESCRIPTION
Refinements の詳細は英語版リファレンスへのリンクになっていますが、URL 体系が変わって? 404 になっているようでした。
