### PR TITLE
OpenSSL::SSL::SSLSocket のサンプルを実際に動作するものに変更

### DIFF
--- a/refm/api/src/openssl/SSL__SSLSocket
+++ b/refm/api/src/openssl/SSL__SSLSocket
@@ -384,13 +384,24 @@ SSL/TLS サーバに接続して write します。
   require 'openssl'
   include OpenSSL
   
+  ctx = SSL::SSLContext.new
+  ctx.set_params(verify_mode: OpenSSL::SSL::VERIFY_PEER, verify_hostname: true)
+  
   soc = TCPSocket.new('www.example.com', 443)
-  ssl = SSL::SSLSocket.new(soc)
+  ssl = SSL::SSLSocket.new(soc, ctx)
+  ssl.hostname = 'www.example.com' # SNI
   ssl.connect
   ssl.post_connection_check('www.example.com')
   raise "verification error" if ssl.verify_result != OpenSSL::X509::V_OK
-  ssl.write('hoge')
   print ssl.peer_cert.to_text
+  
+  # HTTP リクエストを送信
+  ssl.write("GET / HTTP/1.1\r\n")
+  ssl.write("Host: www.example.com\r\n")
+  ssl.write("Connection: close\r\n")
+  ssl.write("\r\n")
+  print ssl.read
+  
   ssl.close
   soc.close
 


### PR DESCRIPTION
OpenSSL::SSL::SSLSocket のドキュメントのサンプルは example.com:443 に接続して `hoge` を送信するものでしたが、これは以下の理由で実際には動作しないものでした。

- example.com:443 は SNI を用いないと example.com の証明書を使わない
- SSLContext なしではシステムの証明書ストアが使われず、検証に成功しない
- (`hoge` は有効な HTTP リクエストではない)

このパッチはこれらの問題を解消するものです。