### PR TITLE
Fix dead links in net-http and net-https

### DIFF
--- a/refm/api/src/net/http.rd
+++ b/refm/api/src/net/http.rd
@@ -1491,7 +1491,7 @@ SSL/TLS が有効でなかったり、接続前である場合には nil
 [[m:OpenSSL::SSL::SSLContext.new]] で指定できるものと同じです。
 
 @param ver 利用するプロトコルの種類(文字列 or シンボル)
-@see [[m:Net::HTTP#ssl_version]], [[m:OpenSSL::SSL::SSL#ssl_version=]]
+@see [[m:Net::HTTP#ssl_version]], [[m:OpenSSL::SSL::SSLContext#ssl_version=]]
 
 
 --- ciphers -> String | [String] | nil

--- a/refm/api/src/net/https.rd
+++ b/refm/api/src/net/https.rd
@@ -243,7 +243,7 @@ SSL/TLS が有効でなかったり、接続前である場合には nil
 [[m:OpenSSL::SSL::SSLContext.new]] で指定できるものと同じです。
 
 @param ver 利用するプロトコルの種類
-@see [[m:Net::HTTP#ssl_version]], [[m:OpenSSL::SSL::SSL#ssl_version=]]
+@see [[m:Net::HTTP#ssl_version]], [[m:OpenSSL::SSL::SSLContext#ssl_version=]]
 
 
 --- ciphers -> String | [String] | nil


### PR DESCRIPTION
[Net::HTTP#ssl_version= (Ruby 3.2 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/latest/method/Net=3a=3aHTTP/i/ssl_version=3d.html)
> [SEE_ALSO] [Net::HTTP#ssl_version](https://docs.ruby-lang.org/ja/latest/method/Net=3a=3aHTTP/i/ssl_version.html), [OpenSSL::SSL::SSL#ssl_version=](https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aSSL=3a=3aSSL/i/ssl_version=3d.html)

の [OpenSSL::SSL::SSL#ssl_version=](https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aSSL=3a=3aSSL/i/ssl_version=3d.html) 部分がリンク切れとなっています。

正しくは [OpenSSL::SSL::SSLContext#ssl_version=](https://docs.ruby-lang.org/ja/latest/method/OpenSSL=3a=3aSSL=3a=3aSSLContext/i/ssl_version=3d.html) だと思いますので、そのように修正しました。

ちなみに、 #622 でもリンク切れとして報告されていました。
> .../2.4.0/method/OpenSSL=SSL=SSL/i/ssl_version=3d


また、 net-https でも同様の記述を見つけました。
net-https は [library net/https (Ruby 3.2 リファレンスマニュアル)](https://docs.ruby-lang.org/ja/latest/library/net=2fhttps.html) によると使われていないようですが、合わせて修正しておきました。
> このライブラリは Ruby 1.9.2 で [net/http](https://docs.ruby-lang.org/ja/latest/library/net=2fhttp.html) にマージされました。そちらを使ってください。
