### PR TITLE
Update misspell integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install misspell
-      run: 'go get github.com/client9/misspell/...'
+      run: 'go install github.com/client9/misspell/cmd/misspell@latest'
     - name: Run misspell
       run: |
         git ls-files -z | xargs -0 $HOME/go/bin/misspell -error -i addopt


### PR DESCRIPTION
Fix unrelated CI failure of #2753
https://github.com/kachick/rurema-doctree/actions/runs/3395601206/jobs/5645694700

https://github.com/client9/misspell/issues/191
https://github.com/client9/misspell/pull/192