### PR TITLE
Addrinfo.newのtypoを修正

### DIFF
--- a/refm/api/src/socket/Addrinfo
+++ b/refm/api/src/socket/Addrinfo
@@ -13,7 +13,7 @@ struct addrinfo に対応します。
 新たな Addrinfo オブジェクトを返します。
 
 sockaddr は [[man:connect(2)]] などで使われるパラメータで、
-struct sockaddr に対応します。faimily, socktype, protocol
+struct sockaddr に対応します。family, socktype, protocol
 は [[man:socket(2)]] のパラメータに対応します。
 
 sockaddr には文字列もしくは配列を指定します。


### PR DESCRIPTION
`Addrinfo.new`の説明で誤植があったため修正しました、ご確認をよろしくお願いいたします。