### PR TITLE
CI: skip runs for refm/- and docs/-only changes, narrow misspell scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'refm/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'refm/**'
 
 jobs:
   ruby-versions:
@@ -103,4 +111,4 @@ jobs:
       run: 'curl -L https://git.io/misspell | bash'
     - name: Run misspell
       run: |
-        git ls-files -z | xargs -0 ./bin/misspell -error -i addopt
+        git ls-files -z -- ':(top)' ':(exclude)refm' ':(exclude)docs' | xargs -0 ./bin/misspell -error -i addopt


### PR DESCRIPTION
## 概要

Markdown 移行後、`refm/` は凍結（ビルド対象は `manual/`）、`docs/` は wiki から取り込むプロジェクト文書置き場で、どちらもビルドに影響しません。これらだけを変更する PR / push（今後の refm/ 削除や docs/ の棚卸しなど）で 3 OS × 全バージョンの rake マトリクスを回すのは無駄なので、CI にパス制限を追加します。

## 変更内容

- **`paths-ignore`**: `push` / `pull_request` の両トリガーに `docs/**` と `refm/**` を追加。変更ファイルがこの2ツリーに収まる場合はワークフロー全体（rake マトリクス + misspell）をスキップ
- **misspell の対象制限**: `git ls-files` の対象から `refm/`（凍結ツリー・919ファイル）と `docs/` を除外

## 補足

- pathspec が `:(top)` / `:(exclude)` の長形式なのは、`git ls-files` では除外のみの pathspec だと1件もマッチしなくなるため（正の pathspec が必須）。除外後の対象は 1,265 ファイル（manual/ ほか）で、ローカルで件数・除外の効きを確認済みです
- master のブランチ保護は無効（required checks なし）なので、スキップされた PR がステータス待ちで塞がることはありません
- docs/ 取り込み PR より先にこの PR をマージすると、取り込み PR（docs/ のみ変更）では CI が走りません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
