### PR TITLE
削除された `Object#=~` メソッドへのリンクを削除

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -788,8 +788,6 @@ obj = nil
 p (obj !~ /re/) # => true
 #@end
 
-@see [[m:Object#=~]]
-
 --- display(out = $stdout) -> nil
 
 オブジェクトを out に出力します。


### PR DESCRIPTION
`Object#=~ ` というメソッドはもう存在していないので、
https://docs.ruby-lang.org/ja/latest/class/Object.html ページにおいて上記メソッドに対するリンクを削除しました。