### PR TITLE
Psych.loadの引数filenameの追従

### DIFF
--- a/refm/api/src/psych.rd
+++ b/refm/api/src/psych.rd
@@ -112,18 +112,13 @@ libyaml のバージョンを返します。
 
 @see [[m:Psych::LIBYAML_VERSION]]
 
-#@since 2.5.0
-#@since 2.6.0
-#@since 3.1
---- load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
-#@else
---- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
+#@if("2.6.0" <= version)
 --- load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
 #@end
-#@else
+#@if("2.5.0" <= version and version < "3.1")
 --- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
 #@end
-#@else
+#@if(version < "2.5.0")
 --- load(yaml, filename = nil, fallback = false) -> object
 #@end
 

--- a/refm/api/src/psych.rd
+++ b/refm/api/src/psych.rd
@@ -114,8 +114,12 @@ libyaml のバージョンを返します。
 
 #@since 2.5.0
 #@since 2.6.0
+#@since 3.1
+--- load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
+#@else
 --- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
 --- load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
+#@end
 #@else
 --- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
 #@end

--- a/refm/api/src/psych.rd
+++ b/refm/api/src/psych.rd
@@ -113,7 +113,12 @@ libyaml のバージョンを返します。
 @see [[m:Psych::LIBYAML_VERSION]]
 
 #@since 2.5.0
+#@since 2.6.0
 --- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
+--- load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
+#@else
+--- load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
+#@end
 #@else
 --- load(yaml, filename = nil, fallback = false) -> object
 #@end

--- a/refm/api/src/psych.rd
+++ b/refm/api/src/psych.rd
@@ -142,6 +142,19 @@ filename はパース中に発生した例外のメッセージに用います�
 @raise Psych::SyntaxError YAMLドキュメントに文法エラーが発見されたときに発生します
 @see [[m:Psych.parse]]
 
+#@since 2.6.0
+#@samplecode 例
+Psych.load("--- a")           # => 'a'
+Psych.load("---\n - a\n - b") # => ['a', 'b']
+
+begin
+  Psych.load("--- `", filename: "file.txt")
+rescue Psych::SyntaxError => ex
+  p ex.file    # => 'file.txt'
+  p ex.message # => "(file.txt): found character that cannot start any token while scanning for the next token at line 1 column 5"
+end
+#@end
+#@else
 #@samplecode 例
 Psych.load("--- a")           # => 'a'
 Psych.load("---\n - a\n - b") # => ['a', 'b']
@@ -152,6 +165,7 @@ rescue Psych::SyntaxError => ex
   p ex.file    # => 'file.txt'
   p ex.message # => "(file.txt): found character that cannot start any token while scanning for the next token at line 1 column 5"
 end
+#@end
 #@end
 
 キーワード引数 symbolize_names に true を指定した場合はハッシュのキー


### PR DESCRIPTION
以下の対応を行いました．

- https://github.com/rurema/doctree/pull/2870/commits/5fa1ea29444bb9ca4350390dcfa09cb178e023b3 ruby-2.6.0でキーワード引数filenameが使えるようになったことに追従
- https://github.com/rurema/doctree/pull/2870/commits/f2186500fb5789024d8016d494603dcb6111a35d ruby-3.1で第二引数filenameがなくなったことに追従

## 動作確認

以下のようになることを確認しました．

### ruby-3.1

![image](https://github.com/rurema/doctree/assets/62389/457e1aa1-a90a-4acd-a1e0-3db4a885aa88)

### ruby-3.0

![image](https://github.com/rurema/doctree/assets/62389/aa2e716a-1506-4fff-9277-26810577603f)

### ruby-2.6.0

![image](https://github.com/rurema/doctree/assets/62389/f5afe0f0-4577-41de-9e40-b3e9449c8c47)

### ruby-2.5.0

![image](https://github.com/rurema/doctree/assets/62389/e4530de2-edf4-4d61-8aa1-15ccc6242fb2)

### ruby-2.4.0

![image](https://github.com/rurema/doctree/assets/62389/054da5c4-f434-4a63-9108-b1a46152ef4f)
