### PR TITLE
IO#linesメソッド、IO#bytesメソッドの除去（Class IO）

### DIFF
--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -198,8 +198,6 @@ IO#readline                   EOFError
 IO#readlines                  []
 IO#readpartial                EOFError
 IO#sysread                    EOFError
-IO#bytes                      通常どおり
-IO#lines                      通常どおり
 //}
 
 == Class Methods


### PR DESCRIPTION
「IO#linesメソッド」、「IO#bytesメソッド」について、Rubyのメソッドから削除されているように見えるので、class IOのドキュメントから削除すると良いのではと思い、PRを作成しました。

PRの出し方が間違っていたら教えてください。
よろしくお願いします。

### 参考
- 「IO#linesメソッド」、「IO#bytesメソッド」の操作結果
```
$ ruby -v
ruby 3.2.2

$ irb
irb(main):001:0> f = File.open('t.txt', 'w+:shift_jis:euc-jp')
=> #<File:t.txt>
irb(main):002:0> f.lines
(irb):2:in `<main>': undefined method `lines' for #<File:t.txt> (NoMethodError)
Did you mean?  lineno
irb(main):003:0> f.bytes
(irb):3:in `<main>': undefined method `bytes' for #<File:t.txt> (NoMethodError)
```