### PR TITLE
`BasicSocket`クラスにリンクを追加する

### DIFF
--- a/refm/api/src/socket/BasicSocket
+++ b/refm/api/src/socket/BasicSocket
@@ -196,7 +196,7 @@ EAGAIN, EINTR を含め例外 [[c:Errno::EXXX]] が発生します。
 に対しては送り先である dest_sockaddr を指定する必要があります。実際に送っ
 たデータの長さを返します。
 
-dest_sockaddr には「ソケットアドレス構造体を pack した文字列」
+dest_sockaddr には[[ref:lib:socket#pack_string]]
 を指定します。
 
 データの送信に失敗した場合は例外 [[c:Errno::EXXX]] が発生します。
@@ -205,7 +205,7 @@ dest_sockaddr には「ソケットアドレス構造体を pack した文字列
 
 @param flags      [[man:send(2)]] の flags を参照してください。
 
-@param dest_sockaddr  「ソケットアドレス構造体を pack した文字列」を指定します。
+@param dest_sockaddr  [[ref:lib:socket#pack_string]]を指定します。
 
 @raise Errno::EXXX データの送信に失敗した場合に発生します。
 


### PR DESCRIPTION
「ソケットアドレス構造体を pack した文字列」について、`[[ref:lib:socket#pack_string]]`を使用するようにしてリンクになるように変更しました。

![notlink](https://github.com/user-attachments/assets/74524493-0518-4a40-859a-eddb06114b6b)
