### PR TITLE
variable $stdinのサンプルコードの修正

### DIFF
--- a/refm/api/src/_builtin/specialvars
+++ b/refm/api/src/_builtin/specialvars
@@ -489,7 +489,7 @@ $stdin に代入すれば十分です。
 
 #@samplecode 例
 # 標準入力の入力元 /tmp/foo に変更
-$stdin = File.open("/tmp/foo", "w")
+$stdin = File.open("/tmp/foo", "r")
 gets               # 入力する
 $stdin = STDIN     # 元に戻す
 #@end


### PR DESCRIPTION
$stdinへ代入するファイルを'w'で開くと、IOErrorがおき、ファイル内の記述は削除されます。 `gets': not opened for reading (IOError)
サンプルコードを'r'で開くように修正しました。
間違えてたら申し訳ありません。ご確認をお願いいたします。

私が理解していないことですが、$stdinに渡したファイルはcloseが不要なのでしょうか。
もし必要ならサンプルコードに含めた方がいいと思いますし、closeが不要なのであればその旨、説明に追加してもいいと思います。 これは$stdinだけでなく、$stdoutも同様です。