### PR TITLE
JSONの参照するRFCをRFC 7159に更新

### DIFF
--- a/refm/api/src/json.rd
+++ b/refm/api/src/json.rd
@@ -2,10 +2,10 @@ category FileFormat
 
 JSON (JavaScript Object Notation)を扱うライブラリです。
 
-JSON の仕様は [[rfc:4627]] を参照してください。
-
 このライブラリでは、[[c:JSON]] モジュールに JSON を操作するための代表的なメソッドが集められています。
 詳細は [[c:JSON]] モジュールを参照してください。
+
+JSON の仕様は [[rfc:7159]] を参照してください。
 
 #@samplecode 例
 require "json"


### PR DESCRIPTION
https://github.com/flori/json の記述に従い、参照する RFC を RFC 7159 に更新しました。
JSON の仕様自体は RFC 8259 が最新ですが、ライブラリの記述に従っています。