### PR TITLE
Ruby 2.3+で `Enumerable#grep_v` が増えたことへの対応

### DIFF
--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -231,7 +231,7 @@ pattern === item が成立する要素を全て含んだ配列を返します。
 #@samplecode 例
 ['aa', 'bb', 'cc', 'dd', 'ee'].grep(/[bc]/)  # => ["bb", "cc"]
 
-  Array.instance_methods.grep(/gr/) # => [:grep, :group_by]
+  Array.instance_methods.grep(/gr/) # => [:grep, :grep_v, :group_by]
 #@end
 
 @see [[m:Enumerable#select]]


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/Enumerable/i/grep.html