### PR TITLE
open-uriでno_proxy環境変数も使用できるので追加

### DIFF
--- a/refm/api/src/open-uri.rd
+++ b/refm/api/src/open-uri.rd
@@ -69,7 +69,7 @@ http/ftp の URL を、普通のファイルのように開けます。
   }
 #@end
 
-http_proxy や ftp_proxy などの環境変数は、デフォルトで有効になっています。
+http_proxy, ftp_proxy, no_proxy などの環境変数は、デフォルトで有効になっています。
 プロキシを無効にするには :proxy => nil とします。
 
 #@since 2.7.0
@@ -212,7 +212,7 @@ options には [[c:Hash]] を与えます。理解するハッシュの
    文字列:           "http://proxy.example.com:8000/" のようなプロクシの URI。
    URI オブジェクト: URI.parse("http://proxy.example.com:8000/") のようなプロクシの URI オブジェクト。
    true:             Proxy を環境変数などから見つけようとする。使う環境変数は schema に応じて
-                     http_proxy, https_proxy, ftp_proxy が使われる。
+                     http_proxy, https_proxy, ftp_proxy, no_proxy が使われる。
    false:            Proxy を用いない。
    nil:              Proxy を用いない。
 //}


### PR DESCRIPTION
## 概要

https://github.com/rurema/doctree/issues/484 のissueに関するPRです。

`open-uri` で `no_proxy` 環境変数をデフォルトで使用できるので、プロキシを使用する場合の環境変数の説明に追加しました。

Ruby 2.7.0のURIの `find_proxy` でも `no_proxy` 環境変数が使用できます。
`open-uri` は内部で上記を呼び出していますので、現在のRubyリファレンスマニュアルのサポート対象がRuby 2.7～3.2のようですのでドキュメントの説明にそのまま追加しました。

https://github.com/ruby/ruby/blob/v2_7_0/lib/uri/generic.rb#L1475-L1489