### PR TITLE
Array#sample に random オプションを使う例を追加

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2258,6 +2258,14 @@ p a.sample(3)     #=> [1, 9, 3]
 p a               #=> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 #@end
 
+random [[c:SecureRandom]] などの乱数生成器を渡すことができます。
+
+#@samplecode 例
+require 'securerandom'
+a = (1..10).to_a
+p a.sample(random: SecureRandom)  #=>  2
+#@end
+
 --- cycle(n=nil) {|obj| block } -> nil
 #@since 1.9.1
 --- cycle(n=nil) -> Enumerator


### PR DESCRIPTION
`Array#sample` の `random` オプションで乱数生成器を指定する例を追加します。
SecureRandom を使う場合、インスタンスではなくクラスを渡さなければならないことを分かりやすくするねらいです。

実際には `require 'securerandom'` しなければ動かないコードになりますが、このような場合どのように表記すればよいでしょう。