### PR TITLE
const_nameが既に定義されているときのautoloadの説明を追加

### DIFF
--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -341,6 +341,10 @@ end
 
 定数 const_name を最初に参照した時に feature を [[m:Kernel.#require]] するように設定します。
 
+const_name が autoload 設定されていて、まだ定義されてない(ロードされていない)ときは、
+autoload する対象を置き換えます。
+const_name が(autoloadではなく)既に定義されているときは何もしません。
+
 @param const_name [[c:String]] または [[c:Symbol]] で指定します。
        なお、const_name には、"::" 演算子を含めることはできません。
        つまり、self の直下に定義された定数しか指定できません。

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1118,6 +1118,10 @@ p a # undefined local variable or method `a' for #<Object:0x294f9ec @a=1> (NameE
 const_name には、 "::" 演算子を含めることはできません。
 ネストした定数を指定する方法は [[m:Module#autoload]] を参照してください。
 
+const_name が autoload 設定されていて、まだ定義されてない(ロードされていない)ときは、
+autoload する対象を置き換えます。
+const_name が(autoloadではなく)既に定義されているときは何もしません。
+
 @param const_name 定数をString または Symbol で指定します。
 @param feature require と同様な方法で autoload する対象を指定します。
 @raise LoadError featureのロードに失敗すると発生します。


### PR DESCRIPTION
see https://github.com/ruby/ruby/commit/1b44fcf22205dd9f1c6beb5e83ab3c98374ad1e4
