### PR TITLE
`Range#reverse_each`の記述を追加

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -1112,11 +1112,11 @@ e.take_while {|i| i < 3 }   # => [1, 2]
 [[c:Enumerator]] を返します。
 
 #@samplecode 例
-(1..3).reverse_each # => #<Enumerator: 1..3:reverse_each>
-(1..3).reverse_each { |v| p v }
-# => 3
-#    2
-#    1
+{a: 1, b: 2, c: 3}.reverse_each # => #<Enumerator: ...>
+{a: 1, b: 2, c: 3}.reverse_each { |v| p v }
+# => [:c, 3]
+#    [:b, 2]
+#    [:a, 1]
 #@end
 
 --- each_with_object(obj) -> Enumerator

--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -387,6 +387,30 @@ Range#each は各要素の succ メソッドを使用してイテレーション
 # raises: TypeError: can't iterate from Float
 #@end
 
+#@since 3.3
+--- reverse_each -> Enumerator
+--- reverse_each {|element| ... } -> self
+
+逆順に各要素に対してブロックを評価します。
+
+内部で各要素を保持した配列を作ります。ただし、端点が [[c:Integer]] である場合は、配列を作らないように最適化が行われています。
+
+ブロックを省略した場合は、各要素を逆順に辿る
+[[c:Enumerator]] を返します。
+
+@raise TypeError 終端を持たない範囲オブジェクトに対してこのメソッドを呼んだ場合に発生します。
+
+#@samplecode 例
+(1..3).reverse_each # => #<Enumerator: ...>
+(1..3).reverse_each { |v| p v }
+# => 3
+#    2
+#    1
+(1..).reverse_each { |v| p v } # raises: TypeError: can't iterate from NilClass
+#@end
+
+#@end
+
 --- end -> object
 --- last -> object
 


### PR DESCRIPTION
Ruby 3.3から`Range#reverse_each`の実装が追加されたため、記述を追加。
`Enumrable#reverse_each`のサンプルコードは`Range`から`Hash`に変更。