### PR TITLE
docs/WritingRule.md: 相談窓口を ML から GitHub Issues / ruby-jp Slack に更新

### DIFF
--- a/docs/WritingRule.md
+++ b/docs/WritingRule.md
@@ -45,4 +45,4 @@
 
 ## 最終奥技
 
-* 悩んだら ML で聞く
+* 悩んだら GitHub Issues や ruby-jp Slack（#rurema チャンネル）で聞く


### PR DESCRIPTION
docs/ 全体の鮮度確認（wiki 移設時の宿題の続き。Tutorial.md は #3055 で対応済み）の結果です。docs/*.md 全 18 ファイルを現状（manual/ が編集ソース、静的検索、ML 終了など）と突き合わせましたが、大半は先行の鮮度更新（`docs: refresh the partially outdated pages` ほか）で対応済みで、残っていた古い記述は WritingRule.md の 1 箇所だけでした。

- **WritingRule.md** — 「悩んだら ML で聞く」を「GitHub Issues や ruby-jp Slack（#rurema チャンネル）で聞く」に変更。旧 ML は事実上終了しており、Communication-and-knowledge-sharing.md の現行案内に合わせました。

## 確認したが変更しなかったもの（要判断のメモ）

- HowToWriteMethodEntry.md ほかにある旧 ML アーカイブ（fdiary.net）への出典リンク: FrequentlyAskedQuestions.md にも同種リンクが約10箇所あり、出典情報を残すか一括で外すかは方針を決めてから一貫対応するのがよさそうです。
- HowToWriteRequire.md の「kconv に require: nkf を書いてはいけない」という例に対し、実データ `manual/api/kconv.md` の front matter には `require: [nkf]` があります。ドキュメントではなくデータ側の問題の可能性があるため、別途確認が必要です。
- SampleCodeGuideline.md の RDoc 外部リンクが docs.ruby-lang.org/en/2.5.0 固定です（生死未確認のため保留）。
