### PR TITLE
Enumerator::Lazy のサンプルコードにハイライトを追加

### DIFF
--- a/refm/api/src/_builtin/Enumerator__Lazy
+++ b/refm/api/src/_builtin/Enumerator__Lazy
@@ -36,22 +36,22 @@ Lazyオブジェクトは、[[m:Enumerable#lazy]]メソッドによって生成�
 Lazyから値を取り出すには、[[m:Enumerator::Lazy#force]] または
 [[m:Enumerable#first]] を呼びます。
 
-例:
-
-  # 二乗して偶数になるような整数を、小さい方から5個表示する
-  p 1.step.lazy.select{|n| (n**2).even?}.first(5)
-  # LTSV (http://ltsv.org/) 形式のログファイルから検索を行う
-  # Enumerator::Lazy#map は配列ではなく Enumerator を返すため、
-  # 巨大な配列を確保しようとしてメモリを使い切ったりはしない
-  open("log.txt"){|f|
-    f.each_line.lazy.map{|line|
-      Hash[line.split(/\t/).map{|s| s.split(/:/, 2)}]
-    }.select{|hash|
-      hash["req"] =~ /GET/ && hash["status"] == "200"
-    }.each{|hash|
-      p hash
-    }
+#@samplecode 例
+# 二乗して偶数になるような整数を、小さい方から5個表示する
+p 1.step.lazy.select{|n| (n**2).even?}.first(5)
+# LTSV (http://ltsv.org/) 形式のログファイルから検索を行う
+# Enumerator::Lazy#map は配列ではなく Enumerator を返すため、
+# 巨大な配列を確保しようとしてメモリを使い切ったりはしない
+open("log.txt"){|f|
+  f.each_line.lazy.map{|line|
+    Hash[line.split(/\t/).map{|s| s.split(/:/, 2)}]
+  }.select{|hash|
+    hash["req"] =~ /GET/ && hash["status"] == "200"
+  }.each{|hash|
+    p hash
   }
+}
+#@end
 
 == Class Methods
 
@@ -62,25 +62,25 @@ Lazy Enumerator を作成します。[[m:Enumerator::Lazy#force]] メソッド�
 ブロックに渡されます。ブロックは、yielder を使って最終的に yield される値を
 指定できます。
 
-Enumerable#filter_map と、その遅延評価版を定義する例:
+#@samplecode Enumerable#filter_map と、その遅延評価版を定義する例
+module Enumerable
+  def filter_map(&block)
+    map(&block).compact
+  end
+end
 
-  module Enumerable
-    def filter_map(&block)
-      map(&block).compact
+class Enumerator::Lazy
+  def filter_map
+    Lazy.new(self) do |yielder, *values|
+      result = yield *values
+      yielder << result if result
     end
   end
+end
 
-  class Enumerator::Lazy
-    def filter_map
-      Lazy.new(self) do |yielder, *values|
-        result = yield *values
-        yielder << result if result
-      end
-    end
-  end
-
-  1.step.lazy.filter_map{|i| i*i if i.even?}.first(5)
-      # => [4, 16, 36, 64, 100]
+1.step.lazy.filter_map{|i| i*i if i.even?}.first(5)
+    # => [4, 16, 36, 64, 100]
+#@end
 
 @raise ArgumentError 引数を指定しなかった場合、ブロックを指定しなかった場合に発生します。
 
@@ -95,12 +95,13 @@ Enumerable#filter_map と、その遅延評価版を定義する例:
 
 @raise ArgumentError ブロックを指定しなかった場合に発生します。
 
-例:
-  1.step.lazy.map{ |n| n % 3 == 0 }
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:map>
+#@samplecode 例
+1.step.lazy.map{ |n| n % 3 == 0 }
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:map>
 
-  1.step.lazy.collect{ |n| n.succ }.take(10).force
-  # => [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+1.step.lazy.collect{ |n| n.succ }.take(10).force
+# => [2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+#@end
 
 @see [[m:Enumerable#map]]
 
@@ -110,8 +111,10 @@ Enumerable#filter_map と、その遅延評価版を定義する例:
 ブロックの実行結果をひとつに繋げたものに対してイテレートするような
 Enumerator::Lazy のインスタンスを返します。
 
-  ["foo", "bar"].lazy.flat_map {|i| i.each_char.lazy}.force
-  #=> ["f", "o", "o", "b", "a", "r"]
+#@samplecode
+["foo", "bar"].lazy.flat_map {|i| i.each_char.lazy}.force
+#=> ["f", "o", "o", "b", "a", "r"]
+#@end
 
 ブロックの返した値 x は、以下の場合にのみ分解され、連結されます。
 
@@ -120,8 +123,10 @@ Enumerator::Lazy のインスタンスを返します。
 
 それ以外のときは、x は分解されず、そのままの値として使われます。
 
-  [{a:1}, {b:2}].lazy.flat_map {|i| i}.force
-  #=> [{:a=>1}, {:b=>2}]
+#@samplecode
+[{a:1}, {b:2}].lazy.flat_map {|i| i}.force
+#=> [{:a=>1}, {:b=>2}]
+#@end
 
 @raise ArgumentError ブロックを指定しなかった場合に発生します。
 
@@ -137,12 +142,13 @@ Enumerator::Lazy のインスタンスを返します。
 
 @raise ArgumentError ブロックを指定しなかった場合に発生します。
 
-例:
-  1.step.lazy.find_all { |i| i.even? }
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:find_all>
+#@samplecode 例
+1.step.lazy.find_all { |i| i.even? }
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:find_all>
 
-  1.step.lazy.select { |i| i.even? }.take(10).force
-  # => [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+1.step.lazy.select { |i| i.even? }.take(10).force
+# => [2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
+#@end
 
 @see [[m:Enumerable#select]]
 
@@ -170,12 +176,13 @@ Enumerator::Lazy のインスタンスを返します。
 
 @raise ArgumentError ブロックを指定しなかった場合に発生します。
 
-例:
-  1.step.lazy.reject { |i| i.even? }
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:reject>
+#@samplecode 例
+1.step.lazy.reject { |i| i.even? }
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:reject>
 
-  1.step.lazy.reject { |i| i.even? }.take(10).force
-  # => [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+1.step.lazy.reject { |i| i.even? }.take(10).force
+# => [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+#@end
 
 @see [[m:Enumerable#reject]]
 
@@ -183,11 +190,12 @@ Enumerator::Lazy のインスタンスを返します。
 
 [[m:Enumerable#grep]] と同じですが、配列ではなくEnumerator::Lazy を返します。
 
-例:
-  (100..Float::INFINITY).lazy.map(&:to_s).grep(/\A(\d)\1+\z/)
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 100..Infinity>:map>:grep(/\A(\d)\1+\z/)>
-  (100..Float::INFINITY).lazy.map(&:to_s).grep(/\A(\d)\1+\z/).take(10).force
-  # => ["111", "222", "333", "444", "555", "666", "777", "888", "999", "1111"]
+#@samplecode 例
+(100..Float::INFINITY).lazy.map(&:to_s).grep(/\A(\d)\1+\z/)
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 100..Infinity>:map>:grep(/\A(\d)\1+\z/)>
+(100..Float::INFINITY).lazy.map(&:to_s).grep(/\A(\d)\1+\z/).take(10).force
+# => ["111", "222", "333", "444", "555", "666", "777", "888", "999", "1111"]
+#@end
 
 #@until 2.3.0
 @see [[m:Enumerable#grep]]
@@ -198,11 +206,12 @@ Enumerator::Lazy のインスタンスを返します。
 
 [[m:Enumerable#grep_v]] と同じですが、配列ではなくEnumerator::Lazy を返します。
 
-例:
-  (100..Float::INFINITY).lazy.map(&:to_s).grep_v(/(\d).*\1/)
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 100..Infinity>:map>:grep_v(/(\d).*\1/)>
-  (100..Float::INFINITY).lazy.map(&:to_s).grep_v(/(\d).*\1/).take(15).force
-  # => ["102", "103", "104", "105", "106", "107", "108", "109", "120", "123", "124", "125", "126", "127", "128"]
+#@samplecode 例
+(100..Float::INFINITY).lazy.map(&:to_s).grep_v(/(\d).*\1/)
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: 100..Infinity>:map>:grep_v(/(\d).*\1/)>
+(100..Float::INFINITY).lazy.map(&:to_s).grep_v(/(\d).*\1/).take(15).force
+# => ["102", "103", "104", "105", "106", "107", "108", "109", "120", "123", "124", "125", "126", "127", "128"]
+#@end
 
 @see [[m:Enumerable#grep_v]], [[m:Enumerable#grep]], [[m:Enumerator::Lazy#grep]]
 #@end
@@ -215,12 +224,13 @@ Enumerator::Lazy のインスタンスを返します。
 ただし一貫性のため、ブロック付きで呼び出した場合は Enumerable#zip と
 同じ挙動になります。
 
-例:
-  1.step.lazy.zip(('a'..'z').cycle)
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:zip(#<Enumerator: "a".."z":cycle>)>
+#@samplecode 例
+1.step.lazy.zip(('a'..'z').cycle)
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:zip(#<Enumerator: "a".."z":cycle>)>
 
-  1.step.lazy.zip(('a'..'z').cycle).take(30).force.last(6)
-  # => [[25, "y"], [26, "z"], [27, "a"], [28, "b"], [29, "c"], [30, "d"]]
+1.step.lazy.zip(('a'..'z').cycle).take(30).force.last(6)
+# => [[25, "y"], [26, "z"], [27, "a"], [28, "b"], [29, "c"], [30, "d"]]
+#@end
 
 @see [[m:Enumerable#zip]]
 
@@ -235,12 +245,13 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 @raise ArgumentError n に負の数を指定した場合に発生します。
 
-例:
-  1.step.lazy.take(5)
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:take(5)>
+#@samplecode 例
+1.step.lazy.take(5)
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:take(5)>
 
-  1.step.lazy.take(5).force
-  # => [1, 2, 3, 4, 5]
+1.step.lazy.take(5).force
+# => [1, 2, 3, 4, 5]
+#@end
 
 @see [[m:Enumerable#take]]
 
@@ -249,12 +260,13 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 [[m:Enumerable#take_while]] と同じですが、配列ではなくEnumerator::Lazy を返します。
 
-例:
-  1.step.lazy.zip(('a'..'z').cycle).take_while { |e| e.first < 100_000 }
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:zip(#<Enumerator: "a".."z":cycle>)>:take_while>
+#@samplecode 例
+1.step.lazy.zip(('a'..'z').cycle).take_while { |e| e.first < 100_000 }
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:zip(#<Enumerator: "a".."z":cycle>)>:take_while>
 
-  1.step.lazy.zip(('a'..'z').cycle).take_while { |e| e.first < 100_000 }.force.last(5)
-  # => [[99995, "y"], [99996, "z"], [99997, "a"], [99998, "b"], [99999, "c"]]
+1.step.lazy.zip(('a'..'z').cycle).take_while { |e| e.first < 100_000 }.force.last(5)
+# => [[99995, "y"], [99996, "z"], [99997, "a"], [99998, "b"], [99999, "c"]]
+#@end
 
 @see [[m:Enumerable#take_while]]
 
@@ -266,12 +278,13 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 @raise ArgumentError n に負の数を指定した場合に発生します。
 
-例:
-  1.step.lazy.drop(3)
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:drop(3)>
+#@samplecode 例
+1.step.lazy.drop(3)
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:drop(3)>
 
-  1.step.lazy.drop(3).take(10).force
-  # => [4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+1.step.lazy.drop(3).take(10).force
+# => [4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
+#@end
 
 @see [[m:Enumerable#drop]]
 
@@ -279,12 +292,13 @@ n が大きな数 (100000とか) の場合に備えて再定義されていま�
 
 [[m:Enumerable#drop_while]] と同じですが、配列ではなくEnumerator::Lazy を返します。
 
-例:
-  1.step.lazy.drop_while { |i| i < 42 }
-  # => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:drop_while>
+#@samplecode 例
+1.step.lazy.drop_while { |i| i < 42 }
+# => #<Enumerator::Lazy: #<Enumerator::Lazy: #<Enumerator: 1:step>>:drop_while>
 
-  1.step.lazy.drop_while { |i| i < 42 }.take(10).force
-  # => [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+1.step.lazy.drop_while { |i| i < 42 }.take(10).force
+# => [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+#@end
 
 @see [[m:Enumerable#drop_while]]
 
@@ -312,22 +326,24 @@ p enum.select { |n| n.even? }.first(5)
 
 self を返します。
 
-例:
-  lazy = (100..Float::INFINITY).lazy
-  p lazy.lazy         # => #<Enumerator::Lazy: 100..Infinity>
-  p lazy == lazy.lazy # => true
+#@samplecode 例
+lazy = (100..Float::INFINITY).lazy
+p lazy.lazy         # => #<Enumerator::Lazy: 100..Infinity>
+p lazy == lazy.lazy # => true
+#@end
 
 --- chunk {|elt| ... } -> Enumerator::Lazy
 --- chunk(initial_state) {|elt, state| ... } -> Enumerator::Lazy
 
 [[m:Enumerable#chunk]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
-例:
-  1.step.lazy.chunk{ |n| n % 3 == 0 }
-  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x007f8bf18118f0>:each>>
+#@samplecode 例
+1.step.lazy.chunk{ |n| n % 3 == 0 }
+# => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x007f8bf18118f0>:each>>
 
-  1.step.lazy.chunk{ |n| n % 3 == 0 }.take(5).force
-  # => [[false, [1, 2]], [true, [3]], [false, [4, 5]], [true, [6]], [false, [7, 8]]]
+1.step.lazy.chunk{ |n| n % 3 == 0 }.take(5).force
+# => [[false, [1, 2]], [true, [3]], [false, [4, 5]], [true, [6]], [false, [7, 8]]]
+#@end
 
 @see [[m:Enumerable#chunk]]
 
@@ -337,12 +353,13 @@ self を返します。
 
 [[m:Enumerable#slice_before]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
-例:
-  1.step.lazy.slice_before { |e| e.even? }
-  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x00007f9f31844ce8>:each>>
+#@samplecode 例
+1.step.lazy.slice_before { |e| e.even? }
+# => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x00007f9f31844ce8>:each>>
 
-  1.step.lazy.slice_before { |e| e % 3 == 0 }.take(5).force
-  # => [[1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14]]
+1.step.lazy.slice_before { |e| e % 3 == 0 }.take(5).force
+# => [[1, 2], [3, 4, 5], [6, 7, 8], [9, 10, 11], [12, 13, 14]]
+#@end
 
 @see [[m:Enumerable#slice_before]]
 
@@ -352,12 +369,13 @@ self を返します。
 
 [[m:Enumerable#slice_after]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
-例:
-  1.step.lazy.slice_after { |e| e % 3 == 0 }
-  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x007fd73980e6f8>:each>>
+#@samplecode 例
+1.step.lazy.slice_after { |e| e % 3 == 0 }
+# => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x007fd73980e6f8>:each>>
 
-  1.step.lazy.slice_after { |e| e % 3 == 0 }.take(5).force
-  # => [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]
+1.step.lazy.slice_after { |e| e % 3 == 0 }.take(5).force
+# => [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]
+#@end
 
 @see [[m:Enumerable#slice_after]]
 
@@ -365,12 +383,13 @@ self を返します。
 
 [[m:Enumerable#slice_when]] と同じですが、配列ではなく Enumerator::Lazy を返します。
 
-例:
-  1.step.lazy.slice_when { |i, j| (i + j) % 5 == 0 }
-  # => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x00007fce84118348>:each>>
+#@samplecode 例
+1.step.lazy.slice_when { |i, j| (i + j) % 5 == 0 }
+# => #<Enumerator::Lazy: #<Enumerator: #<Enumerator::Generator:0x00007fce84118348>:each>>
 
-  1.step.lazy.slice_when { |i, j| (i + j) % 5 == 0 }.take(5).force
-  # => [[1, 2], [3, 4, 5, 6, 7], [8, 9, 10, 11, 12], [13, 14, 15, 16, 17], [18, 19, 20, 21, 22]]
+1.step.lazy.slice_when { |i, j| (i + j) % 5 == 0 }.take(5).force
+# => [[1, 2], [3, 4, 5, 6, 7], [8, 9, 10, 11, 12], [13, 14, 15, 16, 17], [18, 19, 20, 21, 22]]
+#@end
 
 @see [[m:Enumerable#slice_when]]
 #@end
@@ -381,12 +400,13 @@ self を返します。
 
 [[m:Enumerable#to_a]] のエイリアスです。
 
-例:
-  1.step.lazy.take(10).force
-  # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+#@samplecode 例
+1.step.lazy.take(10).force
+# => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
-  1.step.lazy.take(10).to_a
-  # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+1.step.lazy.take(10).to_a
+# => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+#@end
 
 --- to_enum(method = :each, *args)                 -> Enumerator::Lazy
 --- enum_for(method = :each, *args)                -> Enumerator::Lazy
@@ -400,34 +420,34 @@ Enumerator を返す」ようなメソッドを定義するときによく使わ
 このときに lazy 性が正しく引き継がれるように、Lazy#to_enum は
 素のEnumerator ではなく Enumerator::Lazy を返すようになっています。
 
-例:
-
-  module Enumerable
-    # 要素をn回ずつ繰り返すメソッド
-    # 例：[1,2,3].repeat(2)  #=> [1,1,2,2,3,3]
-    def repeat(n)
-      raise ArgumentError if n < 0
-      if block_given?
-        each do |*val|
-          n.times { yield *val }
-        end
-      else
-        to_enum(:repeat, n)
+#@samplecode 例
+module Enumerable
+  # 要素をn回ずつ繰り返すメソッド
+  # 例：[1,2,3].repeat(2)  #=> [1,1,2,2,3,3]
+  def repeat(n)
+    raise ArgumentError if n < 0
+    if block_given?
+      each do |*val|
+        n.times { yield *val }
       end
+    else
+      to_enum(:repeat, n)
     end
   end
+end
 
-  r = 1..10
-  p r.map{|n| n**2}.repeat(2).first(5)
-  #=> [1, 1, 4, 4, 9]
+r = 1..10
+p r.map{|n| n**2}.repeat(2).first(5)
+#=> [1, 1, 4, 4, 9]
 
-  r = 1..Float::INFINITY
-  p r.lazy.map{|n| n**2}.repeat(2).first(5)
-  #=> [1, 1, 4, 4, 9]
+r = 1..Float::INFINITY
+p r.lazy.map{|n| n**2}.repeat(2).first(5)
+#=> [1, 1, 4, 4, 9]
 
-  # Lazy#to_enum のおかげで、repeat の返り値は
-  # もとが Enumerator のときは Enumerator に、
-  # もとが Lazy のときは Lazy になる
+# Lazy#to_enum のおかげで、repeat の返り値は
+# もとが Enumerator のときは Enumerator に、
+# もとが Lazy のときは Lazy になる
+#@end
 
 #@since 2.4.0
 --- chunk_while {|elt_before, elt_after| ... } -> Enumerator::Lazy


### PR DESCRIPTION
[`Enumerator::Lazy` のサンプルコード](https://docs.ruby-lang.org/ja/latest/class/Enumerator=3a=3aLazy.html)にハイライトを追加しました。