### PR TITLE
Thread#ignore_deadlockのドキュメントを追加しました

### DIFF
--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -685,6 +685,38 @@ ensure 節を実行せずにスレッドの実行を終了させます。
     p Thread.current.group == ThreadGroup::Default
     # => true
 
+#@since 3.0.0
+--- ignore_deadlock -> bool
+
+デッドロック検知を無視する機能のon/offを返します。
+
+デフォルト値はfalseで、デッドロックが検知されます。
+
+#@#noexample Thread#ignore_deadlock=を参照
+
+@see [[m:Thread#ignore_deadlock=]]
+#@end
+
+#@since 3.0.0
+--- ignore_deadlock=(bool)
+
+デッドロック検知を無視する機能をon/offします。デフォルト値はfalseです。
+
+trueを渡すとデッドロックを検知しなくなります。
+
+#@samplecode
+Thread.ignore_deadlock = true
+queue = Thread::Queue.new
+
+trap(:SIGUSR1){queue.push "Received signal"}
+
+# ignore_deadlockがfalseだとエラーが発生する
+puts queue.pop
+#@end
+
+@see [[m:Thread#ignore_deadlock]]
+#@end
+
 --- join           -> self
 --- join(limit)    -> self | nil
 


### PR DESCRIPTION
Ruby3.0から追加された `Thread#ignore_deadlock` と `Thread#ignore_deadlock=` のドキュメントを追加しました。

【参考】
- [プロと読み解く Ruby 3.0 NEWS - クックパッド開発者ブログ](https://techlife.cookpad.com/entry/2020/12/25/155741) の `デッドロック検知を無効にするオプションが導入された`
- [class Thread - Documentation for Ruby 3.2](https://docs.ruby-lang.org/en/3.2/Thread.html#method-c-ignore_deadlock)
- https://github.com/rurema/doctree/issues/2458