### PR TITLE
fix StringScanner#<<

### DIFF
--- a/refm/api/src/strscan.rd
+++ b/refm/api/src/strscan.rd
@@ -189,14 +189,14 @@ selfを返します。
 require 'strscan'
 
 s = StringScanner.new('test') # => #<StringScanner 0/4 @ "test">
-s.match(/\w(\w*)/)            # => "test"
+s.scan(/\w(\w*)/)             # => "test"
 s[0]                          # => "test"
 s[1]                          # => "est"
 s << ' string'                # => #<StringScanner 4/11 "test" @ " stri...">
 s[0]                          # => "test"
 s[1]                          # => "est"
-s.match(/\s+/)                # => " "
-s.match(/\w+/)                # => "string"
+s.scan(/\s+/)                 # => " "
+s.scan(/\w+/)                 # => "string"
 #@end
 
 この操作は StringScanner.new に渡した文字列にも影響することがあります。


### PR DESCRIPTION
存在しない `StringScanner#match` が使用されていたので `StringScanner#scan` を用いた説明に変更

See: https://github.com/rurema/doctree/issues/2865

## 補足

Ruby 1.8.7 の時点からの記述の様ですが、大昔から間違った記述になっていたのかもしれません。
https://docs.ruby-lang.org/ja/1.8.7/method/StringScanner/i/=3c=3c.html