### PR TITLE
Fix link in MatchData#offset

### DIFF
--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -180,7 +180,7 @@ n 番目の部分文字列のオフセットの配列 [start, end] を返
 @raise IndexError 範囲外の n を指定した場合に発生します。
 
 #@since 3.2
-@see [[m:MatchData#begin]], [[m:MatchData#end]], [[m:MatchData#offset]]
+@see [[m:MatchData#begin]], [[m:MatchData#end]], [[m:MatchData#byteoffset]]
 #@else
 @see [[m:MatchData#begin]], [[m:MatchData#end]]
 #@end
@@ -211,7 +211,7 @@ p $~.offset('century') # => `offset': undefined group name reference: century (I
 #@end
 
 #@since 3.2
-@see [[m:MatchData#begin]], [[m:MatchData#end]], [[m:MatchData#offset]]
+@see [[m:MatchData#begin]], [[m:MatchData#end]], [[m:MatchData#byteoffset]]
 #@else
 @see [[m:MatchData#begin]], [[m:MatchData#end]]
 #@end


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/MatchData/i/offset.html の SEE_ALSO に `MatchData#offset` 自身へのリンクが入っていますが、
[当該リンク追加のコミット](https://github.com/rurema/doctree/commit/f9da536f517d2bc34248c65f299f33ae691f6ed7) を見た感じ、 https://docs.ruby-lang.org/ja/latest/method/MatchData/i/byteoffset.html へのリンクとするのが良いのではないかと思いました。