### PR TITLE
String#dumpのサンプルコードの実行結果がruby-1.9.0-0よりも前の内容だったため修正

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -1334,7 +1334,7 @@ str == eval(str.dump) となることが保証されています。
 
 #@samplecode 例
 # p だとさらにバックスラッシュが増えて見にくいので puts している
-puts "abc\r\n\f\x00\b10\\\"".dump   # => "abc\r\n\f\000\01010\\\""
+puts "abc\r\n\f\x00\b10\\\"".dump   # => "abc\r\n\f\x00\b10\\\""
 #@end
 
 #@since 2.5.0


### PR DESCRIPTION
String#dumpのサンプルコードの実行例がruby-1.9.0-0よりも前の古い結果となっていたため修正しました。

```
$ docker run -it --rm rubylang/all-ruby ./all-ruby -e 'puts "abc\r\n\f\x00\b10\\\"".dump'

...
ruby-1.1c6            "abc\r\n\f\000\01010\\\"
ruby-1.1c7            "abc\r\n\f\016\01010\\\"
ruby-1.1c8            "abc\r\n\f\000\01010\\\"
ruby-1.1c9            "abc\r\n\f\000\01010\\\"
ruby-1.1d0            "abc\r\n\f\000\01010\\\""
ruby-1.1d1            "abc\r\n\f\000\01010\\\""
ruby-1.2              "abc\r\n\f\000\01010\\\"
...
ruby-1.2.3            "abc\r\n\f\000\01010\\\"
ruby-1.2.4            "abc\r\n\f\000\01010\\\""
...
ruby-1.8.5-preview1   "abc\r\n\f\000\01010\\\""
ruby-1.8.5-preview2   "abc\r\n\f\000\b10\\\""
...
ruby-1.8.7-p374       "abc\r\n\f\000\b10\\\""
ruby-1.9.0-0          "abc\r\n\f\x00\b10\\\""
...
ruby-3.3.0            "abc\r\n\f\x00\b10\\\""
```