### PR TITLE
`Dir#chdir` の `~` の展開に関する記述を追加

### DIFF
--- a/refm/api/src/_builtin/Dir
+++ b/refm/api/src/_builtin/Dir
@@ -152,6 +152,9 @@ Dir.chdir("/tmp") do
   p Dir.pwd                  #=> "/tmp"
 end 
 p Dir.pwd                    #=> "/var/spool/mail"
+
+# ~ は展開されない
+Dir.chdir("~/.ssh")          # => Errno::ENOENT
 #@end
 
 --- chroot(path)    -> 0


### PR DESCRIPTION
refs #2808 

`Dir.chdir("~/filename")` などで `~` が展開されるか否かの記述を追加しました。

https://github.com/rurema/doctree/issues/2808#issuecomment-2478911030 の追記例より 2 点変更しています。
- 実装例の文字列の quote が `""` を使用しているため、あわせる形で `''` → `""` に変更
- 実際に存在しているであろうディレクトリ名のほうが明瞭と判断し、 `~/foo` → `~/.ssh` に変更
