### PR TITLE
Prime::PseudoPrimeGenerator#each_with_index のサンプルコードが動かないのを解決

### DIFF
--- a/manual/api/prime/Prime__PseudoPrimeGenerator.md
+++ b/manual/api/prime/Prime__PseudoPrimeGenerator.md
@@ -68,13 +68,14 @@ include:
 
 ```ruby title="例"
 require 'prime'
-Prime::EratosthenesGenerator.new(10).each_with_index do |prime, index|
+Prime::EratosthenesGenerator.new.each_with_index do |prime, index|
+  break if prime > 10
   p [prime, index]
 end
-# [2, 0]
-# [3, 1]
-# [5, 2]
-# [7, 3]
+# => [2, 0]
+#    [3, 1]
+#    [5, 2]
+#    [7, 3]
 ```
 
 - **SEE** [m:Enumerator#with_index]


### PR DESCRIPTION
https://github.com/rurema/doctree/issues/2114
を解決します。