### PR TITLE
Dependabot version updates を有効にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
GitHub Actions のアップデートを週次で確認するようにします。
https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

@hsbt のコメントを参考にしました。ありがとうございます！
https://github.com/rurema/doctree/pull/2790#issuecomment-1421793158