### PR TITLE
Fix broken links in irb documentation

### DIFF
--- a/refm/api/src/irb.rd
+++ b/refm/api/src/irb.rd
@@ -486,7 +486,7 @@ irb のコマンドは、簡単な名前と頭に「irb_」をつけた名前と
   Ruby の require の irb 版です。
   ファイル path を現在の irb インタプリタ上で実行します。
 
-  path に Ruby スクリプトを指定した場合は、[[m:Kernel.#kernel]] と異な
+  path に Ruby スクリプトを指定した場合は、[[m:Kernel.#require]] と異な
   り、path の内容を irb で一行ずつタイプしたかのように、irb 上で一行ず
   つ評価されます。require に成功した場合は true を、そうでない場合は
   false を返します。

--- a/refm/api/src/irb/cmd/load.rd
+++ b/refm/api/src/irb/cmd/load.rd
@@ -42,7 +42,7 @@ irb 中の irb_require コマンドのための拡張を定義したクラスで
 
 ファイル file_name を現在の irb インタプリタ上で実行します。
 
-file_name に Ruby スクリプトを指定した場合は、[[m:Kernel.#kernel]] と異
+file_name に Ruby スクリプトを指定した場合は、[[m:Kernel.#require]] と異
 なり、file_name の内容を irb で一行ずつタイプしたかのように、irb 上で一
 行ずつ評価されます。require に成功した場合は true を、そうでない場合は
 false を返します。


### PR DESCRIPTION
# 修正内容

`Kernel` に、`kernel` なるメソッドは存在しません。前後の文脈から、意図したのは `Kernel#require` であろうと判断しました。