### PR TITLE
ruby3.2からRandom::DEFAULTのドキュメントが削除されたのリンクしている箇所を削除する

### DIFF
--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -2161,7 +2161,11 @@ seeds << srand
 p seeds #=> [455675, 2995620310703489221660585195204777696, 455675]
 #@end
 
+#@since 3.2
+@see [[m:Kernel.#rand]]
+#@else
 @see [[m:Kernel.#rand]], [[m:Random::DEFAULT]]
+#@end
 
 --- global_variables -> [Symbol]
 


### PR DESCRIPTION
close #2900 

`ja/{version}/method/Kernel/m/srand.html`に`Random::DEFAULT`へのリンクが残っていたので3.2以降は表示しないようにしました。動作未確認です。

[チュートリアルの編集内容をプレビューする](https://github.com/rurema/doctree/wiki/Tutorial#6-%E7%B7%A8%E9%9B%86%E5%86%85%E5%AE%B9%E3%82%92%E3%83%97%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC%E3%81%99%E3%82%8B)に基づいて、6.1か6.2の方法で表示を確認したかったのですが、どうやらうまく動かないようでしたので、動作未確認の状態でPR出させてもらっています🙏 