### PR TITLE
Pass --eol-warning to statichtml for EOL versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: c7500e5e2f5d2ed765af5e81e524d7e50734829d
+  revision: b656b9a000386d6d4208424c4b688cce40180979
   specs:
     bitclust-core (1.4.0)
       drb

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,10 @@ OLD_VERSIONS = %w[
 ]
 SUPPORTED_VERSIONS = %w[3.0 3.1 3.2 3.3 3.4 4.0]
 UNRELEASED_VERSIONS = %w[4.1]
+# メンテナンスが継続している最古のバージョン。これより古い版の静的 HTML には
+# bitclust statichtml --eol-warning で警告バナーを表示する。
+# EOL 状況は https://www.ruby-lang.org/ja/downloads/branches/ を参照して更新する
+MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")
 ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 CI_VERSIONS = [*SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 HTML_DIRECTORY_BASE = ENV.fetch("HTML_DIRECTORY_BASE", "/tmp/html/")
@@ -60,6 +64,7 @@ def generate_statichtml(version)
     "--fs-casesensitive",
     "--canonical-base-url=https://docs.ruby-lang.org/ja/latest/",
   ]
+  commands << "--eol-warning" if MINIMUM_SUPPORTED_RUBY_VERSION > version
   commands << "--edit-base-url=https://github.com/rurema/doctree/edit/master/" unless ENV['CI']
   # To suppress progress bar
   # because it exceeded Travis CI max log length


### PR DESCRIPTION
## 概要

rurema/bitclust の `statichtml --eol-warning`（bitclust 側 PR 参照）に対応し、
EOL バージョンの静的 HTML 生成時に警告バナーを有効にします。

- `MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")` を追加
  （3.2 は 2026-04-01 に EOL。https://www.ruby-lang.org/ja/downloads/branches/ ）
- `generate_statichtml` で `MINIMUM_SUPPORTED_RUBY_VERSION > version` の場合に
  `--eol-warning` を付与（`Gem::Version#<=>` は String をそのまま比較可能）
- 対象: OLD_VERSIONS 全部（1.8.7〜2.7.0）と 3.0〜3.2。3.3 以降は対象外

EOL 判定ロジックを bitclust 側に持たせない設計なので、今後 Ruby の
ブランチが EOL になったらこの定数を上げるだけで済みます。

本番サイト側の対応は rurema/generated-documents の対応 PR
（tool/vars.rb / tool/static_html.rb）で行います。

## 依存・マージ順

**bitclust 側 PR（statichtml --eol-warning 追加）のマージが先**です。
旧 bitclust に `--eol-warning` を渡すと optparse エラーで
`rake statichtml:3.0` 等が失敗します（doctree は `../bitclust` または
git master の bitclust を使うため、bitclust マージ後は問題ありません）。

## 検証

- `ruby -c Rakefile` / `rake -T` のロード確認
- 条件の確認: 1.8.7, 2.7.0, 3.0, 3.2 → 付与 / 3.3, 3.4, 4.0, 4.1 → 付与なし
- バナー本体の描画・全ページ反映は bitclust 側 PR で検証済み
  （実 DB で 12,000+ ページ生成し全ページにバナーが入ることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
