### PR TITLE
`rb_alias` の第2引数と第3引数が逆になっているのを修正

### DIFF
--- a/refm/capi/src/eval.c.rd
+++ b/refm/capi/src/eval.c.rd
@@ -236,7 +236,7 @@ Proc.yield の実体。
 クラス klass に mid という名前のメソッドを定義する。
 その本体は node であり、noex で示される可視性を持つ。
 
---- void rb_alias(VALUE klass, ID name, ID def)
+--- void rb_alias(VALUE klass, ID def, ID name)
 
 クラス klass に定義されたメソッド name の
 本体を実体とする新しいメソッド def を定義します。


### PR DESCRIPTION
https://github.com/rurema/doctree/blob/8f60d1c746df397ad1c6ca4dd3ace3c5f8c00c40/refm/capi/src/eval.c.rd#L239-L242 の説明によると第2引数の `name` がメソッドの本体で 第3引数の `def` がaliasになるメソッドの名前という記載があります。

しかしCRuby側の `rb_alias` の実装を見る限り、第2引数がaliasの名前で第3引数がメソッドの本体の名前であると思われるので修正しました。

* https://github.com/ruby/ruby/blob/v3_3_4/vm_method.c#L2272
* https://github.com/ruby/ruby/blob/v3_3_4/include/ruby/internal/intern/vm.h#L262-L274