### PR TITLE
README: point to docs/ instead of the retired wiki

### DIFF
--- a/README
+++ b/README
@@ -5,4 +5,5 @@ Rubyリファレンスマニュアル刷新計画 README
 (2026年7月に RD ベースの独自記法 RRD から移行しました)。
 編集のしかたは CONTRIBUTING.md を参照してください。
 
-See: https://github.com/rurema/doctree/wiki
+執筆ガイド・参加方法などのプロジェクト文書は docs/ にあります
+(旧 GitHub wiki は docs/ へ移行しました)。


### PR DESCRIPTION
## 概要

wiki の内容は docs/ に移行済みで（#3037/#3039/#3040)、wiki 側も案内スタブへの置き換えが済んだので、README の「See: wiki」リンクを docs/ への案内に差し替えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
