### PR TITLE
Pathname#writeで、キーワード引数を渡すメソッドがハッシュを渡す表記になっていたのを修正

### DIFF
--- a/refm/api/src/pathname.rd
+++ b/refm/api/src/pathname.rd
@@ -966,11 +966,11 @@ FileTest.world_writable?(self.to_s) と同じです。
 
 #@since 2.1.0
 
---- write(string, offset=nil, opt={}) -> Integer
+--- write(string, offset=nil, **opts) -> Integer
 
 #@#noexample IO.write の例を参照
 
-IO.write(self.to_s, *args)と同じです。
+IO.write(self.to_s, string, offset, **opts)と同じです。
 
 @see [[m:IO.write]]
 


### PR DESCRIPTION
### Hash

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.6 ./all-ruby -rpathname -e "Pathname('/tmp/foo').write('foo', nil, { binmode: true })"
ruby-2.6.0
...
ruby-2.7.0-preview1
ruby-2.7.0-preview2 -e:1: warning: The last argument is used as the keyword parameter
...
ruby-2.7.0-rc1      -e:1: warning: The last argument is used as the keyword parameter
ruby-2.7.0-rc2      -e:1: warning: The last argument is used as keyword parameters
ruby-2.7.0          -e:1: warning: Using the last argument as keyword parameters is deprecated
...
ruby-2.7.7          -e:1: warning: Using the last argument as keyword parameters is deprecated
ruby-3.0.0-preview1 -e:1:in `write': wrong number of arguments (given 4, expected 2..3) (ArgumentError)
                        from -e:1:in `write'
                        from -e:1:in `<main>'
                exit 1
...
ruby-3.2.0-preview1 -e:1:in `write': wrong number of arguments (given 4, expected 2..3) (ArgumentError)
                        from -e:1:in `write'
                        from -e:1:in `<main>'
                exit 1
ruby-3.2.0-preview2 -e:1:in `write': wrong number of arguments (given 4, expected 2..3) (ArgumentError)

                    Pathname('/tmp/foo').write('foo', nil, { binmode: true })
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        from -e:1:in `write'
                        from -e:1:in `<main>'
                exit 1
...
ruby-3.2.0          -e:1:in `write': wrong number of arguments (given 4, expected 2..3) (ArgumentError)

                    Pathname('/tmp/foo').write('foo', nil, { binmode: true })
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        from -e:1:in `write'
                        from -e:1:in `<main>'
                exit 1
```

### キーワード引数

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.6 ./all-ruby -rpathname -e "Pathname('/tmp/foo').write('foo', nil, binmode: true)"
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
ruby-2.6.0
...
ruby-3.2.0
```