### PR TITLE
Fix version guard

### DIFF
--- a/refm/doc/index.rd
+++ b/refm/doc/index.rd
@@ -4,7 +4,7 @@
 #@since 4.1
  * 開発版対応リファレンス
 #@end
-#@since 4.0
+#@if("4.0" <= version and version < "4.1")
  * version 4.0 対応リファレンス
 #@end
 #@if("3.4" <= version and version < "4.0")


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/master/doc/index.html で「開発版対応リファレンス」と「version 4.0 対応リファレンス」の両方がでてしまっているのを修正

<img width="291" height="185" alt="スクリーンショット 2025-12-26 10 04 46" src="https://github.com/user-attachments/assets/e6d82ec6-91c7-4008-b714-94aa17afe2e8" />
