### PR TITLE
Integer#pow に計算を放棄する場合について追記

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -690,28 +690,21 @@ self を other で割った商を [[c:Float]] で返します。
 @see [[m:Numeric#quo]], [[m:Numeric#div]], [[m:Integer#div]]
 
 --- **(other) -> Numeric
-#@since 2.5.0
 --- pow(other) -> Numeric
 --- pow(other, modulo) -> Integer
-#@end
 
 算術演算子。冪(べき乗)を計算します。
 
 @param other 二項演算の右側の引数(対象)
-#@since 2.5.0
 @param modulo 指定すると、計算途中に巨大な値を生成せずに (self**other) % modulo と同じ結果を返します。
-#@end
 @return 計算結果
-#@since 2.5.0
 @raise TypeError 2引数 pow で Integer 以外を指定した場合に発生します。
 @raise RangeError 2引数 pow で other に負の数を指定した場合に発生します。
-#@end
 
 #@samplecode
 2 ** 3 # => 8
 2 ** 0 # => 1
 0 ** 0 # => 1
-#@since 2.5.0
 3.pow(3,  8)  # =>  3
 3.pow(3, -8)  # => -5
 3.pow(2, -2)  # => -1
@@ -719,11 +712,19 @@ self を other で割った商を [[c:Float]] で返します。
 -3.pow(3, -8) # => -3
 5.pow(2, -8)  # => -7
 #@end
+
+結果が巨大すぎる整数になりそうなとき、警告を出したうえで Float::INFINITY を返します。
+
+#@samplecode 計算を放棄して Float::INFINITY を返す例
+p 100**9999999
+# => warning: in a**b, b may be too big
+#    Infinity
 #@end
 
-#@since 2.5.0
+判定の閾値は変わりえます。
+
 @see [[m:BigDecimal#power]]
-#@end
+
 --- abs -> Integer
 --- magnitude -> Integer
 


### PR DESCRIPTION
Integer#pow
https://docs.ruby-lang.org/ja/3.2/method/Integer/i/=2a=2a.html
への追記です。

https://github.com/rurema/doctree/issues/2259
に対するプルリクエストです。

古い分岐の削除も行なっています。