### PR TITLE
create_makefileのブロック引数とdependファイルについて追加

### DIFF
--- a/refm/api/src/mkmf.rd
+++ b/refm/api/src/mkmf.rd
@@ -851,6 +851,19 @@ extconf.rb は普通このメソッドの呼び出しで終ります。
 
   /path/to/ruby/sitearchdir/test/foo.so
 
+ブロックを与える場合、生成する Makefile の設定部分を文字列の配列として
+yield します。
+
+   create_makefile('foo') {|conf|
+     [
+       *conf,
+       "MACRO_YOU_NEED = something",
+     ]
+   }
+
+ソースディレクトリに depend ファイルが存在する場合、その内容が
+[[m:Kernel#depend_rules]] メソッドで整形されて、生成される Makefile に加えられます。
+
 --- find_executable(bin, path = nil) -> String | nil
 
 パス path から実行ファイル bin を探します。


### PR DESCRIPTION
一月にRubyの https://github.com/ruby/ruby/commit/4daa5ebb77282b0c004ae07b0fa37a74dacdedf8 で追加されたドキュメントをこちらにも持って来ました。

よろしくお願いします。