### PR TITLE
Add docker to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
Dockerfile の ruby が 3.3.3 のままだったので、自動更新されるようにします。