### PR TITLE
Revert "Exclude version 3.2 for ruby on windows-2022"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        exclude:
-          - os: windows-latest
-            ruby: '3.2'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Reverts rurema/doctree#2767

https://github.com/ruby/setup-ruby/pull/435 で対応されたので、Ruby 3.2 for windows-2022 も含めます