### PR TITLE
Ruby起動セクションの内部エンコーディングの出力例を修正

### DIFF
--- a/refm/doc/spec/rubycmd.rd
+++ b/refm/doc/spec/rubycmd.rd
@@ -149,8 +149,8 @@ nil
 # 内部エンコーディングをWindows-31Jにする場合
 
 $ ruby -E :Windows-31J -e 'p Encoding.default_external; p Encoding.default_internal'
-#<Encoding:Windows-31J>
 #<Encoding:UTF-8>
+#<Encoding:Windows-31J>
 
 $ ruby --encoding :Windows-31J -e 'p Encoding.default_external; p Encoding.default_internal'
 #<Encoding:UTF-8>


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/doc/spec=2frubycmd.html の「内部エンコーディングをWindows-31Jにする場合」の出力が逆だと思うので修正しました

![スクリーンショット 2025-06-22 16 04 53](https://github.com/user-attachments/assets/5bc31c7c-a7eb-476d-a433-04226c622206)
