### PR TITLE
Fix return type of Kernerl#y which is added by psych

### DIFF
--- a/refm/api/src/psych/core_ext.rd
+++ b/refm/api/src/psych/core_ext.rd
@@ -84,9 +84,9 @@ syck が廃止された場合  psych_to_yaml は廃止
 
 == Instance Methods
 
---- y(*objects) -> String
---- psych_y(*objects) -> String
-objects を YAML document に変換します。
+--- y(*objects) -> nil
+--- psych_y(*objects) -> nil
+objects を YAML document として標準出力に出力します。
 
 このメソッドは irb 上でのみ定義されます。
 


### PR DESCRIPTION
psych gem によって追加される Kernel#y について、実装当初も今も、String を返すのではなく標準出力に出力する実装になっていました。これを受けてドキュメントの方を修正しました。

- https://github.com/ruby/psych/blob/b051cf80bcafa6776fe3e3ac4b230c18bea3e95b/lib/psych/core_ext.rb#L12-L16
- https://github.com/ruby/psych/blob/045b31104754579c61bb5d2df9395a055cbb3354/lib/psych/y.rb#L5-L7