### PR TITLE
TracePoint#bindingの戻り値の型をRuby 3.2以降で変更

### DIFF
--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -430,12 +430,10 @@ end
 
 @see [[ruby-core:50864]]
 
-#@until 3.2
---- binding -> Binding
-#@end
-
 #@since 3.2
 --- binding -> Binding | nil
+#@else
+--- binding -> Binding
 #@end
 
 発生したイベントによって生成された [[c:Binding]] オブジェクトを返します。

--- a/refm/api/src/_builtin/TracePoint
+++ b/refm/api/src/_builtin/TracePoint
@@ -430,7 +430,13 @@ end
 
 @see [[ruby-core:50864]]
 
+#@until 3.2
 --- binding -> Binding
+#@end
+
+#@since 3.2
+--- binding -> Binding | nil
+#@end
 
 発生したイベントによって生成された [[c:Binding]] オブジェクトを返します。
 


### PR DESCRIPTION
#2838 の続きです。