### PR TITLE
MatchData#named_captures の symbolize_names オプションの説明を追加

### DIFF
--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -380,11 +380,17 @@ m2 = r.match("abcabc", 0) # => #<MatchData "abc">
 m1 == m2  # => true
 #@end
 
+#@since 3.3.0
+--- named_captures(symbolize_names: false) -> Hash
+#@else
 --- named_captures -> Hash
+#@end
 
 名前付きキャプチャをHashで返します。
 
 Hashのキーは名前付きキャプチャの名前です。Hashの値はキーの名前に対応した名前付きグループのうち最後にマッチした文字列です。
+
+@param symbolize_names 真を指定するとハッシュのキーを文字列ではなくシンボルにします。デフォルトは偽です。
 
 #@samplecode 例
 m = /(?<a>.)(?<b>.)/.match("01")
@@ -398,6 +404,11 @@ m.named_captures # => {"a" => "1"}
 
 m = /(?<a>x)|(?<a>y)/.match("x")
 m.named_captures # => {"a" => "x"}
+#@since 3.3.0
+
+m = /(?<a>.)(?<a>.)/.match("01")
+m.named_captures(symbolize_names: true) #=> {:a => "1"}
+#@end
 #@end
 
 @see [[m:MatchData#captures]]


### PR DESCRIPTION
Ruby 3.3.0 で追加された MatchData#named_captures の symbolize_names オプションの説明を追加しました

cf. https://docs.ruby-lang.org/en/3.3/MatchData.html#method-i-named_captures
cf. https://github.com/ruby/ruby/blob/v3_4_0_preview1/doc/NEWS/NEWS-3.3.0.md?plain=1#L59-L62

symbolize_names の説明は https://product.st.inc/entry/2023/12/25/160504 の

> `symbolize_names` というキーワード名は、`JSON.parse` の既存のキーワードにならっています。

という記載から JSON.#parse と同じにしています

cf. https://github.com/rurema/doctree/blob/5aa0a74b04505041e9cbd713bd8bfb3cee1c3a9c/refm/api/src/json/JSON#L317-L318

追加したサンプルコードは https://docs.ruby-lang.org/en/3.3/MatchData.html#method-i-named_captures の symbolize_names のものをそのまま引用しています