### PR TITLE
Drop outdated Gem::Dependency#requirement_list

### DIFF
--- a/refm/api/src/rubygems/dependency.rd
+++ b/refm/api/src/rubygems/dependency.rd
@@ -33,7 +33,6 @@ self が other との依存関係を満たしていれば真を返します。�
 
 @see [[c:Gem::Requirement]]
 #@end
---- requirement_list  -> [String]
 --- requirements_list -> [String]
 
 バージョンの必要条件を文字列の配列として返します。


### PR DESCRIPTION
rubygems からは 2009年の段階で削除されているようです。  https://github.com/rubygems/rubygems/commit/3efe3b056d4375fb3b2f1cd3330f47f8f9d6342c

現在のサポート対象には含まれていないだろうということで、 https://github.com/rurema/doctree/blob/c3aaccee316afe815b8a98b8048a85b9cd768d2f/CONTRIBUTING.md?plain=1#L17-L28 に沿って記述自体を削除しておきました。

```ruby
RUBY_VERSION
#=> "3.1.2"

Gem::Dependency.new('1.0.0').requirements_list
#=> [">= 0"]
Gem::Dependency.new('1.0.0').requirement_list
#=> undefined method `requirement_list' for <Gem::Dependency type=:runtime name="1.0.0" requirements=">= 0">:Gem::Dependency (NoMethodError)
```

```console
$ ruby -v -e 'Gem::Dependency.new("1.0.0").requirement_list'
ruby 2.6.10p210 (2022-04-12 revision 67958) [x86_64-linux]
-e:1:in `<main>': undefined method `requirement_list' for <Gem::Dependency type=:runtime name="1.0.0" requirements=">= 0">:Gem::Dependency (NoMethodError)
Did you mean?  requirements_list
```