### PR TITLE
CSV.readのtypoを修正

### DIFF
--- a/refm/api/src/csv.rd
+++ b/refm/api/src/csv.rd
@@ -814,7 +814,7 @@ headers オプションに偽でない値を指定した場合は [[c:CSV::Table
 
 @param options [[m:CSV.new]] のオプションと同じオプションを指定できます。
                :encoding というキーを使用すると入力のエンコーディングを指定することができます。
-               入力のエンコーディングか [[m:Encoding.default_external]] と異なる場合は
+               入力のエンコーディングが [[m:Encoding.default_external]] と異なる場合は
                必ず指定しなければなりません。
 
 #@samplecode 例


### PR DESCRIPTION
`CSV.read` の説明文に誤植がありそうなので修正しました。（`or` の意味の「か」ではないと思ったのですが、間違っていたらすみません）
https://docs.ruby-lang.org/ja/latest/class/CSV.html#S_READ
