### PR TITLE
Fiddle 3.0を新設

### DIFF
--- a/refm/api/src/fiddle/3.0/Fiddle
+++ b/refm/api/src/fiddle/3.0/Fiddle
@@ -1,0 +1,276 @@
+= module Fiddle
+
+[[lib:fiddle]] の名前空間をなすモジュールです。
+
+UNIX の [[man:dlopen(3)]] や Windows の LoadLibrary() 
+などのダイナミックリンカへの低レベルなインターフェースを提供するモジュールです。
+
+== Singleton Methods
+--- win32_last_error -> Integer
+最後に [[m:Fiddle::Function#call]] で C の関数を呼び出した
+結果設定された errno を返します。
+
+このメソッドは Windows 環境でのみ定義されています。
+
+この値はスレッドローカルです。
+
+--- win32_last_error=(errno)
+[[m:Fiddle.win32_last_error]] で返される値を設定します。
+
+errno は fiddle が設定するのでユーザはこのメソッドを使わないでください。
+
+このメソッドは Windows 環境でのみ定義されています。
+
+@param errno 設定する errno
+
+--- last_error -> Integer
+最後に [[m:Fiddle::Function#call]] で C の関数を呼び出した
+結果設定された errno を返します。
+
+この値はスレッドローカルです。
+
+--- last_error=(errno)
+[[m:Fiddle.last_error]] で返される値を設定します。
+
+errno は fiddle が設定するのでユーザはこのメソッドを使わないでください。
+
+@param errno 設定する errno
+
+== Module Functions
+
+--- dlopen(lib)                    -> Fiddle::Handle
+
+ダイナミックライブラリ lib をロードし、
+[[c:Fiddle::Handle]] として返します。
+
+[[m:Fiddle::Handle.new]](lib) と等価です。
+
+@param lib ロードしたいライブラリを文字列で与えます。
+
+@raise Fiddle::DLError [[man:dlopen(3)]] に失敗した時に発生します。
+
+--- malloc(size)    -> Integer
+
+size バイトのメモリ領域を確保し、その領域を指す整数を返します。
+
+メモリを確保できなかった場合、例外 NoMemoryError が発生するか、あるいは ruby インタプリタが強制終了します。
+
+@param size 必要なメモリ領域のサイズを整数で指定します。
+
+--- realloc(addr, size)   -> Integer
+
+addr で指定したメモリ領域を size バイトにリサイズし、その領域を指す整数
+を返します。
+
+addr には [[m:Fiddle.#malloc]] で確保したメモリ領域を渡します。
+また、リサイズの結果、返り値が addr と異なる場合があります。
+
+@param addr リサイズしたいメモリアドレス整数
+@param size リサイズ後のバイト数
+@see [[m:Fiddle.#malloc]]
+
+--- free(addr)      -> nil
+
+指定された addr が指すメモリ領域を開放します。
+
+必ず [[m:Fiddle.#malloc]] が返した整数を addr に与えなければいけません。
+そうでない場合、ruby インタプリタが異常終了します。
+
+@param addr [[m:Fiddle.#malloc]] で確保されたメモリ領域を指す整数を指定します。
+
+例:
+  require 'fiddle'
+  addr = Fiddle.malloc(10)
+  p addr               #=> 136942800
+  Fiddle.free(addr)
+
+--- dlwrap(obj)    -> Integer
+
+指定されたオブジェクト obj のアドレスを表す整数を返します。
+
+@param obj Ruby のオブジェクトを指定します。
+
+例:
+
+  require 'fiddle'
+  s = 'abc'
+  p addr = Fiddle.dlwrap(s)   #=> 136122440
+  p Fiddle.dlunwrap(addr)     #=> "abc"
+
+--- dlunwrap(addr)  -> object
+
+指定されたアドレスの Ruby オブジェクトを返します。
+
+@param addr [[m:Fiddle.#dlwrap]] が返した Ruby オブジェクトのアドレス(整数)を指定します。
+
+例:
+
+  require 'fiddle'
+  s = 'abc'
+  p addr = Fiddle.dlwrap(s)   #=> 136122440
+  p Fiddle.dlunwrap(addr)     #=> "abc"
+
+== Constants
+
+#@# Constants for internal use
+#@# --- CdeclCallbackProcs
+#@# 
+#@# --- CdeclCallbackAddrs
+#@# 
+#@# --- StdcallCallbackProcs
+#@# 
+#@# --- StdcallCallbackAddrs
+
+--- ALIGN_CHAR -> Integer
+C の構造体における char のアライメントの値。
+
+--- ALIGN_DOUBLE -> Integer
+C の構造体における double のアライメントの値。
+
+--- ALIGN_FLOAT -> Integer
+C の構造体における float のアライメントの値。
+
+--- ALIGN_INT -> Integer
+C の構造体における int のアライメントの値。
+
+--- ALIGN_LONG -> Integer
+C の構造体における long のアライメントの値。
+
+--- ALIGN_LONG_LONG -> Integer
+C の構造体における long long のアライメントの値。
+
+--- ALIGN_SHORT -> Integer
+C の構造体における short のアライメントの値。
+
+--- ALIGN_VOIDP -> Integer
+C の構造体における void* のアライメントの値。
+
+--- ALIGN_INTPTR_T -> Integer
+C の構造体における intptr_t のアライメントの値。
+
+--- ALIGN_PTRDIFF_T -> Integer
+C の構造体における ptrdiff_t のアライメントの値。
+
+--- ALIGN_SIZE_T -> Integer
+C の構造体における size_t のアライメントの値。
+
+--- ALIGN_SSIZE_T -> Integer
+C の構造体における ssize_t のアライメントの値。
+
+--- ALIGN_UINTPTR_T -> Integer
+C の構造体における uintptr_t のアライメントの値。
+
+--- BUILD_RUBY_PLATFORM -> String
+ビルドに用いた ruby のプラットフォームを表す文字列。
+
+通常、[[m:Object::RUBY_PLATFORM]] と同じ。
+
+--- NULL -> DL::CPtr
+C の NULL ポインタ
+
+#@# nodoc
+#@# --- RTLD_GLOBAL -> Integer
+#@# --- RTLD_LAZY -> Integer
+#@# --- RTLD_NOW -> Integer
+
+
+--- RUBY_FREE -> Integer
+ruby_xfree の関数ポインタのアドレスの値。
+
+--- SIZEOF_CHAR -> Integer
+Cでの sizeof(char) の値
+
+--- SIZEOF_DOUBLE -> Integer
+Cでの sizeof(double) の値
+
+--- SIZEOF_FLOAT -> Integer
+Cでの sizeof(float) の値
+
+--- SIZEOF_INT -> Integer
+Cでの sizeof(int) の値
+
+--- SIZEOF_LONG -> Integer
+Cでの sizeof(long) の値
+
+--- SIZEOF_LONG_LONG -> Integer
+Cでの sizeof(long long) の値
+
+--- SIZEOF_SHORT -> Integer
+Cでの sizeof(short) の値
+
+--- SIZEOF_VOIDP -> Integer
+Cでの sizeof(void*) の値
+
+--- SIZEOF_INTPTR_T -> Integer
+Cでの sizeof(intptr_t) の値
+
+--- SIZEOF_UINTPTR_T -> Integer
+Cでの sizeof(uintptr_t) の値
+
+--- SIZEOF_PTRDIFF_T -> Integer
+Cでの sizeof(ptrdiff_t) の値
+
+--- SIZEOF_SIZE_T -> Integer
+Cでの sizeof(size_t) の値
+
+--- SIZEOF_SSIZE_T -> Integer
+Cでの sizeof(ssize_t) の値
+
+--- TYPE_CHAR -> Integer
+C の char 型を表す定数。
+
+unsigned char を表すには符号を逆転させます。
+         
+--- TYPE_DOUBLE -> Integer
+C の double 型を表す定数。
+
+--- TYPE_FLOAT -> Integer
+C の float 型を表す定数。
+
+--- TYPE_INT -> Integer
+C の int 型を表す定数。
+
+unsigned int を表すには符号を逆転させます。
+
+--- TYPE_LONG -> Integer
+C の long 型を表す定数。
+
+unsigned long を表すには符号を逆転させます。
+
+--- TYPE_LONG_LONG -> Integer
+C の long long 型を表す定数。
+
+unsigned long long を表すには符号を逆転させます。
+
+--- TYPE_SHORT -> Integer
+C の short 型を表す定数。
+
+unsigned short を表すには符号を逆転させます。
+
+--- TYPE_VOID -> Integer
+C の void を表す定数。
+
+--- TYPE_VOIDP -> Integer
+C の void* 型を表す定数。
+
+--- TYPE_INTPTR_T -> Integer
+C の intptr_t 型を表す定数。
+
+--- TYPE_UINTPTR_T -> Integer
+C の uintptr_t 型を表す定数。
+
+--- TYPE_PTRDIFF_T -> Integer
+C の ptrdiff_t 型を表す定数。
+
+--- TYPE_SIZE_T -> Integer
+C の size_t 型を表す定数。
+
+--- TYPE_SSIZE_T -> Integer
+C の ssize_t 型を表す定数。
+
+--- WINDOWS -> bool
+Windows 上ならば真です。
+
+= class Fiddle::DLError < StandardError
+Fiddle のエラー全般を表すクラス。
+

--- a/refm/api/src/fiddle/3.0/Fiddle__CStruct
+++ b/refm/api/src/fiddle/3.0/Fiddle__CStruct
@@ -1,0 +1,61 @@
+= class Fiddle::CStruct
+C の構造体を表すクラスです。
+
+このクラスは直接は使わず、[[m:Fiddle::Importer#struct]] を用いて
+このクラスを継承したクラスを生成し、それを利用します。
+
+[[m:Fiddle::Importer#struct]] が生成するクラスには
+構造体の各メンバへのアクセサが定義されています。
+このアクセサはシグネチャの型とメンバ名に従って定義されます。
+例えば 
+  require 'fiddle/import'
+  include Fiddle::Importer
+  S = struct(["long foo", "void* bar"])
+とすると、 S#foo, S#foo= というアクセサが Integer とやりとり
+するように定義され、 S#bar, S#bar= というアクセサが Fiddle::Pointer
+でやりとりするように定義されます。
+
+このクラスは実際にはこのドキュメントに書かれているメソッドを保持していません。
+[[m:Fiddle::Importer#struct]] によって動的にメソッドが定義されます。
+このドキュメントは説明の便宜のためだと考えてください。
+
+== Class Methods
+--- new(addr) -> Fiddle::CStruct
+addr のアドレスが指すメモリを構造体のアドレスとみなし、
+構造体を作ります。
+
+C におけるキャストと似ています。
+  return (struct foo*)addr;
+というコードと対応していると言えます。
+
+@param addr アドレス
+
+--- malloc -> Fiddle::CStruct
+構造体のためのメモリを確保し、Fiddle::CStruct の(子孫クラスの)
+オブジェクトで返します。
+
+C における
+  return (struct foo*)malloc(sizeof(struct foo));
+というコードと対応していると言えます。
+
+--- size -> Integer
+構造体のサイズをバイト数で返します。
+
+このメソッドが返す値は C の構造体としてのサイズです。
+Ruby のオブジェクトとしてはより大きなメモリを消費しています。
+
+== Instance Methods
+--- to_i -> Integer
+保持している構造体の先頭アドレスを整数で返します。
+
+--- to_ptr -> Fiddle::Pointer
+保持している構造体へのポインタを返します。
+
+= class Fiddle::CUnion
+
+C の共用体を表すクラスです。
+
+このクラスは直接は使わず、[[m:Fiddle::Importer#union]] を用いて
+このクラスを継承したクラスを生成し、それを利用します。
+
+[[m:Fiddle::CStruct]] と同様の構造をしています。詳しくはそちらを見てください。

--- a/refm/api/src/fiddle/3.0/Fiddle__Function
+++ b/refm/api/src/fiddle/3.0/Fiddle__Function
@@ -1,0 +1,215 @@
+= class Fiddle::Function < Object
+C の関数を表すクラスです。
+
+== Class Methods
+--- new(ptr, args, ret_type, abi=Fiddle::Function::DEFAULT, name: nil) -> Fiddle::Function
+ptr (関数ポインタ)から Fiddle::Function オブジェクトを
+生成します。
+
+ptr には [[c:Fiddle::Handle]] から [[m:Fiddle::Handle#sym]] などで取りだした
+関数ポインタ(を表す整数)、もしくは関数を指している
+[[c:Fiddle::Pointer]] を渡します。
+
+args、ret_type で関数の引数と返り値の型を指定します。これには以下の
+定数が利用できます。「-TYPE_INT」 のように符号を反転させると unsigned を
+意味します。
+  * [[m:Fiddle::TYPE_VOID]]
+  * [[m:Fiddle::TYPE_VOIDP]]
+  * [[m:Fiddle::TYPE_CHAR]]
+  * [[m:Fiddle::TYPE_SHORT]]
+  * [[m:Fiddle::TYPE_INT]]
+  * [[m:Fiddle::TYPE_LONG]]
+  * [[m:Fiddle::TYPE_LONG_LONG]]
+  * [[m:Fiddle::TYPE_FLOAT]]
+  * [[m:Fiddle::TYPE_DOUBLE]]
+  * [[m:Fiddle::TYPE_INTPTR_T]]
+  * [[m:Fiddle::TYPE_UINTPTR_T]]
+  * [[m:Fiddle::TYPE_PTRDIFF_T]]
+  * [[m:Fiddle::TYPE_SIZE_T]]
+  * [[m:Fiddle::TYPE_SSIZE_T]]
+
+
+abi で呼出規約を指定します。
+  * [[m:Fiddle::Function::DEFAULT]]
+  * [[m:Fiddle::Function::STDCALL]]
+のどちらかを指定します。
+
+  require 'fiddle'
+  
+  h = Fiddle::Handle.new('libc.so.6')
+  func = Fiddle::Function.new(h.sym("strlen"), [Fiddle::TYPE_VOIDP], 
+                              Fiddle::TYPE_INT, name: "strlen")
+  p func.ptr == h.sym("strlen") # => true
+  p func.call("abc") # => 3
+  p func.name # => "strlen"
+
+@param ptr C の関数を指す [[c:Fiddle::Pointer]] オブジェクトもしくは
+       アドレスを表す整数
+@param args 引数の型を表す配列
+@param ret_type 返り値の型
+@param abi 呼出規約
+@param name 関数の名前(文字列)
+
+== Instance Methods
+--- call(*args) -> Integer|DL::CPtr|nil
+関数を呼び出します。
+
+[[m:Fiddle::Function.new]] で指定した引数と返り値の型に基いて
+Ruby のオブジェクトを適切に C のデータに変換して C の関数を呼び出し、
+その返り値を Ruby のオブジェクトに変換して返します。
+
+#@include(callargs)
+
+@param args 関数の引数
+@see [[m:Fiddle::Function.new]]
+
+--- abi -> Integer
+呼出規約を返します。
+
+@see [[m:Fiddle::Function.new]]
+
+--- name -> nil | String
+関数の名前を返します。
+
+名前が定義されていない場合は nil を返します。
+
+@see [[m:Fiddle::Function.new]]
+
+--- ptr -> Integer | Fiddle::Function
+関数ポインタを返します。
+
+[[m:Fiddle::Function.new]] の第1引数として指定したものを返します。
+
+--- to_i -> Integer
+関数ポインタのアドレスを整数で返します。
+
+@see [[m:Fiddle::Function#ptr]]
+
+== Constants
+--- DEFAULT -> Integer
+デフォルトの呼出規約を表します。
+
+@see [[m:Fiddle::Function.new]]
+
+--- STDCALL -> Integer
+Windows の stdcall 呼出規約を表します。
+
+stdcall 呼出規約を持つ環境でのみ定義されます。
+
+@see [[m:Fiddle::Function.new]]
+
+= class Fiddle::Closure < Object
+コールバック関数を表すクラスです。
+
+Ruby のメソッド(call)を C の関数ポインタとして表現するためのクラスです。
+
+FFI の closure の wrapper です。
+
+利用法としては、このクラスのサブクラスを作って
+そのサブクラスに call メソッドを定義し、
+new でオブジェクトを生成することで利用します。
+  
+  require 'fiddle'
+  include Fiddle # TYPE_* を使うために include する
+  
+  class Compare < Fiddle::Closure
+    # qsort の比較関数は 型が int(*)(void*, void*) であるため、
+    # このメソッドには DL::CPtr オブジェクトが渡される。
+    # そのポインタが指す先は比較している文字なので、
+    # DL::CPtr#to_s で1文字の文字列に変換している
+    def call(x, y)
+      x.to_s(1) <=> y.to_s(1)
+    end
+  end
+  
+  libc = DL.dlopen("/lib/libc.so.6")
+  qs = Fiddle::Function.new(libc["qsort"],
+                            [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
+                            TYPE_VOID)
+  s = "7x0cba(Uq)"
+  qs.call(s, s.size, 1, Compare.new(TYPE_INT, [TYPE_VOIDP, TYPE_VOIDP]))
+  p s # =>  "()07Uabcqx"
+
+[[m:Class.new]] を使うことで、サブクラスを明示的に作ることなしに
+コールバックオブジェクトを作ることができます。
+  require 'fiddle'
+  include Fiddle # TYPE_* を使うために include する
+  compare = Class.new(Fiddle::Closure){
+    def call(x, y)
+      x.to_s(1) <=> y
+    end
+  }.new(TYPE_INT, [TYPE_VOIDP, TYPE_VOIDP])
+
+単に Ruby のブロックを C の(コールバック)関数に変換したい場合は
+[[c:Fiddle::Closure::BlockCaller]] を使うほうが簡単です。
+
+== Class Methods
+--- new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
+
+そのクラスの call メソッドを呼びだすような
+Fiddle::Closure オブジェクトを返します。
+
+args、ret で関数の引数と返り値の型を指定します。
+指定は [[m:Fiddle::Function.new]] と同様なので、そちら
+を参照してください。
+
+@param ret 返り値の型
+@param args 引数の型を表す配列
+@param abi 呼出規約
+
+== Instance Methods
+--- to_i -> Integer
+
+C の関数ポインタのアドレスを返します。
+
+--- ctype -> Integer
+返り値の型を返します。
+
+--- args -> [Integer]
+引数の型を表す配列を返します。
+
+= class Fiddle::Closure::BlockCaller < Fiddle::Closure
+Ruby のブロックをラップしたコールバック関数を表すクラスです。
+
+Ruby のブロックを C の関数ポインタとして表現するためのクラスです。
+
+  require 'fiddle'
+  include Fiddle
+
+  libc = Fiddle.dlopen("/lib/libc.so.6")
+  qs = Fiddle::Function.new(libc["qsort"],
+                            [TYPE_VOIDP, TYPE_INT, TYPE_INT, TYPE_VOIDP],
+                            TYPE_VOID)
+  compare = Fiddle::Closure::BlockCaller.new(TYPE_INT, [TYPE_VOIDP, TYPE_VOIDP]){|x, y|
+    # qsort の比較関数は 型が int(*)(void*, void*) であるため、
+    # このブロックには DL::CPtr オブジェクトが渡される。
+    # そのポインタが指す先は比較している文字なので、
+    # DL::CPtr#to_s で1文字の文字列に変換している
+    x.to_s(1) <=> y.to_s(1)
+  }
+  s = "7x0cba(Uq)"
+  qs.call(s, s.size, 1, compare)
+  p s # =>  "()07Uabcqx"
+
+== Class Methods
+--- new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
+
+Ruby のブロックを呼び出す Fiddle::Closure オブジェクトを返します。
+
+
+args、ret で関数の引数と返り値の型を指定します。
+指定は [[m:Fiddle::Function.new]] と同様なので、そちら
+を参照してください。
+
+@param ret 返り値の型
+@param args 引数の型を表す配列
+@param abi 呼出規約
+
+== Instance Methods
+--- call(*args) -> object
+
+wrap しているブロックを呼び出します。
+
+そのブロックの返り値がこのメソッドの返り値となります。
+
+@param args 引数

--- a/refm/api/src/fiddle/3.0/Fiddle__Handle
+++ b/refm/api/src/fiddle/3.0/Fiddle__Handle
@@ -1,0 +1,129 @@
+= class Fiddle::Handle < Object
+
+オープンされたダイナミックライブラリを表すクラスです。
+
+[[man:dlopen(3)]] が返すハンドラーのラッパーです。
+
+== Class Methods
+
+--- new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) -> Fiddle::Handle
+--- new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) {|handle| ... }    -> Fiddle::Handle
+
+ライブラリ lib をオープンし、Handle オブジェクトとして返します。
+
+ブロックを指定すれば、生成した Handle を引数としてブロックを実行します。
+Handle はブロックの終りで自動的にクローズされます。
+
+flags で [[man:dlopen(3)]] の第2引数として渡すフラグを指定できます。
+[[m:Fiddle::Handle::RTLD_LAZY]]、[[m:Fiddle::Handle::RTLD_NOW]] 
+のどちらか一方を指定する必要があり、
+またそれに [[m:Fiddle::Handle::RTLD_GLOBAL]] と OR を取ることができます。
+詳しい意味は manpage([[man:dlopen(3)]]) を参照してください。
+
+@param lib ライブラリを文字列で指定します。
+@param flags フラグ
+@raise Fiddle::DLError ライブラリのオープンに失敗した場合に発生します
+
+例:
+
+  require 'fiddle'
+  
+  h = Fiddle::Handle.new('libc.so.6')
+  i = h.sym('strlen')
+  func = Fiddle::Function.new(i, [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+  p func.call("uxyz") # => 4
+
+--- sym(func) -> Integer
+--- [](func) -> Integer
+
+ライブラリのデフォルトの検索順序に従い、現在のライブラリ以降の
+シンボルを探します。
+
+Fiddle::Handle::NEXT.sym(func) と同じです。詳しくは [[man:dlsym(3)]] の
+RTLD_NEXT を見てください。
+
+@raise Fiddle::DLError シンボルが見つからなかった時に発生します。
+
+== Instance Methods
+
+--- close    -> Integer
+
+自身をクローズします。成功した場合は 0 を返します。そうでない場合は、
+0 以外の整数を返します。
+
+@see [[man:dlclose(3)]]
+
+--- enable_close     -> nil
+GC によるオブジェクトの回収時に self をクローズする([[m:Fiddle::Handle#close]])
+ように設定します。
+
+デフォルトでは close しません。
+
+@see [[m:Fiddle::Handle#disable_close]], [[m:Fiddle::Handle#close_enabled?]]
+
+--- disable_close    -> nil
+
+GC によるオブジェクトの回収時に self をクローズしない([[m:Fiddle::Handle#close]])
+ように設定します。
+
+デフォルトでは close しません。
+
+@see [[m:Fiddle::Handle#enable_close]], [[m:Fiddle::Handle#close_enabled?]]
+
+--- close_enabled? -> bool 
+
+GC によるオブジェクトの回収時に self をクローズする([[m:Fiddle::Handle#close]])
+かどうかを真偽値で返します。
+
+
+@see [[m:Fiddle::Handle#enable_close]], [[m:Fiddle::Handle#disable_close]]
+
+--- sym(func) -> Integer
+--- [](func)  -> Integer
+
+関数やグローバル変数 func へのポインタを取得し、整数として返します。
+
+@param func 得たいシンボルの名前を文字列で与えます。
+
+@raise Fiddle::DLError シンボルが見つからなかった時に発生します。
+
+  require 'fiddle'
+  
+  h = Fiddle::Handle.new('libc.so.6')
+  p h.sym('strlen') # 関数ポインタのアドレスを整数で表示
+
+--- to_i    -> Integer
+
+自身が表すハンドル([[man:dlopen(3)]] が返したもの)のアドレスを返します。
+
+== Constants
+--- NEXT -> Fiddle::Handle
+RTLD_NEXT で表わされる擬似ハンドルを表します。
+
+詳しくは [[man:dlsym(3)]] を参照してください。
+
+--- DEFAULT -> Fiddle::Handle
+RTLD_DEFAULT で表わされる擬似ハンドルを表します。
+
+詳しくは [[man:dlsym(3)]] を参照してください。
+
+--- RTLD_GLOBAL -> Integer
+dlopen のフラグ RTLD_GLOBAL を表す定数です。
+
+[[m:DL::Handle.new]] の flags として用います。
+
+詳しくは [[man:dlopen(3)]] を見てください。
+
+--- RTLD_LAZY -> Integer
+dlopen のフラグ RTLD_LAZY を表す定数です。
+
+[[m:DL::Handle.new]] の flags として用います。
+
+詳しくは [[man:dlopen(3)]] を見てください。
+
+--- RTLD_NOW -> Integer
+dlopen のフラグ RTLD_NOW を表す定数です。
+
+[[m:DL::Handle.new]] の flags として用います。
+
+詳しくは [[man:dlopen(3)]] を見てください。

--- a/refm/api/src/fiddle/3.0/Fiddle__Importer
+++ b/refm/api/src/fiddle/3.0/Fiddle__Importer
@@ -1,0 +1,265 @@
+= module Fiddle::Importer
+C の関数をモジュールにインポートするためのモジュールです。
+
+対象となるモジュールに [[m:Object#extend]] することで、
+そのモジュールにインポートできるようになります。
+
+使いかたは [[lib:fiddle]] や [[lib:fiddle/import]] を参照してください。
+
+== Instance Methods
+
+--- [](name) -> Fiddle::Function|nil
+[[m:Fiddle::Importer#extern]] でインポートした関数の 
+[[c:Fiddle::Function]] オブジェクト
+を返します。
+
+name という名前の関数が存在しない場合は nil を返します。
+
+@param name 関数の名前の文字列
+
+--- bind(signature, *opts){ ... } -> Fiddle::Function
+Ruby のブロックを C の関数で wrap し、その関数をモジュールに
+インポートします。
+
+これでインポートされた関数はモジュール関数として定義されます。
+また、[[m:Fiddle::Importer#[] ]] で [[c:Fiddle::Function]] オブジェクトとして
+取り出すことができます。
+
+signature で関数の名前とシネグチャを指定します。例えば
+"int compare(void*, void*)" のように指定します。
+
+opts には :stdcall もしくは :cdecl を渡すことができ、
+呼出規約を明示することができます。
+
+@return インポートした関数を表す [[c:Fiddle::Function]] オブジェクトを返します。
+
+@param signature 関数の名前とシネグチャ
+@param opts オプション
+
+例
+  require 'fiddle/import'
+  
+  module M
+    extend Fiddle::Importer
+    dlload "libc.so.6"
+    typealias "size_t", "unsigned long"
+    extern "int qsort(void*, size_t, size_t, void*)"
+    
+    bind("int compare(void*, void*)"){|px, py|
+      x = px.to_s(Fiddle::SIZEOF_INT).unpack("i!")
+      y = py.to_s(Fiddle::SIZEOF_INT).unpack("i!")
+
+      x <=> y
+    }
+  end
+  
+  data = [32, 180001, -13, -1, 0, 49].pack("i!*")
+  M.qsort(Fiddle::Pointer[data], 6, Fiddle::SIZEOF_INT, M["compare"])
+  p data.unpack("i!*") # => [-13, -1, 0, 32, 49, 180001]
+
+
+--- dlload(*libs) -> ()
+
+C の動的ライブラリをモジュールにインポートします。
+
+これで取り込んだライブラリの関数は [[m:Fiddle::Importer#extern]] で
+インポートできます。
+
+複数のライブラリを指定することができます。
+ファイル名文字列を指定することでそのライブラリをインポートします。
+[[c:Fiddle::Handle]] を渡すとそのハンドルが指しているライブラリをインポート
+します。
+
+このメソッドは同じモジュールで2回呼ばないでください。
+
+#@# Fiddle::Importer#handler の返り値を使えるように見えるがたぶん駄目
+
+@param libs インポートするライブラリ
+@raise Fiddle::DLError ライブラリのインポートができなかった場合に発生します
+
+--- extern(signature, *opts) -> Fiddle::Function
+
+[[m:Fiddle::Importer#dlload]] で取り込んだライブラリから
+C の関数をインポートします。
+
+インポートした関数はそのモジュールにモジュール関数として定義されます。
+
+signature で関数の名前とシネグチャを指定します。例えば
+"int strcmp(char*, char*)" のように指定することができます。
+
+opts には :stdcall もしくは :cdecl を渡すことができ、
+呼出規約を明示することができます。
+
+@return インポートした関数を表す [[c:Fiddle::Function]] オブジェクトを返します。
+
+@param signature 関数の名前とシネグチャ
+@param opts オプション
+
+例
+  require 'fiddle/import'
+  
+  module M
+    extern Fiddle::Importer
+    dlload "libc.so.6"
+    extern "int strcmp(char*, char*)"
+  end
+   
+  M.strcmp("abc", "abc") # => 0
+  M.strcmp("abc", "abd") # => -1
+
+--- sizeof(t) -> Integer
+
+C における sizeof(t) の値を返します。
+
+t が文字列の場合、その文字列が表す C の型の size が返されます。
+例えば、sizeof("char") は 1 を返します。
+sizeof("char*") は環境によって 4 や 8 といった値を返します。
+
+[[m:Fiddle::Importer#struct]] で定義した
+構造体クラスを渡すと、その構造体のサイズを返します。
+[[m:Fiddle::Importer#union]] で定義した共用体クラスも同様です。
+
+t がクラスの場合、t が to_ptr というインスタンスメソッドを持っている
+ならば t.size を返します。
+
+それ以外の場合は Pointer[t].size を返します。
+
+@param t サイズを計算する対象
+@raise Fiddle::DLError t として文字列を渡し、それが表している型を Fiddle が知らなかった
+       場合に発生します
+
+例:
+
+  require 'fiddle/import'
+  
+  module M
+    extend Fiddle::Importer
+    Timeval = struct(["long tv_sec", "long tv_usec"])
+    p sizeof("char") # => 1
+    p sizeof("void*") # => 8
+    p sizeof(Timeval) # => 16
+  end
+
+--- struct(signature) -> Class
+C の構造体型に対応する Ruby のクラスを構築して返します。
+
+構造体の各要素は C と似せた表記ができます。そしてそれを
+配列で signature に渡してデータを定義します。例えば C における
+  struct timeval {
+    long tv_sec;
+    long tv_usec;
+  };
+という構造体型に対応して
+  Timeval = struct(["long tv_sec", "long tv_usec"])
+として構造体に対応するクラスを生成します。
+
+このメソッドが返すクラスには以下のメソッドが定義されています
+  * クラスメソッド malloc
+  * initialize
+  * to_ptr
+  * to_i
+  * 構造体の各メンバへのアクセサ
+返されるクラスは [[c:Fiddle::CStruct]] を継承しています。詳しくは
+そちらを参照してください。
+
+#@# これで定義したクラスについては Fiddle::CStruct を参照せよ
+
+@param signature 構造体の各要素を文字列で表現したものの配列
+
+  require 'fiddle/import'
+  
+  module M
+    extend Fiddle::Importer
+    dlload "libc.so.6"
+    extern "int gettimeofday(void*, void*)"
+    Timeval = struct(["long tv_sec", "long tv_usec"])
+  end
+  
+  time = M::Timeval.malloc
+  M.gettimeofday(time, Fiddle::NULL)
+  p time.tv_sec
+  p time.tv_usec
+
+--- typealias(new, orig) -> ()
+extern や struct で利用する型の別名を定義します。
+
+@param new 別名(文字列)
+@param orig 別名を付けたい型の名前(文字列)
+@see [[m:Fiddle::Importer#extern]], [[m:Fiddle::Importer#sizeof]], 
+     [[m:Fiddle::Importer#struct]], [[m:Fiddle::Importer#union]]
+
+--- union(signature) -> Class
+C の共用体型に対応する Ruby のクラスを構築して返します。
+
+共用体型を Ruby 上で定義する方法は [[m:Fiddle::Importer#struct]] と
+ほぼ同様です。C における
+  typedef union epoll_data
+  {
+    void *ptr;
+    int fd;
+    uint32_t u32;
+    uint64_t u64;
+  } epoll_data_t;
+は、Ruby上では
+  require 'fiddle/import'
+  
+  module M
+    extend Fiddle::Importer
+    dlload "libc.so.6"
+    typealias("uint32_t", "unsigned int")
+    typealias("uint64_t", "unsigned long long")
+  
+    EPollData = union(["void *ptr",
+                       "int fd",
+                       "uint32_t u32",
+                       "uint64_t u64",
+                      ])
+  end
+となります。
+
+返されるクラスは [[c:Fiddle::CUnion]] を継承しています。
+
+1.9.x ではこのメソッドで返されるクラスは正しく動作しません。
+2.0以降では修正されています。
+
+@param signature 共用体の各要素を文字列で表現したものの配列
+
+--- create_value(type, val = nil) -> Fiddle::CStruct
+--- value(type, val = nil) -> Fiddle::CStruct
+型が type で要素名が "value" であるような構造体を
+定義([[m:Fiddle::Importer#struct]])し、
+その構造体のメモリを [[m:Fiddle::CStruct#malloc]] で確保し、
+確保したメモリを保持しているオブジェクトを返します。
+
+type は "int", "void*" といった文字列で型を指定します。
+val に nil 以外を指定すると、確保された構造体に
+その値を代入します。
+
+@param type 型を表す文字列
+@param val 構造体に確保される初期値
+
+例
+  require 'fiddle/import'
+  
+  module M
+    extend Fiddle::Importer
+  end
+  
+  v = M.value("int", 32)
+  p v.value # => 32
+  v.value = 48
+  p v.value # => 48
+
+--- import_symbol(name) -> Fiddle::Pointer
+取り込んだライブラリからシンボルをインポートします。
+
+返り値はシンボルがロードされたメモリのアドレスを持つ [[c:Fiddle::Pointer]] 
+オブジェクトを返します。
+
+@param name シンボル名(文字列)
+
+#@# For internal use from Importer#bind
+#@# --- bind_function(name, ctype, argtype, call_type){ ... } -> Fiddle::Function
+
+#@# --- create_temp_function
+#@# --- create_carried_function

--- a/refm/api/src/fiddle/3.0/Fiddle__Pointer
+++ b/refm/api/src/fiddle/3.0/Fiddle__Pointer
@@ -1,0 +1,324 @@
+= class Fiddle::Pointer < Object
+
+メモリ領域を表すクラスです。C 言語のポインタに相当します。 
+
+#@since 2.2.0
+2.2.0 で削除された dl の DL::CPtr に対応します。
+#@else
+2.2.0 で削除された [[lib:dl]] の [[c:DL::CPtr]] に対応します。
+#@end
+DL::CPtrとほぼ同じインターフェースを持ちます。
+
+== Singleton Methods
+
+--- new(addr, size = 0, free = nil)   -> Fiddle::Pointer
+
+与えられた addr が指すメモリ領域を表す Pointer オブジェクトを生成して返します。
+
+size を指定した場合、アドレス addr に確保されているメモリ領域のサイズは
+size であると仮定されます。GC は free 関数を使用してメモリを解放します。
+
+@param addr 生成する Pointer オブジェクトが指すアドレスを整数で指定します。
+
+@param size 生成する Pointer オブジェクトが指すメモリ領域のサイズを整数で指定します。
+
+@param free GC 時に呼ばれる free 関数を [[c:Fiddle::Function]] オブジェクトか
+       整数で指定します。
+
+--- malloc(size, free = nil)   -> Fiddle::Pointer
+
+与えられた長さ size のメモリ領域を確保し、それを表す Pointer オブジェクトを生成して返します。
+
+@param size 確保したいメモリ領域のサイズを整数で指定します。
+
+@param free GC 時に呼ばれる Pointer オブジェクトの free 関数を 
+       [[c:Fiddle::Function]] オブジェクトか整数で指定します。
+
+--- [](val)       -> Fiddle::Pointer
+--- to_ptr(val)   -> Fiddle::Pointer
+
+与えられた val と関連した Pointer オブジェクトを生成して返します。
+
+val が文字列の場合は文字列が格納されているメモリ領域を指す Pointer 
+オブジェクトを返します。
+
+IO オブジェクトの場合は FILE ポインタを表す Pointer オブジェクトを返します。
+
+val に to_ptr メソッドが定義されている場合は、val.to_ptr を呼び、
+Pointer オブジェクトに変換したものを返します。
+
+val が整数の場合はそれをアドレスとする Pointer オブジェクトを返します。
+
+上以外の場合は、整数に変換(to_int)し
+それをアドレスとする Pointer オブジェクトを返します。
+
+
+@param val Ruby オブジェクトを指定します。
+
+@raise Fiddle::DLError to_ptr の返り値が Pointer オブジェクトでない場合に発生します
+@raise TypeError 上記のいずれの変換も不可能であった場合に発生します
+
+例:
+
+ require 'fiddle'
+ s = "abc"
+ p Fiddle::Pointer[s].to_i                 #=> 136186388
+ p [s].pack('p*').unpack('l!*')[0]  #=> 136186388
+
+== Instance Methods
+
+--- +(n)   -> Fiddle::Pointer
+
+自身のアドレスに n バイトを足した新しい Pointer オブジェクトを返します。
+
+この返り値には、free 関数がセットされず、size は 0 とされます。
+
+@param n アドレスの増分を整数で指定します。
+
+例:
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr = Fiddle::Pointer[s]
+ p cptr[0,1]         #=> "a"
+ cptr += 1
+ p cptr[0,1]         #=> "b"
+
+--- ptr   -> Fiddle::Pointer
+--- +@    -> Fiddle::Pointer
+
+自身の指す値を Pointer にして返します。
+
+自身の指す値はポインタであると仮定します。
+C 言語におけるポインタのポインタに対する間接参照 *p と同じです。 
+
+この返り値には、free 関数がセットされず、size は 0 とされます。
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr = Fiddle::Pointer[s]
+ cref = cptr.ref
+ p cref.to_s(4).unpack('l*')[0]  #=> 136121648
+ p cptr.to_i                     #=> 136121648
+ p cref.ptr.to_s                 #=> "abc"
+
+--- -(n)   -> Fiddle::Pointer
+
+自身のアドレスから n バイトを引いた新しい Pointer オブジェクトを返します。
+
+この返り値には、free 関数がセットされず、size は 0 とされます。
+
+@param n アドレスの差分を整数で指定します。
+
+例:
+ require 'fiddle' 
+ 
+ s = 'abc'
+ cptr = Fiddle::Pointer[s]
+ cptr += 1
+ p cptr[0,1]         #=> "b"
+ cptr -= 1
+ p cptr[0,1]         #=> "a"
+
+--- ref   -> Fiddle::Pointer
+--- -@    -> Fiddle::Pointer
+
+自身を指す Pointer オブジェクトを返します。
+C 言語におけるポインタへのアドレス演算子の適用 &p と同じです。
+
+この返り値には、free 関数がセットされず、size は 0 とされます。
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr = Fiddle::Pointer[s]
+ cref = cptr.ref
+ p cref.to_s(4).unpack('l*')[0]  #=> 136121648
+ p cptr.to_i                     #=> 136121648
+ p cref.ptr.to_s                 #=> "abc"
+
+
+--- <=>(other)    -> Integer
+
+ポインタの指すアドレスの大小を比較します。
+
+other より小さい場合は -1, 等しい場合は 0、other より大きい場合は
+1を返します。
+
+@param other 比較対象の Pointer オブジェクト
+
+--- eql?(other)     -> bool
+--- ==(other)       -> bool
+
+ポインタの指すアドレスが同一ならばtrueを返します。
+
+@param other 比較対象の Pointer オブジェクト
+
+例:
+
+ require 'fiddle' 
+ 
+ s = 'abc'
+ cptr  = Fiddle::Pointer[s]
+ cptr0 = Fiddle::Pointer[s]
+ cptr1 = cptr + 1
+ 
+ p cptr == cptr1     #=> false
+ p cptr == cptr0     #=> true
+
+--- [](offset)            -> Integer
+
+自身の指すアドレスに offset バイトを足したメモリ領域の先頭を整数として返します。
+
+@param offset 値を得たい領域のアドレスまでのオフセット
+@raise Fiddle::DLError self の保持するポインタが NULL である場合に発生します
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr  = Fiddle::Pointer[s]
+ p cptr[0]            #=> 97           
+ p cptr[1]            #=> 98
+
+--- [](offset, len)       -> String
+
+自身の指すアドレスに offset バイトを足したメモリ領域の先頭 len バイトを複製し、
+文字列として返します。
+
+(self + offset).to_s(len) と同等です。
+offset + len が自身のサイズより小さいかを検証しません。
+
+@param offset 値を得たい領域の先頭のアドレスまでのオフセットを整数で与えます。
+
+@param len 値を得たい領域のサイズを指定します。
+@raise Fiddle::DLError self の保持するポインタが NULL である場合に発生します
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr  = Fiddle::Pointer[s]
+ p cptr[0, 1]            #=> "a"
+ p cptr[1, 2]            #=> "bc"
+
+--- []=(offset, n)
+
+自身の指すアドレスに offset バイトを足したメモリ領域を指定された n に書き換えます。
+
+@param n 整数を指定します。
+@raise Fiddle::DLError self の保持するポインタが NULL である場合に発生します
+
+例:
+
+ require 'fiddle'
+
+ s = 'abc'
+ cptr  = Fiddle::Pointer[s]
+ cptr[0] = 65
+ p cptr.to_s         #=> "Bbc"
+
+
+--- []=(offset, len, v) 
+
+自身の指すアドレスに offset バイトを足したメモリ領域の先頭 len バイトに
+文字列 v をコピーします。
+
+str のサイズが len より小さい場合は、残りの領域を 0 で埋めます。
+コピー先の領域が len より大きいか検証しません。
+
+@param offset 書き換えたいメモリ領域のオフセットを整数で与えます。
+
+@param len 書き換えたいメモリ領域のサイズを整数で指定します。
+
+@param v メモリ領域にセットしたいバイト列を文字列で指定します。
+
+@raise Fiddle::DLError self の保持するポインタが NULL である場合に発生します
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ cptr  = Fiddle::Pointer[s]
+ p cptr[1,2] = "AA"
+ p cptr.to_s         #=> "aAA"
+
+
+--- free     -> Fiddle::CFunc
+
+GC がメモリを解放するのに使用する [[c:Fiddle::CFunc]] オブジェクトを返します。
+
+これは普通 [[m:Fiddle::Pointer#free=]] や [[m:Fiddle::Pointer.new]] によって設定されます。
+
+--- free=(cfunc)
+
+GC が自身を解放するのに使う関数を [[c:Fiddle::CFunc]] で指定します。
+
+@param cfunc 自身を解放するのに使われる関数を [[c:Fiddle::CFunc]] か整数で指定します。
+
+--- null?    -> bool
+
+自身が NULL なら true を返します。そうでないなら false を返します。
+
+--- size        -> Integer
+自身の指す領域のサイズを返します。
+
+基本的には [[m:Fiddle::Pointer.new]] で指定したサイズが返されます。
+[[m:Fiddle::Pointer.to_ptr]] で文字列を変換したときは、そのバイト数が返されます。
+[[m:Fiddle::Pointer#size=]] でこの値を変更することができます。
+
+--- size=(s)
+
+自身の指す領域のサイズを変えます。
+
+変更してもメモリの再割り当てはしません。単にオブジェクトが記録している
+size の情報が変更されるだけです。
+
+@param s 自身が指すメモリのサイズを整数で指定します。
+
+--- to_i    -> Integer
+--- to_int  -> Integer
+
+自身が指すアドレスを整数で返します。
+
+--- to_s         -> String
+--- to_s(len)    -> String
+
+自身が指す領域から長さ len の文字列を複製して返します。
+
+len を省略した場合は、文字列の終りは '\0' であると仮定して、
+[[man:strlen(3)]] を使って長さを算出します。
+
+@param len 文字列の長さを整数で指定します。
+
+--- to_str         -> String
+--- to_str(len)    -> String
+
+自身が指す領域から長さ len の文字列を複製して返します。
+
+len を省略した場合は、self.size をその代わりに使います。
+
+@param len 文字列の長さを整数で指定します。
+
+--- to_value    -> object
+
+自身はヒープに確保された Ruby のオブジェクトを指すポインタであると仮定して、
+自身が指すオブジェクトを返します。
+
+例:
+
+ require 'fiddle'
+ 
+ s = 'abc'
+ i = Fiddle.dlwrap(s)
+ cptr = Fiddle::Pointer.new(i)
+ p cptr.to_value   #=> "abc"
+

--- a/refm/api/src/fiddle/3.0/callargs
+++ b/refm/api/src/fiddle/3.0/callargs
@@ -1,0 +1,29 @@
+引数の変換は以下の通りです。
+
+: void* (つまり任意のポインタ型)
+  nil ならば C の NULL に変換されます
+  [[c:Fiddle::Pointer]] は保持している C ポインタに変換されます。
+  文字列であればその先頭ポインタになります。
+  [[c:IO]] オブジェクトであれば FILE* が渡されます。
+  整数であればそれがアドレスとみなされます。
+  to_ptr を持っているならば、それを呼びだし Fiddle::Pointer に
+  変換したものを用います。
+  to_i を持っているならば、それを呼びだし結果の整数を
+  アドレスと見なします
+    
+: (unsigned) char/short/int/long/long long
+  Ruby の整数を C の整数に変換します。
+
+: double/float
+  Ruby の整数 or 浮動小数点数を C の浮動小数点数に変換します
+  
+返り値の変換は以下の通りです。
+
+: void
+  nil を返します
+
+: (unsigned) char/short/int/long/long long
+  C の整数を Ruby の整数に変換します
+
+: void*(つまり任意のポインタ型)
+  C のポインタを保持した [[c:Fiddle::Pointer]] を返します。

--- a/refm/api/src/fiddle/3.0/fiddle.rd
+++ b/refm/api/src/fiddle/3.0/fiddle.rd
@@ -1,0 +1,133 @@
+*.dllや*.soなど、ダイナミックリンクライブラリを扱うためのライブラリです。
+
+#@since 2.2.0
+dl と同等の機能を持ちますが、
+#@else
+[[lib:dl]] と同等の機能を持ちますが、
+#@end
+dl は 2.0 以降deprecated となり、2.2.0 で削除されました。このライブラリ
+を代わりに使います。
+
+=== 使い方
+
+通常は [[lib:fiddle/import]] ライブラリを require して 
+[[c:Fiddle::Importer]] モジュールを使用します。
+#@until 2.2.0
+[[lib:dl]] と基本的な使いかたは良く似ています。
+#@end
+[[c:Fiddle]] モジュール自体はプリミティブな機能しか提供していません。
+[[c:Fiddle::Importer]] モジュールは以下のようにユーザが定義した
+モジュールを拡張する形で使います。
+
+  require "fiddle/import"
+  module M
+    extend Fiddle::Importer
+  end
+
+以後、このモジュールで dlload や extern などのメソッドが使用できるようになります。
+以下のように dlload を使ってライブラリをロードし、
+使用したいライブラリ関数に対して extern メソッドを呼んで
+ラッパーメソッドを定義します。
+
+  require "fiddle/import"
+  module M
+    extend Fiddle::Importer
+    dlload "libc.so.6","libm.so.6"
+    extern "int strlen(char*)"
+  end
+  # Note that we should not include the module M from some reason.
+  
+  p M.strlen('abc') #=> 3
+
+M.strlen を使用することで、ライブラリ関数 strlen() を使用できます。
+
+==== 構造体を扱う
+
+構造体も扱うことができます。たとえば [[man:gettimeofday(2)]]
+を使って現在時刻を得たい場合は以下のとおりです。
+
+ require 'fiddle/import'
+ module M
+   extend Fiddle::Importer
+   dlload "libc.so.6"
+   extern('int gettimeofday(void *, void *)')
+   Timeval = struct( ["long tv_sec",
+                      "long tv_usec"])
+ end
+ 
+ timeval = M::Timeval.malloc
+ e = M.gettimeofday(timeval, nil)
+
+ if e == 0
+  p timeval.tv_sec #=> 1173519547
+ end
+
+上の例で、メモリの割り当てに M::Timeval.new ではなく
+M::Timeval.malloc を使用していることに注意してください。
+
+==== コールバック
+
+以下のようにモジュール関数 bind を使用したコールバックを定義できます。
+
+  require 'fiddle/import'
+  module M 
+    extend Fiddle::Importer
+    dlload "libc.so.6"
+    QsortCallback = bind("void *qsort_callback2(void*,void*)"){|ptr1,ptr2| 
+      ptr1[0] <=> ptr2[0]
+    }
+    type
+    extern 'void qsort(void *, int, int, void *)'
+  end
+
+  buff = "3465721"
+  M.qsort(buff, buff.size, 1, M::QsortCallback)
+  p buff #=>   "1234567"
+
+ここで M::QsortCallback はブロックを呼ぶ [[c:Fiddle::Function]] オブジェクトです。
+
+
+==== ポインタを扱う
+
+fiddle においては、文字列/整数/[[c:Fiddle::Pointer]]をポインタとして
+扱うことができます。
+文字列をポインタ引数として渡すと文字列のメモリ領域を指す
+ポインタとして扱われます。
+
+ require 'fiddle/import' 
+ 
+ module M
+   extend Fiddle::Importer
+   dlload 'libc.so.6'
+   extern 'void * memmove(void *, void *, unsigned long)'
+ end
+ 
+ s = 'xxxyyyzzz'
+ M.memmove(s, 'abc', 3)
+ p s                    #=> "abcyyyzzz"
+
+char * 以外の型のポインタを受け取る関数に対しても文字列を渡します。
+
+ require "fiddle/import"
+ module M
+   extend Fiddle::Importer
+   dlload 'libm.so.6'
+   extern 'double modf(double, double *)'
+ end 
+ 
+ s = ' ' * 8
+ p M2.modf(1.25, s)  #=> 0.25
+ p s.unpack('d')[0]  #=> 1.0
+
+==== 関数の引数と返り値
+fiddle でインポートした C の関数を呼び出すとき、
+その引数と返り値はインポートする際に指定した型と
+Ruby のオブジェクトの種類によって変換されます。
+
+#@include(callargs)
+
+#@include(Fiddle)
+#@include(Fiddle__Pointer)
+#@include(Fiddle__Handle)
+#@include(Fiddle__Function)
+

--- a/refm/api/src/fiddle/3.0/import.rd
+++ b/refm/api/src/fiddle/3.0/import.rd
@@ -1,0 +1,80 @@
+require fiddle
+
+fiddle ライブラリのための高レベルインターフェースを提供するライブラリです。
+
+通常は fiddle ライブラリを使わずこの fiddle/import ライブラリを使います。
+
+主な使い方は [[lib:fiddle]] も参照してください。
+
+=== 高度な使用法
+
+==== ○○の配列を関数に渡したい
+
+例えば与えられた長さ len の double の配列の和を計算する関数
+  double sum(double *arry, int len);
+があったとします。これを呼び出したい場合は以下のように [[m:Array#pack]] を使用します。
+
+ require 'fiddle/import'
+ module M
+   extend Fiddle::Importer
+   dlload './libsum.so'
+   extern 'double sum(double*, int)'
+ end
+ p M.sum([2.0, 3.0, 4.0].pack('d*'), 3)   #=> 9.0
+
+また与えられた文字列の配列 s (長さlen)の各要素の最初の文字を buf にコピーする関数
+  void first_char(char **s, char *buf, int len)
+があったとします。これを呼び出すにも以下のように [[m:Array#pack]] を使用します。
+
+ require 'fiddle/import'
+ module M
+   extend Fiddle::Importer
+   dlload './libstrfirst.so'
+   extern 'void first_char(char **, char *, int)'
+ end
+ buf = '111'
+ M.first_char(['Abc', 'Def', 'Ghi'].pack('p*'), buf, 3) 
+ p buf  #=> 'ADG'
+
+==== Ruby のオブジェクトをコールバックに渡したい
+
+任意のクラスの Ruby オブジェクトをコールバックへ渡したい場合は [[m:Fiddle.#dlwrap]] を使って
+ポインタ(整数)へ変換してから関数に渡し、コールバックの方で元に戻します。
+
+例えば libc の qsort を使って Ruby の Time の配列をソートするには以下のようにします。
+
+  require 'fiddle/import'
+  module M 
+    extend Fiddle::Importer
+    dlload "libc.so.6"
+    QsortCallback = bind("void *qsort_callback(void*, void*)"){|a, b|
+      a0 = Fiddle.dlunwrap(a.ptr.to_i)
+      b0 = Fiddle.dlunwrap(b.ptr.to_i)
+      a0 <=> b0
+    }
+    extern 'void qsort(void *, int, int, void *)'
+  end
+
+  buff =  [Time.at(1), Time.now, Time.at(100), Time.at(10)]
+  a = buff.map{|t| Fiddle.dlwrap(t)}.pack('l!*')
+  M.qsort(a, buff.size, Fiddle::SIZEOF_VOIDP, M::QsortCallback)
+  p a.unpack('l!*').map{|t| Fiddle.dlunwrap(t).to_i }             #=> [1, 10, 100, 1241603848]
+
+==== 複雑な構造体を定義したい
+
+構造体をメンバとして持つ構造体を [[m:Fiddle::Importer#struct]] を使って定義することは残念ながらできません。
+自力でメンバを展開してから [[m:Fiddle::Importer#struct]] を使ってください。
+
+#@include(Fiddle__CStruct)
+#@include(Fiddle__Importer)
+
+
+
+
+
+
+
+
+
+
+

--- a/refm/api/src/fiddle/3.0/types.rd
+++ b/refm/api/src/fiddle/3.0/types.rd
@@ -1,0 +1,58 @@
+
+C の型の別名を定義するライブラリです。
+
+[[c:Fiddle::Win32Types]] や [[c:Fiddle::BasicTypes]] を [[m:Module#include]] する
+ことで、[[m:Fiddle::Importer#extern]] や [[m:Fiddle::Importer#struct]] で
+利用できる型が増えます。内部で [[m:Fiddle::Importer#typealias]] を
+呼び出しています。
+
+実装の問題があるため、 [[m:Fiddle::Importer#dlload]] を呼びだしてから
+include してください。
+
+例
+  require 'fiddle/import'
+  require 'fiddle/types'
+  
+  module M
+    extend Fiddle::Importer
+    dlload "libc.so.6" # include の前に dlload を呼ぶ
+    include Fiddle::BasicTypes
+  end
+  
+  # uint は Fiddle::BasicTypes によって定義された型で、unsigned int の別名
+  p(M.sizeof("uint") == M.sizeof("unsigned int"))
+  
+= module Fiddle::Win32Types
+Windows 用の型の別名を定義するモジュールです。
+
+include すると 以下の型が定義されます。
+  * "DWORD"
+  * "PDWORD"
+  * "DWORD32"
+  * "DWORD64"
+  * "WORD"
+  * "PWORD"
+  * "BOOL"
+  * "ATOM"
+  * "BYTE"
+  * "PBYTE"
+  * "UINT"
+  * "ULONG"
+  * "UCHAR"
+  * "HANDLE"
+  * "PHANDLE"
+  * "PVOID"
+  * "LPCSTR"
+  * "LPSTR"
+  * "HINSTANCE"
+  * "HDC"
+  * "HWND"
+
+= module Fiddle::BasicTypes
+よく使われる型の別名を定義するモジュールです。
+
+include すると 以下の型が定義されます。
+  * "uint" 
+  * "u_int"
+  * "ulong" 
+  * "u_long" 

--- a/refm/api/src/fiddle/import.rd
+++ b/refm/api/src/fiddle/import.rd
@@ -1,1 +1,1 @@
-#@include(2.0/import.rd)
+#@include(3.0/import.rd)

--- a/refm/api/src/fiddle/types.rd
+++ b/refm/api/src/fiddle/types.rd
@@ -1,1 +1,1 @@
-#@include(2.0/types.rd)
+#@include(3.0/types.rd)


### PR DESCRIPTION
Fiddleのドキュメントが古くなっており、現在のFiddleとは異なる部分が多いように感じます。

たとえば、[library fiddle/import](https://docs.ruby-lang.org/ja/latest/library/fiddle=2fimport.html)のページを見ると、

> ![image](https://github.com/rurema/doctree/assets/5798442/08b9072c-70c7-4703-8bb9-bf50ef6349ce)

という記述がありますが、現在ではネストされた構造体はサポートされています。参照: [FiddleのREADME](https://github.com/ruby/fiddle#nested-structs)

ドキュメントを改善する必要性を感じました。

しかし、現在のドキュメントは、kouさんがメンテナンスを引き継ぐ前の古いFiddle（特にRuby 2.6ぐらいまでのバージョン）に関する情報としては適切なものであり、直接編集することは躊躇されました。そのため、新しく3.0のディレクトリを作成することが適切だと考えました。

したがって、新たに3.0というディレクトリを作成しました。これは、単純に2.0のディレクトリをコピーしただけのものです。
よろしくおねがいします。