### PR TITLE
IO#pathおよびIO.newの:pathオプションに関する記述を追加

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -268,6 +268,9 @@ IO.new, IO.for_fd はブロックを受け付けません。
   * :textmode 真を渡すと mode の "t" と同じ意味になります。
   * :binmode 真を渡すと mode の "b" と同じ意味になります。
   * :autoclose 偽を渡すと close時/GCでのファイナライザ呼出時に fd を close しません。
+#@since 3.2
+  * :path 文字列を渡すと、[[m:IO#path]] メソッドがその値を返すようになります。
+#@end
 また、[[m:String#encode]] で説明されている :invalid => :replace などの
 変換オプションも指定することができます。外部エンコーディングから
 内部エンコーディングへの変換をするときに用いられます。
@@ -2417,6 +2420,22 @@ posix_fadvise をサポートしていないプラットフォーム上では
 
 #@samplecode 例
 File.open("testfile") { |f| p f.advise(:sequential) } # => nil
+#@end
+
+#@since 3.2
+--- path -> String | nil
+--- to_path -> String | nil
+
+IO に関連付けられたパスを返します。IO がパスに関連付けられていない場合は nil を返します。
+
+このメソッドが返すパスがファイルシステム上に存在することは保証されていません。
+
+#@samplecode 例
+p STDIN.path                                 # => "<STDIN>"
+p IO.new(IO.sysopen("/")).path               # => "/"
+p IO.new(IO.sysopen("/"), path: "foo").path  # => "foo"
+#@end
+
 #@end
 
 == Constants


### PR DESCRIPTION
3.2 で追加されました。

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.6 ./all-ruby -e 'p IO.new(IO.sysopen("/"), path: "foo").path'
ruby-2.6.0          -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)
                exit 1
...
ruby-3.0.5          -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)
                exit 1
ruby-3.1.0-preview1 -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)

                    p IO.new(IO.sysopen("/"), path: "foo").path
                                                          ^^^^^
                exit 1
ruby-3.1.0          -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)
                exit 1
ruby-3.1.1          -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)

                    p IO.new(IO.sysopen("/"), path: "foo").path
                                                          ^^^^^
                exit 1
...
ruby-3.2.0-rc1      -e:1:in `<main>': undefined method `path' for #<IO:fd 5> (NoMethodError)

                    p IO.new(IO.sysopen("/"), path: "foo").path
                                                          ^^^^^
                exit 1
ruby-3.2.0          "foo"
```