### PR TITLE
CSV.foreach: ブロックが与えられていない場合の挙動を加筆

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -486,10 +486,12 @@ end
 
 @see [[m:CSV.new]]
 
+--- foreach(path, options = Hash.new) -> Enumerator
 --- foreach(path, options = Hash.new){|row| ... } -> nil
 
 このメソッドは CSV ファイルを読むための主要なインターフェイスです。
 各行が与えられたブロックに渡されます。
+ブロックが与えられていない場合、Enumeratorを返します。
 
 #@samplecode 例
 require 'csv'


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/8929 の変更以降、ブロックなしの CSV.foreach は Enumerator を返します。

```
irb(main):001> require 'csv'
=> true
irb(main):002> CSV.foreach('test.csv').to_a
=> []
```

この挙動をドキュメントに追加しました。