### PR TITLE
{Method,UnboundMethod}#{public?,private?,protected?} の説明を追加

### DIFF
--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -700,3 +700,17 @@ C.new.method(:bar).original_name # => :foo
 
 @see [[m:UnboundMethod#original_name]]
 #@end
+
+#@if (version == "3.1.0")
+--- public? -> bool
+
+self が public であるかどうかを返します。
+
+--- protected? -> bool
+
+self が protected であるかどうかを返します。
+
+--- private? -> bool
+
+self が private であるかどうかを返します。
+#@end

--- a/refm/api/src/_builtin/Method
+++ b/refm/api/src/_builtin/Method
@@ -701,7 +701,7 @@ C.new.method(:bar).original_name # => :foo
 @see [[m:UnboundMethod#original_name]]
 #@end
 
-#@if (version == "3.1.0")
+#@if (version == "3.1")
 --- public? -> bool
 
 self が public であるかどうかを返します。

--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -297,3 +297,17 @@ C.instance_method(:bar).original_name # => :foo
 
 @see [[m:Method#original_name]]
 #@end
+
+#@if (version == "3.1.0")
+--- public? -> bool
+
+self が public であるかどうかを返します。
+
+--- protected? -> bool
+
+self が protected であるかどうかを返します。
+
+--- private? -> bool
+
+self が private であるかどうかを返します。
+#@end

--- a/refm/api/src/_builtin/UnboundMethod
+++ b/refm/api/src/_builtin/UnboundMethod
@@ -298,7 +298,7 @@ C.instance_method(:bar).original_name # => :foo
 @see [[m:Method#original_name]]
 #@end
 
-#@if (version == "3.1.0")
+#@if (version == "3.1")
 --- public? -> bool
 
 self が public であるかどうかを返します。

--- a/refm/doc/news/3_1_0.rd
+++ b/refm/doc/news/3_1_0.rd
@@ -169,7 +169,7 @@ C.subclasses    #=> []
 
   * [[c:Method]] / [[c:UnboundMethod]]
     * 新規メソッド
-      * Method#public?, Method#private?, Method#protected?, UnboundMethod#public?, UnboundMethod#private?, UnboundMethod#protected? が追加されました。 [[feature:11689]]
+      * [[m:Method#public?]], [[m:Method#private?]], [[m:Method#protected?]], [[m:UnboundMethod#public?]], [[m:UnboundMethod#private?]], [[m:UnboundMethod#protected?]] が追加されました。 [[feature:11689]]
 
   * [[c:Module]]
     * 変更されたメソッド

--- a/refm/doc/news/3_1_0.rd
+++ b/refm/doc/news/3_1_0.rd
@@ -169,7 +169,11 @@ C.subclasses    #=> []
 
   * [[c:Method]] / [[c:UnboundMethod]]
     * 新規メソッド
+#@if (version == "3.1")
       * [[m:Method#public?]], [[m:Method#private?]], [[m:Method#protected?]], [[m:UnboundMethod#public?]], [[m:UnboundMethod#private?]], [[m:UnboundMethod#protected?]] が追加されました。 [[feature:11689]]
+#@else
+      * Method#public?, Method#private?, Method#protected?, UnboundMethod#public?, UnboundMethod#private?, UnboundMethod#protected? が追加されました。 [[feature:11689]]
+#@end
 
   * [[c:Module]]
     * 変更されたメソッド


### PR DESCRIPTION
3.1 で追加された {Method,UnboundMethod}#{public?,private?,protected?} の説明を追加しました

cf. https://github.com/ruby/ruby/commit/27278150685e738f84105d09843d3ba371146c7a

{Method,UnboundMethod}#{public?,private?,protected?} は 3.1 で追加後に 3.2 で削除されているためサンプルコードは追加せず最低限の説明にとどめています

cf. https://techlife.cookpad.com/entry/2022/12/26/121950#%E5%89%8A%E9%99%A4%E3%81%95%E3%82%8C%E3%81%9F%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89