### PR TITLE
CSV.table()に関する不要な説明の削除

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -857,7 +857,6 @@ p table[0]    # => #<CSV::Row "id":"1" "first name":"taro" "last name":"tanaka" 
 --- table(path, options = Hash.new) -> CSV::Table | [Array]
 
 以下と同等のことを行うメソッドです。
-日本語の CSV ファイルを扱う場合はあまり使いません。
 
 #@samplecode
 CSV.read( path, { headers:           true,


### PR DESCRIPTION
日本語のCSVファイルでも利用可能なのと、使えない印象を与える可能性があるのでこの文言は削除でよいかと思いました。