### PR TITLE
NEWS for Ruby 3.1.0の英語から日本語へ変更

### DIFF
--- a/refm/doc/news/3_1_0.rd
+++ b/refm/doc/news/3_1_0.rd
@@ -8,7 +8,7 @@
 
 == 言語仕様の変更
 
-  * The block argument can now be anonymous if the block will only be passed to another method. [[Feature #11256]]
+  * ブロックが他のメソッドに渡されるだけの場合は、ブロックの引数を無名にできるようになりました。 [[feature:11256]]
 
 //emlist{
 def foo(&)
@@ -16,14 +16,14 @@ def foo(&)
 end
 //}
 
-  * Pin operator now takes an expression. [[Feature #17411]]
+  * ピン演算子に式を書けるようになりました。 [[feature:17411]]
 
 //emlist{
 Prime.each_cons(2).lazy.find_all{_1 in [n, ^(n + 2)]}.take(3).to_a
 #=> [[3, 5], [5, 7], [11, 13]]
 //}
 
-  * Pin operator now supports instance, class, and global variables. [[Feature #17724]]
+  * ピン演算子がインスタンス変数、クラス変数、グローバル変数をサポートしました。 [[feature:17724]]
 
 //emlist{
 @n = 5
@@ -31,9 +31,9 @@ Prime.each_cons(2).lazy.find{_1 in [n, ^@n]}
 #=> [3, 5]
 //}
 
-  * One-line pattern matching is no longer experimental.
+  * 1行パターンマッチが実験的な機能ではなくなりました。
 
-  * Parentheses can be omitted in one-line pattern matching. [[Feature #16182]]
+  * 1行パターンマッチが括弧を省略できるようになりました。 [[feature:16182]]
 
 //emlist{
 [0, 1] => _, x
@@ -42,77 +42,76 @@ x #=> 1
 y #=> 2
 //}
 
-  * Multiple assignment evaluation order has been made consistent with single assignment evaluation order. With single assignment, Ruby uses a left-to-right evaluation order.  With this code:
+  * 多重代入の評価順序が、単一代入の評価順序と一致するようになりました。単一代入では、Rubyは左から右への評価順序を使用します。このコードでは、
 
 #@samplecode
 foo[0] = bar
 #@end
 
-The following evaluation order is used:
+  * 次の評価順序になります。
 
+//emlist{
   1. `foo`
   2. `bar`
   3. `[]=` called on the result of `foo`
+//}
 
-In Ruby before 3.1.0, multiple assignment did not follow this evaluation order.  With this code:
+  * Ruby 3.1.0より前は、多重代入の評価順序が上記のようではありませんでした。このコードでは、
 
 #@samplecode
 foo[0], bar.baz = a, b
 #@end
 
-Versions of Ruby before 3.1.0 would evaluate in the following order
+  * 次の評価順序になります。
 
+//emlist{
   1. `a`
   2. `b`
   3. `foo`
   4. `[]=` called on the result of `foo`
   5. `bar`
   6. `baz=` called on the result of `bar`
+//}
 
-Starting in Ruby 3.1.0, the evaluation order is now consistent with single assignment, with the left-hand side being evaluated before the right-hand side:
+  * Ruby 3.1.0から単一代入と評価順序が一致するようになり、左が右より先に評価されます。
 
+//emlist{
   1. `foo`
   2. `bar`
   3. `a`
   4. `b`
   5. `[]=` called on the result of `foo`
   6. `baz=` called on the result of `bar`
+//}
 
-    [[Bug #4443]]
+  * [[bug:4443]]
 
-  * Values in Hash literals and keyword arguments can be omitted. [[Feature #14579]]
+  * ハッシュリテラルやキーワード引数の値が省略可能になりました。 [[feature:14579]]
 
-    For example,
+    * {x:, y:} は {x: x, y: y} の糖衣構文です。
+    * foo(x:, y:) は foo(x: x, y: y) の糖衣構文です。
 
-    * `{x:, y:}` is a syntax sugar of `{x: x, y: y}`.
-    * `foo(x:, y:)` is a syntax sugar of `foo(x: x, y: y)`.
+  * 定数名、ローカル変数名、メソッド名をキー名に使用することができます。予約語はselfのような疑似変数名であっても、ローカル変数やメソッド名とみなされることに注意してください。
 
-    Constant names, local variable names, and method names are allowed as
-    key names.  Note that a reserved word is considered as a local
-    variable or method name even if it's a pseudo variable name such as
-    `self`.
+  * クラスやモジュールのインスタンス変数がshareableなオブジェクトを代入している場合、メイン以外のRactorが参照できるようになりました。 [[feature:17592]]
 
-  * Non main-Ractors can get instance variables (ivars) of classes/modules if ivars refer to shareable objects. [[Feature #17592]]
-
-  * A command syntax is allowed in endless method definitions, i.e., you can now write `def foo = puts "Hello"`. Note that `private def foo = puts "Hello"` does not parse. [[Feature #17398]]
+  * 1行のメソッド定義が括弧なしで書けるようになりました。例として def foo = puts "Hello" と記述できるようになりました。 private def foo = puts "Hello" はパースされないことに注意してください。 [[feature:17398]]
 
 == コマンドラインオプション
 
-  * `--disable-gems` is now explicitly declared as "just for debugging". Never use it in any real-world codebase. [[Feature #17684]]
+  * --disable-gems は"デバッグ専用"として明示的に宣言されました。デバッグ専用以外のコードでは使用しないでください。 [[feature:17684]]
 
-== 主要クラスの更新
+== 組み込みクラスの更新(注目すべきもののみ)
 
-Note: We're only listing outstanding class updates.
+  * [[c:Array]]
+    * 新規メソッド
+      * [[m:Array#intersect?]]が追加されました。 [[feature:15198]]
 
-  * Array
-    * Array#intersect? is added. [[Feature #15198]]
-  * Class
-    * Class#subclasses, which returns an array of classes
-      directly inheriting from the receiver, not
-      including singleton classes.
-      [[Feature #18273]]
+  * [[c:Class]]
+    * 新規メソッド
+      * [[m:Class#subclasses]]はレシーバを継承した子クラスを要素に持つ配列(シングルトンクラスを含まない)を返します。
 
-#@samplecode
+#@samplecode Class#subclasses
 class A; end
 class B < A; end
 class C < B; end
@@ -122,12 +121,13 @@ B.subclasses    #=> [C]
 C.subclasses    #=> []
 #@end
 
-  * Enumerable
-    * Enumerable#compact is added. [[Feature #17312]]
-    * Enumerable#tally now accepts an optional hash to count. [[Feature #17744]]
-    * Enumerable#each_cons and each_slice to return a receiver. [[GH-1509]]
+  * [[c:Enumerable]]
+    * 新規メソッド
+      * [[m:Enumerable#compact]]が追加されました。 [[feature:17312]]
+      * [[m:Enumerable#tally]]がカウント集計用のハッシュオブジェクトを任意で渡せるようになりました。 [[feature:17744]]
+      * [[m:Enumerable#each_cons]]と[[m:Enumerable#each_slice]]がレシーバを返すようになりました。 [[url:https://github.com/ruby/ruby/pull/1509]]
 
-#@samplecode
+#@samplecode Enumerable#each_cons Enumerable#each_slice
 [1, 2, 3].each_cons(2){}
 # 3.0 => nil
 # 3.1 => [1, 2, 3]
@@ -137,80 +137,114 @@ C.subclasses    #=> []
 # 3.1 => [1, 2, 3]
 #@end
 
-  * Enumerator::Lazy
-    * Enumerator::Lazy#compact is added. [[Feature #17312]]
-  * File
-    * File.dirname now accepts an optional argument for the level to strip path components. [[Feature #12194]]
-  * GC
-    * "GC.measure_total_time = true" enables the measurement of GC.
-      Measurement can introduce overhead. It is enabled by default.
-      GC.measure_total_time returns the current setting.
-      GC.stat[:time] or GC.stat(:time) returns measured time
-      in milli-seconds. [[[Feature #10917]]]
-    * GC.total_time returns measured time in nano-seconds. [[[Feature #10917]]]
-  * Integer
-    * Integer.try_convert is added. [[Feature #15211]]
-  * Kernel
-    * Kernel#load now accepts a module as the second argument, and will load the file using the given module as the top-level module. [[Feature #6210]]
-  * Marshal
-    * Marshal.load now accepts a `freeze: true` option. All returned objects are frozen except for `Class` and `Module` instances. Strings are deduplicated. [[Feature #18148]]
-  * MatchData
-    * MatchData#match is added [[Feature #18172]]
-    * MatchData#match_length is added [[Feature #18172]]
-  * Method / UnboundMethod
-    * Method#public?, Method#private?, Method#protected?, UnboundMethod#public?, UnboundMethod#private?, UnboundMethod#protected? have been added. [[Feature #11689]]
-  * Module
-    * Module#prepend now modifies the ancestor chain if the receiver already includes the argument. Module#prepend still does not modify the ancestor chain if the receiver has already prepended the argument. [[Bug #17423]]
-    * Module#private, #public, #protected, and #module_function will now return their arguments.  If a single argument is given, it is returned. If no arguments are given, nil is returned.  If multiple arguments are given, they are returned as an array. [[Feature #12495]]
-  * Process
-    * Process.\_fork is added. This is a core method for fork(2). Do not call this method directly; it is called by existing fork methods: Kernel.#fork, Process.fork, and IO.popen("-"). Application monitoring libraries can overwrite this method to hook fork events. [[Feature #17795]]
-  * Struct
-    * Passing only keyword arguments to Struct#initialize is warned. You need to use a Hash literal to set a Hash to a first member. [[Feature #16806]]
-    * StructClass#keyword_init? is added [[Feature #18008]]
-  * String
-    * Update Unicode version to 13.0.0 [[Feature #17750]] and Emoji version to 13.0 [[Feature #18029]]
-    * String#unpack and String#unpack1 now accept an `offset:` keyword argument to start the unpacking after an arbitrary number of bytes have been skipped. If `offset` is outside of the string bounds `ArgumentError` is raised. [[Feature #18254]]
-  * Thread
-    * Thread#native_thread_id is added. [[Feature #17853]]
-  * Thread::Backtrace
-    * Thread::Backtrace.limit, which returns the value to limit backtrace length set by `--backtrace-limit` command line option, is added. [[Feature #17479]]
-  * Thread::Queue
-    * Thread::Queue.new now accepts an Enumerable of initial values. [[Feature #17327]]
-  * Time
-    * Time.new now accepts optional `in:` keyword argument for the timezone, as well as `Time.at` and `Time.now`, so that is now you can omit minor arguments to `Time.new`. [[Feature #17485]]
+  * [[c:Enumerator::Lazy]]
+    * 新規メソッド
+      * [[m:Enumerator::Lazy#compact]] が追加されました。 [[feature:17312]]
 
-#@samplecode
+  * [[c:File]]
+    * 変更されたメソッド
+      * [[m:File.dirname]] がパスの階層を取り除く任意の引数を渡せるようになりました。 [[feature:12194]]
+
+  * [[c:GC]]
+    * 新規メソッド
+      * GC.measure_total_time = true でGCの計測を有効にします。計測によってオーバーヘッドが発生する可能性があります。デフォルトで有効になっています。 GC.measure_total_time は現在の設定を返します。 GC.stat[:time] または GC.stat(:time) は、測定された時間をミリ秒で返します。 [[feature:10917]]
+      * GC.total_time が計測された時間をナノ秒で返します。 [[feature:10917]]
+
+  * [[c:Integer]]
+    * 新規メソッド
+      * [[m:Integer.try_convert]] が追加されました。 [[feature:15211]]
+
+  * [[c:Kernel]]
+    * 変更されたメソッド
+      * Kernel#load が第2引数にモジュールを渡せるようになり、渡されたモジュールをトップレベルのモジュールとしてファイルを読み込むようになりました。 [[feature:6210]]
+
+  * [[c:Marshal]]
+    * 変更されたメソッド
+      * Marshal.load が freeze: true オプションを渡せるようになりました。返されるオブジェクトはクラスやモジュールのオブジェクトを除き、すべてfreezeされます。文字列は重複排除されます。 [[feature:18148]]
+
+  * [[c:MatchData]]
+    * 新規メソッド
+      * MatchData#match が追加されました。 [[feature:18172]]
+      * MatchData#match_length が追加されました。 [[feature:18172]]
+
+  * [[c:Method]] / [[c:UnboundMethod]]
+    * 新規メソッド
+      * Method#public?, Method#private?, Method#protected?, UnboundMethod#public?, UnboundMethod#private?, UnboundMethod#protected? が追加されました。 [[feature:11689]]
+
+  * [[c:Module]]
+    * 変更されたメソッド
+      * [[m:Module#prepend]] はレシーバが既に引数をincludeしている場合、継承ツリーを変更するようになりました。レシーバが既に引数をprependしている場合、継承ツリーを変更しません。 [[bug:17423]]
+      * [[m:Module#private]], [[m:Module#public]], [[m:Module#protected]], [[m:Module#module_function]]が引数を返すようになりました。引数が1つでも渡されている場合、それが返されます。引数なしの場合、nilが返されます。複数の引数を渡した場合、それらを要素に持つ配列が返されます。 [[feature:12495]]
+
+  * [[c:Process]]
+    * 新規メソッド
+      * Process._forkが追加されました。これは [[man:fork(2)]] のコアメソッドです。このメソッドを直接呼び出さないでください。既存のforkメソッド([[m:Kernel.#fork]]、[[m:Process.fork]]、IO.popen("-"))によって呼び出されます。アプリケーションモニタリングライブラリは、このメソッドを上書きしてforkイベントをフックすることができます。 [[feature:17795]]
+
+  * [[c:Struct]]
+    * 新規メソッド
+      * StructClass#keyword_init? が追加されました。 [[feature:18008]]
+    * 変更されたメソッド
+      * Struct#initialize はキーワード引数のみを渡すと警告されるようになりました。ハッシュを最初のメンバにするには、ハッシュリテラルを使用する必要があります。 [[feature:16806]]
+
+  * [[c:String]]
+    * Unicodeと絵文字のバージョンが13.0.0に更新されました。 [[feature:17750]] [[feature:18029]]
+    * [[m:String#unpack]] と [[m:String#unpack1]] が任意のバイト数をスキップした後にアンパックを開始するための offset: キーワード引数を渡せるようになりました。 offset が文字列の範囲外の場合、 [[c:ArgumentError]] 例外が発生します。 [[feature:18254]]
+
+  * [[c:Thread]]
+    * 新規メソッド
+      * Thread#native_thread_id が追加されました。 [[feature:17853]]
+
+  * Thread::Backtrace
+    * 新規メソッド
+      * --backtrace-limit コマンドラインオプションで設定したバックトレースの長さを制限する値を返す Thread::Backtrace.limit が追加されました。 [[feature:17479]]
+
+  * [[c:Thread::Queue]]
+    * 変更されたメソッド
+      * [[m:Thread::Queue.new]] が、初期値のEnumerableオブジェクトを渡せるようになりました。 [[feature:17327]]
+
+  * [[c:Time]]
+    * 変更されたメソッド
+      * [[m:Time.new]] は、Time.at や Time.now と同じようにタイムゾーンの in: キーワード引数を任意で渡せるようになりました。これにより Time.new の細かい引数を省略できるようになりました。 [[feature:17485]]
+
+#@samplecode Time.new
 Time.new(2021, 12, 25, in: "+07:00")
 #=> 2021-12-25 00:00:00 +0700
 #@end
 
-      At the same time, time component strings are converted to integers more strictly now.
+      * 同時に、時刻の要素の文字列がより厳密に整数に変換されるようになりました。
 
-#@samplecode
+#@samplecode Time.new
 Time.new(2021, 12, 25, "+07:30")
 #=> invalid value for Integer(): "+07:30" (ArgumentError)
 #@end
 
-      Ruby 3.0 or earlier returned probably unexpected result `2021-12-25 07:00:00`, not `2021-12-25 07:30:00` nor `2021-12-25 00:00:00 +07:30`.
+      * Ruby 3.0 以前では、予期しない結果の 2021-12-25 07:00:00 が返されました。 2021-12-25 07:30:00 や 2021-12-25 00:00:00 +07:30 でもありません。
 
-    * Time#strftime supports RFC 3339 UTC for unknown offset local time, `-0000`, as `%-z`. [[Feature #17544]]
+      * [[m:Time#strftime]] がRFC 3339 UTCのunknown offset local timeに対応しました。 -0000 を \%-z としてサポートします。 [[feature:17544]]
 
-  * TracePoint
-    * TracePoint.allow_reentry is added to allow reenter while TracePoint callback. [[Feature #15912]]
-  * $LOAD_PATH
-    * $LOAD_PATH.resolve_feature_path does not raise. [[Feature #16043]]
+  * [[c:TracePoint]]
+    * 新規メソッド
+      * TracePoint のコールバック中に再入を許す TracePoint.allow_reentry が追加されました。 [[feature:15912]]
+
+  * [[m:$LOAD_PATH]]
+    * 変更されたメソッド
+      * $LOAD_PATH.resolve_feature_path が失敗時に例外を発生させなくなりました。 [[feature:16043]]
+
   * Fiber Scheduler
-    * Add support for `Addrinfo.getaddrinfo` using `address_resolve` hook. [[Feature #17370]]
-    * Introduce non-blocking `Timeout.timeout` using `timeout_after` hook. [[Feature #17470]]
-    * Introduce new scheduler hooks `io_read` and `io_write` along with a low level `IO::Buffer` for zero-copy read/write. [[Feature #18020]]
-    * IO hooks `io_wait`, `io_read`, `io_write`, receive the original IO object where possible. [[Bug #18003]]
-    * Make `Monitor` fiber-safe. [[Bug #17827]]
-    * Replace copy coroutine with pthread implementation. [[Feature #18015]]
-  * Refinement
-    * New class which represents a module created by Module#refine. `include` and `prepend` are deprecated, and `import_methods` is added instead. [[Bug #17429]]
+    * 変更されたメソッド
+      * [[m:Addrinfo.getaddrinfo]] がaddress_resolveフックをサポートしました。 [[feature:17370]]
+      * ブロックなしの Timeout.timeout に timeout_after フックが導入されました。 [[feature:17470]]
+      * 新しいSchedulerのフックのio_readとio_writeが導入され、zero-copy read/writeのための低レベルのIO::Bufferが導入されました。 [[feature:18020]]
+      * IOフックのio_wait、io_read、io_writeは、可能ならばオリジナルのIOオブジェクトを受け取るようになりました。 [[bug:18003]]
+      * MonitorがFiberセーフになりました。 [[bug:17827]]
+      * コピーコルーチンをpthread実装に置き換えました。 [[feature:18015]]
 
-== 標準添付ライブラリの更新
-  * The following default gem are updated.
+  * [[c:Refinement]]
+    * [[m:Module#refine]]で作成されたモジュールを表す新しいクラス。includeとprependは非推奨になり、代わりにimport_methodsが追加されました。
+
+== 標準添付ライブラリの更新(機能追加とバグ修正を除く)
+
+  * 以下のdefault gemsが更新されました。
     * RubyGems 3.3.3
     * base64 0.1.1
     * benchmark 0.2.0
@@ -266,7 +300,7 @@ Time.new(2021, 12, 25, "+07:30")
     * uri 0.11.0
     * yaml 0.2.0
     * zlib 2.1.1
-  * The following bundled gems are updated.
+  * 以下のbundled gemsが更新されました。
     * minitest 5.15.0
     * power_assert 2.0.1
     * rake 13.0.6
@@ -274,7 +308,7 @@ Time.new(2021, 12, 25, "+07:30")
     * rexml 3.2.5
     * rbs 2.0.0
     * typeprof 0.21.1
-  * The following default gems are now bundled gems.
+  * 以下のdefault gemsがbundled gemsに変更されました。
     * net-ftp 0.1.3
     * net-imap 0.2.2
     * net-pop 0.1.1
@@ -282,63 +316,65 @@ Time.new(2021, 12, 25, "+07:30")
     * matrix 0.4.2
     * prime 0.1.2
     * debug 1.4.0
-  * The following gems has been removed from the Ruby standard library.
+  * 以下が標準添付ライブラリから削除されました。
     * dbm
     * gdbm
     * tracer
 
-  * Coverage measurement now supports suspension. You can use `Coverage.suspend` to stop the measurement temporarily, and `Coverage.resume` to restart it. See [[Feature #18176]] in detail.
-  * Random::Formatter is moved to random/formatter.rb, so that you can use `Random#hex`, `Random#base64`, and so on without SecureRandom. [[Feature #18190]]
+  * Coverageの計測が一時停止をサポートされるようになりました。 Coverage.suspendで計測を一時停止し、Coverage.resumeで再開することができます。詳細は [[feature:18176]] を参照してください。
+  * Random::Formatterは random/formatter.rb に移動され、SecureRandomを使わずに Random#hex や Random#base64 などが使用できるようになりました。 [[feature:18190]]
 
-== 互換性
+== 互換性 (機能追加とバグ修正を除く)
 
-Note: Excluding feature bug fixes.
-
-* `rb_io_wait_readable`, `rb_io_wait_writable` and `rb_wait_for_single_fd` are deprecated in favour of `rb_io_maybe_wait_readable`, `rb_io_maybe_wait_writable` and `rb_io_maybe_wait` respectively. `rb_thread_wait_fd` and `rb_thread_fd_writable` are deprecated. [[Bug #18003]]
+  * rb_io_wait_readable、 rb_io_wait_writable、 rb_wait_for_single_fd は非推奨で、それぞれ rb_io_maybe_wait_readable、 rb_io_maybe_wait_writable、 rb_io_maybe_wait に置き換えられます。 rb_thread_wait_fd と rb_thread_fd_writable は非推奨になりました。 [[bug:18003]]
 
 == 標準添付ライブラリの互換性
 
-  * `ERB#initialize` warns `safe_level` and later arguments even without -w. [[Feature #14256]]
-  * `lib/debug.rb` is replaced with `debug.gem`
-  * `Kernel#pp` in `lib/pp.rb` uses the width of `IO#winsize` by default. This means that the output width is automatically changed depending on your terminal size. [[Feature #12913]]
-  * Psych 4.0 changes `Psych.load` as `safe_load` by the default. You may need to use Psych 3.3.2 for migrating to this behavior. [[Bug #17866]]
+  * ERB#initializeが-wオプションなしでもsafe_level以降の引数に警告されるようになりました。 [[feature:14256]]
+  * lib/debug.rb が debug.gem に置き換えられました。
+  * lib/pp.rb の Kernel#pp がデフォルトで [[m:IO#winsize]] の幅を使用するようになりました。出力幅が端末サイズに応じて自動的に変更されることを意味します。 [[feature:12913]]
+  * Psych 4.0では、デフォルトで [[m:Psych.load]] が [[m:Psych.safe_load]] に変更されました。この動作に移行するにはPsych 3.3.2を使用する必要があるかもしれません。 [[bug:17866]]
 
 == C API の更新
 
-  * Documented. [[GH-4815]]
-  * `rb_gc_force_recycle` is deprecated and has been changed to a no-op. [[Feature #18290]]
+  * ドキュメント化されました。 [[url:https://github.com/ruby/ruby/pull/4815]]
+  * rb_gc_force_recycleは非推奨で、no-op関数に変更されました。 [[feature:18290]]
 
 == 実装の改善
-  * Inline cache mechanism is introduced for reading class variables. [[Feature #17763]]
-  * `instance_eval` and `instance_exec` now only allocate a singleton class when required, avoiding extra objects and improving performance. [[GH-5146]]
-  * The performance of `Struct` accessors is improved. [[GH-5131]]
-  * `mandatory_only?` builtin special form to improve performance on builtin methods. [[GH-5112]]
-  * Experimental feature Variable Width Allocation in the garbage collector. This feature is turned off by default and can be enabled by compiling Ruby with flag `USE_RVARGC=1` set. [[Feature #18045]] [[Feature #18239]]
+
+  * クラス変数の読み込みにインラインキャッシュが導入されました。 [[feature:17763]]
+  * instance_eval と instance_exec は、必要な時だけシングルトンクラスを割り当てるようになり、余分なオブジェクトの生成を回避してパフォーマンスを向上させるようになりました。 [[url:https://github.com/ruby/ruby/pull/5146]]
+  * [[c:Struct]]のアクセサが高速化されました。 [[url:https://github.com/ruby/ruby/pull/5131]]
+  * 組み込みメソッドのパフォーマンス向上のために、特殊な組み込みメソッドの mandatory_only? が追加されました。 [[url:https://github.com/ruby/ruby/pull/5112]]
+  * 実験的な機能のガベージコレクタのVariable Width Allocationはデフォルトでオフになっており、USE_RVARGC=1フラグをセットしてRubyをコンパイルすることで有効にできるようになりました。 [[feature:18045]] [[feature:18239]]
 
 == JIT
-  * Rename Ruby 3.0's `--jit` to `--mjit`, and alias `--jit` to `--yjit` on non-Windows x86-64 platforms and to `--mjit` on others.
+
+  * Ruby 3.0の --jit が --mjit にリネームされ、 --jit がWindows以外のx86-64プラットフォームでは --yjit に、その他のプラットフォームでは --mjit に変更されました。
 
 === MJIT
-  * The default `--mjit-max-cache` is changed from 100 to 10000.
-  * JIT-ed code is no longer cancelled when a TracePoint for class events is enabled.
-  * The JIT compiler no longer skips compilation of methods longer than 1000 instructions.
-  * `--mjit-verbose` and `--mjit-warning` output "JIT cancel" when JIT-ed code is disabled because TracePoint or GC.compact is used.
 
-=== YJIT: New experimental in-process JIT compiler
+  * --mjit-max-cache のデフォルト値が100から10000に変更されました。
+  * クラスイベントでTracePointが有効になっている場合にJITコンパイルされたコードをキャンセルしなくなりました。
+  * JITコンパイラは、1000命令列長より長いメソッドのコンパイルをスキップしなくなりました。
+  * --mjit-verbose や --mjit-warning は、TracePoint または GC.compact が使用されており、JITコンパイルされたコードが無効になった時に "JIT cancel" と出力されるようになりました。
 
-New JIT compiler available as an experimental feature. [[Feature #18229]]
+=== YJIT
 
-See [this blog post](https://shopify.engineering/yjit-just-in-time-compiler-cruby) introducing the project.
+新しいJITコンパイラが実験的な機能として利用可能です。 [[feature:18229]]
 
-  * Disabled by default, use `--yjit` command-line option to enable YJIT.
-  * Performance improvements on benchmarks based on real-world software, up to 22% on railsbench, 39% on liquid-render.
-  * Fast warm-up times.
-  * Limited to Unix-like x86-64 platforms for now.
+詳細はブログ([[url:https://shopify.engineering/yjit-just-in-time-compiler-cruby]])を参照してください。
+
+  * --yjit コマンドラインオプションでYJITを有効(デフォルトは無効)にできるようになりました。
+  * 実世界のソフトウェアに基づくベンチマークでrailsbenchで最大22%、liquid-renderで最大39%の性能向上が実現されました。
+  * ウォームアップタイムが高速。
+  * 現時点では、Unixライクなx86-64プラットフォームに限定されています。
 
 == 静的解析
 
 === RBS
-  * Generics type parameters can be bounded ([PR](https://github.com/ruby/rbs/pull/844)).
+
+  * ジェネリクスの型パラメータに制約を与えることができるようになりました。 [[url:https://github.com/ruby/rbs/pull/844]]
 
 //emlist{
 # `T` must be compatible with the `_Output` interface.
@@ -354,7 +390,7 @@ class PrettyPrint[T < _Output]
 end
 //}
 
-  * Type aliases can be generic. ([PR](https://github.com/ruby/rbs/pull/823))
+  * ジェネリックな型エイリアスが定義できるようになりました。 [[url:https://github.com/ruby/rbs/pull/823]]
 
 //emlist{
 # Defines a generic type `list`.
@@ -365,29 +401,32 @@ type str_list = list[String]
 type int_list = list[Integer]
 //}
 
-  * [rbs collection](https://github.com/ruby/rbs/blob/cdd6a3a896001e25bd1feda3eab7f470bae935c1/docs/collection.md) has been introduced to manage gems’ RBSs.
-  * Many signatures for built-in and standard libraries have been added/updated.
-  * It includes many bug fixes and performance improvements too.
+  * gemsのRBSを管理するためのrbs collectionコマンド([[url:https://github.com/ruby/rbs/blob/cdd6a3a896001e25bd1feda3eab7f470bae935c1/docs/collection.md]])が導入されました。
+  * いろいろな組み込みクラスの型定義が追加、更新されました。
+  * 多数のバグ修正と性能の改善が含まれています。
 
-See the [CHANGELOG.md](https://github.com/ruby/rbs/blob/cdd6a3a896001e25bd1feda3eab7f470bae935c1/CHANGELOG.md) for more information.
+詳細はCHANGELOG.md([[url:https://github.com/ruby/rbs/blob/cdd6a3a896001e25bd1feda3eab7f470bae935c1/CHANGELOG.md]])を参照してください。
 
 === TypeProf
-  * [Experimental IDE support](https://github.com/ruby/typeprof/blob/ca15c5dae9bd62668463165f8409bd66ce7de223/doc/ide.md) has been implemented.
-  * Many bug fixes and performance improvements since Ruby 3.0.0.
+
+  * 実験的なIDEサポート([[url:https://github.com/ruby/typeprof/blob/ca15c5dae9bd62668463165f8409bd66ce7de223/doc/ide.md]])が実装されました。
+  * Ruby 3.0.0以降、多くのバグ修正とパフォーマンス向上がなされています。
 
 == Debugger
 
-  * A new debugger [debug.gem](https://github.com/ruby/debug) is bundled. debug.gem is a fast debugger implementation, and it provides many features like remote debugging, colorful REPL, IDE (VSCode) integration, and more. It replaces `lib/debug.rb` standard library.
-  * `rdbg` command is also installed into `bin/` directory to start and control debugging execution.
+  * 新しいデバッガのdebug.gem([[url:https://github.com/ruby/debug]])がbundled gemsに追加されました。高速なデバッガの実装で、リモートデバッグの多数の機能を提供、カラフルなREPL、IDE(VSCode)インテグレーション、など。標準ライブラリの lib/debug.rb は debug.gem で置き換えられました。
+  * デバッグ実行の開始・管理用のrdbgコマンドがbin/ディレクトリにインストールされました。
 
 == error_highlight
 
-A built-in gem called error_highlight has been introduced.
-It shows fine-grained error locations in the backtrace.
+error_highlightが組み込みgemに導入されました。
+バックトレースで詳細なエラー位置を表示します。
 
-Example: `title = json[:article][:title]`
+#@samplecode 例
+title = json[:article][:title]
+#@end
 
-If `json` is nil, it shows:
+jsonがnilの時、
 
 //emlist{
 $ ruby test.rb
@@ -397,7 +436,7 @@ title = json[:article][:title]
             ^^^^^^^^^^
 //}
 
-If `json[:article]` returns nil, it shows:
+json[:article] が返す時、
 
 //emlist{
 $ ruby test.rb
@@ -407,31 +446,24 @@ title = json[:article][:title]
                       ^^^^^^^^
 //}
 
-This feature is enabled by default.
-You can disable it by using a command-line option `--disable-error_highlight`.
-See [the repository](https://github.com/ruby/error_highlight) in detail.
+この機能はデフォルトで有効になっています。
+--disable-error_highlight コマンドラインオプションを指定することで無効化できます。
+詳細はリポジトリ([[url:https://github.com/ruby/error_highlight]])を参照してください。
 
-== IRB Autocomplete and Document Display
+== IRBのオートコンプリートとドキュメント表示
 
-The IRB now has an autocomplete feature, where you can just type in the code, and the completion candidates dialog will appear. You can use Tab and Shift+Tab to move up and down.
+IRBにオートコンプリート機能が実装され、コードを入力するだけで補完候補ダイアログが表示されるようになりました。TabやShift+Tabで上下に移動できます。
 
-If documents are installed when you select a completion candidate, the documentation dialog will appear next to the completion candidates dialog, showing part of the content. You can read the full document by pressing Alt+d.
+また、補完候補を選択している時に、ドキュメントがインストールされている場合、補完候補ダイアログの横にドキュメントダイアログが表示され、内容の一部が表示されます。Alt+dを押すことでドキュメント全文を読むことができます。
 
 == その他の変更
 
-  * lib/objspace/trace.rb is added, which is a tool for tracing the object
-    allocation. Just by requiring this file, tracing is started *immediately*.
-    Just by `Kernel#p`, you can investigate where an object was created.
-    Note that just requiring this file brings a large performance overhead.
-    This is only for debugging purposes. Do not use this in production.
-    [[Feature #17762]]
+  * lib/objspace/trace.rb が追加されました。オブジェクトのアロケーションをトレースするためのツールです。このファイルを読み込むだけで、トレースが即座に開始されます。 Kernel#p だけで、オブジェクトがどこで作られたかを調べることができます。 このファイルを読み込むだけで、パフォーマンスに大きなオーバーヘッドが発生することに注意してください。これはあくまでもデバッグのためのものです。実運用では使用しないでください。 [[feature:17762]]
 
-  * Now exceptions raised in finalizers will be printed to `STDERR`, unless
-    `$VERBOSE` is `nil`.  [[Feature #17798]]
+  * ファイナライザで発生した例外は、$VERBOSEがnilでない限り、STDERRに出力されるようになりました。 [[feature:17798]]
 
-  * `ruby -run -e httpd` displays URLs to access.  [[Feature #17847]]
+  * ruby -run -e httpd はアクセスされた時にURLを出力するようになりました。 [[feature:17847]]
 
-  * Add `ruby -run -e colorize` to colorize Ruby code using
-    `IRB::Color.colorize_code`.
+  * IRB::Color.colorize_code を使ってRubyのコードをカラー化するために ruby -run -e colorize が追加されました。
 
 #@end


### PR DESCRIPTION
## 概要

NEWS for Ruby 3.1.0の英語を日本語へ変更しました。

* Ruby Issue Tracking SystemFeatureやBugのチケットへのリンクを追加
* 言語仕様のpreタグで囲まれた中に番号付きリストが含まれている箇所を、preタグの外で表示するように変更
* 組み込みクラスのサンプルコードの表示のコメントにメソッド名を追加
* Rubyリファレンスマニュアルの既にページがあるメソッドはリンクを追加

### 英語から日本語への変更について

最初にGoogle翻訳やDeepL翻訳で英語から日本語へ翻訳しました。
日本語の表現を以下のURL先の情報を参考にして英語から日本語に変更しました。

以下のRubyの公式サイトで、同じテキストを翻訳していると思われる箇所はそのまま使用しました。

https://www.ruby-lang.org/ja/news/2021/12/25/ruby-3-1-0-released/
https://www.ruby-lang.org/ja/news/2021/11/09/ruby-3-1-0-preview1-released/

また、Rubyの機能について以下のサイトも参考にしました。

https://techlife.cookpad.com/entry/2021/12/25/220002
https://qiita.com/jnchito/items/bcd9b7f59bf4b30ea5b3

### スクリーンショット

ローカル環境でNEWS for Ruby 3.1.0のページの変更を確認しました。
以下はローカル環境で確認した時のページのスクリーンショットです。

![screenshot-doctree-20230502](https://user-images.githubusercontent.com/645970/235589798-4b6b1601-3ee0-4c80-a414-8857214cbf6d.png)
