### PR TITLE
Update TCPSocket.md

### DIFF
--- a/manual/api/socket/Socket.md
+++ b/manual/api/socket/Socket.md
@@ -450,8 +450,22 @@ sockets でサーバソケットを受け取り、接続を待ち受け、
 ### def ip_address_list -> [Addrinfo]
 ローカルの IP アドレスを配列で返します。
 
+#@if("4.0" <= version)
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) -> Socket
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) {|socket| ... } -> object
+#@end
+#@if("3.4" <= version and version < "4.0")
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) -> Socket
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) {|socket| ... } -> object
+#@end
+#@if("2.7.0" <= version and version < "3.4")
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) -> Socket
+### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) {|socket| ... } -> object
+#@end
+#@if(version < "2.7.0")
 ### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil) -> Socket
 ### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil) {|socket| ... } -> object
+#@end
 TCP/IP で host:port に接続するソケットオブジェクトを作成します。
 
 local_host や local_port を指定した場合、ソケットをそこにバインドします。
@@ -463,7 +477,16 @@ local_host や local_port を指定した場合、ソケットをそこにバイ
 - **param** `port` -- 接続先のポート番号
 - **param** `local_host` -- 接続元のホスト名
 - **param** `local_port` -- 接続元のポート番号
-- **param** `connect_timeout` -- タイムアウトまでの秒数
+- **param** `connect_timeout` -- 接続確立のタイムアウトを秒数で指定します。
+#@if (version >= "2.7.0")
+- **param** `resolv_timeout` -- 名前解決のタイムアウトを秒数で指定します。
+#@end
+#@if (version >= "4.0")
+- **param** `open_timeout` -- 名前解決から接続確立までのタイムアウトを秒数で指定します。
+#@end
+#@if (version >= "3.4")
+- **param** `fast_fallback` -- Happy Eyeballs Version 2 ([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305)) を有効にします。
+#@end
 - **return** -- ブロック付きで呼ばれた場合はブロックが返した値です。
         ブロックなしで呼ばれた場合はソケットオブジェクトを返します。
 

--- a/manual/api/socket/TCPSocket.md
+++ b/manual/api/socket/TCPSocket.md
@@ -29,10 +29,19 @@ s.close
 
 ## Class Methods
 
-#@since 3.0
+#@if("4.0" <= version)
+### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
+### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
+#@end
+#@if("3.4" <= version and version < "4.0")
+### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
+### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
+#@end
+#@if("3.0" <= version and version < "3.4")
 ### def open(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
 ### def new(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
-#@else
+#@end
+#@if(version < "3.0")
 ### def open(host, service, local_host=nil, local_service=nil) -> TCPSocket
 ### def new(host, service, local_host=nil, local_service=nil) -> TCPSocket
 #@end
@@ -51,12 +60,19 @@ host で指定したホストの service で指定したポートと接続した
 - **param** `service` --        /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
 - **param** `local_host` --     ホスト名、またはインターネットアドレスを示す文字列を指定します。
 - **param** `local_service` --  /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
-#@since 3.0
-#@# getaddrinfo_a(3) が入らなかったので、3.0 では resolv_timeout は指定しても無視される。
-#@# https://github.com/ruby/ruby/commit/c6b37cb169f190bac46c76a643350ee4ffc3dfca
-#@#@param resolv_timeout 名前解決のタイムアウトを秒数で指定します。
-- **param** `connect_timeout` -- タイムアウトを秒数で指定します。
+#@if (version >= "3.4")
+- **param** `resolv_timeout` -- 名前解決のタイムアウトを秒数で指定します。
 #@end
+#@if (version >= "3.0")
+- **param** `connect_timeout` -- 接続確立のタイムアウトを秒数で指定します。
+#@end
+#@if (version >= "4.0")
+- **param** `open_timeout` -- 名前解決から接続確立までのタイムアウトを秒数で指定します。
+#@end
+#@if (version >= "3.4")
+- **param** `fast_fallback` -- Happy Eyeballs Version 2 ([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305)) を有効にします。
+#@end
+
 ### def gethostbyname(host) -> Array
 
 ホスト名または IP アドレス (整数または"127.0.0.1"


### PR DESCRIPTION
TCPSocket.new のオプションを追加しました。

https://speakerdeck.com/coe401_/the-less-told-story-of-socket-timeouts の発表に基づいた内容となっています。

resolv_timeout オプションは 3.0 で追加されたものの効果はなく、3.4 から利用できるようになったということで、since 3.4 として記述しています。現時点でもコメントアウトされており、利用できるようになるまで記述しないという意図だと解釈しました。

~この内容で問題ないようであれば `Socket.tcp` にも同様の修正を出します。~ 追加しました。

参考: #2980