### PR TITLE
GitHub Actionsのset-outputが廃止されることへの対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - id: versions
         run: |
           versions=$(curl -s 'https://cache.ruby-lang.org/pub/misc/ci_versions/cruby.json' | jq -c '. + []')
-          echo "::set-output name=value::${versions}"
+          echo "value=${versions}" >> $GITHUB_OUTPUT
 
   rake:
     needs: ruby-versions


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/