### PR TITLE
StringIO#getbyte の例で getc の関数が使用されていた

### DIFF
--- a/refm/api/src/stringio.rd
+++ b/refm/api/src/stringio.rd
@@ -257,9 +257,9 @@ a.getc                   # => nil
 #@samplecode 例
 require "stringio"
 a = StringIO.new("ho")
-a.getc                   #=> 104
-a.getc                   #=> 111
-a.getc                   #=> nil
+a.getbyte                #=> 104
+a.getbyte                #=> 111
+a.getbyte                #=> nil
 #@end
 
 --- gets(rs = $/)    -> String | nil


### PR DESCRIPTION
StringIO#getbyte の例で getc の関数が使用されておりました。
例の中のコメントに書いてある結果から考えても`getbyte`を呼び出すことを意図しているように見えたので、変更してみました。

***

元々書いてあった例
```
require "stringio"
a = StringIO.new("ho")
a.getc                   #=> 104
a.getc                   #=> 111
a.getc                   #=> nil
```

getbyteに書き換えて実行した結果
```
irb(main):001:0> require "stringio"
=> true
irb(main):002:0> a = StringIO.new("ho")
=> #<StringIO:0x0000000104041f50>
irb(main):003:0> a.getbyte
=> 104
irb(main):004:0> a.getbyte
=> 111
irb(main):005:0> a.getbyte
=> nil
```