### PR TITLE
中置引数の例示の結果が不完全

### DIFF
--- a/refm/doc/spec/def.rd
+++ b/refm/doc/spec/def.rd
@@ -377,7 +377,7 @@ def f(a, b, c, m = 1, n = 1, *rest, x, y, z, k: 1, **kwrest, &blk)
   puts "c: %p" % c
   puts "m: %p" % m
   puts "n: %p" % n
-  puts "rest: %p" % rest
+  puts "rest: %p" % [rest]
   puts "x: %p" % x
   puts "y: %p" % y
   puts "z: %p" % z
@@ -392,7 +392,7 @@ f("a", "b", "c", 2, 3, "foo", "bar", "baz", "x", "y", "z", k: 42, u: "unknown") 
   #   c: "c"
   #   m: 2
   #   n: 3
-  #   rest: "foo"
+  #   rest: ["foo", "bar", "baz"]
   #   x: "x"
   #   y: "y"
   #   z: "z"


### PR DESCRIPTION
例示に使われている `String#%(arg)` は `arg` が配列のとき、レシーバー内の各フォーマット指定に対し `arg` の要素を先頭から順々に渡すため、元の書き方では先頭要素しか表示されません。そのため分かりにくい例示になっています。 `rest` という配列の全要素を表示させるためには `rest` 自体を要素とする配列を渡す必要があります。