### PR TITLE
Fix incorrect example output in Array#fetch_values

### DIFF
--- a/refm/api/src/_builtin/Array
+++ b/refm/api/src/_builtin/Array
@@ -1103,7 +1103,7 @@ p result #=> 999
 ary = ["a", "b", "c"]
 
 ary.fetch_values(0, 2)  # => ["a", "c"]
-ary.fetch_values(-1, 1) # => ["d", "b"]
+ary.fetch_values(-1, 1) # => ["c", "b"]
 ary.fetch_values(0, 10) # => index 10 outside of array bounds: -3...3 (IndexError)
 ary.fetch_values(0, 10) { |i| i.to_s } # => ["a", "10"]
 #@end


### PR DESCRIPTION
https://docs.ruby-lang.org/ja/latest/method/Array/i/fetch_values.html のサンプルコードの出力結果が誤っていたため修正しました。

`ary.fetch_values(-1, 1)` の結果は `["d", "b"]` ではなく `["c", "b"]` になります。
