### PR TITLE
ヒアドキュメントの評価結果から末尾の改行が抜けていたのを修正

### DIFF
--- a/refm/doc/spec/literal.rd
+++ b/refm/doc/spec/literal.rd
@@ -310,7 +310,7 @@ p  <<LABEL.upcase
 the lower case string
 LABEL
 
-# => "THE LOWER CASE STRING"
+# => "THE LOWER CASE STRING\n"
 #@end
 
 開始ラベルの次の行は常にヒアドキュメントとなります。例えば、以下のよう


### PR DESCRIPTION
```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.7 ./all-ruby -e "p <<LABEL.upcase
the lower case string
LABEL
"
ruby-2.7.0          "THE LOWER CASE STRING\n"
...
ruby-3.2.0          "THE LOWER CASE STRING\n"
```