### PR TITLE
fix: Encoding.compatible? broken link

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -867,7 +867,7 @@ nil は文字列のエンコーディングが非互換の時に返されます�
 "\u{e4 f6 fc}".encode("ISO-8859-1").casecmp("\u{c4 d6 dc}")   #=> nil
 #@end
 
-@see [[m:String#<=>]], [[m:Encoding#compatible?]]
+@see [[m:String#<=>]], [[m:Encoding.compatible?]]
 
 #@since 2.4.0
 --- casecmp?(other) -> bool | nil


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/String/i/casecmp.html
における
https://docs.ruby-lang.org/ja/latest/method/Encoding/s/compatible=3f.html
へのリンクができていなかったのを修正しました

関連 issue: https://github.com/rurema/doctree/issues/622