### PR TITLE
Logger クラスのオプション `binmode`, `reraise_write_errors`, `skip_header` の説明を追加

### DIFF
--- a/refm/api/src/logger.rd
+++ b/refm/api/src/logger.rd
@@ -270,7 +270,7 @@ include Logger::Severity
 == Class Methods
 
 #@since 2.4.0
---- new(logdev, shift_age = 0, shift_size = 1048576, level: Logger::Severity::DEBUG, progname: nil, formatter: Formatter.new, datetime_format: nil, shift_period_suffix: '%Y%m%d') -> Logger
+--- new(logdev, shift_age = 0, shift_size = 1048576, level: Logger::Severity::DEBUG, progname: nil, formatter: Formatter.new, datetime_format: nil, binmode: false, shift_period_suffix: '%Y%m%d', reraise_write_errors: [], skip_header: false) -> Logger
 #@else
 --- new(logdev, shift_age = 0, shift_size = 1048576) -> Logger
 #@end
@@ -298,10 +298,22 @@ Logger オブジェクトを生成します。
 @param datetime_format ログに記録する時の日時のフォーマットを指定します。
                        省略した場合は '%Y-%m-%d %H:%M:%S' です。
 
+@param binmode ログに記録する時にバイナリモードを使用するかどうかを指定します。
+               省略した場合は false です。
+               Logger v1.4.0 以降で利用可能です。
+
 @param shift_period_suffix daily、weekly、monthlyでログファイルの切り替
                            えを行う時のログファイルの名の末尾に追加する
                            文字列のフォーマットを指定します。
                            省略した場合は '%Y%m%d' です。
+
+@param reraise_write_errors ログ書き込み時にエラーが発生した場合に raise される例外クラスの配列。
+                            省略した場合は空配列です。
+                            Logger v1.6.1 以降で利用可能です。
+
+@param skip_header ログファイルの先頭にヘッダー行を出力するかどうかを指定します。
+                   true の場合は出力しません。省略した場合は false です。
+                   Logger v1.7.0 以降で利用可能です。
 #@end
 
 #@since 2.4.0


### PR DESCRIPTION
## 概要

下記ページの修正です。
https://docs.ruby-lang.org/ja/latest/method/Logger/s/new.html

2025年7月24日時点の最新版 v1.7.0 における、Logger クラスのオプションのうち  `binmode`, `reraise_write_errors`, `skip_header`　3つの説明がなかったので追加しました。
https://github.com/ruby/logger/blob/v1.7.0/lib/logger.rb#L598-L601

説明文はコード中のコメントを参考にしました。
https://github.com/ruby/logger/blob/v1.7.0/lib/logger.rb#L584-L596

## 補足
### `binmode` オプションの追加バージョン

リリースノートによると v1.4.0 です。
https://github.com/ruby/logger/releases/tag/v1.4.0

PR は以下です。

- https://github.com/ruby/logger/pull/33 

### `reraise_write_errors` オプションの追加バージョン

リリースノートによると v1.6.1 です。
https://github.com/ruby/logger/releases/tag/v1.6.1

PR は以下です。
- https://github.com/ruby/logger/pull/37

### `skip_header` オプションの追加バージョン

リリースノートによると v1.7.0 です。
https://github.com/ruby/logger/releases/tag/v1.7.0

PR は以下です。
- https://github.com/ruby/logger/pull/119

## ローカル環境での確認結果
<img width="1883" height="896" alt="image" src="https://github.com/user-attachments/assets/f64f62b3-ae18-4455-8de0-492a08dfac40" />
