### PR TITLE
Gem::GemPathSearcherクラスの[SEE_ALSO]リンクを修正

### DIFF
--- a/refm/api/src/rubygems/gem_path_searcher.rd
+++ b/refm/api/src/rubygems/gem_path_searcher.rd
@@ -12,13 +12,13 @@ Gem パッケージに含まれているファイルのうちロード可能な�
 
 与えられたパスにマッチする [[c:Gem::Specification]] を一つだけ返します。
 
-@see [[m:Array#find]]
+@see [[m:Enumerable#detect]]
 
 --- find_all(path) -> [Gem::Specification]
 
 与えられたパスにマッチする [[c:Gem::Specification]] を全て返します。
 
-@see [[m:Array#find_all]]
+@see [[m:Enumerable#filter]]
 
 --- init_gemspecs -> [Gem::Specification]
 

--- a/refm/api/src/rubygems/gem_path_searcher.rd
+++ b/refm/api/src/rubygems/gem_path_searcher.rd
@@ -12,13 +12,13 @@ Gem パッケージに含まれているファイルのうちロード可能な�
 
 与えられたパスにマッチする [[c:Gem::Specification]] を一つだけ返します。
 
-@see [[m:Enumerable#detect]]
+@see [[m:Enumerable#find]]
 
 --- find_all(path) -> [Gem::Specification]
 
 与えられたパスにマッチする [[c:Gem::Specification]] を全て返します。
 
-@see [[m:Enumerable#filter]]
+@see [[m:Enumerable#find_all]]
 
 --- init_gemspecs -> [Gem::Specification]
 
@@ -57,5 +57,3 @@ Gem パッケージに含まれているファイルのうちロード可能な�
 --- new -> Gem::GemPathSearcher
 
 検索を行うのに必要なデータを初期化します。
-
-


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/class/Gem=3a=3aGemPathSearcher.html#I_FIND
https://docs.ruby-lang.org/ja/latest/class/Gem=3a=3aGemPathSearcher.html#I_FIND_ALL

[SEE_ALSO]のリンクが切れていたため修正しました。
fix https://github.com/rurema/doctree/issues/2852
