### PR TITLE
`Range#overlap?`に@see Range#cover?を追加

### DIFF
--- a/refm/api/src/_builtin/Range
+++ b/refm/api/src/_builtin/Range
@@ -334,6 +334,8 @@ self と range に重なりがある場合は true を、そうでない場合�
 
 @raise TypeError 引数に Range でないオブジェクトを指定した場合に発生します。
 
+@see [[m:Range#cover?]]
+
 #@samplecode 例
 (0..2).overlap?(1..3)  #=> true
 (0..2).overlap?(3..4)  #=> false


### PR DESCRIPTION
#2860 での指摘によるものです。