### PR TITLE
Hash#shiftのハッシュが空かつデフォルト値が設定されている場合の説明とサンプルコードの実行結果が古かったのを修正

### DIFF
--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -577,8 +577,11 @@ p h1.compare_by_identity? #=> true
 
 shiftは破壊的メソッドです。selfは要素を取り除かれた残りのハッシュに変更されます。
 
+#@until 3.2
 Ruby 3.2以前は、ハッシュが空の場合、デフォルト値（[[m:Hash#default]]または[[m:Hash#default_proc]]のブロックの値か、どちらもnilならばnil）
 を返します(このとき、[key,value] という形式の値を返すわけではないことに注意)。
+
+3.2以降ではデフォルト値に関わらず nil を返すよう変更されています。
 
 #@samplecode 例
 h = {:ab => "some" , :cd => "all"}
@@ -596,7 +599,9 @@ p h2                    #=> {}
 p h2.shift              #=> [{}, nil]
 #@end
 
-Ruby 3.2以降はハッシュが空の場合、デフォルト値に関わらず nil を返します。
+#@else
+
+ハッシュが空の場合、デフォルト値に関わらず nil を返します。
 
 #@samplecode 例
 h = {:ab => "some" , :cd => "all"}
@@ -612,6 +617,8 @@ p h1.shift              #=> nil
 h2 = Hash.new {|*arg| arg}
 p h2                    #=> {}
 p h2.shift              #=> nil
+#@end
+
 #@end
 
 @see [[m:Array#shift]]

--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -577,11 +577,7 @@ p h1.compare_by_identity? #=> true
 
 shiftは破壊的メソッドです。selfは要素を取り除かれた残りのハッシュに変更されます。
 
-ハッシュが空の場合、デフォルト値（[[m:Hash#default]]または[[m:Hash#default_proc]]のブロックの値か、どちらもnilならばnil）
-を返します(このとき、[key,value] という形式の値を返すわけではないことに注意)。
-
-将来のバージョン(Ruby 3.2を予定)ではデフォルト値に関わらず nil になる予定なので、デフォルト値を設定しているハッシュで
-shift を使う場合は注意してください。([[bug:16908]])
+ハッシュが空の場合、デフォルト値に関わらず nil を返します。
 
 #@samplecode 例
 h = {:ab => "some" , :cd => "all"}
@@ -592,11 +588,11 @@ p h.shift               #=> nil
 
 h1 = Hash.new("default value")
 p h1                    #=> {}
-p h1.shift              #=> "default value"
+p h1.shift              #=> nil
 
 h2 = Hash.new {|*arg| arg}
 p h2                    #=> {}
-p h2.shift              #=> [{}, nil]
+p h2.shift              #=> nil
 #@end
 
 @see [[m:Array#shift]]

--- a/refm/api/src/_builtin/Hash
+++ b/refm/api/src/_builtin/Hash
@@ -577,7 +577,26 @@ p h1.compare_by_identity? #=> true
 
 shiftは破壊的メソッドです。selfは要素を取り除かれた残りのハッシュに変更されます。
 
-ハッシュが空の場合、デフォルト値に関わらず nil を返します。
+Ruby 3.2以前は、ハッシュが空の場合、デフォルト値（[[m:Hash#default]]または[[m:Hash#default_proc]]のブロックの値か、どちらもnilならばnil）
+を返します(このとき、[key,value] という形式の値を返すわけではないことに注意)。
+
+#@samplecode 例
+h = {:ab => "some" , :cd => "all"}
+p h.shift               #=> [:ab, "some"]
+p h.shift               #=> [:cd, "all"]
+p h                     #=> {}
+p h.shift               #=> nil
+
+h1 = Hash.new("default value")
+p h1                    #=> {}
+p h1.shift              #=> "default value"
+
+h2 = Hash.new {|*arg| arg}
+p h2                    #=> {}
+p h2.shift              #=> [{}, nil]
+#@end
+
+Ruby 3.2以降はハッシュが空の場合、デフォルト値に関わらず nil を返します。
 
 #@samplecode 例
 h = {:ab => "some" , :cd => "all"}


### PR DESCRIPTION
Hash#shiftのハッシュが空かつデフォルト値が設定されている場合の説明とサンプルコードの実行結果がruby-3.3.0の内容になっていなかったため修正しました。

```
$ docker run -it --rm rubylang/all-ruby ./all-ruby -e 'h1 = Hash.new("default value"); p h1; p h1.shift'

...
ruby-1.4.6            {}
                      nil
ruby-1.6.0            {}
                      "default value"
...
ruby-3.1.4            {}
                      "default value"
ruby-3.2.0-preview1   {}
                      nil
...
ruby-3.3.0            {}
                      nil
```

```
$ docker run -it --rm rubylang/all-ruby ./all-ruby -e 'h2 = Hash.new {|*arg| arg}; p h2; p h2.shift'

...
ruby-1.6.8            {}
                      nil
ruby-1.8.0            {}
                      [{}, nil]
...
ruby-3.1.4            {}
                      [{}, nil]
ruby-3.2.0-preview1   {}
                      nil
...
ruby-3.3.0            {}
                      nil
```