### PR TITLE
トップページに「るりま」「公式」の文言を追加

### DIFF
--- a/manual/doc/index.md
+++ b/manual/doc/index.md
@@ -1,5 +1,8 @@
 # オブジェクト指向スクリプト言語 Ruby リファレンスマニュアル
 
+本マニュアルは Ruby の公式日本語リファレンスマニュアル
+(Ruby Reference Manual、通称「るりま」/ rurema)です。
+
  - Ruby オフィシャルサイト [url:https://www.ruby-lang.org/ja/]
 #@since 4.1
  - 開発版対応リファレンス


### PR DESCRIPTION
## 解決したい問題

Fixes rurema/bitclust#80

リファレンスマニュアルの通称「るりま」「rurema」がトップページ
(`manual/doc/index.md`)に含まれておらず、通称や「公式」での検索に
ヒットしにくい状態でした。issue での議論の結論(トップページに入れる・
「公式」の文言も入れる)に沿った対応です。

## 変更内容

トップページの見出し直後に一文を追加:

> 本マニュアルは Ruby の公式日本語リファレンスマニュアル
> (Ruby Reference Manual、通称「るりま」/ rurema)です。

表現は `manual/doc/glossary.md` の「るりま」の定義と揃えています。

## 動作確認

ローカルで `rake generate:3.4 statichtml:3.4` を実行し、生成された
`doc/index.html` に追加文が表示されることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
