### PR TITLE
fix: CSV::Row.field -> CSV::Row#field

### DIFF
--- a/refm/api/src/csv/CSV__Row
+++ b/refm/api/src/csv/CSV__Row
@@ -294,7 +294,7 @@ row.field_row?        # => true
 
 与えられた引数に対応する値の配列を返します。
 
-要素の探索に [[m:CSV::Row.field]] を使用しています。
+要素の探索に [[m:CSV::Row#field]] を使用しています。
 
 @param headers_and_or_indices ヘッダの名前かインデックスか [[c:Range]]
                               のインスタンスか第 1 要素がヘッダの名前で


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/CSV=3a=3aRow/i/fields.html から、以下の `CSV::Row.field` のリンクを踏むと、404になります。

> 要素の探索に [CSV::Row.field](https://docs.ruby-lang.org/ja/latest/method/CSV=3a=3aRow/s/field.html) を使用しています。

Ruby 3.3.4で確認すると、`undefined method `field' for class CSV::Row (NoMethodError)`になりました。

正しくは、インスタンスメソッドであるため修正を提案します。

ref: https://github.com/ruby/csv/blob/ce9119802be7685ec93a68741a5d9da3dbe86122/lib/csv/row.rb#L545