### PR TITLE
NEWS for Ruby 3.3.0の日本語を追加

### DIFF
--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -1,0 +1,347 @@
+#@since 3.3
+= NEWS for Ruby 3.3.0
+
+This document is a list of user-visible feature changes
+since the **3.2.0** release, except for bug fixes.
+
+Note that each entry is kept to a minimum, see links for details.
+
+== Command line options
+
+  * A new `performance` warning category was introduced.They are not displayed by default even in verbose mode.Turn them on with `-W:performance` or `Warning[:performance] = true`. [[feature:19538]]
+  * A new `RUBY_CRASH_REPORT` environment variable was introduced to allow redirecting Ruby crash reports to a file or sub command. See the `BUG REPORT ENVIRONMENT` section of the ruby manpage for further details. [[feature:19790]]
+
+== Core classes updates
+
+Note: We're only listing outstanding class updates.
+
+  * [[c:Array]]
+    * Array#pack now raises ArgumentError for unknown directives. [[bug:19150]]
+
+  * [[c:Dir]]
+    * Dir.for_fd added for returning a Dir object for the directory specified by the provided directory file descriptor. [[feature:19347]]
+    * Dir.fchdir added for changing the directory to the directory specified by the provided directory file descriptor. [[feature:19347]]
+    * Dir#chdir added for changing the directory to the directory specified by the provided `Dir` object. [[feature:19347]]
+
+  * [[c:Encoding]]
+      * `Encoding#replicate` has been removed, it was already deprecated.  [[feature:18949]]
+
+  * [[c:Fiber]]
+      * Introduce Fiber#kill. [[bug:595]]
+
+//emlist{
+fiber = Fiber.new do
+  while true
+    puts "Yielding..."
+    Fiber.yield
+  end
+ensure
+  puts "Exiting..."
+end
+
+fiber.resume
+# Yielding...
+fiber.kill
+# Exiting...
+//}
+
+  * [[c:MatchData]]
+    * MatchData#named_captures now accepts optional `symbolize_names` keyword.[[feature:19591]]
+
+  * [[c:Module]]
+    * Module#set_temporary_name added for setting a temporary name for a module.[[feature:19521]]
+
+  * ObjectSpace::WeakKeyMap
+    * New core class to build collections with weak references.The class use equality semantic to lookup keys like a regular hash, but it doesn't hold strong references on the keys.[[feature:18498]]
+
+  * [[c:ObjectSpace::WeakMap]]
+    * ObjectSpace::WeakMap#delete was added to eagerly clear weak map entries.[[feature:19561]]
+
+  * [[c:Proc]]
+    * Now Proc#dup and Proc#clone call `#initialize_dup` and `#initialize_clone` hooks respectively.[[feature:19362]]
+
+  * [[c:Process]]
+    * New Process.warmup method that notify the Ruby virtual machine that the boot sequence is finished, and that now is a good time to optimize the application. This is useful for long-running applications. The actual optimizations performed are entirely implementation-specific and may change in the future without notice.[[feature:18885]]
+
+  * [[c:Process::Status]]
+    * Process::Status#& and Process::Status#>> are deprecated.[[bug:19868]]
+
+  * [[c:Range]]
+    * Range#reverse_each can now process beginless ranges with an Integer endpoint.[[feature:18515]]
+    * Range#reverse_each now raises TypeError for endless ranges.[[feature:18551]]
+    * Range#overlap? added for checking if two ranges overlap.[[feature:19839]]
+
+  * [[c:Refinement]]
+    * Add Refinement#target as an alternative of Refinement#refined_class. Refinement#refined_class is deprecated and will be removed in Ruby 3.4.[[feature:19714]]
+
+  * [[c:Regexp]]
+    * The cache-based optimization now supports lookarounds and atomic groupings. That is, match for Regexp containing these extensions can now also be performed in linear time to the length of the input string. However, these cannot contain captures and cannot be nested.[[feature:19725]]
+
+  * [[c:String]]
+    * 変更されたメソッド
+      * String#unpack now raises ArgumentError for unknown directives.[[bug:19150]]
+      * String#bytesplice now accepts new arguments index/length or range of the source string to be copied.[[feature:19314]]
+
+  * [[c:Thread::Queue]]
+    * Thread::Queue#freeze now raises TypeError.[[bug:17146]]
+
+  * [[c:Thread::SizedQueue]]
+    * Thread::SizedQueue#freeze now raises TypeError.[[bug:17146]]
+
+  * [[c:Time]]
+    * Time.new with a string argument became stricter.[[bug:19293]]
+
+//emlist{
+Time.new('2023-12-20')
+#  no time information (ArgumentError)
+//}
+
+  * [[c:TracePoint]]
+    * TracePoint supports `rescue` event. When the raised exception was rescued, the TracePoint will fire the hook. `rescue` event only supports Ruby-level `rescue`. [[bug:19572]]
+
+== Stdlib updates
+  * RubyGems and Bundler warn if users do `require` the following gems without adding them to Gemfile or gemspec.
+    This is because they will become the bundled gems in the future version of Ruby. This warning is suppressed if you use bootsnap gem. We recommend to run your application with `DISABLE_BOOTSNAP=1` environmental variable at least once. This is limitation of this version.[[feature:19351]][[feature:19776]][[feature:19843]]
+    * abbrev
+    * base64
+    * bigdecimal
+    * csv
+    * drb
+    * getoptlong
+    * mutex_m
+    * nkf
+    * observer
+    * racc
+    * resolv-replace
+    * rinda
+    * syslog
+
+  * Socket#recv and Socket#recv_nonblock returns `nil` instead of an empty string on closed connections. Socket#recvmsg and Socket#recvmsg_nonblock returns `nil` instead of an empty packet on closed connections.[[bug:19012]]
+
+  * Name resolution such as Socket.getaddrinfo, Socket.getnameinfo, Addrinfo.getaddrinfo, etc. can now be interrupted.  [[feature:19965]]
+
+  * Random::Formatter#alphanumeric is extended to accept optional `chars` keyword argument.[[feature:18183]]
+
+The following default gem is added.
+  * prism 0.19.0
+
+The following default gems are updated.
+  * RubyGems 3.5.3
+  * abbrev 0.1.2
+  * base64 0.2.0
+  * benchmark 0.3.0
+  * bigdecimal 3.1.5
+  * bundler 2.5.3
+  * cgi 0.4.1
+  * csv 3.2.8
+  * date 3.3.4
+  * delegate 0.3.1
+  * drb 2.2.0
+  * english 0.8.0
+  * erb 4.0.3
+  * error_highlight 0.6.0
+  * etc 1.4.3
+  * fcntl 1.1.0
+  * fiddle 1.1.2
+  * fileutils 1.7.2
+  * find 0.2.0
+  * getoptlong 0.2.1
+  * io-console 0.7.1
+  * io-nonblock 0.3.0
+  * io-wait 0.3.1
+  * ipaddr 1.2.6
+  * irb 1.11.0
+  * json 2.7.1
+  * logger 1.6.0
+  * mutex_m 0.2.0
+  * net-http 0.4.0
+  * net-protocol 0.2.2
+  * nkf 0.1.3
+  * observer 0.1.2
+  * open-uri 0.4.1
+  * open3 0.2.1
+  * openssl 3.2.0
+  * optparse 0.4.0
+  * ostruct 0.6.0
+  * pathname 0.3.0
+  * pp 0.5.0
+  * prettyprint 0.2.0
+  * pstore 0.1.3
+  * psych 5.1.2
+  * rdoc 6.6.2
+  * readline 0.0.4
+  * reline 0.4.1
+  * resolv 0.3.0
+  * rinda 0.2.0
+  * securerandom 0.3.1
+  * set 1.1.0
+  * shellwords 0.2.0
+  * singleton 0.2.0
+  * stringio 3.1.0
+  * strscan 3.0.7
+  * syntax_suggest 2.0.0
+  * syslog 0.1.2
+  * tempfile 0.2.1
+  * time 0.3.0
+  * timeout 0.4.1
+  * tmpdir 0.2.0
+  * tsort 0.2.0
+  * un 0.3.0
+  * uri 0.13.0
+  * weakref 0.1.3
+  * win32ole 1.8.10
+  * yaml 0.3.0
+  * zlib 3.1.0
+
+The following bundled gem is promoted from default gems.
+  * racc 1.7.3
+
+The following bundled gems are updated.
+  * minitest 5.20.0
+  * rake 13.1.0
+  * test-unit 3.6.1
+  * rexml 3.2.6
+  * rss 0.3.0
+  * net-ftp 0.3.3
+  * net-imap 0.4.9
+  * net-smtp 0.4.0
+  * rbs 3.4.0
+  * typeprof 0.21.9
+  * debug 1.9.1
+
+See GitHub releases like Logger([[url:https://github.com/ruby/logger/releases]]) orchangelog for details of the default gems or bundled gems.
+
+  * Prism
+    * Introduced the Prism parser([[url:https://github.com/ruby/prism]]) as a default gem
+      * Prism is a portable, error tolerant, and maintainable recursive descent parser for the Ruby language
+    * Prism is production ready and actively maintained, you can use it in place of Ripper
+      * There is extensive documentation([[url:https://ruby.github.io/prism/]]) on how to use Prism
+      * Prism is both a C library that will be used internally by CRuby and a Ruby gem that can be used by any tooling which needs to parse Ruby code
+      * Notable methods in the Prism API are:
+        * Prism.parse(source) which returns the AST as part of a parse result object
+        * Prism.parse_comments(source) which returns the comments
+        * Prism.parse_success?(source) which returns true if there are no errors
+    * You can make pull requests or issues directly on the Prism repository([[url:https://github.com/ruby/prism]]) if you are interested in contributing
+    * You can now use ruby --parser=prism or RUBYOPT="--parser=prism" to experiment with the Prism compiler. Please note that this flag is for debugging only.
+
+== Compatibility issues
+  * Subprocess creation/forking via the following file open methods is deprecated. [[feature:19630]]
+    * [[m:Kernel.#open]]
+    * [[m:URI.open]]
+    * [[m:IO.binread]]
+    * [[m:IO.foreach]]
+    * [[m:IO.readlines]]
+    * [[m:IO.read]]
+    * [[m:IO.write]]
+  * When given a non-lambda, non-literal block, Kernel#lambda with now raises ArgumentError instead of returning it unmodified. These usages have been issuing warnings under the `Warning[:deprecated]` category since Ruby 3.0.0.[[feature:19777]]
+  * The `RUBY_GC_HEAP_INIT_SLOTS` environment variable has been deprecated and removed. Environment variables `RUBY_GC_HEAP_%d_INIT_SLOTS` should be used instead.[[feature:19785]]
+  * `it` calls without arguments in a block with no ordinary parameters are deprecated. `it` will be a reference to the first block parameter in Ruby 3.4. [[feature:18980]]
+  * Error message for NoMethodError have changed to not use the target object's `#inspect` for efficiency, and says "instance of ClassName" instead.[[feature:18285]]
+//emlist{
+([1] * 100).nonexisting
+# undefined method `nonexisting' for an instance of Array (NoMethodError)
+//}
+  * Now anonymous parameters forwarding is disallowed inside a block that uses anonymous parameters.[[feature:19370]]
+
+== Stdlib compatibility issues
+  * `racc` is promoted to bundled gems
+    * You need to add `racc` to your `Gemfile` if you use `racc` under bundler environment.
+  * `ext/readline` is retired
+    * We have `reline` that is pure Ruby implementation compatible with `ext/readline` API. We rely on `reline` in the future. If you need to use `ext/readline`, you can install `ext/readline` via rubygems.org with `gem install readline-ext`.
+    * We no longer need to install libraries like `libreadline` or `libedit`.
+
+== C API updates
+  * `rb_postponed_job` updates
+    * New APIs and deprecated APIs (see comments for details)
+      * added: `rb_postponed_job_preregister()`
+      * added: `rb_postponed_job_trigger()`
+      * deprecated: `rb_postponed_job_register()` (and semantic change. see below)
+      * deprecated: `rb_postponed_job_register_one()`
+    * The postponed job APIs have been changed to address some rare crashes. To solve the issue, we introduced new two APIs and deprecated current APIs. The semantics of these functions have also changed slightly; `rb_postponed_job_register` now behaves like the `once` variant in that multiple calls with the same `func` might be coalesced into a single execution of the `func` [[feature:20057]]
+  * Some updates for internal thread event hook APIs
+    * `rb_internal_thread_event_data_t` with a target Ruby thread (VALUE) and callback functions (`rb_internal_thread_event_callback`) receive it.[[url:https://github.com/ruby/ruby/pull/8885]]
+    * The following functions are introduced to manipulate Ruby thread local data from internal thread event hook APIs (they are introduced since Ruby 3.2).[[url:https://github.com/ruby/ruby/pull/8936]]
+      * rb_internal_thread_specific_key_create()
+      * rb_internal_thread_specific_get()
+      * rb_internal_thread_specific_set()
+    * rb_profile_thread_frames() is introduced to get a frames from a specific thread.[[feature:10602]]
+    * rb_data_define() is introduced to define `Data`.[[feature:19757]]
+    * rb_ext_resolve_symbol() is introduced to search a function from extension libraries.[[feature:20005]]
+  * IO related updates:
+    * The details of `rb_io_t` will be hidden and deprecated attributes are added for each members.[[feature:19057]]
+    * rb_io_path(VALUE io) is introduced to get a path of `io`.
+    * rb_io_closed_p(VALUE io) to get opening or closing of `io`.
+    * rb_io_mode(VALUE io) to get the mode of `io`.
+    * rb_io_open_descriptor() is introduced to make an IO object from a file descriptor.
+
+== Implementation improvements
+=== Parser
+  * Replace Bison with Lrama LALR parser generator([[url:https://github.com/ruby/lrama]]) No need to install Bison to build Ruby from source code anymore. We will no longer suffer bison compatibility issues and we can use new features by just implementing it to Lrama.[[feature:19637]]
+    * See The future vision of Ruby Parser([[url:https://rubykaigi.org/2023/presentations/spikeolaf.html]]) for detail.
+    * Lrama internal parser is a LR parser generated by Racc for maintainability.
+    * Parameterizing Rules `(?, *, +)` are supported, it will be used in Ruby parse.y.
+
+=== GC / Memory management
+  * Major performance improvements over Ruby 3.2
+    * Young objects referenced by old objects are no longer immediately promoted to the old generation. This significantly reduces the frequency of major GC collections.[[feature:19678]]
+    * A new `REMEMBERED_WB_UNPROTECTED_OBJECTS_LIMIT_RATIO` tuning variable was introduced to control the number of unprotected objects cause a major GC collection to trigger. The default is set to `0.01` (1%). This significantly reduces the frequency of major GC collection.[[feature:19571]]
+    * Write Barriers were implemented for many core types that were missing them, notably Time, Enumerator, MatchData, Method, File::Stat, BigDecimal and several others. This significantly reduces minor GC collection time and major GC collection frequency.
+    * Most core classes are now using Variable Width Allocation, notably Hash, Time, Thread::Backtrace, Thread::Backtrace::Location, File::Stat, Method. This makes these classes faster to allocate and free, use less memory and reduce heap fragmentation.
+  * defined?(@ivar) is optimized with Object Shapes.
+
+=== YJIT
+  * Major performance improvements over Ruby 3.2
+    * Support for splat and rest arguments has been improved.
+    * Registers are allocated for stack operations of the virtual machine.
+    * More calls with optional arguments are compiled. Exception handlers are also compiled.
+    * Unsupported call types and megamorphic call sites no longer exit to the interpreter.
+    * Basic methods like Rails `#blank?` and specialized `#present?`[[url:https://github.com/rails/rails/pull/49909]] are inlined.
+    * `Integer#*`, `Integer#!=`, `String#!=`, `String#getbyte`, `Kernel#block_given?`, `Kernel#is_a?`, `Kernel#instance_of?`, and `Module#===` are specially optimized.
+    * Compilation speed is now slightly faster than Ruby 3.2.
+    * Now more than 3x faster than the interpreter on Optcarrot!
+  * Significantly improved memory usage over Ruby 3.2
+    * Metadata for compiled code uses a lot less memory.
+    * `--yjit-call-threshold` is automatically raised from 30 to 120
+      when the application has more than 40,000 ISEQs.
+    * `--yjit-cold-threshold` is added to skip compiling cold ISEQs.
+    * More compact code is generated on Arm64.
+  * Code GC is now disabled by default
+    * `--yjit-exec-mem-size` is treated as a hard limit where compilation of new code stops.
+    * No sudden drops in performance due to code GC. Better copy-on-write behavior on servers reforking with Pitchfork([[url:https://github.com/shopify/pitchfork]]).
+    * You can still enable code GC if desired with `--yjit-code-gc`
+  * Add `RubyVM::YJIT.enable` that can enable YJIT at run-time
+    * You can start YJIT without modifying command-line arguments or environment variables. Rails 7.2 will enable YJIT by default([[url:https://github.com/rails/rails/pull/49947]]) using this method.
+    * This can also be used to enable YJIT only once your application is done booting. `--yjit-disable` can be used if you want to use other YJIT options while disabling YJIT at boot.
+  * More YJIT stats are available by default
+    * `yjit_alloc_size` and several more metadata-related stats are now available by default.
+    * `ratio_in_yjit` stat produced by `--yjit-stats` is now available in release builds, a special stats or dev build is no longer required to access most stats.
+  * Add more profiling capabilities
+    * `--yjit-perf` is added to facilitate profiling with Linux perf.
+    * `--yjit-trace-exits` now supports sampling with `--yjit-trace-exits-sample-rate=N`
+  * More thorough testing and multiple bug fixes
+  * `--yjit-stats=quiet` is added to avoid printing stats on exit.
+
+=== MJIT
+  * MJIT is removed.
+    * `--disable-jit-support` is removed. Consider using `--disable-yjit --disable-rjit` instead.
+
+=== RJIT
+  * * Introduced a pure-Ruby JIT compiler RJIT.
+    * RJIT supports only x86\_64 architecture on Unix platforms.
+    * Unlike MJIT, it doesn't require a C compiler at runtime.
+  * RJIT exists only for experimental purposes.
+      * You should keep using YJIT in production.
+
+=== M:N Thread scheduler
+  * M:N Thread scheduler is introduced.[[feature:19842]]
+    * Background: Ruby 1.8 and before, M:1 thread scheduler (M Ruby threads with 1 native thread. Called as User level threads or Green threads) is used. Ruby 1.9 and later, 1:1 thread scheduler (1 Ruby thread with 1 native thread).
+      M:1 threads takes lower resources compare with 1:1 threads because it needs only 1 native threads. However it is difficult to support context switching for all of blocking operation so 1:1 threads are employed from Ruby 1.9.
+      M:N thread scheduler uses N native threads for M Ruby threads (N is small number in general). It doesn't need same number of native threads as Ruby threads (similar to the M:1 thread scheduler).
+      Also our M:N threads supports blocking operations well same as 1:1 threads. See the ticket for more details.
+      Our M:N thread scheduler refers on the goroutine scheduler in the Go language.
+    * In a ractor, only 1 thread can run in a same time because of implementation. Therefore, applications that use only one Ractor (most applications) M:N thread scheduler works as M:1 thread scheduler with further extension from Ruby 1.8.
+    * M:N thread scheduler can introduce incompatibility for C-extensions, so it is disabled by default on the main Ractors.
+      `RUBY_MN_THREADS=1` environment variable will enable it. On non-main Ractors, M:N thread scheduler is enabled (and can not disable it now).
+    * `N` (the number of native threads) can be specified with `RUBY_MAX_CPU` environment variable. The default is 8.
+      Note that more than `N` native threads are used to support many kind of blocking operations.
+#@end

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -1,33 +1,33 @@
 #@since 3.3
 = NEWS for Ruby 3.3.0
 
-This document is a list of user-visible feature changes
-since the **3.2.0** release, except for bug fixes.
+このドキュメントは前回リリース以降のバグ修正を除くユーザーに影響のある機能の変更のリストです。
 
-Note that each entry is kept to a minimum, see links for details.
+それぞれのエントリーは参照情報があるため短いです。
+十分な情報と共に書かれた全ての変更のリストはリンク先を参照してください。
 
-== Command line options
+== コマンドラインオプション
 
-  * A new `performance` warning category was introduced.They are not displayed by default even in verbose mode.Turn them on with `-W:performance` or `Warning[:performance] = true`. [[feature:19538]]
-  * A new `RUBY_CRASH_REPORT` environment variable was introduced to allow redirecting Ruby crash reports to a file or sub command. See the `BUG REPORT ENVIRONMENT` section of the ruby manpage for further details. [[feature:19790]]
+  * 新しい警告カテゴリ performance が導入されました。この警告は詳細表示モードでもデフォルトでは表示されません。 -W:performance または Warning[:performance] = true で表示を切り替えてください。[[feature:19538]]
+  * Rubyのクラッシュレポートをファイルまたはサブコマンドにリダイレクトするための新しい環境変数 RUBY_CRASH_REPORT が導入されました。詳細はrubyのmanページのBUG REPORT ENVIRONMENTセクションをご覧ください。[[feature:19790]]
 
-== Core classes updates
-
-Note: We're only listing outstanding class updates.
+== 組み込みクラスの更新(注目すべきもののみ)
 
   * [[c:Array]]
-    * Array#pack now raises ArgumentError for unknown directives. [[bug:19150]]
+    * 変更されたメソッド
+      * [[m:Array#pack]]が不明なディレクティブに対してArgumentErrorを発生するようになりました。 [[bug:19150]]
 
   * [[c:Dir]]
-    * Dir.for_fd added for returning a Dir object for the directory specified by the provided directory file descriptor. [[feature:19347]]
-    * Dir.fchdir added for changing the directory to the directory specified by the provided directory file descriptor. [[feature:19347]]
-    * Dir#chdir added for changing the directory to the directory specified by the provided `Dir` object. [[feature:19347]]
+    * 新規メソッド
+      * Dir.for_fd Dir.fchdir Dir#chdir が追加されました。 [[feature:19347]]
 
   * [[c:Encoding]]
-      * `Encoding#replicate` has been removed, it was already deprecated.  [[feature:18949]]
+    * 削除されたメソッド
+      * 非推奨だった Encoding#replicate が削除されました。[[feature:18949]]
 
   * [[c:Fiber]]
-      * Introduce Fiber#kill. [[bug:595]]
+    * 新規メソッド
+      * Fiber#kill が導入されました。[[bug:595]]
 
 //emlist{
 fiber = Fiber.new do
@@ -46,50 +46,61 @@ fiber.kill
 //}
 
   * [[c:MatchData]]
-    * MatchData#named_captures now accepts optional `symbolize_names` keyword.[[feature:19591]]
+    * 変更されたメソッド
+      * MatchData#named_captures が symbolize_names キーワード引数を受け取るようになりました。[[feature:19591]]
 
   * [[c:Module]]
-    * Module#set_temporary_name added for setting a temporary name for a module.[[feature:19521]]
+    * 新規メソッド
+      * 無名モジュールや無名クラスに仮の名前を与える Module#set_temporary_name が追加されました。[[feature:19521]]
 
   * ObjectSpace::WeakKeyMap
-    * New core class to build collections with weak references.The class use equality semantic to lookup keys like a regular hash, but it doesn't hold strong references on the keys.[[feature:18498]]
+    * weak reference を持つコレクションを構築するための新しい組み込みクラス ObjectSpace::WeakKeyMap が導入されました。このクラスは通常のハッシュと同様に equality でキーを検索しますが、キーに対する strong reference は保持しません。[[feature:18498]]
 
   * [[c:ObjectSpace::WeakMap]]
-    * ObjectSpace::WeakMap#delete was added to eagerly clear weak map entries.[[feature:19561]]
+    * 新規メソッド
+      * ObjectSpace::WeakMap#delete が導入されました。[[feature:19561]]
 
   * [[c:Proc]]
-    * Now Proc#dup and Proc#clone call `#initialize_dup` and `#initialize_clone` hooks respectively.[[feature:19362]]
+    * 変更されたメソッド
+      * Proc#dup と Proc#clone が、それぞれ #initialize_dup と #initialize_clone を呼ぶようになりました。[[feature:19362]]
 
   * [[c:Process]]
-    * New Process.warmup method that notify the Ruby virtual machine that the boot sequence is finished, and that now is a good time to optimize the application. This is useful for long-running applications. The actual optimizations performed are entirely implementation-specific and may change in the future without notice.[[feature:18885]]
+    * 新規メソッド
+      * [[c:RubyVM]]にアプリケーションの起動が終了したこと及び、アプリケーションの最適化に適したタイミングであることを通知する Process.warmup が追加されました。このメソッドが行う最適化は実装依存であり、将来予告なく変更される可能性があります。[[feature:18885]]
 
   * [[c:Process::Status]]
-    * Process::Status#& and Process::Status#>> are deprecated.[[bug:19868]]
+    * 変更されたメソッド
+      * [[m:Process::Status#&]] と [[m:Process::Status#>>]] が非推奨になりました。[[bug:19868]]
 
   * [[c:Range]]
-    * Range#reverse_each can now process beginless ranges with an Integer endpoint.[[feature:18515]]
-    * Range#reverse_each now raises TypeError for endless ranges.[[feature:18551]]
-    * Range#overlap? added for checking if two ranges overlap.[[feature:19839]]
+    * 新規メソッド
+      * beginless rangeに対しても動作する Range#reverse_each が追加されました。[[feature:18515]]
+      * Range#reverse_each は endless range に対しては例外を投げます[[feature:18551]]
+      * 2つの範囲が重複しているかどうかを確認する Range#overlap? が追加されました。[[feature:19839]]
 
   * [[c:Refinement]]
-    * Add Refinement#target as an alternative of Refinement#refined_class. Refinement#refined_class is deprecated and will be removed in Ruby 3.4.[[feature:19714]]
+    * 変更されたメソッド
+      * Refinement#refined_class が #target に名前変更されました。 Refinement#refined_class は非推奨となり、Ruby 3.4 で削除予定です。[[feature:19714]]
 
   * [[c:Regexp]]
-    * The cache-based optimization now supports lookarounds and atomic groupings. That is, match for Regexp containing these extensions can now also be performed in linear time to the length of the input string. However, these cannot contain captures and cannot be nested.[[feature:19725]]
+    * Ruby3.2で導入されたReDos対策のメモ化最適化が先読み・後読みやアトミックグループをサポートするようになり、これらの拡張を含む正規表現も入力文字列の長さに対して線形時間で実行できるようになりました。ただし、これらの拡張にはキャプチャを含めることはできず、ネストもできません。[[feature:19725]]
 
   * [[c:String]]
     * 変更されたメソッド
-      * String#unpack now raises ArgumentError for unknown directives.[[bug:19150]]
-      * String#bytesplice now accepts new arguments index/length or range of the source string to be copied.[[feature:19314]]
+      * [[m:String#unpack]]が不明なディレクティブに対して例外を投げるようになりました。[[bug:19150]]
+      * [[m:String#bytesplice]]がコピー元の文字列のインデックス/長さまたはrangeを引数に取れるようになりました。これによりコピー元の部分範囲を指定できるようになりました。[[feature:19314]]
 
   * [[c:Thread::Queue]]
-    * Thread::Queue#freeze now raises TypeError.[[bug:17146]]
+    * 変更されたメソッド
+      * [[m:Thread::Queue#freeze]]がTypeErrorを発生するようになりました。 [[bug:17146]]
 
   * [[c:Thread::SizedQueue]]
-    * Thread::SizedQueue#freeze now raises TypeError.[[bug:17146]]
+    * 変更されたメソッド
+      * [[m:Thread::SizedQueue#freeze]]がTypeErrorを発生するようになりました。 [[bug:17146]]
 
   * [[c:Time]]
-    * Time.new with a string argument became stricter.[[bug:19293]]
+    * 変更されたメソッド
+      * [[m:Time.new]]の文字列引数がより厳格になりました。 [[bug:19293]]
 
 //emlist{
 Time.new('2023-12-20')
@@ -97,11 +108,10 @@ Time.new('2023-12-20')
 //}
 
   * [[c:TracePoint]]
-    * TracePoint supports `rescue` event. When the raised exception was rescued, the TracePoint will fire the hook. `rescue` event only supports Ruby-level `rescue`. [[bug:19572]]
+    * rescue イベントが追加され、rescue節を開始するときに発火するフックを入れることができるようになりました。rescue イベントはRubyレベルで記述された rescue のみサポートします。 [[bug:19572]]
 
-== Stdlib updates
-  * RubyGems and Bundler warn if users do `require` the following gems without adding them to Gemfile or gemspec.
-    This is because they will become the bundled gems in the future version of Ruby. This warning is suppressed if you use bootsnap gem. We recommend to run your application with `DISABLE_BOOTSNAP=1` environmental variable at least once. This is limitation of this version.[[feature:19351]][[feature:19776]][[feature:19843]]
+== 標準添付ライブラリの更新(機能追加とバグ修正を除く)
+  * RubyGems と Bundler は将来リリースされる Ruby で bundled gems となる予定の gem が Gemfile または gemspec に存在しない状態で require された際に警告を行う機能が追加されました。この警告は bootsnap gem を使っている場合には 3.3.0 の時点では機能上の制限により出力されません。そのため、環境変数として DISABLE_BOOTSNAP=1 などを設定して、少なくとも1度はアプリケーションを実行することを推奨します。以下のライブラリが警告の対象となります。[[feature:19351]][[feature:19776]][[feature:19843]]
     * abbrev
     * base64
     * bigdecimal
@@ -116,116 +126,116 @@ Time.new('2023-12-20')
     * rinda
     * syslog
 
-  * Socket#recv and Socket#recv_nonblock returns `nil` instead of an empty string on closed connections. Socket#recvmsg and Socket#recvmsg_nonblock returns `nil` instead of an empty packet on closed connections.[[bug:19012]]
+  * クローズされた Socket に対して Socket#recv と Socket#recv_nonblock は空文字列ではなくnilを返すようになり、Socket#recvmsg と Socket#recvmsg_nonblock は空のパケットではなくnilを返すようになりました。[[bug:19012]]
 
-  * Name resolution such as Socket.getaddrinfo, Socket.getnameinfo, Addrinfo.getaddrinfo, etc. can now be interrupted.  [[feature:19965]]
+  * [[m:Socket.getaddrinfo]] [[m:Socket.getnameinfo]] [[m:Addrinfo.getaddrinfo]] などの名前解決を中断できるようになりました。 [[feature:19965]]
 
-  * Random::Formatter#alphanumeric is extended to accept optional `chars` keyword argument.[[feature:18183]]
+  * [[m:Random::Formatter#alphanumeric]] がオプションの chars キーワード引数を受け取るようになりました。[[feature:18183]]
 
-The following default gem is added.
-  * prism 0.19.0
+  * 以下がdefault gemsに追加されました。
+    * prism 0.19.0
 
-The following default gems are updated.
-  * RubyGems 3.5.3
-  * abbrev 0.1.2
-  * base64 0.2.0
-  * benchmark 0.3.0
-  * bigdecimal 3.1.5
-  * bundler 2.5.3
-  * cgi 0.4.1
-  * csv 3.2.8
-  * date 3.3.4
-  * delegate 0.3.1
-  * drb 2.2.0
-  * english 0.8.0
-  * erb 4.0.3
-  * error_highlight 0.6.0
-  * etc 1.4.3
-  * fcntl 1.1.0
-  * fiddle 1.1.2
-  * fileutils 1.7.2
-  * find 0.2.0
-  * getoptlong 0.2.1
-  * io-console 0.7.1
-  * io-nonblock 0.3.0
-  * io-wait 0.3.1
-  * ipaddr 1.2.6
-  * irb 1.11.0
-  * json 2.7.1
-  * logger 1.6.0
-  * mutex_m 0.2.0
-  * net-http 0.4.0
-  * net-protocol 0.2.2
-  * nkf 0.1.3
-  * observer 0.1.2
-  * open-uri 0.4.1
-  * open3 0.2.1
-  * openssl 3.2.0
-  * optparse 0.4.0
-  * ostruct 0.6.0
-  * pathname 0.3.0
-  * pp 0.5.0
-  * prettyprint 0.2.0
-  * pstore 0.1.3
-  * psych 5.1.2
-  * rdoc 6.6.2
-  * readline 0.0.4
-  * reline 0.4.1
-  * resolv 0.3.0
-  * rinda 0.2.0
-  * securerandom 0.3.1
-  * set 1.1.0
-  * shellwords 0.2.0
-  * singleton 0.2.0
-  * stringio 3.1.0
-  * strscan 3.0.7
-  * syntax_suggest 2.0.0
-  * syslog 0.1.2
-  * tempfile 0.2.1
-  * time 0.3.0
-  * timeout 0.4.1
-  * tmpdir 0.2.0
-  * tsort 0.2.0
-  * un 0.3.0
-  * uri 0.13.0
-  * weakref 0.1.3
-  * win32ole 1.8.10
-  * yaml 0.3.0
-  * zlib 3.1.0
+  * 以下のdefault gemsが更新されました。
+    * RubyGems 3.5.3
+    * abbrev 0.1.2
+    * base64 0.2.0
+    * benchmark 0.3.0
+    * bigdecimal 3.1.5
+    * bundler 2.5.3
+    * cgi 0.4.1
+    * csv 3.2.8
+    * date 3.3.4
+    * delegate 0.3.1
+    * drb 2.2.0
+    * english 0.8.0
+    * erb 4.0.3
+    * error_highlight 0.6.0
+    * etc 1.4.3
+    * fcntl 1.1.0
+    * fiddle 1.1.2
+    * fileutils 1.7.2
+    * find 0.2.0
+    * getoptlong 0.2.1
+    * io-console 0.7.1
+    * io-nonblock 0.3.0
+    * io-wait 0.3.1
+    * ipaddr 1.2.6
+    * irb 1.11.0
+    * json 2.7.1
+    * logger 1.6.0
+    * mutex_m 0.2.0
+    * net-http 0.4.0
+    * net-protocol 0.2.2
+    * nkf 0.1.3
+    * observer 0.1.2
+    * open-uri 0.4.1
+    * open3 0.2.1
+    * openssl 3.2.0
+    * optparse 0.4.0
+    * ostruct 0.6.0
+    * pathname 0.3.0
+    * pp 0.5.0
+    * prettyprint 0.2.0
+    * pstore 0.1.3
+    * psych 5.1.2
+    * rdoc 6.6.2
+    * readline 0.0.4
+    * reline 0.4.1
+    * resolv 0.3.0
+    * rinda 0.2.0
+    * securerandom 0.3.1
+    * set 1.1.0
+    * shellwords 0.2.0
+    * singleton 0.2.0
+    * stringio 3.1.0
+    * strscan 3.0.7
+    * syntax_suggest 2.0.0
+    * syslog 0.1.2
+    * tempfile 0.2.1
+    * time 0.3.0
+    * timeout 0.4.1
+    * tmpdir 0.2.0
+    * tsort 0.2.0
+    * un 0.3.0
+    * uri 0.13.0
+    * weakref 0.1.3
+    * win32ole 1.8.10
+    * yaml 0.3.0
+    * zlib 3.1.0
 
-The following bundled gem is promoted from default gems.
-  * racc 1.7.3
+  * 以下の gem が defalut gems から budled gems に変更されました。
+    * racc 1.7.3
 
-The following bundled gems are updated.
-  * minitest 5.20.0
-  * rake 13.1.0
-  * test-unit 3.6.1
-  * rexml 3.2.6
-  * rss 0.3.0
-  * net-ftp 0.3.3
-  * net-imap 0.4.9
-  * net-smtp 0.4.0
-  * rbs 3.4.0
-  * typeprof 0.21.9
-  * debug 1.9.1
+  * 以下の bundled gemsが更新されました。
+    * minitest 5.20.0
+    * rake 13.1.0
+    * test-unit 3.6.1
+    * rexml 3.2.6
+    * rss 0.3.0
+    * net-ftp 0.3.3
+    * net-imap 0.4.9
+    * net-smtp 0.4.0
+    * rbs 3.4.0
+    * typeprof 0.21.9
+    * debug 1.9.1
 
-See GitHub releases like Logger([[url:https://github.com/ruby/logger/releases]]) orchangelog for details of the default gems or bundled gems.
+default gems と bundled gems の詳細については Logger の GitHub Releases([[url:https://github.com/ruby/logger/releases]]) のような GitHub releases または changelog ファイルを参照してください。
 
   * Prism
-    * Introduced the Prism parser([[url:https://github.com/ruby/prism]]) as a default gem
-      * Prism is a portable, error tolerant, and maintainable recursive descent parser for the Ruby language
-    * Prism is production ready and actively maintained, you can use it in place of Ripper
-      * There is extensive documentation([[url:https://ruby.github.io/prism/]]) on how to use Prism
-      * Prism is both a C library that will be used internally by CRuby and a Ruby gem that can be used by any tooling which needs to parse Ruby code
-      * Notable methods in the Prism API are:
-        * Prism.parse(source) which returns the AST as part of a parse result object
-        * Prism.parse_comments(source) which returns the comments
-        * Prism.parse_success?(source) which returns true if there are no errors
-    * You can make pull requests or issues directly on the Prism repository([[url:https://github.com/ruby/prism]]) if you are interested in contributing
-    * You can now use ruby --parser=prism or RUBYOPT="--parser=prism" to experiment with the Prism compiler. Please note that this flag is for debugging only.
+    * default gemとしてPrismパーサーが導入されました。
+      * Prismは、Ruby言語のためのポータブルで、エラートレラントで、保守可能な再帰下降パーサです。
+    * Prismは本番環境で使用する準備が整っており、積極的にメンテナンスされています。Ripperの代わりに使用することができます。
+      * Prismの使用方法については、詳細なドキュメンテーション([[url:https://ruby.github.io/prism/]])があります。
+      * Prismは、CRubyに内部的に使用されるCライブラリと、Rubyコードを解析する必要がある任意のツールに使用できるRuby gemの2つのコンポーネントを持っています。
+      * Prism APIの注目すべきメソッドには以下のものがあります。
+        * Prism.parse(source) は、パース結果オブジェクトの一部としてASTを返します。
+        * Prism.parse_comments(source) はコメントを返します。
+        * Prism.parse_success?(source) はエラーがない場合にtrueを返します。
+    * Prism開発への貢献に興味がある場合は、Prismリポジトリ([[url:https://github.com/ruby/prism]])に直接Pull RequestやIssueを作成することができます。
+    * 今後は ruby --parser=prism または RUBYOPT="--parser=prism" を使用してPrismコンパイラを試すことができます。ただし、このフラグはデバッグ用であることに注意してください。
 
-== Compatibility issues
-  * Subprocess creation/forking via the following file open methods is deprecated. [[feature:19630]]
+== 互換性に関する変更
+  * 以下のファイルオープンメソッドによるサブプロセスの作成/フォークは非推奨です。[[feature:19630]]
     * [[m:Kernel.#open]]
     * [[m:URI.open]]
     * [[m:IO.binread]]
@@ -233,115 +243,119 @@ See GitHub releases like Logger([[url:https://github.com/ruby/logger/releases]])
     * [[m:IO.readlines]]
     * [[m:IO.read]]
     * [[m:IO.write]]
-  * When given a non-lambda, non-literal block, Kernel#lambda with now raises ArgumentError instead of returning it unmodified. These usages have been issuing warnings under the `Warning[:deprecated]` category since Ruby 3.0.0.[[feature:19777]]
-  * The `RUBY_GC_HEAP_INIT_SLOTS` environment variable has been deprecated and removed. Environment variables `RUBY_GC_HEAP_%d_INIT_SLOTS` should be used instead.[[feature:19785]]
-  * `it` calls without arguments in a block with no ordinary parameters are deprecated. `it` will be a reference to the first block parameter in Ruby 3.4. [[feature:18980]]
-  * Error message for NoMethodError have changed to not use the target object's `#inspect` for efficiency, and says "instance of ClassName" instead.[[feature:18285]]
+  * [[m:Kernel.#lambda]]が非ラムダ式、非リテラルブロックが与えられた場合、Ruby 3.0 以降では deprecated category の警告を発していましたが、ArgumentError を発生させるようになりました。[[feature:19777]]
+  * 環境変数 RUBY_GC_HEAP_INIT_SLOTS は非推奨となり削除されました。代わりに RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS を利用してください。[[feature:19785]]
+  * ブロック内での引数なし it の呼び出しは非推奨となりました。 Ruby 3.4から最初のブロック引数を参照するようになります。 [[feature:18980]]
+  * NoMethodError が　#inspect を使ってレシーバーの中身を表示せず、クラス名だけ表示するようになりました。[[feature:18285]]
 //emlist{
 ([1] * 100).nonexisting
 # undefined method `nonexisting' for an instance of Array (NoMethodError)
 //}
-  * Now anonymous parameters forwarding is disallowed inside a block that uses anonymous parameters.[[feature:19370]]
+  * ブロック内で匿名のメソッド引数を移譲することが禁止になりました。[[feature:19370]]
 
-== Stdlib compatibility issues
-  * `racc` is promoted to bundled gems
-    * You need to add `racc` to your `Gemfile` if you use `racc` under bundler environment.
-  * `ext/readline` is retired
-    * We have `reline` that is pure Ruby implementation compatible with `ext/readline` API. We rely on `reline` in the future. If you need to use `ext/readline`, you can install `ext/readline` via rubygems.org with `gem install readline-ext`.
-    * We no longer need to install libraries like `libreadline` or `libedit`.
+== 標準添付ライブラリの互換性に関する変更
+  * racc が budled gems となりました。
+    * bundler 環境で利用する場合は Gemfile に racc を追記する必要があります。
+  * ext/readline の削除
+    * 今後は Ruby で書かれた GNU Readline の互換ライブラリである reline をすべての環境で標準で利用し、ext/readline は削除されました。以前の ext/readline が必要なユーザーは gem install readline-ext でインストールすることができます。
+    * この変更により、Ruby のインストール時に libreadline や libedit などのライブラリのインストールは不要となります。
 
-== C API updates
-  * `rb_postponed_job` updates
-    * New APIs and deprecated APIs (see comments for details)
-      * added: `rb_postponed_job_preregister()`
-      * added: `rb_postponed_job_trigger()`
-      * deprecated: `rb_postponed_job_register()` (and semantic change. see below)
-      * deprecated: `rb_postponed_job_register_one()`
-    * The postponed job APIs have been changed to address some rare crashes. To solve the issue, we introduced new two APIs and deprecated current APIs. The semantics of these functions have also changed slightly; `rb_postponed_job_register` now behaves like the `once` variant in that multiple calls with the same `func` might be coalesced into a single execution of the `func` [[feature:20057]]
-  * Some updates for internal thread event hook APIs
-    * `rb_internal_thread_event_data_t` with a target Ruby thread (VALUE) and callback functions (`rb_internal_thread_event_callback`) receive it.[[url:https://github.com/ruby/ruby/pull/8885]]
-    * The following functions are introduced to manipulate Ruby thread local data from internal thread event hook APIs (they are introduced since Ruby 3.2).[[url:https://github.com/ruby/ruby/pull/8936]]
+== C APIの変更
+  * rb_postponed_job が更新されました。
+    * 以下のAPIが追加されました。
+      * rb_postponed_job_preregister()
+      * rb_postponed_job_trigger()
+    * 以下のAPIが非推奨となりました。
+      * rb_postponed_job_register()
+      * rb_postponed_job_register_one()
+    * 稀に発生するクラッシュに対処するため、postponed job APIが変更されました。2つの新しいAPIを導入し、既存のAPIを非推奨としました。これらの関数のセマンティクスに若干変更が加えられています。rb_postponed_job_register は同じ関数の複数の呼び出しが関数の単一の実行に結合される可能性があるという点で、once バリアントのように動作するようになりました。 [[feature:20057]]
+  * 内部スレッドイベントフックAPIの更新
+    * rb_internal_thread_event_data_t が対象 Ruby スレッド（VALUE）を保持し、そのデータがコールバック関数（rb_internal_thread_event_callback）に渡されるようになりました。[[url:https://github.com/ruby/ruby/pull/8885]]
+    * 内部スレッドイベントフック API から Ruby スレッドローカルデータを操作するために以下の関数が追加されました (Ruby 3.2 以降で導入されていました) 。[[url:https://github.com/ruby/ruby/pull/8936]]
       * rb_internal_thread_specific_key_create()
       * rb_internal_thread_specific_get()
       * rb_internal_thread_specific_set()
-    * rb_profile_thread_frames() is introduced to get a frames from a specific thread.[[feature:10602]]
-    * rb_data_define() is introduced to define `Data`.[[feature:19757]]
-    * rb_ext_resolve_symbol() is introduced to search a function from extension libraries.[[feature:20005]]
-  * IO related updates:
-    * The details of `rb_io_t` will be hidden and deprecated attributes are added for each members.[[feature:19057]]
-    * rb_io_path(VALUE io) is introduced to get a path of `io`.
-    * rb_io_closed_p(VALUE io) to get opening or closing of `io`.
-    * rb_io_mode(VALUE io) to get the mode of `io`.
-    * rb_io_open_descriptor() is introduced to make an IO object from a file descriptor.
+    * rb_profile_thread_frames()
+      * 特定のスレッドからフレームを取得するために追加されました。[[feature:10602]]
+    * rb_data_define()
+      * Dataを定義するために追加されました。[[feature:19757]]
+    * rb_ext_resolve_symbol()
+      * 拡張ライブラリから関数を検索するために追加されました。[[feature:20005]]
+  * IO関連アップデート:
+    * rb_io_t の詳細は隠され、各メンバに非推奨の属性が追加されます。 [[feature:19057]]
+    * rb_io_path(VALUE io)
+      * io のパスを取得するために追加されました。
+    * rb_io_closed_p(VALUE io)
+      * io の開始または終了を取得します。
+    * rb_io_mode(VALUE io)
+      * io のモードを取得します。
+    * rb_io_open_descriptor()
+      * ファイルディスクリプタからIOオブジェクトを作成するために追加されました。
 
-== Implementation improvements
-=== Parser
-  * Replace Bison with Lrama LALR parser generator([[url:https://github.com/ruby/lrama]]) No need to install Bison to build Ruby from source code anymore. We will no longer suffer bison compatibility issues and we can use new features by just implementing it to Lrama.[[feature:19637]]
-    * See The future vision of Ruby Parser([[url:https://rubykaigi.org/2023/presentations/spikeolaf.html]]) for detail.
-    * Lrama internal parser is a LR parser generated by Racc for maintainability.
-    * Parameterizing Rules `(?, *, +)` are supported, it will be used in Ruby parse.y.
+== 実装の改善
+=== パーサー
+  * Bison から Lrama LALRパーサジェネレータ([[url:https://github.com/ruby/lrama]]) に置き換えられました。[[feature:19637]]
+    * 興味がある方は、The future vision of Ruby Parser([[url:https://rubykaigi.org/2023/presentations/spikeolaf.html]])の発表をご覧ください。
+    * Lramaの内部パーサは、保守性のためにRaccによって生成されたLRパーサに置き換えられました。
+  * パラメータ化ルール (?, *, +) がサポートされ、CRubyのparse.yで使用されます。
 
-=== GC / Memory management
-  * Major performance improvements over Ruby 3.2
-    * Young objects referenced by old objects are no longer immediately promoted to the old generation. This significantly reduces the frequency of major GC collections.[[feature:19678]]
-    * A new `REMEMBERED_WB_UNPROTECTED_OBJECTS_LIMIT_RATIO` tuning variable was introduced to control the number of unprotected objects cause a major GC collection to trigger. The default is set to `0.01` (1%). This significantly reduces the frequency of major GC collection.[[feature:19571]]
-    * Write Barriers were implemented for many core types that were missing them, notably Time, Enumerator, MatchData, Method, File::Stat, BigDecimal and several others. This significantly reduces minor GC collection time and major GC collection frequency.
-    * Most core classes are now using Variable Width Allocation, notably Hash, Time, Thread::Backtrace, Thread::Backtrace::Location, File::Stat, Method. This makes these classes faster to allocate and free, use less memory and reduce heap fragmentation.
-  * defined?(@ivar) is optimized with Object Shapes.
+=== GC / メモリ管理
+  * Ruby 3.2 からの大幅なパフォーマンス向上
+    * 古い世代のオブジェクトから参照された新しい世代のオブジェクトの世代変更を少し遅延することにより、 major GC の頻度が下がりました。[[feature:19678]]
+    * 環境変数 RUBY_GC_HEAP_REMEMBERED_WB_UNPROTECTED_OBJECTS_LIMIT_RATIO が追加され、 WB unprotected object の数に起因する major GC の回数をチューニングできるようになりました。デフォルトは0.01(1%)に設定されています。これにより、 major GC の頻度が下がりました。[[feature:19571]]
+    * ライトバリアが [[c:Time]] [[c:Enumerator]] [[c:MatchData]] [[c:Method]] [[c:File::Stat]] [[c:BigDecimal]] など多くのクラスに実装されました。これにより minor GC の収集時間と major GC の収集頻度が削減されました。
+    * [[c:Hash]] [[c:Time]] Thread::Backtrace [[c:Thread::Backtrace::Location]] [[c:File::Stat]] [[c:Method]] などほとんどの組み込みクラスで Variable Width Allocation(VBA) が使用されるようになりました。
+  * defined?(@ivar) が Object Shapes を使って最適化されるようになりました。
 
 === YJIT
-  * Major performance improvements over Ruby 3.2
-    * Support for splat and rest arguments has been improved.
-    * Registers are allocated for stack operations of the virtual machine.
-    * More calls with optional arguments are compiled. Exception handlers are also compiled.
-    * Unsupported call types and megamorphic call sites no longer exit to the interpreter.
-    * Basic methods like Rails `#blank?` and specialized `#present?`[[url:https://github.com/rails/rails/pull/49909]] are inlined.
-    * `Integer#*`, `Integer#!=`, `String#!=`, `String#getbyte`, `Kernel#block_given?`, `Kernel#is_a?`, `Kernel#instance_of?`, and `Module#===` are specially optimized.
-    * Compilation speed is now slightly faster than Ruby 3.2.
-    * Now more than 3x faster than the interpreter on Optcarrot!
-  * Significantly improved memory usage over Ruby 3.2
-    * Metadata for compiled code uses a lot less memory.
-    * `--yjit-call-threshold` is automatically raised from 30 to 120
-      when the application has more than 40,000 ISEQs.
-    * `--yjit-cold-threshold` is added to skip compiling cold ISEQs.
-    * More compact code is generated on Arm64.
-  * Code GC is now disabled by default
-    * `--yjit-exec-mem-size` is treated as a hard limit where compilation of new code stops.
-    * No sudden drops in performance due to code GC. Better copy-on-write behavior on servers reforking with Pitchfork([[url:https://github.com/shopify/pitchfork]]).
-    * You can still enable code GC if desired with `--yjit-code-gc`
-  * Add `RubyVM::YJIT.enable` that can enable YJIT at run-time
-    * You can start YJIT without modifying command-line arguments or environment variables. Rails 7.2 will enable YJIT by default([[url:https://github.com/rails/rails/pull/49947]]) using this method.
-    * This can also be used to enable YJIT only once your application is done booting. `--yjit-disable` can be used if you want to use other YJIT options while disabling YJIT at boot.
-  * More YJIT stats are available by default
-    * `yjit_alloc_size` and several more metadata-related stats are now available by default.
-    * `ratio_in_yjit` stat produced by `--yjit-stats` is now available in release builds, a special stats or dev build is no longer required to access most stats.
-  * Add more profiling capabilities
-    * `--yjit-perf` is added to facilitate profiling with Linux perf.
-    * `--yjit-trace-exits` now supports sampling with `--yjit-trace-exits-sample-rate=N`
-  * More thorough testing and multiple bug fixes
-  * `--yjit-stats=quiet` is added to avoid printing stats on exit.
+  * 大幅なパフォーマンスの改善
+    * * を使った引数のサポートが改善されました。
+    * 仮想マシンのスタック操作のためにレジスタが使われるようになりました。
+    * オプション引数を持つ呼び出しで全ての組合せがコンパイルされます。例外ハンドラもコンパイルされます。
+    * サポートされていない呼び出し方や分岐の数の多い呼出しでのインタプリタへのフォールバックが行なわれなくなりました。
+    * Railsの #blank? や 特別化された #present? [[url:https://github.com/rails/rails/pull/49909]]などの単純なメソッドがインライン化されます。
+    * Integer#*、Integer#!=、String#!=、String#getbyte、Kernel#block_given?、Kernel#is_a?、Kernel#instance_of?、および Module#=== が特別に最適化されます。
+    * コンパイル速度はRuby 3.2よりわずかに速くなりました。
+    * Optcarrotでは、インタプリタよりも3倍以上速くなりました！
+  * メモリ使用量の大幅な改善
+    * コンパイルされたコードのメタデータは、はるかに少ないメモリを使用します。
+    * アプリケーションが4万個以上のISEQを持つ場合、--yjit-call-threshold は自動的に30から120に上げられます。
+    * 呼出しの少ないISEQのコンパイルをスキップするために --yjit-cold-threshold が追加されました。
+    * Arm64ではよりコンパクトなコードが生成されます。
+  * コードGCはデフォルトで無効になりました
+    * --yjit-exec-mem-size は新しいコードのコンパイルが停止するハードリミットとして扱われます。
+    * これにより、デフォルトではコードGC実行によるパフォーマンスの急激な低下がなくなりました。Pitchfork([[url:https://github.com/shopify/pitchfork]])を使って定期的にforkするサーバーでのコピーオンライトの挙動が改善されました。
+    * 必要に応じて --yjit-code-gc でコードGCを有効にすることもできます。
+  * RubyVM::YJIT.enable を追加し、実行時にYJITを有効にできるようにしました
+    * コマンドライン引数や環境変数を変更せずにYJITを開始できます。Rails 7.2はこの方法を使用して デフォルトでYJITを有効にします。
+    * これはまた、アプリケーションの起動が完了した後にのみYJITを有効にするために使用できます。YJITの他のオプションを使用しながら起動時にYJITを無効にしたい場合は、--yjit-disable を使用できます。
+  * デフォルトで利用可能なYJITの統計が増えました
+    * yjit_alloc_size およびその他いくつかのメタデータ関連の統計がデフォルトで利用可能になりました。
+    * --yjit-stats によって生成される ratio_in_yjit 統計は、リリースビルドで利用可能になりました。特別な統計や開発ビルドは、ほとんどの統計にアクセスするためにはもはや必要ありません。
+  * プロファイリング機能を追加
+    * Linux perfでのプロファイリングを容易にするために --yjit-perf が追加されました。
+    * --yjit-trace-exits は、--yjit-trace-exits-sample-rate=N を使用したサンプリングをサポートします。
+  * より網羅的なテストと複数のバグ修正
 
 === MJIT
-  * MJIT is removed.
-    * `--disable-jit-support` is removed. Consider using `--disable-yjit --disable-rjit` instead.
+  * MJIT は削除されました。
+    * --disable-jit-support は削除されました。 代わりに--disable-yjit や --disable-rjit の使用を検討してください。
 
 === RJIT
-  * * Introduced a pure-Ruby JIT compiler RJIT.
-    * RJIT supports only x86\_64 architecture on Unix platforms.
-    * Unlike MJIT, it doesn't require a C compiler at runtime.
-  * RJIT exists only for experimental purposes.
-      * You should keep using YJIT in production.
+  * Rubyで書かれたJITコンパイラであるRJITを導入し、MJITを置き換えました。
+    * RJITはUnixプラットフォーム上のx86_64アーキテクチャのみをサポートします。
+    * MJITとは異なり、実行時にCコンパイラを必要としません。
+  * RJITは実験的な目的のためだけに存在します。
+    * 本番環境ではYJITを引き続き使用してください。
+  * RubyのJITの開発に興味がある場合は、RubyKaigi 2023のk0kubunの発表([[url:https://rubykaigi.org/2023/presentations/k0kubun.html#day3]])をご覧ください。
 
-=== M:N Thread scheduler
-  * M:N Thread scheduler is introduced.[[feature:19842]]
-    * Background: Ruby 1.8 and before, M:1 thread scheduler (M Ruby threads with 1 native thread. Called as User level threads or Green threads) is used. Ruby 1.9 and later, 1:1 thread scheduler (1 Ruby thread with 1 native thread).
-      M:1 threads takes lower resources compare with 1:1 threads because it needs only 1 native threads. However it is difficult to support context switching for all of blocking operation so 1:1 threads are employed from Ruby 1.9.
-      M:N thread scheduler uses N native threads for M Ruby threads (N is small number in general). It doesn't need same number of native threads as Ruby threads (similar to the M:1 thread scheduler).
-      Also our M:N threads supports blocking operations well same as 1:1 threads. See the ticket for more details.
-      Our M:N thread scheduler refers on the goroutine scheduler in the Go language.
-    * In a ractor, only 1 thread can run in a same time because of implementation. Therefore, applications that use only one Ractor (most applications) M:N thread scheduler works as M:1 thread scheduler with further extension from Ruby 1.8.
-    * M:N thread scheduler can introduce incompatibility for C-extensions, so it is disabled by default on the main Ractors.
-      `RUBY_MN_THREADS=1` environment variable will enable it. On non-main Ractors, M:N thread scheduler is enabled (and can not disable it now).
-    * `N` (the number of native threads) can be specified with `RUBY_MAX_CPU` environment variable. The default is 8.
-      Note that more than `N` native threads are used to support many kind of blocking operations.
+=== M:Nスレッドスケジューラ
+  * M:N スレッドスケジューラが導入されました。[[feature:19842]]
+    * M個のRuby スレッドを、N個のネイティブスレッド（OSスレッド）で管理するので、生成管理のコストを抑えることができるようになりました。
+  * C拡張ライブラリの互換性に問題が生じる可能性があるため、メインRactorでのM:Nスレッドスケジューラはデフォルトでは無効にされています。
+    * RUBY_MN_THREADS=1 と環境変数を設定することで、メインRactorでM:Nスレッドスケジューラを有効にします。
+    * メインRactor以外ではM:Nスレッドスケジューラが常に有効です。
+  * RUBY_MAX_CPU=n と環境変数を設定することで、Nの最大数（利用するネイティブスレッドの最大数）を設定できます。デフォルトは8です。
+    * 一つの Ractor ではたかだか1つのスレッドしか同時に実行されないので、実際に利用するネイティブスレッド数は、RUBY_MAX_CPUで指定した数か実行中のRactorの数の少ないほうになります。つまり、Ractorの数が1つのアプリケーション（多くのアプリケーション）では1つのネイティブスレッドだけ利用されます。
+    * ブロックする処理をサポートするため、N個以上のネイティブスレッドが利用されることがあります。
 #@end

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -203,7 +203,7 @@ Time.new('2023-12-20')
     * yaml 0.3.0
     * zlib 3.1.0
 
-  * 以下の gem が defalut gems から budled gems に変更されました。
+  * 以下の gem が defalut gems から bundled gems に変更されました。
     * racc 1.7.3
 
   * 以下の bundled gemsが更新されました。
@@ -246,7 +246,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
   * [[m:Kernel.#lambda]]が非ラムダ式、非リテラルブロックが与えられた場合、Ruby 3.0 以降では deprecated category の警告を発していましたが、ArgumentError を発生させるようになりました。[[feature:19777]]
   * 環境変数 RUBY_GC_HEAP_INIT_SLOTS は非推奨となり削除されました。代わりに RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS を利用してください。[[feature:19785]]
   * ブロック内での引数なし it の呼び出しは非推奨となりました。 Ruby 3.4から最初のブロック引数を参照するようになります。 [[feature:18980]]
-  * NoMethodError が　#inspect を使ってレシーバーの中身を表示せず、クラス名だけ表示するようになりました。[[feature:18285]]
+  * NoMethodError が #inspect を使ってレシーバーの中身を表示せず、クラス名だけ表示するようになりました。[[feature:18285]]
 //emlist{
 ([1] * 100).nonexisting
 # undefined method `nonexisting' for an instance of Array (NoMethodError)
@@ -254,7 +254,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
   * ブロック内で匿名のメソッド引数を移譲することが禁止になりました。[[feature:19370]]
 
 == 標準添付ライブラリの互換性に関する変更
-  * racc が budled gems となりました。
+  * racc が bundled gems となりました。
     * bundler 環境で利用する場合は Gemfile に racc を追記する必要があります。
   * ext/readline の削除
     * 今後は Ruby で書かれた GNU Readline の互換ライブラリである reline をすべての環境で標準で利用し、ext/readline は削除されました。以前の ext/readline が必要なユーザーは gem install readline-ext でインストールすることができます。

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -19,7 +19,9 @@
 
   * [[c:Dir]]
     * 新規メソッド
-      * Dir.for_fd Dir.fchdir Dir#chdir が追加されました。 [[feature:19347]]
+      * Dir.for_fd が追加されました。指定されたディレクトリファイルディスクリプタに対応する Dir オブジェクトを返します。 [[feature:19347]]
+      * Dir.fchdir が追加されました。指定されたディレクトリファイルディスクリプタが指すディレクトリにカレントディレクトリを変更します。 [[feature:19347]]
+      * Dir#chdir が追加されました。その Dir オブジェクトが指すディレクトリにカレントディレクトリを変更します。 [[feature:19347]]
 
   * [[c:Encoding]]
     * 削除されたメソッド
@@ -58,7 +60,7 @@ fiber.kill
 
   * [[c:ObjectSpace::WeakMap]]
     * 新規メソッド
-      * ObjectSpace::WeakMap#delete が導入されました。[[feature:19561]]
+      * weak map のエントリを積極的にクリアするために ObjectSpace::WeakMap#delete が導入されました。[[feature:19561]]
 
   * [[c:Proc]]
     * 変更されたメソッド
@@ -66,7 +68,7 @@ fiber.kill
 
   * [[c:Process]]
     * 新規メソッド
-      * Ruby 仮想マシン (VM) にアプリケーションの起動が終了したこと及び、アプリケーションの最適化に適したタイミングであることを通知する Process.warmup が追加されました。このメソッドが行う最適化は実装依存であり、将来予告なく変更される可能性があります。[[feature:18885]]
+      * Ruby 仮想マシン (VM) にアプリケーションの起動が終了したこと及び、アプリケーションの最適化に適したタイミングであることを通知する Process.warmup が追加されました。これは長時間稼働するアプリケーションで有用です。このメソッドが行う最適化は実装依存であり、将来予告なく変更される可能性があります。[[feature:18885]]
 
   * [[c:Process::Status]]
     * 変更されたメソッド
@@ -111,7 +113,12 @@ Time.new('2023-12-20')
     * rescue イベントが追加され、rescue節を開始するときに発火するフックを入れることができるようになりました。rescue イベントはRubyレベルで記述された rescue のみサポートします。 [[bug:19572]]
 
 == 標準添付ライブラリの更新(機能追加とバグ修正を除く)
-  * RubyGems と Bundler は将来リリースされる Ruby で bundled gems となる予定の gem が Gemfile または gemspec に存在しない状態で require された際に警告を行う機能が追加されました。この警告は bootsnap gem を使っている場合には 3.3.0 の時点では機能上の制限により出力されません。そのため、環境変数として DISABLE_BOOTSNAP=1 などを設定して、少なくとも1度はアプリケーションを実行することを推奨します。以下のライブラリが警告の対象となります。[[feature:19351]][[feature:19776]][[feature:19843]]
+  * RubyGems と Bundler は将来リリースされる Ruby で bundled gems となる予定の gem が
+    Gemfile または gemspec に存在しない状態で require された際に警告を行う機能が
+    追加されました。この警告は bootsnap gem を使っている場合には 3.3.0 の時点では
+    機能上の制限により出力されません。そのため、環境変数として DISABLE_BOOTSNAP=1
+    などを設定して、少なくとも1度はアプリケーションを実行することを推奨します。
+    以下のライブラリが警告の対象となります。[[feature:19351]][[feature:19776]][[feature:19843]]
     * abbrev
     * base64
     * bigdecimal
@@ -245,13 +252,13 @@ default gems と bundled gems の詳細については Logger の GitHub Release
     * [[m:IO.write]]
   * [[m:Kernel.#lambda]]が非ラムダ式、非リテラルブロックが与えられた場合、Ruby 3.0 以降では deprecated category の警告を発していましたが、ArgumentError を発生させるようになりました。[[feature:19777]]
   * 環境変数 RUBY_GC_HEAP_INIT_SLOTS は非推奨となり削除されました。代わりに RUBY_GC_HEAP_{0,1,2,3,4}_INIT_SLOTS を利用してください。[[feature:19785]]
-  * ブロック内での引数なし it の呼び出しは非推奨となりました。 Ruby 3.4から最初のブロック引数を参照するようになります。 [[feature:18980]]
+  * 通常の引数を持たないブロック内での引数なし it の呼び出しは非推奨となりました。 Ruby 3.4から最初のブロック引数を参照するようになります。 [[feature:18980]]
   * NoMethodError が #inspect を使ってレシーバーの中身を表示せず、クラス名だけ表示するようになりました。[[feature:18285]]
 //emlist{
 ([1] * 100).nonexisting
 # undefined method `nonexisting' for an instance of Array (NoMethodError)
 //}
-  * ブロック内で匿名のメソッド引数を移譲することが禁止になりました。[[feature:19370]]
+  * 匿名引数を使うブロック内で匿名のメソッド引数を移譲することが禁止になりました。[[feature:19370]]
 
 == 標準添付ライブラリの互換性に関する変更
   * racc が bundled gems となりました。
@@ -294,7 +301,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
 
 == 実装の改善
 === パーサー
-  * Bison から Lrama LALRパーサジェネレータ([[url:https://github.com/ruby/lrama]]) に置き換えられました。[[feature:19637]]
+  * Bison から Lrama LALRパーサジェネレータ([[url:https://github.com/ruby/lrama]]) に置き換えられました。これにより、ソースコードから Ruby をビルドするために Bison をインストールする必要がなくなりました。また bison の互換性問題に悩まされることがなくなり、新機能を Lrama に実装するだけで利用できるようになります。[[feature:19637]]
     * 興味がある方は、The future vision of Ruby Parser([[url:https://rubykaigi.org/2023/presentations/spikeolaf.html]])の発表をご覧ください。
     * Lramaの内部パーサは、保守性のためにRaccによって生成されたLRパーサに置き換えられました。
   * パラメータ化ルール (?, *, +) がサポートされ、CRubyのparse.yで使用されます。
@@ -303,16 +310,16 @@ default gems と bundled gems の詳細については Logger の GitHub Release
   * Ruby 3.2 からの大幅なパフォーマンス向上
     * 古い世代のオブジェクトから参照された新しい世代のオブジェクトの世代変更を少し遅延することにより、 major GC の頻度が下がりました。[[feature:19678]]
     * 環境変数 RUBY_GC_HEAP_REMEMBERED_WB_UNPROTECTED_OBJECTS_LIMIT_RATIO が追加され、 WB unprotected object の数に起因する major GC の回数をチューニングできるようになりました。デフォルトは0.01(1%)に設定されています。これにより、 major GC の頻度が下がりました。[[feature:19571]]
-    * ライトバリアが [[c:Time]] [[c:Enumerator]] [[c:MatchData]] [[c:Method]] [[c:File::Stat]] [[c:BigDecimal]] など多くのクラスに実装されました。これにより minor GC の収集時間と major GC の収集頻度が削減されました。
-    * [[c:Hash]] [[c:Time]] Thread::Backtrace [[c:Thread::Backtrace::Location]] [[c:File::Stat]] [[c:Method]] などほとんどの組み込みクラスで Variable Width Allocation(VWA) が使用されるようになりました。
+    * ライトバリアが [[c:Time]], [[c:Enumerator]], [[c:MatchData]], [[c:Method]], [[c:File::Stat]], [[c:BigDecimal]] など多くのクラスに実装されました。これにより minor GC の収集時間と major GC の収集頻度が削減されました。
+    * [[c:Hash]], [[c:Time]], Thread::Backtrace, [[c:Thread::Backtrace::Location]], [[c:File::Stat]], [[c:Method]] などほとんどの組み込みクラスで Variable Width Allocation(VWA) が使用されるようになりました。これにより、これらのクラスの確保と解放が高速になり、メモリ使用量が減少し、ヒープの断片化が低減されます。
   * defined?(@ivar) が Object Shapes を使って最適化されるようになりました。
 
 === YJIT
   * 大幅なパフォーマンスの改善
-    * * を使った引数のサポートが改善されました。
+    * splat 引数と rest 引数のサポートが改善されました。
     * 仮想マシンのスタック操作のためにレジスタが使われるようになりました。
     * オプション引数を持つより多くの呼び出しがコンパイルされます。例外ハンドラもコンパイルされます。
-    * サポートされていない呼び出し方や分岐の数の多い呼出しでのインタプリタへのフォールバックが行なわれなくなりました。
+    * サポートされていない呼び出し方や megamorphic な(多数のレシーバ型を持つ)呼び出し箇所でのインタプリタへのフォールバックが行なわれなくなりました。
     * Railsの #blank? や 特別化された #present? [[url:https://github.com/rails/rails/pull/49909]]などの単純なメソッドがインライン化されます。
     * Integer#*、Integer#!=、String#!=、String#getbyte、Kernel#block_given?、Kernel#is_a?、Kernel#instance_of?、および Module#=== が特別に最適化されます。
     * コンパイル速度はRuby 3.2よりわずかに速くなりました。
@@ -352,6 +359,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
 
 === M:Nスレッドスケジューラ
   * M:N スレッドスケジューラが導入されました。[[feature:19842]]
+    * 背景: Ruby 1.8 以前は M:1 スレッドスケジューラ（M個の Ruby スレッドを1個のネイティブスレッドで動かす方式。ユーザレベルスレッドやグリーンスレッドと呼ばれます）が使われていました。Ruby 1.9 以降は 1:1 スレッドスケジューラ（1個の Ruby スレッドに1個のネイティブスレッド）が使われています。M:1 は必要なネイティブスレッドが1個で済むため 1:1 より低リソースですが、全てのブロッキング操作でコンテキストスイッチをサポートするのが難しいため、1.9 からは 1:1 が採用されました。M:N スレッドスケジューラは M個の Ruby スレッドに対して N個（一般に小さい数）のネイティブスレッドを使います。M:1 と同様に Ruby スレッドと同数のネイティブスレッドを必要とせず、かつ 1:1 と同様にブロッキング操作も適切にサポートします。この M:N スレッドスケジューラは Go 言語の goroutine スケジューラを参考にしています。
     * M個のRuby スレッドを、N個のネイティブスレッド（OSスレッド）で管理するので、生成管理のコストを抑えることができるようになりました。
   * C拡張ライブラリの互換性に問題が生じる可能性があるため、メインRactorでのM:Nスレッドスケジューラはデフォルトでは無効にされています。
     * RUBY_MN_THREADS=1 と環境変数を設定することで、メインRactorでM:Nスレッドスケジューラを有効にします。

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -83,7 +83,7 @@ fiber.kill
       * Refinement#refined_class が #target に名前変更されました。 Refinement#refined_class は非推奨となり、Ruby 3.4 で削除予定です。[[feature:19714]]
 
   * [[c:Regexp]]
-    * Ruby3.2で導入されたReDos対策のメモ化最適化が先読み・後読みやアトミックグループをサポートするようになり、これらの拡張を含む正規表現も入力文字列の長さに対して線形時間で実行できるようになりました。ただし、これらの拡張にはキャプチャを含めることはできず、ネストもできません。[[feature:19725]]
+    * Ruby 3.2で導入されたReDoS対策のメモ化最適化が先読み・後読みやアトミックグループをサポートするようになり、これらの拡張を含む正規表現も入力文字列の長さに対して線形時間で実行できるようになりました。ただし、これらの拡張にはキャプチャを含めることはできず、ネストもできません。[[feature:19725]]
 
   * [[c:String]]
     * 変更されたメソッド
@@ -203,7 +203,7 @@ Time.new('2023-12-20')
     * yaml 0.3.0
     * zlib 3.1.0
 
-  * 以下の gem が defalut gems から bundled gems に変更されました。
+  * 以下の gem が default gems から bundled gems に変更されました。
     * racc 1.7.3
 
   * 以下の bundled gemsが更新されました。
@@ -286,7 +286,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
     * rb_io_path(VALUE io)
       * io のパスを取得するために追加されました。
     * rb_io_closed_p(VALUE io)
-      * io の開始または終了を取得します。
+      * io が開いているか閉じているかを取得します。
     * rb_io_mode(VALUE io)
       * io のモードを取得します。
     * rb_io_open_descriptor()

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -66,7 +66,7 @@ fiber.kill
 
   * [[c:Process]]
     * 新規メソッド
-      * [[c:RubyVM]]にアプリケーションの起動が終了したこと及び、アプリケーションの最適化に適したタイミングであることを通知する Process.warmup が追加されました。このメソッドが行う最適化は実装依存であり、将来予告なく変更される可能性があります。[[feature:18885]]
+      * Ruby 仮想マシン (VM) にアプリケーションの起動が終了したこと及び、アプリケーションの最適化に適したタイミングであることを通知する Process.warmup が追加されました。このメソッドが行う最適化は実装依存であり、将来予告なく変更される可能性があります。[[feature:18885]]
 
   * [[c:Process::Status]]
     * 変更されたメソッド
@@ -75,12 +75,12 @@ fiber.kill
   * [[c:Range]]
     * 新規メソッド
       * beginless rangeに対しても動作する Range#reverse_each が追加されました。[[feature:18515]]
-      * Range#reverse_each は endless range に対しては例外を投げます[[feature:18551]]
+      * Range#reverse_each は endless range に対しては例外を投げます。 [[feature:18551]]
       * 2つの範囲が重複しているかどうかを確認する Range#overlap? が追加されました。[[feature:19839]]
 
   * [[c:Refinement]]
     * 変更されたメソッド
-      * Refinement#refined_class が #target に名前変更されました。 Refinement#refined_class は非推奨となり、Ruby 3.4 で削除予定です。[[feature:19714]]
+      * Refinement#refined_class の代替として Refinement#target が追加されました。 Refinement#refined_class は非推奨となり、Ruby 3.4 で削除予定です。[[feature:19714]]
 
   * [[c:Regexp]]
     * Ruby 3.2で導入されたReDoS対策のメモ化最適化が先読み・後読みやアトミックグループをサポートするようになり、これらの拡張を含む正規表現も入力文字列の長さに対して線形時間で実行できるようになりました。ただし、これらの拡張にはキャプチャを含めることはできず、ネストもできません。[[feature:19725]]
@@ -275,12 +275,12 @@ default gems と bundled gems の詳細については Logger の GitHub Release
       * rb_internal_thread_specific_key_create()
       * rb_internal_thread_specific_get()
       * rb_internal_thread_specific_set()
-    * rb_profile_thread_frames()
-      * 特定のスレッドからフレームを取得するために追加されました。[[feature:10602]]
-    * rb_data_define()
-      * Dataを定義するために追加されました。[[feature:19757]]
-    * rb_ext_resolve_symbol()
-      * 拡張ライブラリから関数を検索するために追加されました。[[feature:20005]]
+  * rb_profile_thread_frames()
+    * 特定のスレッドからフレームを取得するために追加されました。[[feature:10602]]
+  * rb_data_define()
+    * Dataを定義するために追加されました。[[feature:19757]]
+  * rb_ext_resolve_symbol()
+    * 拡張ライブラリから関数を検索するために追加されました。[[feature:20005]]
   * IO関連アップデート:
     * rb_io_t の詳細は隠され、各メンバに非推奨の属性が追加されます。 [[feature:19057]]
     * rb_io_path(VALUE io)
@@ -304,14 +304,14 @@ default gems と bundled gems の詳細については Logger の GitHub Release
     * 古い世代のオブジェクトから参照された新しい世代のオブジェクトの世代変更を少し遅延することにより、 major GC の頻度が下がりました。[[feature:19678]]
     * 環境変数 RUBY_GC_HEAP_REMEMBERED_WB_UNPROTECTED_OBJECTS_LIMIT_RATIO が追加され、 WB unprotected object の数に起因する major GC の回数をチューニングできるようになりました。デフォルトは0.01(1%)に設定されています。これにより、 major GC の頻度が下がりました。[[feature:19571]]
     * ライトバリアが [[c:Time]] [[c:Enumerator]] [[c:MatchData]] [[c:Method]] [[c:File::Stat]] [[c:BigDecimal]] など多くのクラスに実装されました。これにより minor GC の収集時間と major GC の収集頻度が削減されました。
-    * [[c:Hash]] [[c:Time]] Thread::Backtrace [[c:Thread::Backtrace::Location]] [[c:File::Stat]] [[c:Method]] などほとんどの組み込みクラスで Variable Width Allocation(VBA) が使用されるようになりました。
+    * [[c:Hash]] [[c:Time]] Thread::Backtrace [[c:Thread::Backtrace::Location]] [[c:File::Stat]] [[c:Method]] などほとんどの組み込みクラスで Variable Width Allocation(VWA) が使用されるようになりました。
   * defined?(@ivar) が Object Shapes を使って最適化されるようになりました。
 
 === YJIT
   * 大幅なパフォーマンスの改善
     * * を使った引数のサポートが改善されました。
     * 仮想マシンのスタック操作のためにレジスタが使われるようになりました。
-    * オプション引数を持つ呼び出しで全ての組合せがコンパイルされます。例外ハンドラもコンパイルされます。
+    * オプション引数を持つより多くの呼び出しがコンパイルされます。例外ハンドラもコンパイルされます。
     * サポートされていない呼び出し方や分岐の数の多い呼出しでのインタプリタへのフォールバックが行なわれなくなりました。
     * Railsの #blank? や 特別化された #present? [[url:https://github.com/rails/rails/pull/49909]]などの単純なメソッドがインライン化されます。
     * Integer#*、Integer#!=、String#!=、String#getbyte、Kernel#block_given?、Kernel#is_a?、Kernel#instance_of?、および Module#=== が特別に最適化されます。

--- a/refm/doc/news/3_3_0.rd
+++ b/refm/doc/news/3_3_0.rd
@@ -75,7 +75,7 @@ fiber.kill
   * [[c:Range]]
     * 新規メソッド
       * beginless rangeに対しても動作する Range#reverse_each が追加されました。[[feature:18515]]
-      * Range#reverse_each は endless range に対しては例外を投げます。 [[feature:18551]]
+      * Range#reverse_each は endless range に対しては TypeError を投げます。 [[feature:18551]]
       * 2つの範囲が重複しているかどうかを確認する Range#overlap? が追加されました。[[feature:19839]]
 
   * [[c:Refinement]]
@@ -87,7 +87,7 @@ fiber.kill
 
   * [[c:String]]
     * 変更されたメソッド
-      * [[m:String#unpack]]が不明なディレクティブに対して例外を投げるようになりました。[[bug:19150]]
+      * [[m:String#unpack]]が不明なディレクティブに対して ArgumentError を投げるようになりました。[[bug:19150]]
       * [[m:String#bytesplice]]がコピー元の文字列のインデックス/長さまたはrangeを引数に取れるようになりました。これによりコピー元の部分範囲を指定できるようになりました。[[feature:19314]]
 
   * [[c:Thread::Queue]]
@@ -336,6 +336,7 @@ default gems と bundled gems の詳細については Logger の GitHub Release
     * Linux perfでのプロファイリングを容易にするために --yjit-perf が追加されました。
     * --yjit-trace-exits は、--yjit-trace-exits-sample-rate=N を使用したサンプリングをサポートします。
   * より網羅的なテストと複数のバグ修正
+  * --yjit-stats=quiet が追加され、終了時に統計を出力しないようにできます。
 
 === MJIT
   * MJIT は削除されました。

--- a/refm/doc/news/index.rd
+++ b/refm/doc/news/index.rd
@@ -1,5 +1,7 @@
 = Ruby変更履歴
-
+#@since 3.3
+  * [[d:news/3_3_0]]
+#@end
 #@since 3.1
   * [[d:news/3_1_0]]
 #@end

--- a/refm/doc/news/index.rd
+++ b/refm/doc/news/index.rd
@@ -1,5 +1,8 @@
 = Ruby変更履歴
 
+#@since 3.3
+  * [[d:news/3_3_0]]
+#@end
 #@since 3.2
   * [[d:news/3_2_0]]
 #@end


### PR DESCRIPTION
NEWS for Ruby 3.3.0の日本語を追加しました。

### やったこと
- Ruby Issue Tracking SystemFeatureやBugのチケットへのリンクを追加
- リンク可能なものは、るりま内のクラス、メソッド等へのリンクを設定
- 変更履歴にリンクを追加

### 翻訳について
- 主に参考にしたもの
    - [Ruby 3\.3\.0 リリース](https://www.ruby-lang.org/ja/news/2023/12/25/ruby-3-3-0-released/)
    - [プロと読み解くRuby 3\.3 NEWS \- STORES Product Blog](https://product.st.inc/entry/2023/12/25/160504)

### スクリーンショット
<img width="2294" height="8078" alt="news_3_3_0_1" src="https://github.com/user-attachments/assets/c48b03d2-9903-405f-b5f4-aada5ed39b56" />
