### PR TITLE
psych_y を削除

### DIFF
--- a/refm/api/src/psych/core_ext.rd
+++ b/refm/api/src/psych/core_ext.rd
@@ -85,14 +85,8 @@ syck が廃止された場合  psych_to_yaml は廃止
 == Instance Methods
 
 --- y(*objects) -> nil
---- psych_y(*objects) -> nil
 objects を YAML document として標準出力に出力します。
 
 このメソッドは irb 上でのみ定義されます。
-
-[[lib:syck]] に y メソッドがあるため、
-psych_y が別名として定義されています。将来的に
-syck が廃止された場合  psych_y は廃止
-される予定であるため、特別の事情がない限り y を用いてください。
 
 @param objects YAML document に変換する Ruby のオブジェクト


### PR DESCRIPTION
fix https://github.com/rurema/doctree/issues/2965

以下の通りに`psych_y`を削除しました。

## Before
`/view/method/Kernel/i/y`
<img width="2191" height="656" alt="Screenshot 2025-08-28 at 23 29 32" src="https://github.com/user-attachments/assets/38c130d7-01a4-4c8c-8589-dbd75f35629f" />

`/view/library/psych`
<img width="911" height="221" alt="Screenshot 2025-08-28 at 23 29 56" src="https://github.com/user-attachments/assets/9c70a0cb-bcd9-45f7-a7e0-e53703fe5e39" />

## After
`/view/method/Kernel/i/y`
<img width="1379" height="579" alt="Screenshot 2025-08-28 at 23 25 34" src="https://github.com/user-attachments/assets/dae328e4-c183-4f83-a70a-f2ebc7cf5248" />

`/view/library/psych`
<img width="711" height="171" alt="Screenshot 2025-08-28 at 23 26 04" src="https://github.com/user-attachments/assets/32643aec-fa4b-4019-8a51-33060573f8da" />

認識違い、や対応漏れなどあればお伝えください🙏

