### PR TITLE
rbconfig/sizeof を追加

### DIFF
--- a/refm/api/src/LIBRARIES
+++ b/refm/api/src/LIBRARIES
@@ -181,6 +181,7 @@ rake/tasklib
 rake/testtask
 rake/loaders/makefile
 rbconfig
+rbconfig/sizeof
 rdoc
 rdoc/code_objects
 rdoc/alias

--- a/refm/api/src/rbconfig/sizeof.rd
+++ b/refm/api/src/rbconfig/sizeof.rd
@@ -1,0 +1,29 @@
+category Development
+
+Ruby インタプリタが作成された環境における、データ型のサイズなどに関する情報を格納したライブラリです。
+
+= reopen RbConfig
+
+== Constants
+
+--- SIZEOF -> Hash
+
+Ruby インタプリタが作成された環境における、C の型のサイズ情報を保持します。
+
+下の例では、実行している Ruby インタプリタは int が 4 バイトである環境で作成されたことを表しています。
+
+#@samplecode
+require 'rbconfig/sizeof'
+RbConfig::SIZEOF['int'] # => 4
+#@end
+
+--- LIMITS -> Hash
+
+Ruby インタプリタが作成された環境における、さまざまな型の値の範囲に関する情報を保持します。
+
+下の例では、実行している Ruby インタプリタは INT_MAX が 2147483647 である環境で作成されたことを表しています。
+
+#@samplecode
+require 'rbconfig/sizeof'
+RbConfig::SIZEOF['INT_MAX'] # => 2147483647
+#@end

--- a/refm/api/src/rbconfig/sizeof.rd
+++ b/refm/api/src/rbconfig/sizeof.rd
@@ -25,5 +25,5 @@ Ruby インタプリタが作成された環境における、さまざまな型
 
 #@samplecode
 require 'rbconfig/sizeof'
-RbConfig::SIZEOF['INT_MAX'] # => 2147483647
+RbConfig::LIMITS['INT_MAX'] # => 2147483647
 #@end


### PR DESCRIPTION
rbconfig/sizeof を追加します。

rbconfig/sizeof は 2.1.0 から、
RbConfig::LIMITS は 2.5.0 から利用可能です。