### PR TITLE
`Warning`のカテゴリに`:performance`を追加

### DIFF
--- a/refm/api/src/_builtin/Warning
+++ b/refm/api/src/_builtin/Warning
@@ -27,6 +27,11 @@ category の種類の警告を表示するかどうかのフラグを返しま�
 
     例: パターンマッチング
 
+#@since 3.3
+: :performance
+  パフォーマンスに関する警告。
+#@end
+
 --- []=(category, flag) -> flag
 
 category の警告を表示するかどうかのフラグを設定します。


### PR DESCRIPTION
`Warning[:performance]` は 3.3 で追加されました。