### PR TITLE
`Socket`クラス内で重複している文言「ソケットアドレス構造体を pack した文字列」を削除する

### DIFF
--- a/refm/api/src/socket/Socket
+++ b/refm/api/src/socket/Socket
@@ -364,7 +364,7 @@ service, protoに対応するポート番号を返
 unpack したアドレスを返します。返される値は [port, ipaddr]
 の配列です。
 
-@param sockaddr ソケットアドレス構造体を pack した文字列[[ref:lib:socket#pack_string]]を指定します。
+@param sockaddr [[ref:lib:socket#pack_string]]を指定します。
 
 例:
 
@@ -381,7 +381,7 @@ unpack したアドレスを返します。返される値は [port, ipaddr]
 [[ref:lib:socket#pack_string]]を
 unpack したソケットパス名を返します。
 
-@param sockaddr ソケットアドレス構造体を pack した文字列[[ref:lib:socket#pack_string]]を指定します。
+@param sockaddr [[ref:lib:socket#pack_string]]を指定します。
 
 例:
 
@@ -781,9 +781,9 @@ EAGAIN, EINTR を含め例外 [[c:Errno::EXXX]] が発生します。
 と同じ働きをします。
 
 #@until 1.9.1
-@param my_sockaddr ソケットアドレス構造体を pack した文字列[[ref:lib:socket#pack_string]]を指定します。
+@param my_sockaddr [[ref:lib:socket#pack_string]]を指定します。
 #@else
-@param my_sockaddr ソケットアドレス構造体を pack した文字列[[ref:lib:socket#pack_string]]もしくは[[c:Addrinfo]]オブジェクトを指定します。
+@param my_sockaddr [[ref:lib:socket#pack_string]]もしくは[[c:Addrinfo]]オブジェクトを指定します。
 #@end
 @return 0 を返します。
 


### PR DESCRIPTION
以下のように出力されていたのをリンクのみを使用するように、重複している文言を削除しました。

![重複している文言](https://github.com/user-attachments/assets/0066265e-05e5-4f7e-8157-cbf1b3de6b34)
