### PR TITLE
Add VS Code TextMate grammar for #@ directives in manual/*.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'refm/**'
+      - 'tools/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'refm/**'
+      - 'tools/**'
 
 jobs:
   ruby-versions:
@@ -111,4 +113,4 @@ jobs:
       run: 'curl -L https://git.io/misspell | bash'
     - name: Run misspell
       run: |
-        git ls-files -z -- ':(top)' ':(exclude)refm' ':(exclude)docs' | xargs -0 ./bin/misspell -error -i addopt
+        git ls-files -z -- ':(top)' ':(exclude)refm' ':(exclude)docs' ':(exclude)tools' | xargs -0 ./bin/misspell -error -i addopt

--- a/tools/vscode/rurema-markdown/README.md
+++ b/tools/vscode/rurema-markdown/README.md
@@ -1,0 +1,49 @@
+# Rurema Markdown (#@ directives) — VS Code 拡張
+
+るりまの `manual/**/*.md` で使う `#@` プリプロセッサ指令を Markdown 上で
+ハイライトする VS Code 拡張です。文法（TextMate grammar）だけの小さな拡張で、
+既存の Markdown ハイライトに注入（injection）する形なので、
+Markdown 本来の表示はそのまま維持されます。
+
+対応する指令（bitclust の Preprocessor と同じ集合）:
+
+| 指令 | 表示 |
+|------|------|
+| `#@since 3.0` / `#@until 3.4` | キーワード + バージョン値 |
+| `#@if (version >= "3.1")` | キーワード + 条件式（`version`・比較/論理演算子・文字列） |
+| `#@else` / `#@end` | キーワード |
+| `#@include(pack-template)` | キーワード + パス |
+| `#@samplecode 例` | キーワード + ラベル |
+| `#@todo`（大文字小文字不問） | 作業メモとして強調 |
+| `#@# コメント` | コメント |
+| **上記以外の行頭 `#@...`** | **エラー表示**（ビルドでも parse error になるため。タイポ検出に役立つ） |
+
+指令として扱われるのは**行頭（カラム0）の `#@` 行だけ**です
+（インデントされた `#@` は本文テキスト。bitclust の挙動と同じ）。
+プリプロセッサはコードブロック内の `#@` も処理するため、
+ハイライトもコードブロック内に適用されます。
+YAML front matter 内の `#@since` 等（ゲート付きリスト）にも効きます。
+
+## インストール
+
+marketplace には公開していません。checkout からシンボリックリンクで入れます:
+
+```console
+$ ln -s "$(pwd)/tools/vscode/rurema-markdown" ~/.vscode/extensions/rurema-markdown
+```
+
+（Windows はリンクの代わりにフォルダごと `%USERPROFILE%\.vscode\extensions\` へコピー）
+
+その後 VS Code を再起動（または「開発者: ウィンドウの再読み込み」）してください。
+`manual/` 配下の `.md` を開くと `#@` 行に色が付きます。
+
+アンインストールはリンク（コピー）を消すだけです。
+
+## 制限・今後の拡張候補
+
+- ハイライトのみで、補完・診断（Language Server）はありません
+- るりま独自のリンク記法（`[m:Array#each]` 等）やメソッドシグネチャ
+  （`### def ...`）のハイライトは今後の拡張候補です
+- 記法の仕様は bitclust の
+  [MARKUP_SPEC.md](https://github.com/rurema/bitclust/blob/master/doc/markdown-samples/MARKUP_SPEC.md)
+  を参照してください

--- a/tools/vscode/rurema-markdown/package.json
+++ b/tools/vscode/rurema-markdown/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "rurema-markdown",
+  "displayName": "Rurema Markdown (#@ directives)",
+  "description": "るりま（Ruby リファレンスマニュアル）manual/ の Markdown で使う #@ プリプロセッサ指令（#@since / #@until / #@if / #@else / #@end / #@include / #@samplecode / #@todo / #@#）をハイライトします",
+  "version": "0.1.0",
+  "publisher": "rurema",
+  "engines": {
+    "vscode": "^1.0.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rurema/doctree.git",
+    "directory": "tools/vscode/rurema-markdown"
+  },
+  "contributes": {
+    "grammars": [
+      {
+        "scopeName": "markdown.rurema.injection",
+        "path": "./syntaxes/rurema-directives.tmLanguage.json",
+        "injectTo": [
+          "text.html.markdown"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/vscode/rurema-markdown/syntaxes/rurema-directives.tmLanguage.json
+++ b/tools/vscode/rurema-markdown/syntaxes/rurema-directives.tmLanguage.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Rurema #@ directives (Markdown injection)",
+  "scopeName": "markdown.rurema.injection",
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#directives"
+    }
+  ],
+  "repository": {
+    "directives": {
+      "comment": "bitclust の Preprocessor は行頭（カラム0）の #@ 行だけを指令として処理する（インデントされた #@ は本文）。既知の指令以外の行頭 #@ はビルドで parse error になるため invalid として強調する",
+      "patterns": [
+        {
+          "comment": "#@# プリプロセッサコメント（#@#todo 等も含む）",
+          "match": "^(#@#).*$",
+          "name": "comment.line.number-sign.rurema",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.comment.rurema"
+            }
+          }
+        },
+        {
+          "comment": "#@todo（大文字小文字不問。ビルド出力に @todo として残る作業メモ）",
+          "match": "^((?i:#@todo))(.*)$",
+          "name": "meta.directive.todo.rurema",
+          "captures": {
+            "1": {
+              "name": "keyword.codetag.rurema"
+            },
+            "2": {
+              "name": "comment.line.todo.rurema"
+            }
+          }
+        },
+        {
+          "comment": "#@include(path) 共有断片の展開",
+          "match": "^(#@include)[ \\t]*(\\()([^)]*)(\\)).*$",
+          "name": "meta.directive.include.rurema",
+          "captures": {
+            "1": {
+              "name": "keyword.control.import.rurema"
+            },
+            "2": {
+              "name": "punctuation.section.parens.begin.rurema"
+            },
+            "3": {
+              "name": "string.unquoted.path.rurema"
+            },
+            "4": {
+              "name": "punctuation.section.parens.end.rurema"
+            }
+          }
+        },
+        {
+          "comment": "#@since / #@until バージョンゲート（バージョンは 1.9.1 形式、クォートも可）",
+          "match": "^(#@(?:since|until))[ \\t]+(?:(\"[0-9][0-9.]*\")|([0-9][0-9.]*))[ \\t]*$",
+          "name": "meta.directive.version-gate.rurema",
+          "captures": {
+            "1": {
+              "name": "keyword.control.conditional.rurema"
+            },
+            "2": {
+              "name": "string.quoted.double.version.rurema"
+            },
+            "3": {
+              "name": "constant.numeric.version.rurema"
+            }
+          }
+        },
+        {
+          "comment": "#@samplecode [説明] （Ruby サンプルコードブロック。#@end で閉じる。md では版ゲートを含むコード例など fence で表現できない場合に残る）",
+          "match": "^(#@samplecode)\\b[ \\t]*(.*)$",
+          "name": "meta.directive.samplecode.rurema",
+          "captures": {
+            "1": {
+              "name": "keyword.control.samplecode.rurema"
+            },
+            "2": {
+              "name": "string.unquoted.caption.rurema"
+            }
+          }
+        },
+        {
+          "comment": "#@if (条件式) — version 変数と比較・論理演算子",
+          "match": "^(#@if)\\b(.*)$",
+          "name": "meta.directive.conditional.rurema",
+          "captures": {
+            "1": {
+              "name": "keyword.control.conditional.rurema"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "match": "\"[^\"]*\"",
+                  "name": "string.quoted.double.version.rurema"
+                },
+                {
+                  "match": "\\bversion\\b",
+                  "name": "variable.language.version.rurema"
+                },
+                {
+                  "match": "\\b(?:and|or|not)\\b",
+                  "name": "keyword.operator.logical.rurema"
+                },
+                {
+                  "match": "[<>=!]=|[<>]",
+                  "name": "keyword.operator.comparison.rurema"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "comment": "#@else / #@end（後続テキストは許されない）",
+          "match": "^(#@(?:else|end))[ \\t]*$",
+          "name": "keyword.control.conditional.rurema"
+        },
+        {
+          "comment": "上記のいずれでもない行頭 #@ はビルドで parse error（タイポ検出）",
+          "match": "^#@.*$",
+          "name": "invalid.illegal.directive.rurema"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 概要

`manual/**/*.md` を VS Code で編集するときに `#@` プリプロセッサ指令を
ハイライトする TextMate grammar を追加します（MARKUP_SPEC §15 の
「エディタ支援: `#@` 指令用の VS Code TextMate grammar 作成」の実装）。

`tools/vscode/rurema-markdown/` に文法のみの最小構成の拡張として配置:

- `package.json` — Markdown への injection grammar として contribute
  （既存の Markdown ハイライトはそのまま、`#@` 行にだけ色を足す）
- `syntaxes/rurema-directives.tmLanguage.json` — 文法本体
- `README.md` — インストール手順（`~/.vscode/extensions/` へ symlink）と対応範囲

## 設計のポイント（bitclust Preprocessor と同じ解釈）

- **行頭（カラム0）の `#@` 行だけ**を指令として扱う（インデントされた `#@` は本文。
  Preprocessor の `\A` アンカーと同じ）
- 対応指令: `#@since`/`#@until`（バージョン値を強調）・`#@if`（`version`・
  比較/論理演算子・文字列を強調）・`#@else`/`#@end`（後続テキスト不可）・
  `#@include(path)`・`#@samplecode [ラベル]`・`#@todo`（大文字小文字不問）・
  `#@#` コメント
- **既知の指令以外の行頭 `#@` は invalid（エラー色）表示** — ビルドでも
  parse error になる行なので、編集中のタイポ検出を兼ねる
- プリプロセッサはコードブロック内・YAML front matter 内（§1.6 のゲート付き
  リスト）の `#@` も処理するため、injection はそれらの領域にも適用される

## 検証

- 文法中の全 regex が Onigmo（TextMate の Oniguruma 互換エンジン）でコンパイル可
- **manual/ 全ツリーの行頭 `#@` 全 10,062 行**をパターン順で分類:
  `#@#` 4,028 / `#@else`・`#@end` 2,970 / `#@since`・`#@until` 2,099 /
  `#@todo` 737 / `#@include` 124 / `#@if` 103 / `#@samplecode` 1、
  **invalid・未分類は 0 行**（= 実在する正しい指令を誤ってエラー表示しない）
- 不正形 7 種（`#@sinse`・バージョン欠落・`#@else foo` 等）が invalid に落ち、
  非対象 4 種（インデント付き・`\#@` エスケープ・行中の `#@`）はマッチしないことを確認
- VS Code 上での見た目の最終確認のみ手元でお願いします
  （symlink → ウィンドウ再読み込み → manual/ の適当な .md を開く）

## CI

`tools/**` はマニュアルのビルドに影響しないため、`docs/**`・`refm/**` と同様に
CI の `paths-ignore` と misspell の対象から除外しました（2コミット目）。
除外後も misspell の対象が正しく残ることをローカルで確認済み
（`git ls-files` 1,270 ファイル、tools/docs/refm は 0）。

なお本 PR 自体は `.github/workflows/ci.yml` を変更しているため CI が一度走ります
（`paths-ignore` は変更ファイル全部が ignore に一致した場合のみスキップ）。
workflow 変更の検証を兼ねるのでそのままにしています。
除外が効くのは今後の tools/ のみの変更からです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
