### PR TITLE
open-uri: OpenURI::Meta#content_type は文字列を返す

### DIFF
--- a/refm/api/src/open-uri.rd
+++ b/refm/api/src/open-uri.rd
@@ -383,7 +383,7 @@ open('http://www.rubyist.net/') {|f|
 
 --- content_type    -> String
 
-対象となるリソースの Content-Type を文字列の配列で返します。Content-Type ヘッダの情報が使われます。
+対象となるリソースの Content-Type を文字列で返します。Content-Type ヘッダの情報が使われます。
 Content-Type ヘッダがない場合は、"application/octet-stream" を返します。
 
 #@samplecode 例


### PR DESCRIPTION
見出しには `-> String` と書かれており、例示されているサンプルや、実際の実装も文字列を返しているが、説明は「文字列の配列」となっているため修正します。