### PR TITLE
Kernel.#gets description is supposedly wrong

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1419,8 +1419,8 @@ ARGV << 'b.txt' << 'c.txt'
 p gets #=> "hello\n"
 p gets(nil) #=> "it\ncommon\n"
 p gets("") #=> "ARGF\n\n"
-p gets('、') #=> "スクリプトに指定した引数 (Object::ARGV を参照) をファイル名と\nみなして、"
-p gets #=> "それらのファイルを連結した 1 つの仮想ファイルを表すオブジェクトです。 \n"
+p gets('、') #=> "# スクリプトに指定した引数 (Object::ARGV を参照) をファイル名と\n# みなして、"
+p gets #=> "それらのファイルを連結した 1 つの仮想ファイルを表すオブジェクトです。\n"
 p gets #=> nil
 p readline # end of file reached (EOFError)
 #@end
@@ -1431,8 +1431,9 @@ it
 common
 #@end
 
-#@samplecode b.txt
+#@samplecode c.txt
 ARGF
+
 # スクリプトに指定した引数 (Object::ARGV を参照) をファイル名と
 # みなして、それらのファイルを連結した 1 つの仮想ファイルを表すオブジェクトです。
 #@end


### PR DESCRIPTION
Supposedly Kernel.#gets description was wrong at least after Ruby 2.1.0. 
https://rurema.clear-code.com/2.1.0/method/Kernel/m/gets.html

My environment where I checked is here:
Ubuntu 22.04 LTS
Linux version 5.4.72-microsoft-standard-WSL2 (oe-user@oe-host) (gcc version 8.2.0 (GCC)) #1 SMP Wed Oct 28 23:40:43 UTC 2020
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]

It's not the latest version, but would you please check it out? Thanks.