### PR TITLE
Use bundled Bundler on ruby-head in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
           ruby: head
         - os: windows-latest
           ruby: head
+    env:
+      # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
+      # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
+      BUNDLER_VERSION: ${{ matrix.ruby == 'head' && '0' || '' }}
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Released Bundler is broken on ruby-head due to ruby/ruby#16895. The fix (ruby/rubygems#9529) has not been released yet.