### PR TITLE
`String#append_as_bytes`を追加

### DIFF
--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -459,6 +459,39 @@ p str    # => "foo!!!"
 #@end
 #@end
 
+#@since 3.4
+@see [[m:String#append_as_bytes]]
+#@end
+
+#@since 3.4
+--- append_as_bytes(*objects) -> self
+
+引数で与えたオブジェクトをバイト列として、self に破壊的に連結します。
+
+このメソッドはエンコーディングの検査や変換を一切行いません。
+
+引数が整数である場合は、その数をバイトの値とみなして連結します。
+その数が1バイトの範囲を越える場合は、最下位のバイトのみを使用します。
+
+#@samplecode 例
+s = "あ".b                # => "\xE3\x81\x82"
+s.encoding                # => #<Encoding:BINARY (ASCII-8BIT)>
+s.append_as_bytes("い")   # => "\xE3\x81\x82\xE3\x81\x84"
+
+# s << "い" では連結できない
+s << "い" # => "incompatible character encodings: BINARY (ASCII-8BIT) and UTF-8 (Encoding::CompatibilityError)
+#@end
+
+#@samplecode 引数で整数を渡す例
+t = ""
+t.append_as_bytes(0x61)   # => "a"
+t.append_as_bytes(0x3062) # => "ab"
+#@end
+
+@see [[m:String#<<]], [[m:String#concat]]
+
+#@end
+
 --- =~(other) -> Integer | nil
 
 正規表現 other とのマッチを行います。


### PR DESCRIPTION
Ruby 3.4で導入されたメソッドです。