### PR TITLE
String#bytespliceの説明をruby3.3に合わせて更新

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3691,7 +3691,7 @@ range で指定したバイトの範囲に含まれる部分文字列を返し�
 @see [[m:String#bytesplice]]
 --- bytesplice(index, length, str) -> String
 #@since 3.3
---- bytesplice(range, str, str_index, str_length) -> String
+--- bytesplice(index, length, str, str_index, str_length) -> String
 #@end
 --- bytesplice(range, str)         -> String
 #@since 3.3

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3711,10 +3711,12 @@ str_index と str_length もしくは str_range が与えられたとき、self 
 
 @param index 置換したい文字列の範囲の始端
 @param length 置換したい文字列の範囲の長さ
-@param range 置換したい文字列の範囲を示す Range オブジェクト
 #@since 3.3
 @param str_index str の範囲の始端
 @param str_length str の範囲の長さ
+#@end
+@param range 置換したい文字列の範囲を示す Range オブジェクト
+#@since 3.3
 @param str_range str の範囲を示す Range オブジェクト
 #@end
 @raise IndexError index や length が範囲外の場合に発生

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3691,8 +3691,15 @@ range で指定したバイトの範囲に含まれる部分文字列を返し�
 @see [[m:String#bytesplice]]
 --- bytesplice(index, length, str) -> String
 --- bytesplice(range, str)         -> String
+#@since 3.3
+--- bytesplice(range, str, str_range) -> String
+#@end
 
 self の一部または全部を str で置き換えて str を返します。
+#@since 3.3
+str_range が与えられたとき、self の一部または全部を str.byteslice(str_range) で置き換えて str を返します。
+ただし、str.byteslice(str_range) は新しい文字列としてメモリ割り当てされません。
+#@end
 
 置き換え範囲の指定は、長さの指定が省略できないこと以外は
 [[m:String#byteslice]] と同じです。
@@ -3702,6 +3709,9 @@ self の一部または全部を str で置き換えて str を返します。
 @param index 置換したい文字列の範囲の始端
 @param length 置換したい文字列の範囲の長さ
 @param range 置換したい文字列の範囲を示す Range オブジェクト
+#@since 3.3
+@param str_range str の範囲を示す Range オブジェクト
+#@end
 @raise IndexError index や length が範囲外の場合に発生
 @raise RangeError range が範囲外の場合に発生
 @raise IndexError 指定した始端や終端が文字列の境界と一致しない場合に発生

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3698,9 +3698,10 @@ range で指定したバイトの範囲に含まれる部分文字列を返し�
 --- bytesplice(range, str, str_range) -> String
 #@end
 
-self の一部または全部を str で置き換えて str を返します。
+self の一部または全部を str で置き換えて self を返します。
+
 #@since 3.3
-str_index と str_length もしくは str_range が与えられたとき、self の一部または全部を str.byteslice(str_index, str_length) もしくは str.byteslice(str_range) で置き換えて str を返します。
+str_index と str_length もしくは str_range が与えられたとき、self の一部または全部を str.byteslice(str_index, str_length) もしくは str.byteslice(str_range) で置き換えます。
 ただし、str の部分文字列は新しい文字列オブジェクトとして生成されません。
 #@end
 

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3713,6 +3713,8 @@ str_index と str_length もしくは str_range が与えられたとき、self 
 @param length 置換したい文字列の範囲の長さ
 @param range 置換したい文字列の範囲を示す Range オブジェクト
 #@since 3.3
+@param str_index str の範囲の始端
+@param str_length str の範囲の長さ
 @param str_range str の範囲を示す Range オブジェクト
 #@end
 @raise IndexError index や length が範囲外の場合に発生

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3690,6 +3690,9 @@ range で指定したバイトの範囲に含まれる部分文字列を返し�
 #@since 3.2
 @see [[m:String#bytesplice]]
 --- bytesplice(index, length, str) -> String
+#@since 3.3
+--- bytesplice(range, str, str_index, str_length) -> String
+#@end
 --- bytesplice(range, str)         -> String
 #@since 3.3
 --- bytesplice(range, str, str_range) -> String
@@ -3697,8 +3700,8 @@ range で指定したバイトの範囲に含まれる部分文字列を返し�
 
 self の一部または全部を str で置き換えて str を返します。
 #@since 3.3
-str_range が与えられたとき、self の一部または全部を str.byteslice(str_range) で置き換えて str を返します。
-ただし、str.byteslice(str_range) は新しい文字列としてメモリ割り当てされません。
+str_index と str_length もしくは str_range が与えられたとき、self の一部または全部を str.byteslice(str_index, str_length) もしくは str.byteslice(str_range) で置き換えて str を返します。
+ただし、str の部分文字列は新しい文字列オブジェクトとして生成されません。
 #@end
 
 置き換え範囲の指定は、長さの指定が省略できないこと以外は


### PR DESCRIPTION
Ruby 3.3で追加されたString#bytespliceの新しい引数について説明を追加しました。

# 動作確認
以下のように動作することを確認しました。

Ruby 3.2
<img width="1462" alt="スクリーンショット 2024-05-09 16 39 27" src="https://github.com/rurema/doctree/assets/129704681/166e4101-e8e4-46ba-93b6-c6138051b26d">

Ruby 3.3
<img width="1467" alt="スクリーンショット 2024-05-09 16 38 58" src="https://github.com/rurema/doctree/assets/129704681/f75ca4d4-d0dd-4b9f-b602-5e2a552ab524">

# 参考
https://docs.ruby-lang.org/en/3.3/String.html#method-i-bytesplice
