### PR TITLE
Gem.ruby を追加しました

### DIFF
--- a/refm/api/src/rubygems.rd
+++ b/refm/api/src/rubygems.rd
@@ -330,6 +330,10 @@ Gem を検索するパスをセットします。
 
 @see [[m:Gem.#path]]
 
+--- ruby -> String
+
+実行中のRubyインタプリタのパスを返します。
+
 == Constants
 
 --- ConfigMap -> Hash


### PR DESCRIPTION
`Gem.ruby` が https://ruby-doc.org にありますが https://docs.ruby-lang.org/ にないことに気づいたので追加しました。

![image](https://user-images.githubusercontent.com/1796864/192284427-fd2cec94-1f7b-4119-9635-882e9b494c0b.png)

https://ruby-doc.org/stdlib-3.1.2/libdoc/rubygems/rdoc/Gem.html

不備があれば教えてください。