### PR TITLE
Encoding.replicateに非推奨の説明を追加

### DIFF
--- a/refm/api/src/_builtin/Encoding
+++ b/refm/api/src/_builtin/Encoding
@@ -221,6 +221,8 @@ Encoding::UTF_16BE.ascii_compatible?  #=> false
 複製されたエンコーディングは元のエンコーディングと同じバイト構造を持たなければなりません。
 name という名前のエンコーディングが既に存在する場合は [[c:ArgumentError]] を発生します。
 
+Ruby 3.2 から非推奨となり、Ruby 3.3 で削除予定です。
+
 #@samplecode
 encoding = Encoding::UTF_8.replicate("REPLICATED_UTF-8")     #=> #<Encoding:REPLICATED_UTF-8>
 encoding.name                                                #=> "REPLICATED_UTF-8"


### PR DESCRIPTION
Encoding.replicate は encoding の最適化のためRuby 3.2で非推奨になり、Ruby 3.3で削除予定です。
このメソッドの代替手段はありません。チケット内で調査してもらっていますが、これを使っている人は極わずかなため非推奨の説明だけを追加しています。

https://bugs.ruby-lang.org/issues/18949
https://github.com/ruby/ruby/pull/7079