### PR TITLE
Range#begin, firstの違いを追記

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -328,13 +328,19 @@ p ('aaaaa'..'zzzzy').cover?('aaaaa'...'zzzzz') # => true
 --- begin -> object
 --- first -> object
 
-始端の要素を返します。範囲オブジェクトが始端を含むかどうかは関係ありま
-せん。
-
+始端の要素を返します。
+始端を持たない範囲オブジェクトの場合、begin はnilを返しますが, first は例外 [[c:RangeError]] が発生します。
 
 #@samplecode 例
+# 始端を持つ場合
 p (1..5).begin # => 1
 p (1..0).begin # => 1
+p (1..5).first # => 1
+p (1..0).first # => 1
+
+# 始端を持たない場合
+p (..5).begin #=> nil
+p (..5).first #=> RangeError
 #@end
 
 @see [[m:Range#end]]


### PR DESCRIPTION
### 修正内容

Range#begin, firstの記載の修正依頼です。
始端を持たない範囲オブジェクトの場合、begin はnilを返しますが, first は例外[RangeError]を返すため、その旨を記載しました。

### irb実行結果

```
irb(main):003:0> (..5).begin
=> nil
irb(main):004:0> (..5).first
(irb):4:in `first': cannot get the first element of beginless range (RangeError)
```

### 参考

Range#begin
https://docs.ruby-lang.org/ja/latest/method/Range/i/begin.html

ruby/range.c
range_begin()
https://github.com/ruby/ruby/blob/3401e58f23eb05e40cda67e111a1bb4c382619f5/range.c#L1030-L1034

range_first()
https://github.com/ruby/ruby/blob/3401e58f23eb05e40cda67e111a1bb4c382619f5/range.c#L1074-L1090
