### PR TITLE
Add: Pathname#relative_path_fromのArgumentErrorを追記

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -415,14 +415,14 @@ base_directory も絶対パスでなければなりません。
 
 @param base_directory ベースディレクトリを表す Pathname オブジェクトを指定します。
 
+@raise ArgumentError Windows上でドライブが違うなど、base_directory から self への相対パスが求められないときに例外が発生します。
+
     require 'pathname'
 
     path = Pathname.new("/tmp/foo")
     base = Pathname.new("/tmp")
 
     path.relative_path_from(base) # => #<Pathname:foo>
-
-
 
 --- each_line(*args){|line| ... } -> nil
 #@since 1.9.1

--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -424,6 +424,8 @@ base_directory も絶対パスでなければなりません。
 
     path.relative_path_from(base) # => #<Pathname:foo>
 
+
+
 --- each_line(*args){|line| ... } -> nil
 #@since 1.9.1
 --- each_line(*args) -> Enumerator


### PR DESCRIPTION
```
irb(main):012:0> Pathname.new("A:/test").relative_path_from(Pathname.new("B:/test"))
C:/develop/Ruby30/lib/ruby/3.0.0/pathname.rb:528:in `relative_path_from': different prefix: "A:/" and "B:/test" (ArgumentError)
        from (irb):12:in `<main>'
        from C:/develop/Ruby30/lib/ruby/gems/3.0.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from C:/develop/Ruby30/bin/irb:25:in `load'
        from C:/develop/Ruby30/bin/irb:25:in `<main>'
```
こうなります