### PR TITLE
Pass --run-ruby-wasm to statichtml for versions with a ruby.wasm build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: b656b9a000386d6d4208424c4b688cce40180979
+  revision: 872ccb61e3aadf1c94b9c789bd2fc898e5c809cb
   specs:
     bitclust-core (1.4.0)
       drb

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,40 @@ UNRELEASED_VERSIONS = %w[4.1]
 # bitclust statichtml --eol-warning で警告バナーを表示する。
 # EOL 状況は https://www.ruby-lang.org/ja/downloads/branches/ を参照して更新する
 MINIMUM_SUPPORTED_RUBY_VERSION = Gem::Version.new("3.3")
+# ruby.wasm の npm パッケージ (@ruby/X.Y-wasm-wasi) が存在するバージョンの
+# 静的 HTML にはサンプルコードの RUN ボタンを有効にする
+# (bitclust statichtml --run-ruby-wasm)。https://github.com/ruby/ruby.wasm 参照
+# npm 上の安定版は「<パッケージ版>-<ruby.wasm版>」形式（latest dist-tag の値）
+RUBY_WASM_NPM_VERSION = "2.9.3-2.9.4"
+RUBY_WASM_VERSIONS = %w[3.2 3.3 3.4 4.0]
+def ruby_wasm_url(version)
+  if RUBY_WASM_VERSIONS.include?(version)
+    return "https://cdn.jsdelivr.net/npm/@ruby/#{version}-wasm-wasi@#{RUBY_WASM_NPM_VERSION}/dist/ruby+stdlib.wasm"
+  end
+  return ruby_head_wasm_url(version) if UNRELEASED_VERSIONS.include?(version)
+  nil
+end
+
+# 未リリース版（/ja/master/ の実体）には head 用スナップショット
+# (@ruby/head-wasm-wasi) を使う。ただしスナップショットの元になる ruby/ruby
+# master のバージョンが version と一致するときだけ（リリース移行期に master
+# が次の開発版に進んでいる場合は自動で無効になる）。URL はその日の next
+# スナップショットに完全固定する。判定・取得に失敗してもビルドは止めず、
+# RUN ボタンなしにフォールバックする。
+def ruby_head_wasm_url(version)
+  require "net/http"
+  require "json"
+  version_h = Net::HTTP.get(URI("https://raw.githubusercontent.com/ruby/ruby/master/include/ruby/version.h"))
+  major = version_h[/RUBY_API_VERSION_MAJOR (\d+)/, 1]
+  minor = version_h[/RUBY_API_VERSION_MINOR (\d+)/, 1]
+  return nil unless version == "#{major}.#{minor}"
+  tags = JSON.parse(Net::HTTP.get(URI("https://data.jsdelivr.com/v1/packages/npm/@ruby/head-wasm-wasi")))["tags"]
+  snapshot = tags["next"] or return nil
+  "https://cdn.jsdelivr.net/npm/@ruby/head-wasm-wasi@#{snapshot}/dist/ruby+stdlib.wasm"
+rescue StandardError => e
+  warn "ruby_head_wasm_url: #{e.class}: #{e.message} (disabling the RUN button for #{version})"
+  nil
+end
 ALL_VERSIONS = [*OLD_VERSIONS, *SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 CI_VERSIONS = [*SUPPORTED_VERSIONS, *UNRELEASED_VERSIONS]
 HTML_DIRECTORY_BASE = ENV.fetch("HTML_DIRECTORY_BASE", "/tmp/html/")
@@ -65,6 +99,9 @@ def generate_statichtml(version)
     "--canonical-base-url=https://docs.ruby-lang.org/ja/latest/",
   ]
   commands << "--eol-warning" if MINIMUM_SUPPORTED_RUBY_VERSION > version
+  if (wasm_url = ruby_wasm_url(version))
+    commands << "--run-ruby-wasm=#{wasm_url}"
+  end
   commands << "--edit-base-url=https://github.com/rurema/doctree/edit/master/" unless ENV['CI']
   # To suppress progress bar
   # because it exceeded Travis CI max log length


### PR DESCRIPTION
## 概要

rurema/bitclust の `statichtml --run-ruby-wasm`（bitclust 側 PR 参照）に対応し、
ruby.wasm のビルドが存在するバージョン（3.2〜4.0）の静的 HTML でサンプル
コードの RUN ボタンを有効にします。

- `RUBY_WASM_NPM_VERSION = "2.9.3-2.9.4"`・`RUBY_WASM_VERSIONS = %w[3.2 3.3 3.4 4.0]`・
  `ruby_wasm_url(version)` ヘルパーを追加
- `generate_statichtml` で該当版のみ `--run-ruby-wasm=<版一致の wasm URL>` を付与
- **4.1（未リリース、/ja/master/ symlink の実体）は head 用スナップショット
  `@ruby/head-wasm-wasi` を使用**。ただしビルド時に ruby/ruby master の
  version.h と突き合わせ、スナップショットが本当にその版に対応している
  ときだけ有効化（リリース移行期に master が次の開発版へ進むと自動で
  ボタンが消える）。URL はその日の `next` スナップショットに完全固定。
  判定・取得の失敗はビルドを止めず RUN ボタンなしにフォールバック
- 3.1 以前は従来どおりボタンなし
- 3.2 は EOL バナーと RUN ボタンが共存します（EOL でも動くサンプルは
  そのまま試せる方が親切、という判断。外す場合は 1 行変更）

## 依存・マージ順

前提の rurema/bitclust#216 はマージ済みです。#3048 の教訓どおり doctree CI は
Gemfile.lock にピン留めされた bitclust の git リビジョンを使うため、
**2 コミット目で revision を #216 のマージコミット（872ccb6）にバンプ済み**です
（bitclust#216 は依存 gem を変えていないので revision 行のみで bundler の
生成結果と一致します）。

## 検証

- `ruby -c Rakefile` / `rake -T` ロード確認
- 版→URL の対応: 1.8.7〜3.1・4.1 → nil（フラグなし）、3.2〜4.0 → 版一致 URL
- バナー・ボタンの実描画は bitclust 側 PR で検証済み（実 DB 12,719 ページ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
