### PR TITLE
fix: URI.decode_www_formのサンプルコードでrassocがエラーを出していたので修正

### DIFF
--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -210,11 +210,11 @@ enc で指定したエンコーディングの文字列が URL エンコード�
 
   require 'uri'
   ary = URI.decode_www_form("a=1&a=2&b=3")
-  p ary                   #=> [['a', '1'], ['a', '2'], ['b', '3']]
-  p ary.assoc('a').last   #=> '1'
-  p ary.assoc('b').last   #=> '3'
-  p ary.rassoc('2').first #=> 'a'
-  p Hash[ary]             # => {"a"=>"2", "b"=>"3"}
+  p ary                 #=> [['a', '1'], ['a', '2'], ['b', '3']]
+  p ary.assoc('a').last #=> '1'
+  p ary.assoc('b').last #=> '3'
+  p Hash[ary]['a']      #=> '2'
+  p Hash[ary]           #=> {"a"=>"2", "b"=>"3"}
 
 @param str デコード対象の文字列
 @param enc エンコーディング

--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -213,7 +213,6 @@ enc で指定したエンコーディングの文字列が URL エンコード�
   p ary                 #=> [['a', '1'], ['a', '2'], ['b', '3']]
   p ary.assoc('a').last #=> '1'
   p ary.assoc('b').last #=> '3'
-  p Hash[ary]['a']      #=> '2'
   p Hash[ary]           #=> {"a"=>"2", "b"=>"3"}
 
 @param str デコード対象の文字列

--- a/refm/api/src/uri/URI
+++ b/refm/api/src/uri/URI
@@ -210,11 +210,11 @@ enc で指定したエンコーディングの文字列が URL エンコード�
 
   require 'uri'
   ary = URI.decode_www_form("a=1&a=2&b=3")
-  p ary                  #=> [['a', '1'], ['a', '2'], ['b', '3']]
-  p ary.assoc('a').last  #=> '1'
-  p ary.assoc('b').last  #=> '3'
-  p ary.rassoc('a').last #=> '2'
-  p Hash[ary]            # => {"a"=>"2", "b"=>"3"}
+  p ary                   #=> [['a', '1'], ['a', '2'], ['b', '3']]
+  p ary.assoc('a').last   #=> '1'
+  p ary.assoc('b').last   #=> '3'
+  p ary.rassoc('2').first #=> 'a'
+  p Hash[ary]             # => {"a"=>"2", "b"=>"3"}
 
 @param str デコード対象の文字列
 @param enc エンコーディング


### PR DESCRIPTION
### 問題箇所
[URI. decode_www_form](https://docs.ruby-lang.org/ja/latest/class/URI.html#S_DECODE_WWW_FORM)のサンプルコードで、エラーが出たので修正しました。

具体的には、以下の部分を実行すると

```ruby
require 'uri'
ary = URI.decode_www_form("a=1&a=2&b=3")
p ary.rassoc('a').last
```

以下のようなエラーが出ます。
```bash
before.rb:3:in `<main>': undefined method `last' for nil (NoMethodError)

  p ary.rassoc('a').last
                   ^^^^^
```

### 原因
これは `Array#rassoc` の動作として、配列の配列に対して要素の配列でインデックス 1 の要素が obj に等しいものを検索し見つかった最初の要素を返すので、`'a'` に該当する要素が無いために `nil` が返り、`last` が呼び出せなくなっています。

https://docs.ruby-lang.org/ja/latest/method/Array/i/rassoc.html

### 修正内容
インデックス 1 の要素である `'2'` を `rassoc` の引数に指定し、 `last` のままだと引数がそのまま返ってしまうので、インデックス0の値が返るように `first` を呼び出すようにしました。
また、メソッド名が1文字長くなったので、インデントを揃えました。

### 修正後
以下のように動作します。

```ruby
require 'uri'
ary = URI.decode_www_form("a=1&a=2&b=3")
p ary.rassoc('2').first
```

```bash
"a"
```