### PR TITLE
`Object#initialize_copy`と`Object#initialize_dup`の説明を追加

### DIFF
--- a/refm/api/src/_builtin/Object
+++ b/refm/api/src/_builtin/Object
@@ -1799,7 +1799,9 @@ p it
 
 このメソッドは self を obj の内容で置き換えます。ただ
 し、self のインスタンス変数や特異メソッドは変化しません。
-[[m:Object#clone]], [[m:Object#dup]]の内部で使われています。
+
+デフォルトでは、[[m:Object#clone]] の内部で [[m:Object#initialize_clone]] から、
+また [[m:Object#dup]] の内部で [[m:Object#initialize_dup]] から呼ばれます。
 
 initialize_copy は、Ruby インタプリタが知り得ない情報をコピーするた
 めに使用(定義)されます。例えば C 言語でクラスを実装する場合、情報
@@ -1881,6 +1883,28 @@ check obj.clone
 #@end
         #   singleton methods: :bar
 #@end
+
+@see [[m:Object#initialize_clone]], [[m:Object#initialize_dup]]
+
+--- initialize_clone(obj) -> object
+
+[[m:Object#clone]] がオブジェクトを複製する際に呼び出すメソッドです。
+
+デフォルトでは [[m:Object#initialize_copy]] を呼び出します。
+
+initialize_clone という名前のメソッドは自動的に private に設定されます。
+
+@see [[m:Object#initialize_copy]], [[m:Object#initialize_dup]]
+
+--- initialize_dup(obj) -> object
+
+[[m:Object#dup]] がオブジェクトを複製する際に呼び出すメソッドです。
+
+デフォルトでは [[m:Object#initialize_copy]] を呼び出します。
+
+initialize_dup という名前のメソッドは自動的に private に設定されます。
+
+@see [[m:Object#initialize_copy]], [[m:Object#initialize_clone]]
 
 --- respond_to_missing?(symbol, include_private) -> bool
 


### PR DESCRIPTION
`Object#initialize_copy`と`Object#initialize_dup`の説明を追加しました。