### PR TITLE
Ruby 3.2で、TracePoint#bindingはCで書かれたメソッドではnilを返すことへの対応

### DIFF
--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -434,6 +434,11 @@ end
 
 発生したイベントによって生成された [[c:Binding]] オブジェクトを返します。
 
+#@since 3.2
+C で記述されたメソッドは binding を生成しないため、
+:c_call および :c_return イベントに対しては nil を返すことに注意してください。
+#@end
+
 #@samplecode 例
 def foo(ret)
   ret
@@ -450,6 +455,10 @@ foo 1
 イベントを発生させたオブジェクトを返します。
 
 以下のようにする事で同じ値を取得できます。
+
+#@since 3.2
+なお、self メソッドは binding が nil になる :c_call および :c_return イベントに対しても正しく動作します。
+#@end
 
 #@samplecode 例
 trace.binding.eval('self')


### PR DESCRIPTION
`TracePoint#binding` は、Ruby 3.2では C で書かれたメソッドに対しては `nil` を返すため、注釈を追加しました。

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=ruby-2.7 ./all-ruby -e 'TracePoint.new(:c_call) { |tp| p tp.binding.class }.enable; sprintf("%d", 10)'
ruby-2.7.0          Binding
...
ruby-3.2.0-rc1      Binding
ruby-3.2.0          NilClass
...
ruby-3.3.0-preview2 NilClass
```

参考：https://docs.ruby-lang.org/en/master/TracePoint.html#method-i-binding