### PR TITLE
Kconv.guess: 返り値から nil を削除

### DIFF
--- a/refm/api/src/kconv.rd
+++ b/refm/api/src/kconv.rd
@@ -262,7 +262,7 @@ Kconv.kconv(str, Kconv::SJIS)と同じです。
 #@until 1.9.1
 --- guess(str) -> Integer
 #@else
---- guess(str) -> Encoding | nil
+--- guess(str) -> Encoding
 #@end
 
 文字列 str のエンコーディングを判定します。戻り値は


### PR DESCRIPTION
Kconv.guess の返り値は Encoding | nil と説明されていますが、nil を返すことはなさそうなので、説明から削除しました。

参考

* Kconv.guess は NKF.guess を呼び出している 
    * https://github.com/ruby/nkf/blob/5c0f28e86600d9f8f77c4ede10d5ef9fcbba4612/lib/kconv.rb#L142
* NKF.guess の返り値は Encoding と説明されている
    * https://docs.ruby-lang.org/ja/latest/method/NKF/m/guess.html
* NKF.guess の実装では必ず Encoding オブジェクトを返している
    * https://github.com/ruby/nkf/blob/5c0f28e86600d9f8f77c4ede10d5ef9fcbba4612/ext/nkf/nkf.c#L191
* 英語版 Kconv.guess のドキュメントでも encoding を返すと説明されている
    * https://docs.ruby-lang.org/en/3.3/Kconv.html#method-i-guess