### PR TITLE
Fix error on ruby-head

### DIFF
--- a/refm/doc/spec/pattern_matching.rd
+++ b/refm/doc/spec/pattern_matching.rd
@@ -418,7 +418,7 @@ end
 #@# Binding to variables currently does NOT work for alternative patterns joined with <code>|</code>:
 変数への束縛は現状、『|』 で結合される Alternative パターン と同時には利用できません。
 
-#@samplecode
+//emlist{
 case {a: 1, b: 2}
 in {a: } | Array
   "matched: #{a}"
@@ -426,7 +426,7 @@ else
   "not matched"
 end
 # SyntaxError (illegal variable in alternative pattern (a))
-#@end
+//}
 
 #@# Variables that start with <code>_</code> are the only exclusions from this rule:
 『_』 で始まる変数は例外で、Alternative パターン と同時に利用することができます。


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21572 の変更の影響で
BitClust::SyntaxHighlighter::ParseError になっていたので、
samplecode を止めて emlist に変更。
