### PR TITLE
`Integer#**`, `Rational#**`が`Infinity`を返さなくなった変更に対応

### DIFF
--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -732,6 +732,9 @@ self を other で割り、その(剰余を考えない)商を整数に切り上
 @return 計算結果
 @raise TypeError 2引数 pow で Integer 以外を指定した場合に発生します。
 @raise RangeError 2引数 pow で other に負の数を指定した場合に発生します。
+#@since 3.4
+@raise 計算結果が巨大になりすぎる場合に発生します。
+#@end
 
 #@samplecode
 2 ** 3 # => 8
@@ -745,6 +748,7 @@ self を other で割り、その(剰余を考えない)商を整数に切り上
 5.pow(2, -8)  # => -7
 #@end
 
+#@until 3.4
 結果が巨大すぎる整数になりそうなとき、警告を出したうえで Float::INFINITY を返します。
 
 #@samplecode 計算を放棄して Float::INFINITY を返す例
@@ -754,6 +758,18 @@ p 100**9999999
 #@end
 
 判定の閾値は変わりえます。
+#@end
+
+#@since 3.4
+計算結果が巨大すぎるときは ArgumentError が発生します。
+
+#@samplecode 計算結果が巨大すぎる例
+p 100**9999999999999999999
+# => exponent is too large (ArgumentError)
+#@end
+
+判定の閾値は変わりえます。
+#@end
 
 @see [[m:BigDecimal#power]]
 

--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -733,7 +733,7 @@ self を other で割り、その(剰余を考えない)商を整数に切り上
 @raise TypeError 2引数 pow で Integer 以外を指定した場合に発生します。
 @raise RangeError 2引数 pow で other に負の数を指定した場合に発生します。
 #@since 3.4
-@raise 計算結果が巨大になりすぎる場合に発生します。
+@raise ArgumentError 計算結果が巨大になりすぎる場合に発生します。
 #@end
 
 #@samplecode

--- a/refm/api/src/_builtin/Rational
+++ b/refm/api/src/_builtin/Rational
@@ -45,6 +45,9 @@ r * Rational(1, 2)   # => (3/8)
 冪(べき)乗を計算します。
 
 @param other 自身を other 乗する数
+#@since 3.4
+@raise ArgumentError 計算結果の分母・分子が巨大すぎる場合に発生します。
+#@end
 
 other に [[c:Float]] を指定した場合は、計算結果を [[c:Float]] で返しま
 す。other が有理数であっても、計算結果が無理数だった場合は [[c:Float]]


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20811