### PR TITLE
削除された `IO#chars` メソッドへのリンクを削除

### DIFF
--- a/refm/api/src/_builtin/ARGF
+++ b/refm/api/src/_builtin/ARGF
@@ -342,7 +342,7 @@ ARGF の現在位置から 1 バイトずつ読み込み、それを整数とし
   #    "2"
   #    "\n"
 
-@see [[m:IO#each_char]], [[m:IO#chars]]
+@see [[m:IO#each_char]]
 
 #@until 3.0
 --- chars { |c| ... } -> self


### PR DESCRIPTION
`IO#chars`  というメソッドはもう存在していないので、
https://docs.ruby-lang.org/ja/latest/class/ARGF=2eclass.html ページにおいて上記メソッドに対するリンクを削除しました。