### PR TITLE
Add more usage examples to Enumerable#all? and Array#all? documentation

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -589,6 +589,8 @@ p [5,  6, 7].all? {|v| v > 0 }   # => true
 p [5, -1, 7].all? {|v| v > 0 }   # => false
 p [].all? {|v| v > 0 }           # => true
 p %w[ant bear cat].all?(/t/)     # => false
+p [1, 2, 3].all?(Integer)        # => true
+p [1, 2, 3.0].all?(Integer)      # => false
 #@end
 
 @see [[m:Enumerable#all?]]

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -44,8 +44,8 @@ p (1..4).all?(Integer)                 # => true
 p [1, 2, 3].all?(Integer)              # => true
 p [1, 2, 3.0].all?(Integer)            # => false
 # Hashは[k, v]のペアなのでArray/Hash === [k, v]で評価
-p {foo: 0, bar: 1}.all?(Array)         # => true
-p {foo: 0, bar: 1}.all?(Hash)          # => false
+p({foo: 0, bar: 1}.all?(Array))        # => true
+p({foo: 0, bar: 1}.all?(Hash))         # => false
 #@end
 #@end
 

--- a/refm/api/src/_builtin/Enumerable
+++ b/refm/api/src/_builtin/Enumerable
@@ -40,6 +40,12 @@ p Set[].all? {|v| v > 0 }              # => true
 #@since 2.5.0
 
 p Set['ant', 'bear', 'cat'].all?(/t/)  # => false
+p (1..4).all?(Integer)                 # => true
+p [1, 2, 3].all?(Integer)              # => true
+p [1, 2, 3.0].all?(Integer)            # => false
+# Hashは[k, v]のペアなのでArray/Hash === [k, v]で評価
+p {foo: 0, bar: 1}.all?(Array)         # => true
+p {foo: 0, bar: 1}.all?(Hash)          # => false
 #@end
 #@end
 


### PR DESCRIPTION
I noticed that Enumerable#all? and Array#all? had detailed explanations but relatively few usage examples.

To help make them easier to understand, I added some example code—covering both common use cases and interesting patterns based on examples found in the source code.

Let me know if you'd like any changes. Thanks for reviewing!