### PR TITLE
Fix install misspell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install misspell
-      run: 'go get github.com/client9/misspell/...'
+      run: 'curl -L https://git.io/misspell | bash'
     - name: Run misspell
       run: |
-        git ls-files -z | xargs -0 $HOME/go/bin/misspell -error -i addopt
+        git ls-files -z | xargs -0 ./bin/misspell -error -i addopt


### PR DESCRIPTION
https://github.com/rurema/doctree/actions/runs/3779598981/jobs/6424992406#step:3:5
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```