### PR TITLE
open_timeoutのデフォルト秒数の表記を修正

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -691,7 +691,7 @@ proxyport は時代遅れのメソッドです。
 この秒数たってもコネクションが
 開かなければ例外 [[c:Net::OpenTimeout]] を発生します。
 
-デフォルトは60(秒)です。
+デフォルトは 60 (秒)です。
 
 @see [[m:Net::HTTP#read_timeout]], [[m:Net::HTTP#open_timeout=]]
 


### PR DESCRIPTION
`デフォルトは60(秒)です。` の記述ですが、同ファイルの他の箇所は数値の前後にスペースが入っていたため、そちらに合わせてスペースを入れました。

- https://github.com/rurema/doctree/blob/2006c28684bf63e1bbcf03450a5e102fc5fd31b4/refm/api/src/net/http.rd#L723
- https://github.com/rurema/doctree/blob/2006c28684bf63e1bbcf03450a5e102fc5fd31b4/refm/api/src/net/http.rd#L754
- https://github.com/rurema/doctree/blob/2006c28684bf63e1bbcf03450a5e102fc5fd31b4/refm/api/src/net/http.rd#L770
