### PR TITLE
Ruby 3.4 の引用符変更に伴うバックトレース表示例の更新 (#2974)

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -2084,13 +2084,21 @@ p [].transpose
 
 p [1,2,3].transpose
 
+#@since 3.4
+# => -:1:in 'transpose': cannot convert Fixnum into Array (TypeError)
+#@else
 # => -:1:in `transpose': cannot convert Fixnum into Array (TypeError)
+#@end
 #       from -:1
 
 p [[1,2],
    [3,4,5],
    [6,7]].transpose
+#@since 3.4
+# => -:3:in 'transpose': element size differ (3 should be 2) (IndexError)
+#@else
 # => -:3:in `transpose': element size differ (3 should be 2) (IndexError)
+#@end
 #@end
 
 --- uniq     -> Array

--- a/refm/api/src/_builtin/Data
+++ b/refm/api/src/_builtin/Data
@@ -162,10 +162,17 @@ Point.new に渡した位置引数の数が多い場合(上から2番目)のみ 
 #@samplecode 例
 Point = Data.define(:x, :y)
 
+#@since 3.4
+Point.new(1)                 # => in 'initialize': missing keyword: :y (ArgumentError)
+Point.new(1, 2, 3)           # => in 'new': wrong number of arguments (given 3, expected 0..2) (ArgumentError)
+Point.new(x: 1)              # => in 'initialize': missing keyword: :y (ArgumentError)
+Point.new(x: 1, y: 2, z: 3)  # => in 'initialize': unknown keyword: :z (ArgumentError)
+#@else
 Point.new(1)                 # => in `initialize': missing keyword: :y (ArgumentError)
 Point.new(1, 2, 3)           # => in `new': wrong number of arguments (given 3, expected 0..2) (ArgumentError)
 Point.new(x: 1)              # => in `initialize': missing keyword: :y (ArgumentError)
 Point.new(x: 1, y: 2, z: 3)  # => in `initialize': unknown keyword: :z (ArgumentError)
+#@end
 #@end
 
 下の例のように、initialize メソッドをオーバーライドすることで new のオプション引数を実現できます。

--- a/refm/api/src/_builtin/Exception
+++ b/refm/api/src/_builtin/Exception
@@ -63,8 +63,13 @@ end
 
 デフォルトでは
 
+#@since 3.4
+  * "#{sourcefile}:#{sourceline}:in '#{method}'"
+    (メソッド内の場合)
+#@else
   * "#{sourcefile}:#{sourceline}:in `#{method}'"
     (メソッド内の場合)
+#@end
   * "#{sourcefile}:#{sourceline}"
     (トップレベルの場合)
 
@@ -81,7 +86,11 @@ rescue => e
   p e.backtrace
 end
 
+#@since 3.4
+#=> ["filename.rb:2:in 'methd'", "filename.rb:6"]
+#@else
 #=> ["filename.rb:2:in `methd'", "filename.rb:6"]
+#@end
 #@end
 
 #@since 2.1.0
@@ -112,7 +121,11 @@ end
 
 e = get_exception { check_long_month(2) }
 p e.backtrace_locations
+#@since 3.4
+# => ["test.rb:4:in 'check_long_month'", "test.rb:15:in 'block in <main>'", "test.rb:9:in 'get_exception'", "test.rb:15:in '<main>'"]
+#@else
 # => ["test.rb:4:in `check_long_month'", "test.rb:15:in `block in <main>'", "test.rb:9:in `get_exception'", "test.rb:15:in `<main>'"]
+#@end
 #@end
 
 @see [[m:Exception#backtrace]]
@@ -149,7 +162,11 @@ begin
     raise "outer"
   end
 rescue
+#@since 3.4
+  $!.backtrace # => ["/path/to/test.rb:5:in 'rescue in <main>'", "/path/to/test.rb:2:in '<main>'"]
+#@else
   $!.backtrace # => ["/path/to/test.rb:5:in `rescue in <main>'", "/path/to/test.rb:2:in `<main>'"]
+#@end
   $!.set_backtrace(["dummy1", "dummy2"])
   $!.backtrace # => ["dummy1", "dummy2"]
 end
@@ -271,11 +288,23 @@ end
 begin
   raise "test"
 rescue => e
+#@since 3.4
+  p e.full_message   # => "\e[1mTraceback \e[m(most recent call last):\ntest.rb:2:in '<main>': \e[1mtest (\e[4;1mRuntimeError\e[m\e[1m)\n\e[m"
+#@else
   p e.full_message   # => "\e[1mTraceback \e[m(most recent call last):\ntest.rb:2:in `<main>': \e[1mtest (\e[4;1mRuntimeError\e[m\e[1m)\n\e[m"
+#@end
   $stderr = $stdout
+#@since 3.4
+  p e.full_message   # => "test.rb:2:in '<main>': test (RuntimeError)\n"
+#@else
   p e.full_message   # => "test.rb:2:in `<main>': test (RuntimeError)\n"
+#@end
   $stderr = STDERR
+#@since 3.4
+  p e.full_message   # => "\e[1mTraceback \e[m(most recent call last):\ntest.rb:2:in '<main>': \e[1mtest (\e[4;1mRuntimeError\e[m\e[1m)\n\e[m"
+#@else
   p e.full_message   # => "\e[1mTraceback \e[m(most recent call last):\ntest.rb:2:in `<main>': \e[1mtest (\e[4;1mRuntimeError\e[m\e[1m)\n\e[m"
+#@end
 end
 #@end
 

--- a/refm/api/src/_builtin/IO
+++ b/refm/api/src/_builtin/IO
@@ -1855,7 +1855,11 @@ outbuf は空文字列になります。
     buf = f.read(3)
     f.sysseek(0)
   }
+#@since 3.4
+  # => -:3:in 'sysseek': sysseek for buffered IO (IOError)
+#@else
   # => -:3:in `sysseek': sysseek for buffered IO (IOError)
+#@end
   
   File.open("/dev/null", "w") {|f|
     f.print "foo"

--- a/refm/api/src/_builtin/Integer
+++ b/refm/api/src/_builtin/Integer
@@ -78,7 +78,11 @@ self を文字コードとして見た時に、引数で与えたエンコーデ
 p 65.chr
 # => "A"
 p 12354.chr
+#@since 3.4
+# => 'chr': 12354 out of char range (RangeError)
+#@else
 # => `chr': 12354 out of char range (RangeError)
+#@end
 
 p 12354.chr(Encoding::UTF_8)
 # => "あ"

--- a/refm/api/src/_builtin/Marshal
+++ b/refm/api/src/_builtin/Marshal
@@ -36,7 +36,11 @@ obj を指定された出力先に再帰的に出力します。
 
 #@samplecode 例
 p Marshal.dump(Hash.new {})
+#@since 3.4
+# => -:1:in 'dump': cannot dump hash with default proc (TypeError)
+#@else
 # => -:1:in `dump': cannot dump hash with default proc (TypeError)
+#@end
 #@end
 
 マーシャルの動作を任意に定義することもできます。

--- a/refm/api/src/_builtin/MatchData
+++ b/refm/api/src/_builtin/MatchData
@@ -82,7 +82,11 @@ p $~.begin(0)   # => 0
 p $~.begin(1)   # => 0
 p $~.begin(2)   # => 3
 p $~.begin(3)   # => nil
+#@since 3.4
+p $~.begin(4)   # => 'begin': index 4 out of matches (IndexError)
+#@else
 p $~.begin(4)   # => `begin': index 4 out of matches (IndexError)
+#@end
 #@end
 
 @see [[m:MatchData#end]]
@@ -104,7 +108,11 @@ p $~.end(0)   # => 6
 p $~.end(1)   # => 3
 p $~.end(2)   # => 6
 p $~.end(3)   # => nil
+#@since 3.4
+p $~.end(4)   # => 'end': index 4 out of matches (IndexError)
+#@else
 p $~.end(4)   # => `end': index 4 out of matches (IndexError)
+#@end
 #@end
 
 @see [[m:MatchData#begin]]
@@ -207,7 +215,11 @@ p $~.offset(:year)     # => [0, 4]
 p $~.offset('month')   # => [5, 6]
 p $~.offset(:month)    # => [5, 6]
 p $~.offset('day')     # => [nil, nil]
+#@since 3.4
+p $~.offset('century') # => 'offset': undefined group name reference: century (IndexError)
+#@else
 p $~.offset('century') # => `offset': undefined group name reference: century (IndexError)
+#@end
 #@end
 
 #@since 3.2
@@ -248,7 +260,11 @@ p $~.byteoffset(:year)     # => [0, 4]
 p $~.byteoffset('month')   # => [7, 8]
 p $~.byteoffset(:month)    # => [7, 8]
 p $~.byteoffset('day')     # => [nil, nil]
+#@since 3.4
+p $~.byteoffset('century') # => 'offset': undefined group name reference: century (IndexError)
+#@else
 p $~.byteoffset('century') # => `offset': undefined group name reference: century (IndexError)
+#@end
 #@end
 
 @see [[m:MatchData#offset]]

--- a/refm/api/src/_builtin/Module
+++ b/refm/api/src/_builtin/Module
@@ -158,8 +158,11 @@ p Baz < Bar     # => true
 p Baz < Foo     # => true
 p Baz < Qux     # => nil
 p Baz > Qux     # => nil
-
+#@since 3.4
+p Foo < Object.new # => in '<': compared with non class/module (TypeError)
+#@else
 p Foo < Object.new # => in `<': compared with non class/module (TypeError)
+#@end
 #@end
 
 --- <=(other) -> bool | nil
@@ -373,7 +376,11 @@ class Foo
   autoload :Bar, '/tmp/bar.rb'
 end
 p Foo::Bar
+#@since 3.4
+#=> -:4:in '<main>': uninitialized constant Foo::Bar (NameError)
+#@else
 #=> -:4:in `<main>': uninitialized constant Foo::Bar (NameError)
+#@end
 #@end
 
 @see [[m:Kernel.#autoload]]
@@ -1005,7 +1012,11 @@ self の public インスタンスメソッド name をオブジェクト化し�
 
 #@samplecode 例
 Kernel.public_instance_method(:object_id) #=> #<UnboundMethod: Kernel#object_id>
+#@since 3.4
+Kernel.public_instance_method(:p)         #   method 'p' for module 'Kernel' is private (NameError)
+#@else
 Kernel.public_instance_method(:p)         #   method `p' for module `Kernel' is private (NameError)
+#@end
 #@end
 
 @see [[m:Module#instance_method]],[[m:Object#public_method]]
@@ -1129,7 +1140,11 @@ class Foo
   private_class_method :foo
 end
 
+#@since 3.4
+Foo.foo # NoMethodError: private method 'foo' called for Foo:Class
+#@else
 Foo.foo # NoMethodError: private method `foo' called for Foo:Class
+#@end
 
 Foo.public_class_method(:foo) # => Foo
 Foo.foo # => "foo"
@@ -1657,7 +1672,11 @@ end
 
 foo = Foo.new
 p foo.foo1          # => 1
+#@since 3.4
+p foo.foo2          # => private method 'foo2' called for #<Foo:0x401b7628> (NoMethodError)
+#@else
 p foo.foo2          # => private method `foo2' called for #<Foo:0x401b7628> (NoMethodError)
+#@end
 #@end
 
 --- protected() -> nil
@@ -1708,7 +1727,11 @@ p foo.foo2          # => private method `foo2' called for #<Foo:0x401b7628> (NoM
 def foo() 1 end
 p foo             # => 1
 # the toplevel default is private
+#@since 3.4
+p self.foo        # => private method 'foo' called for #<Object:0x401c83b0> (NoMethodError)
+#@else
 p self.foo        # => private method `foo' called for #<Object:0x401c83b0> (NoMethodError)
+#@end
 
 def bar() 2 end
 public :bar       # visibility changed (all access allowed)

--- a/refm/api/src/_builtin/Module.include
+++ b/refm/api/src/_builtin/Module.include
@@ -19,8 +19,13 @@ end
 
 実行結果:
 
+#@since 3.4
+  -:3:in 'append_features': cyclic include detected (ArgumentError)
+          from -:3:in 'include'
+#@else
   -:3:in `append_features': cyclic include detected (ArgumentError)
           from -:3:in `include'
+#@end
           from -:3
 
 

--- a/refm/api/src/_builtin/NameError
+++ b/refm/api/src/_builtin/NameError
@@ -5,7 +5,11 @@
 例:
 
   bar
+#@since 3.4
+  # => NameError: undefined local variable or method 'bar' for main:Object
+#@else
   # => NameError: undefined local variable or method `bar' for main:Object
+#@end
 
 == Class Methods
 
@@ -42,7 +46,11 @@
   begin
     foobar
   rescue NameError => err
+#@since 3.4
+    p err       # => #<NameError: undefined local variable or method 'foobar' for main:Object>
+#@else
     p err       # => #<NameError: undefined local variable or method `foobar' for main:Object>
+#@end
     p err.name  # => :foobar
   end
 
@@ -55,8 +63,13 @@
   begin
     foobar
   rescue NameError => err
+#@since 3.4
+    p err       # => #<NameError: undefined local variable or method 'foobar' for main:Object>
+    p err.to_s  # => "undefined local variable or method 'foobar' for main:Object"
+#@else
     p err       # => #<NameError: undefined local variable or method `foobar' for main:Object>
     p err.to_s  # => "undefined local variable or method `foobar' for main:Object"
+#@end
   end
 
 #@since 2.3.0

--- a/refm/api/src/_builtin/NoMethodError
+++ b/refm/api/src/_builtin/NoMethodError
@@ -5,21 +5,33 @@
 例:
 
   self.bar
+#@since 3.4
+  # => -:1: undefined method 'bar' for #<Object:0x401a6c40> (NoMethodError)
+#@else
   # => -:1: undefined method `bar' for #<Object:0x401a6c40> (NoMethodError)
+#@end
 
 プライベートなインスタンスメソッドを呼び出そうとした場合にも発生します。
 
 例:
 
   "".puts
+#@since 3.4
+  # => -:1:in 'puts': private method 'puts' called for "":String (NoMethodError)
+#@else
   # => NoMethodError: private method `puts' called for "":String
+#@end
 
 メソッド呼び出しの形式でなければ [[c:NameError]] 例外が発生します。
 
 例:
 
   bar
+#@since 3.4
+  # => -:1: undefined local variable or method 'bar' for #<Object:0x401a6c40> (NameError)
+#@else
   # => -:1: undefined local variable or method `bar' for #<Object:0x401a6c40> (NameError)
+#@end
 
 == Class Methods
 
@@ -71,8 +83,12 @@
     p $!.name
     p $!.args
   end
-  
+
+#@since 3.4
+  # => #<NoMethodError: undefined method 'foobar' for main:Object>
+#@else
   # => #<NoMethodError: undefined method `foobar' for main:Object>
+#@end
        :foobar
        [1, 2, 3]
 

--- a/refm/api/src/_builtin/Proc
+++ b/refm/api/src/_builtin/Proc
@@ -89,7 +89,11 @@ pr.call(1) # => 1
 #@end
 
 #@samplecode
+#@since 3.4
+Proc.new # => -e:1:in 'new': tried to create Proc object without a block (ArgumentError)
+#@else
 Proc.new # => -e:1:in `new': tried to create Proc object without a block (ArgumentError)
+#@end
 #@end
 #@end
 

--- a/refm/api/src/_builtin/Regexp
+++ b/refm/api/src/_builtin/Regexp
@@ -148,7 +148,11 @@ p Regexp.last_match # => nil
 begin
   p Regexp.last_match[1] # 例外が発生する
 rescue 
+#@since 3.4
+  puts $! # => undefined method '[]' for nil:NilClass
+#@else
   puts $! # => undefined method `[]' for nil:NilClass
+#@end
 end
 p Regexp.last_match(1) # => nil
 #@end
@@ -484,7 +488,11 @@ nil.captures を呼び出そうとして例外 [[c:NoMethodError]] が発生し�
 #@samplecode 例
 foo, bar, baz = /(foo)(bar)(baz)/.match("foobar").captures
 
+#@since 3.4
+# => -:1: undefined method 'captures' for nil:NilClass (NoMethodError)
+#@else
 # => -:1: undefined method `captures' for nil:NilClass (NoMethodError)
+#@end
 #@end
 
 #@since 2.4.0

--- a/refm/api/src/_builtin/RegexpError
+++ b/refm/api/src/_builtin/RegexpError
@@ -4,8 +4,13 @@
 
 例:
 
-  $ ruby -e 'Regexp.compile("*")'
+$ ruby -e 'Regexp.compile("*")'
+#@since 3.4
+  -e:1:in 'initialize': target of repeat operator is not specified: /*/ (RegexpError)
+          from -e:1:in 'Regexp#compile'
+#@else
   -e:1:in `initialize': target of repeat operator is not specified: /*/ (RegexpError)
           from -e:1:in `Regexp#compile'
+#@end
           from -e:1
 

--- a/refm/api/src/_builtin/RegexpError
+++ b/refm/api/src/_builtin/RegexpError
@@ -4,7 +4,7 @@
 
 例:
 
-$ ruby -e 'Regexp.compile("*")'
+  $ ruby -e 'Regexp.compile("*")'
 #@since 3.4
   -e:1:in 'initialize': target of repeat operator is not specified: /*/ (RegexpError)
           from -e:1:in 'Regexp#compile'

--- a/refm/api/src/_builtin/Struct
+++ b/refm/api/src/_builtin/Struct
@@ -116,7 +116,11 @@ args[0] が [[c:String]] の場合、クラス名になるので、大文字で�
 
 #@samplecode 例
 p Struct.new('foo', 'bar')
+#@since 3.4
+# => -:1:in 'new': identifier foo needs to be constant (NameError)
+#@else
 # => -:1:in `new': identifier foo needs to be constant (NameError)
+#@end
 #@end
 
 また args[1..-1] は、[[c:Symbol]] か [[c:String]] で指定します。
@@ -217,11 +221,19 @@ Foo = Struct.new(:foo, :bar)
 obj = Foo.new('FOO', 'BAR')
 p obj[:foo]     # => "FOO"
 p obj['bar']    # => "BAR"
+#@since 3.4
+# p obj[:baz]     # => in '[]': no member 'baz' in struct (NameError)
+#@else
 # p obj[:baz]     # => in `[]': no member 'baz' in struct (NameError)
+#@end
 p obj[0]        # => "FOO"
 p obj[1]        # => "BAR"
 p obj[-1]       # => "BAR"    # Array のように負のインデックスも指定できます。
-p obj[2]        # => in `[]': offset 2 too large for struct(size:2) (IndexError)
+#@since 3.4
+# p obj[2]        # => in '[]': offset 2 too large for struct(size:2) (IndexError)
+#@else
+# p obj[2]        # => in `[]': offset 2 too large for struct(size:2) (IndexError)
+#@end
 #@end
 
 #@include(Struct.attention)

--- a/refm/api/src/_builtin/Thread
+++ b/refm/api/src/_builtin/Thread
@@ -43,8 +43,13 @@ Thread.abort_on_exception # => true
 
   #<Thread:...> terminated with exception (report_on_exception is true):
   Traceback (most recent call last):
+#@since 3.4
+          2: from -e:1:in 'block in <main>'
+          1: from -e:1:in 'times'
+#@else
           2: from -e:1:in `block in <main>'
           1: from -e:1:in `times'
+#@end
 
 これによってスレッドのエラーを早期に捕捉できるようになります。
 いくつかのケースでは、この出力を望まないかもしれません。
@@ -585,7 +590,11 @@ a.report_on_exception   # => true
 a.run
 # => #<Thread:0x00007fc3f48c7908@(irb):1 run> terminated with exception (report_on_exception is true):
 #    Traceback (most recent call last):
+#@since 3.4
+#    (irb):1:in 'block in irb_binding': unhandled exception
+#@else
 #    (irb):1:in `block in irb_binding': unhandled exception
+#@end
 #    #<Thread:0x00007fc3f48c7908@(irb):1 dead>
 b = Thread.new{ Thread.stop; raise }
 b.report_on_exception = false
@@ -1038,10 +1047,17 @@ end
 th = Thread.new {C1.new.m2; Thread.stop}
 th.backtrace
 # => [
+#@since 3.4
+#      [0] "(irb):3:in 'sleep'",
+#      [1] "(irb):3:in 'm1'",
+#      [2] "(irb):6:in 'm2'",
+#      [3] "(irb):10:in 'block in irb_binding'"
+#@else
 #      [0] "(irb):3:in `sleep'",
 #      [1] "(irb):3:in `m1'",
 #      [2] "(irb):6:in `m2'",
 #      [3] "(irb):10:in `block in irb_binding'"
+#@end
 #    ]
 
 th.kill
@@ -1072,7 +1088,11 @@ th.backtrace   # => nil
 #@samplecode 例
 thread = Thread.new { sleep 1 }
 thread.run
+#@since 3.4
+thread.backtrace_locations # => ["/path/to/test.rb:1:in 'sleep'", "/path/to/test.rb:1:in 'block in <main>'"]
+#@else
 thread.backtrace_locations # => ["/path/to/test.rb:1:in `sleep'", "/path/to/test.rb:1:in `block in <main>'"]
+#@end
 #@end
 
 @see [[c:Thread::Backtrace::Location]]

--- a/refm/api/src/_builtin/Thread__Backtrace__Location
+++ b/refm/api/src/_builtin/Thread__Backtrace__Location
@@ -23,9 +23,15 @@ end
 
 例1の実行結果:
 
+#@since 3.4
+  caller_locations.rb:2:in 'a'
+  caller_locations.rb:5:in 'b'
+  caller_locations.rb:8:in 'c'
+#@else
   caller_locations.rb:2:in `a'
   caller_locations.rb:5:in `b'
   caller_locations.rb:8:in `c'
+#@end
 
 #@samplecode 例2
 # foo.rb
@@ -43,9 +49,15 @@ end
 
 例2の実行結果:
 
+#@since 3.4
+  init.rb:4:in 'initialize'
+  init.rb:8:in 'new'
+  init.rb:8:in '<main>'
+#@else
   init.rb:4:in `initialize'
   init.rb:8:in `new'
   init.rb:8:in `<main>'
+#@end
 
 === 参考
 
@@ -159,9 +171,15 @@ Foo.new(0..2).locations.map do |call|
   puts call.to_s
 end
 
+#@since 3.4
+# => path/to/foo.rb:5:in 'initialize'
+# path/to/foo.rb:9:in 'new'
+# path/to/foo.rb:9:in '<main>'
+#@else
 # => path/to/foo.rb:5:in `initialize'
 # path/to/foo.rb:9:in `new'
 # path/to/foo.rb:9:in `<main>'
+#@end
 #@end
 
 --- inspect -> String
@@ -182,7 +200,13 @@ Foo.new(0..2).locations.map do |call|
   puts call.inspect
 end
 
+#@since 3.4
+# => "path/to/foo.rb:5:in 'initialize'"
+# "path/to/foo.rb:9:in 'new'"
+# "path/to/foo.rb:9:in '<main>'"
+#@else
 # => "path/to/foo.rb:5:in `initialize'"
 # "path/to/foo.rb:9:in `new'"
 # "path/to/foo.rb:9:in `<main>'"
+#@end
 #@end

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1301,9 +1301,15 @@ end
 
 bar
 
+#@since 3.4
+#=> ["-:2:in 'foo'", "-:10:in 'bar'", "-:13:in '<main>'"]
+#   ["-:10:in 'bar'", "-:13:in '<main>'"]
+#   ["-:13:in '<main>'"]
+#@else
 #=> ["-:2:in `foo'", "-:10:in `bar'", "-:13:in `<main>'"]
 #   ["-:10:in `bar'", "-:13:in `<main>'"]
 #   ["-:13:in `<main>'"]
+#@end
 #   []
 #   nil
 #@end

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -128,7 +128,11 @@ puts 'end' #実行されない
 #=> error1
 #@since 2.7.0
 #   Traceback (most recent call last):
+#@since 3.4
+#   sample.rb:11:in '<main>': RuntimeError (RuntimeError)
+#@else
 #   sample.rb:11:in `<main>': RuntimeError (RuntimeError)
+#@end
 #@end
 #@end
 
@@ -1107,7 +1111,11 @@ require 'some'
 p $a #=> 1
 p @a #=> 1
 p A #=> 1
+#@since 3.4
+p a # undefined local variable or method 'a' for #<Object:0x294f9ec @a=1> (NameError)
+#@else
 p a # undefined local variable or method `a' for #<Object:0x294f9ec @a=1> (NameError)
+#@end
 #@end
 
 --- autoload(const_name, feature) -> nil
@@ -1562,7 +1570,11 @@ putc(355)
 #=> cccc
 
 putc(99.00) #=> c
+#@since 3.4
+putc(33333333333333333333333333333333333) # bignum too big to convert into 'long' (RangeError)
+#@else
 putc(33333333333333333333333333333333333) # bignum too big to convert into `long' (RangeError)
+#@end
 #@end
 
 @see [[m:IO#putc]]
@@ -1868,9 +1880,15 @@ p Integer("0o10")     #=> 8
 p Integer("0x10")     #=> 16
 p Integer("0b10")     #=> 2
 p Integer(" \n10\t ") #=> 10 # 先頭と末尾の空白類は無視される
+#@since 3.4
+p Integer("1\n0")     # 'Integer': invalid value for Integer: "1\n0" (ArgumentError)
+p Integer("hoge")     # 'Integer': invalid value for Integer: "hoge" (ArgumentError)
+p Integer("")         # 'Integer': invalid value for Integer: "" (ArgumentError)
+#@else
 p Integer("1\n0")     # `Integer': invalid value for Integer: "1\n0" (ArgumentError)
 p Integer("hoge")     # `Integer': invalid value for Integer: "hoge" (ArgumentError)
 p Integer("")         # `Integer': invalid value for Integer: "" (ArgumentError)
+#@end 
 #@end
 
 @see [[m:String#hex]],[[m:String#oct]],[[m:String#to_i]],[[c:Integer]]
@@ -2423,8 +2441,11 @@ $v = 'str'        # なにも出力されない
 begin
   open("nonexist")
 rescue
+#@since 3.4
+  raise   #=> 'open': No such file or directory - "nonexist" (Errno::ENOENT)
+#@else
   raise   #=> `open': No such file or directory - "nonexist" (Errno::ENOENT)
-end
+#@end
 #@end
 
 引数を渡した場合は、例外メッセージ message を持った error_type の示す例外(省略時 RuntimeError)を

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1393,15 +1393,27 @@ end
 
 caller_locations # => []
 test3(1, nil)
+#@since 3.4
+# => ["/Users/user/test.rb:9:in 'test2'", "/Users/user/test.rb:13:in 'test3'", "/Users/user/test.rb:17:in '<main>'"]
+#@else
 # => ["/Users/user/test.rb:9:in `test2'", "/Users/user/test.rb:13:in `test3'", "/Users/user/test.rb:17:in `<main>'"]
+#@end
 # => [9, 13, 17]
 # => ["/Users/user/test.rb", "/Users/user/test.rb", "/Users/user/test.rb"]
 test3(1, 2)
+#@since 3.4
+# => ["/Users/user/test.rb:9:in 'test2'", "/Users/user/test.rb:13:in 'test3'"]
+#@else
 # => ["/Users/user/test.rb:9:in `test2'", "/Users/user/test.rb:13:in `test3'"]
+#@end
 # => [9, 13]
 # => ["/Users/user/test.rb", "/Users/user/test.rb"]
 test3(2, 1)
+#@since 3.4
+# => ["/Users/user/test.rb:13:in 'test3'"]
+#@else
 # => ["/Users/user/test.rb:13:in `test3'"]
+#@end
 # => [13]
 # => ["/Users/user/test.rb"]
 #@end

--- a/refm/api/src/_builtin/functions
+++ b/refm/api/src/_builtin/functions
@@ -1888,7 +1888,7 @@ p Integer("")         # 'Integer': invalid value for Integer: "" (ArgumentError)
 p Integer("1\n0")     # `Integer': invalid value for Integer: "1\n0" (ArgumentError)
 p Integer("hoge")     # `Integer': invalid value for Integer: "hoge" (ArgumentError)
 p Integer("")         # `Integer': invalid value for Integer: "" (ArgumentError)
-#@end 
+#@end
 #@end
 
 @see [[m:String#hex]],[[m:String#oct]],[[m:String#to_i]],[[c:Integer]]

--- a/refm/api/src/_builtin/lambda_proc
+++ b/refm/api/src/_builtin/lambda_proc
@@ -123,7 +123,11 @@ def foo
 end
 
 foo.call
+#@since 3.4
+# => in 'call': return from proc-closure (LocalJumpError)
+#@else
 # => in `call': return from proc-closure (LocalJumpError)
+#@end
 #@end
 
 以下の表は、手続きオブジェクトの実行を上の例と同じように、手続きオブジェクトが定義されたメソッドを

--- a/refm/api/src/did_you_mean.rd
+++ b/refm/api/src/did_you_mean.rd
@@ -4,7 +4,11 @@ category Development
 きに、自動的に他の似た名前を提案してくれるライブラリです。
 
   "Yuki".starts_with?("Y")
+#@since 3.4
+  # => NoMethodError: undefined method 'starts_with?' for "Yuki":String
+#@else
   # => NoMethodError: undefined method `starts_with?' for "Yuki":String
+#@end
   #    Did you mean?  start_with?
 
 デフォルトで有効になっており、無効にするにはコマンドラインオプションで

--- a/refm/api/src/json/add/exception.rd
+++ b/refm/api/src/json/add/exception.rd
@@ -25,7 +25,11 @@ require "json/add/core"
 begin
   0/0
 rescue => e
+#@since 3.4
+  e.to_json # => "{\"json_class\":\"ZeroDivisionError\",\"m\":\"divided by 0\",\"b\":[\"/path/to/test.rb:4:in '/'\",\"/path/to/test.rb:4:in '<main>'\"]}"
+#@else
   e.to_json # => "{\"json_class\":\"ZeroDivisionError\",\"m\":\"divided by 0\",\"b\":[\"/path/to/test.rb:4:in `/'\",\"/path/to/test.rb:4:in `<main>'\"]}"
+#@end
 end
 #@end
 

--- a/refm/api/src/ripper/lexer.rd
+++ b/refm/api/src/ripper/lexer.rd
@@ -82,7 +82,11 @@ pp Ripper.lex("def m(a) nil end")
 #@if (version >= "3.0")
 
 Ripper.lex("def req(true) end", raise_errors: true)
+#@since 3.4
+# => SyntaxError (syntax error, unexpected 'true', expecting ')')
+#@else
 # => SyntaxError (syntax error, unexpected `true', expecting ')')
+#@end
 #@end
 #@end
 #@end

--- a/refm/api/src/singleton.rd
+++ b/refm/api/src/singleton.rd
@@ -28,7 +28,11 @@ new は private メソッドに移され、外部から呼び出そうとする�
   a = SomeSingletonClass.instance
   b = SomeSingletonClass.instance # a and b are same object
   p [a,b] # => [#<SomeSingletonClass:0x0000562e6e18ddd0>, #<SomeSingletonClass:0x0000562e6e18ddd0>]
+#@since 3.4
+  a = SomeSingletonClass.new  # => NoMethodError (private method 'new' called for SomeSingletonClass:Class)
+#@else
   a = SomeSingletonClass.new  # => NoMethodError (private method `new' called for SomeSingletonClass:Class)
+#@end
 
 == Singleton Methods
 

--- a/refm/api/src/stringio.rd
+++ b/refm/api/src/stringio.rd
@@ -30,7 +30,11 @@ require "stringio"
 sio = StringIO.new("hoge")
 sio.close
 sio.write("a")
+#@since 3.4
+# => in 'write': not opened for writing (IOError)
+#@else
 # => in `write': not opened for writing (IOError)
+#@end
 #@end
 
 == Class Methods


### PR DESCRIPTION
## 概要
Issue #2974 に基づき、Ruby 3.4 以降でバックトレースおよびエラーメッセージ内の引用符がバッククォート（`）からシングルクォート（'）に変更されたことに伴い、該当する実行例の出し分け対応を行いました。

## 修正方針とスコープ
`grep -r "# =>.*\`" refm/api/src` コマンドを用いて、実行結果の出力例に含まれるバッククォートを網羅的に調査しました。

その調査結果に基づき、組み込みライブラリだけでなく、標準添付ライブラリに含まれるエラーメッセージやバックトレースについても修正を行いました。

**※修正対象は「サンプルコードの実行結果（`# =>` 以降）」のみに限定しており、ドキュメントの説明文（地の文）に含まれるバッククォート表記については変更していません。**

## 修正内容
以下のファイルにおいて、`#@since 3.4` ディレクティブを使用して表示例を更新しました。

### 組み込みライブラリ (`_builtin/`)
- `functions` (Kernel.#caller, Kernel.#caller_locations, Kernel.#abort 等)
- `Array`
- `Exception`
- `IO`
- `Integer`
- `Marshal`
- `MatchData`
- `Module` (include, private method 等)
- `NameError`, `NoMethodError`
- `Proc`
- `Regexp`, `RegexpError`
- `Struct`
- `Thread`, `Thread__Backtrace__Location`
- `Data`

### 標準添付ライブラリ
- `stringio.rd`
- `did_you_mean.rd`
- `ripper/lexer.rd`
- `json/add/exception.rd`
- `singleton.rd`

## 修正対象外としたもの
以下のファイルについては、出力結果にバッククォートが含まれていますが、エラーメッセージの引用符ではなくデータそのもの（バイナリ表現など）であるため、意図的に修正対象外としています。

- `_builtin/pack-template` (`["a"].pack("u")` の出力結果など)

## 補足
- `Exception#full_message` について実機 (Ruby 4.0.1) で動作確認した際、引用符の変更以外に、デフォルトで「Traceback (most recent call last):」というヘッダーが出力されない挙動を確認しました。本 PR では Issue の趣旨（引用符の変更）を優先し、引用符の置換のみを行っています。