### PR TITLE
Fix typo mkdir_p's samplecode

### DIFF
--- a/refm/api/src/fileutils.rd
+++ b/refm/api/src/fileutils.rd
@@ -509,7 +509,7 @@ FileUtils.mkdir('notexist', noop: true)  # does not create really
 例えば、
 #@samplecode
 require 'fileutils'
-FileUtils.mkdir_p('/usr/local/lib/ruby')
+FileUtils.mkdir_p('/usr/local/bin/ruby')
 #@end
 
 は以下の全ディレクトリを (なければ) 作成します。


### PR DESCRIPTION
サンプルコード下の実行結果に合わせて、コマンド文字列を修正します。
```
 は以下の全ディレクトリを (なければ) 作成します。

    /usr
    /usr/local
    /usr/local/bin
    /usr/local/bin/ruby
```