### PR TITLE
Hash#fecthの見出しの修正

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -384,7 +384,9 @@ p safe_invert({"a"=>1, "b"=>1, "c"=>3}) # => {1=>["a", "b"], 3=>["c"]}
 
 @see [[m:Hash#key]]
 
---- fetch(key, default = nil) {|key| ... } -> object
+--- fetch(key) -> object
+--- fetch(key, default) -> object
+--- fetch(key) {|key| ... } -> object
 
 key に関連づけられた値を返します。該当するキーが登録されてい
 ない時には、引数 default が与えられていればその値を、ブロッ


### PR DESCRIPTION
fix #2620

[英語版(rdoc)のfetch](https://docs.ruby-lang.org/en/3.0/Hash.html#method-i-fetch)と同じ3通りの記法であり、実用的に使われることを想定しているであろう3通りの記法にしました。