### PR TITLE
Fix a dead link to `Fiber` in the `Continuation` doc

### DIFF
--- a/refm/api/src/continuation.rd
+++ b/refm/api/src/continuation.rd
@@ -1,6 +1,6 @@
 Ruby 1.9 以降で継続オブジェクトを扱うためのライブラリです。
 
-Ruby 2.2.0から非推奨になりました。代わりに[[lib:fiber]]を使ってください。
+Ruby 2.2.0から非推奨になりました。代わりに[[c:Fiber]]を使ってください。
 
 = reopen Kernel
 == Module functions


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/library/continuation.html からリンクされている https://docs.ruby-lang.org/ja/latest/library/fiber.html は 404 Not Found です。

この PR は https://docs.ruby-lang.org/ja/latest/class/Fiber.html にリンクするようにします。

なお、以下のように Ruby 3.0 以下のマニュアル向けに使われている `[[lib:fiber]]` は、 有効なリンクのためそのまま維持しています。

https://github.com/rurema/doctree/blob/32f6f4e82e8dd0e3ebef043a70264a68699633dc/refm/api/src/_builtin/Fiber#L25-L32

3.1 向けの `[[lib:fiber]]` はリンク切れですが、3.0 では有効なリンクであることを確認しました。

- https://docs.ruby-lang.org/ja/3.1/library/fiber.html
- https://docs.ruby-lang.org/ja/3.0/library/fiber.html