### PR TITLE
Add missing indents to sample code in Benchmark

### DIFF
--- a/refm/api/src/benchmark.rd
+++ b/refm/api/src/benchmark.rd
@@ -53,9 +53,9 @@ require 'benchmark'
 
 n = 50000
 Benchmark.bm do |x|
-x.report { for i in 1..n; a = "1"; end }
-x.report { n.times do   ; a = "1"; end }
-x.report { 1.upto(n) do ; a = "1"; end }
+  x.report { for i in 1..n; a = "1"; end }
+  x.report { n.times do   ; a = "1"; end }
+  x.report { 1.upto(n) do ; a = "1"; end }
 end
 
 #=>


### PR DESCRIPTION
以下のサンプルコードにインデントが無かったようなので追加しました！📝✨
https://docs.ruby-lang.org/ja/latest/method/Benchmark/m/bm.html

<img width="374" alt="image" src="https://user-images.githubusercontent.com/155807/232262209-635bdd89-58e0-4afb-b2cb-30873186ee7c.png">
