### PR TITLE
fix : Proc#hashメソッドの説明内に誤ってコピーされたと思われる記述を削除

### DIFF
--- a/refm/api/src/_builtin/Proc
+++ b/refm/api/src/_builtin/Proc
@@ -447,21 +447,6 @@ self のハッシュ値を返します。
 
 #@end
 
-Proc オブジェクトの引数の情報を返します。
-
-Proc オブジェクトが引数を取らなければ空の配列を返します。引数を取る場合は、配列の配列を返し、
-各配列の要素は引数の種類に対応した以下のような Symbol と、引数名を表す Symbol の 2 要素です。
-
-#@samplecode
-prc = proc{|x, y=42, *other|}
-p prc.parameters  # => [[:opt, :x], [:opt, :y], [:rest, :other]]
-prc = lambda{|x, y=42, *other|}
-p prc.parameters  # => [[:req, :x], [:opt, :y], [:rest, :other]]
-prc = proc{|x, y=42, *other|}
-p prc.parameters(lambda: true)  # => [[:req, :x], [:opt, :y], [:rest, :other]]
-prc = lambda{|x, y=42, *other|}
-p prc.parameters(lambda: false) # => [[:opt, :x], [:opt, :y], [:rest, :other]]
-#@end
 #@since 3.2
 --- parameters(lambda: nil) -> [object]
 #@else


### PR DESCRIPTION
[Proc\#hash](https://docs.ruby-lang.org/ja/latest/method/Proc/i/hash.html)に関して、
以下の `Proc#parameters`の説明がコピーされてしまっているようなので削除しました。

https://github.com/rurema/doctree/blob/896cddc28ba21a035aad007d5a27ea1dc10972a8/refm/api/src/_builtin/Proc#L470-L473

https://github.com/rurema/doctree/blob/896cddc28ba21a035aad007d5a27ea1dc10972a8/refm/api/src/_builtin/Proc#L502-L509

### 削除前

![image](https://github.com/rurema/doctree/assets/65953037/2054a155-1cd0-4ddd-b0e1-bc1e169688cc)



### 削除後

![image](https://github.com/rurema/doctree/assets/65953037/b676db8b-1a09-4d04-9519-bafc9d660cb2)

