### PR TITLE
Exclude version 3.2 for ruby on windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        exclude:
+          - os: windows-latest
+            ruby: '3.2'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
https://github.com/rurema/doctree/actions/runs/3779598981/jobs/6424993812#step:3:6
```
Error: Error: Unknown version 3.2 for ruby on windows-2022
        available versions for ruby on windows-2022: 2.0.0, 2.1.9, 2.2.6, 2.3.0, 2.3.1, 2.3.3, 2.4.1, 2.4.2, 2.4.3, 2.4.4, 2.4.5, 2.4.6, 2.4.7, 2.4.9, 2.4.10, 2.5.0, 2.5.1, 2.5.3, 2.5.5, 2.5.6, 2.5.7, 2.5.8, 2.5.9, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5, 2.6.6, 2.6.7, 2.6.8, 2.6.9, 2.6.10, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.7.5, 2.7.6, 2.7.7, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 3.0.5, 3.1.0, 3.1.1, 3.1.2, 3.1.3, head, mingw, mswin, ucrt
        Make sure you use the latest version of the action with - uses: ruby/setup-ruby@v1
    at validateRubyEngineAndVersion (D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68858:13)
    at setupRuby (D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68759:19)
    at run (D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68731:11)
    at D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68892:40
    at D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68894:3
    at Object.<anonymous> (D:\a\_actions\ruby\setup-ruby\v1\dist\index.js:68897:12)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
```