### PR TITLE
`Object#clone`の`freeze`引数に関する説明を修正

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1172,7 +1172,7 @@ marshal_dump/marshal_load を使うべきです。
 @see [[m:Object#marshal_dump]], [[c:Marshal]]
 
 
---- clone(freeze: true) -> object
+--- clone(freeze: nil) -> object
 --- dup -> object
 
 オブジェクトの複製を作成して返します。
@@ -1188,7 +1188,9 @@ clone や dup は浅い(shallow)コピーであることに注意してくださ
 
 [[c:TrueClass]], [[c:FalseClass]], [[c:NilClass]], [[c:Symbol]], そして [[c:Numeric]] クラスのインスタンスなど一部のオブジェクトは複製ではなくインスタンス自身を返します。
 
-@param freeze false を指定すると freeze されていないコピーを返します。
+@param freeze true を指定すると freeze されたコピーを返します。
+              false を指定すると freeze されていないコピーを返します。
+              nil を指定すると、レシーバが freeze されていれば freeze されたコピーを、freeze されていなければ freeze されていないコピーを返します。
 @raise ArgumentError [[c:TrueClass]] などの常に freeze されているオブジェクトの freeze されていないコピーを作成しようとしたときに発生します。
 
 #@samplecode


### PR DESCRIPTION
3.0 で `freeze: nil` を受け取れるようになり、以後現在のような挙動になっています。

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=2.7 ./all-ruby -rset -e 'Object.new.clone(freeze: nil)'
ruby-2.7.0          -e:1:in `clone': unexpected value for freeze: NilClass (ArgumentError)
                        from -e:1:in `<main>'
                exit 1
...
ruby-2.7.8          -e:1:in `clone': unexpected value for freeze: NilClass (ArgumentError)
                        from -e:1:in `<main>'
                exit 1
ruby-3.0.0-preview1
...
ruby-3.4.0-preview1
```

```
% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=3.0 ./all-ruby -rset -e 'o = Object.new; o.freeze; p [o.clone, o.clone(freeze: nil), o.clone(freeze: true), o.clone(freeze: false)].map(&:frozen?)'
ruby-3.0.0          [true, true, true, false]
...
ruby-3.4.0-preview1 [true, true, true, false]

% docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=3.0 ./all-ruby -rset -e 'o = Object.new; p [o.clone, o.clone(freeze: nil), o.clone(freeze: true), o.clone(freeze: false)].map(&:frozen?)'
ruby-3.0.0          [false, false, true, false]
...
ruby-3.4.0-preview1 [false, false, true, false]
```