### PR TITLE
サンプルコードにハイライトを追加

### DIFF
--- a/refm/api/src/ripper/filter.rd
+++ b/refm/api/src/ripper/filter.rd
@@ -9,28 +9,30 @@
 
 === 使用例
 
-  require 'ripper'
-  require 'cgi'
+#@samplecode
+require 'ripper'
+require 'cgi'
 
-  class Ruby2HTML < Ripper::Filter
-    def on_default(event, tok, f)
-      f << CGI.escapeHTML(tok)
-    end
-
-    def on_comment(tok, f)
-      f << %Q[<span class="comment">#{CGI.escapeHTML(tok)}</span>]
-    end
-
-    def on_tstring_beg(tok, f)
-      f << %Q[<span class="string">#{CGI.escapeHTML(tok)}]
-    end
-
-    def on_tstring_end(tok, f)
-      f << %Q[#{CGI.escapeHTML(tok)}</span>]
-    end
+class Ruby2HTML < Ripper::Filter
+  def on_default(event, tok, f)
+    f << CGI.escapeHTML(tok)
   end
 
-  Ruby2HTML.new(ARGF).parse('')
+  def on_comment(tok, f)
+    f << %Q[<span class="comment">#{CGI.escapeHTML(tok)}</span>]
+  end
+
+  def on_tstring_beg(tok, f)
+    f << %Q[<span class="string">#{CGI.escapeHTML(tok)}]
+  end
+
+  def on_tstring_end(tok, f)
+    f << %Q[#{CGI.escapeHTML(tok)}</span>]
+  end
+end
+
+Ruby2HTML.new(ARGF).parse('')
+#@end
 
 Ruby プログラムを解析して、[[m:Ripper::SCANNER_EVENTS]] にあるスキャナ
 イベントを実行します。イベントはプログラムに書いた順番で実行されます。

--- a/refm/api/src/ripper/sexp.rd
+++ b/refm/api/src/ripper/sexp.rd
@@ -14,17 +14,17 @@ Ruby プログラム str を解析して S 式のツリーにして返します�
 
 実行結果は、括弧の代わりに配列の要素として S 式のツリーを表現しています。
 
-例:
+#@samplecode 例
+require 'ripper'
+require 'pp'
 
-  require 'ripper'
-  require 'pp'
-
-  pp Ripper.sexp("def m(a) nil end")
-    # => [:program,
-          [[:def,
-            [:@ident, "m", [1, 4]],
-            [:paren, [:params, [[:@ident, "a", [1, 6]]], nil, nil, nil, nil]],
-            [:bodystmt, [[:var_ref, [:@kw, "nil", [1, 9]]]], nil, nil, nil]]]]
+pp Ripper.sexp("def m(a) nil end")
+# => [:program,
+#     [[:def,
+#       [:@ident, "m", [1, 4]],
+#       [:paren, [:params, [[:@ident, "a", [1, 6]]], nil, nil, nil, nil]],
+#       [:bodystmt, [[:var_ref, [:@kw, "nil", [1, 9]]]], nil, nil, nil]]]]
+#@end
 
 パーサイベントは以下のような形式になります。
 
@@ -61,23 +61,23 @@ Ruby プログラム str を解析して S 式のツリーにして返します�
 
 実行結果は、括弧の代わりに配列の要素として S 式のツリーを表現しています。
 
-例:
+#@samplecode 例
+require 'ripper'
+require 'pp'
 
-  require 'ripper'
-  require 'pp'
-
-  pp Ripper.sexp_raw("def m(a) nil end")
-    # => [:program,
-          [:stmts_add,
-           [:stmts_new],
-           [:def,
-            [:@ident, "m", [1, 4]],
-            [:paren, [:params, [[:@ident, "a", [1, 6]]], nil, nil, nil]],
-            [:bodystmt,
-             [:stmts_add, [:stmts_new], [:var_ref, [:@kw, "nil", [1, 9]]]],
-             nil,
-             nil,
-             nil]]]]
+pp Ripper.sexp_raw("def m(a) nil end")
+# => [:program,
+#     [:stmts_add,
+#      [:stmts_new],
+#      [:def,
+#       [:@ident, "m", [1, 4]],
+#       [:paren, [:params, [[:@ident, "a", [1, 6]]], nil, nil, nil]],
+#       [:bodystmt,
+#        [:stmts_add, [:stmts_new], [:var_ref, [:@kw, "nil", [1, 9]]]],
+#        nil,
+#        nil,
+#        nil]]]]
+#@end
 
 Ripper.sexp_raw は [[m:Ripper.sexp]] とは異なり解析結果を加工しません。
 


### PR DESCRIPTION
[`Ripper::Filter`](https://docs.ruby-lang.org/ja/latest/class/Ripper=3a=3aFilter.html) [`Ripper.sexp`](https://docs.ruby-lang.org/ja/latest/method/Ripper/s/sexp.html) [`Ripper.sexp_raw`](https://docs.ruby-lang.org/ja/latest/method/Ripper/s/sexp_raw.html) のサンプルコードにハイライトを追加しました。