### PR TITLE
Marshal.loadにfreeze: trueオプションを追加

### DIFF
--- a/refm/api/src/_builtin/Marshal
+++ b/refm/api/src/_builtin/Marshal
@@ -63,14 +63,24 @@ p Marshal.dump(Hash.new {})
 
 @see [[m:Object#marshal_dump]], [[m:Object#marshal_load]]
 
+#@since 3.1
+--- load(port, proc = nil, options = {})      -> object
+--- restore(port, proc = nil, options = {})   -> object
+#@else
 --- load(port, proc = nil)      -> object
 --- restore(port, proc = nil)   -> object
+#@end
 
 port からマーシャルデータを読み込んで、元のオブジェクトと同
 じ状態をもつオブジェクトを生成します。
 
 proc として手続きオブジェクトが与えられた場合には読み込んだ
 オブジェクトを引数にその手続きを呼び出します。
+
+#@since 3.1
+options の :freeze キーに真が指定された場合、読み込んだオブジェクトを freeze して返します。
+同一の文字列が freeze されているときオブジェクトは一つしか生まれないため、この指定によりメモリ使用効率が向上する場合があります。
+#@end
 
 #@samplecode 例
 str = Marshal.dump(["a", 1, 10 ** 10, 1.0, :foo])
@@ -89,6 +99,14 @@ p Marshal.load(str, proc {|obj| p obj})
             インスタンスを指定します。
 
 @param proc 手続きオブジェクト。[[c:Proc]]
+
+#@since 3.1
+@param options オプションをハッシュで指定します。指定可能なオプションは以下の通りです。
+
+: :freeze
+  真偽値を指定します。真を指定すると読み込んだオブジェクトを freeze して返します。
+  デフォルトは偽です。
+#@end
 
 @raise TypeError メジャーバージョンが異なるか、バージョンの大きな
                  マーシャルデータを読み込んだ場合に発生します。


### PR DESCRIPTION
Marshal.load にそなわっている `freeze: true` オプションを追加します。

Ruby 3.0 にはなく、Ruby 3.1 から導入されていて、以下で確認できます。

```shell
docker run -it --rm ruby:3.1.0 ruby -e 'p Marshal.load(Marshal.dump("a"), freeze: true)'
"a"
```

```shell
docker run -it --rm ruby:3.0.7 ruby -e 'p Marshal.load(Marshal.dump("a"), freeze: true)'
-e:1:in `load': undefined method `call' for {:freeze=>true}:Hash (NoMethodError)
        from -e:1:in `<main>'
```

参考:
ruby-doc https://ruby-doc.org/3.4.1/Marshal.html#method-c-load
コミット https://github.com/ruby/ruby/commit/afcbb501ac17ba2ad5370ada5fd26e8dda9a5aaa
