### PR TITLE
Math.#sqrtの引数・戻り値の説明を修正

### DIFF
--- a/refm/api/src/_builtin/Math
+++ b/refm/api/src/_builtin/Math
@@ -423,9 +423,9 @@ Math.log10(10**100) # => 100.0
 
 --- sqrt(x) -> Float
 
-x の平方根（square root）を返します。
+x の非負の平方根（principal square root）を返します。
 
-@param x 正の実数
+@param x 0または正の実数
 
 @raise TypeError xに数値以外を指定した場合に発生します。
 


### PR DESCRIPTION
[Math.#sqrt](https://docs.ruby-lang.org/ja/latest/method/Math/m/sqrt.html)について以下の2点修正を行いました。

1. 引数に0を受け取ることが考慮されていなかったため、引数として0を受け取る旨を記述。
2. 任意の正の実数において平方根は2個あるが、このメソッドで負の数が返ってくることはないためprinciple square rootであることを強調した。