### PR TITLE
条件を満たさない場合の表現を柔らかくした

### DIFF
--- a/refm/api/src/_builtin/BasicObject
+++ b/refm/api/src/_builtin/BasicObject
@@ -44,7 +44,7 @@ proxy.to_i #=> 1
 
 == Instance Methods
 --- ==(other) -> bool
-オブジェクトが other と等しければ真を、さもなくば偽を返します。
+オブジェクトが other と等しければ真を、そうでない場合は偽を返します。
 
 このメソッドは各クラスの性質に合わせて、サブクラスで再定義するべきです。
 多くの場合、オブジェクトの内容が等しければ真を返すように (同値性を判定するように) 再定義
@@ -53,7 +53,7 @@ proxy.to_i #=> 1
 デフォルトでは [[m:Object#equal?]] と同じオブジェクトの同一性になっています。
 
 @param other 比較対象となるオブジェクト
-@return other が self と同値であれば真、さもなくば偽
+@return other が self と同値であれば真、そうでない場合は偽
 
 #@samplecode 例
 class Person < BasicObject
@@ -74,7 +74,7 @@ tanaka1 == tanaka2    #=> false
      [[m:Object#eql?]]
 
 --- equal?(other) -> bool
-オブジェクトが other と同一であれば真を、さもなくば偽を返します。
+オブジェクトが other と同一であれば真を、そうでない場合は偽を返します。
 
 このメソッドは2つのオブジェクトが同一のものであるかどうかを判定します。
 一般にはこのメソッドを決して再定義すべきでありません。
@@ -82,7 +82,7 @@ tanaka1 == tanaka2    #=> false
 再定義する際には自分が何をしているのかよく理解してから実行してください。
 
 @param other 比較対象となるオブジェクト
-@return other が self 自身であれば真、さもなくば偽
+@return other が self 自身であれば真、そうでない場合は偽
 
 #@samplecode 例
 original = "a"
@@ -100,14 +100,14 @@ original.equal? substituted #=> true
 --- ! -> bool
 オブジェクトを真偽値として評価し、その論理否定を返します。
 
-このメソッドは self が nil または false であれば真を、さもなくば偽を返します。
+このメソッドは self が nil または false であれば真を、そうでない場合は偽を返します。
 主に論理式の評価に伴って副作用を引き起こすことを目的に
 再定義するものと想定されています。
 
 このメソッドを再定義しても Ruby の制御式において nil や false 以外が偽として
 扱われることはありません。
 
-@return オブジェクトが偽であれば真、さもなくば偽
+@return オブジェクトが偽であれば真、そうでない場合は偽
 
 #@samplecode 例
 class NegationRecorder < BasicObject

--- a/refm/api/src/_builtin/String
+++ b/refm/api/src/_builtin/String
@@ -3447,7 +3447,7 @@ u.force_encoding(Encoding::UTF_8)             #=> "ほへと"
 
 --- ascii_only?  -> bool
 
-文字列がASCII文字のみで構成されている場合に true を返します。さもなくば
+文字列がASCII文字のみで構成されている場合に true を返します。そうでない場合は
 false を返します。
 
 例:
@@ -3460,7 +3460,7 @@ false を返します。
 --- valid_encoding?  -> bool
 
 文字列の内容が、現在のエンコーディングに照らしあわせて妥当であれば
-true を返します。さもなくば false を返します。
+true を返します。そうでない場合は false を返します。
 
 #@samplecode 例
 "\xc2\xa1".force_encoding("UTF-8").valid_encoding?  #=> true
@@ -3529,7 +3529,7 @@ str.encode("Windows-31J", fallback: { "\u00b7" => "\xA5".force_encoding("Windows
 --- encode!(encoding, from_encoding, options = nil) -> self
 
 self を指定したエンコーディングに変換し、自身を置き換えます。引数を2つ
-与えた場合、第二引数は変換元のエンコーディングを意味します。さもなくば
+与えた場合、第二引数は変換元のエンコーディングを意味します。そうでない場合は
 self のエンコーディングが使われます。変換後の self を返します。
 
 (gsub!などと異なり)変換が行なわれなくても self を返します。


### PR DESCRIPTION
「さもなくば」という表現を「そうでない場合」に置換しました

個人的に「さもなくば」は、命令や強い口調の言葉であるように感じます
また「AさもなくばB」という文は、Aを満たさない場合、Bという悪い結果になる時によく用いられるような気がします

[然もなくば(サモナクバ)とは？ 意味や使い方 - コトバンク](https://kotobank.jp/word/%E7%84%B6%E3%82%82%E3%81%AA%E3%81%8F%E3%81%B0-512074)

> 降服せよ。然もなくば撃つぞ

[「さもなくば」の意味や使い方 わかりやすく解説 Weblio辞書](https://www.weblio.jp/content/%E3%81%95%E3%82%82%E3%81%AA%E3%81%8F%E3%81%B0)