### PR TITLE
SEE ALSO・相互リンクの追加/修正(object_id・SimpleDelegator.new・CSV#path)

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -668,7 +668,7 @@ p true.object_id #=> 20
 p true.object_id #=> 20
 ```
 
-- **SEE** [m:Object#equal?],[c:Symbol]
+- **SEE** [m:Object#equal?],[m:BasicObject#__id__],[c:Symbol]
 
 ### def hash -> Integer
 

--- a/manual/api/csv/CSV.md
+++ b/manual/api/csv/CSV.md
@@ -1298,11 +1298,17 @@ csv.lineno # => 1
 
 ### def path    -> String
 
+#@since 3.2
 [m:IO#path] に委譲します。
 
 #@#noexample IO#path の例を参照
 
 - **SEE** [m:IO#path]
+#@end
+#@until 3.2
+保持している IO(または [c:StringIO] 等)オブジェクトが `path` に応答する場合、その `path` を返します。
+#@#noexample IO#path の例を参照
+#@end
 
 ### def pid    -> Integer | nil
 

--- a/manual/api/delegate/SimpleDelegator.md
+++ b/manual/api/delegate/SimpleDelegator.md
@@ -29,8 +29,6 @@ foo2.test   # => 25
 
 - **param** `obj` -- 委譲先のオブジェクト
 
-- **SEE** [m:Delegator.new]
-
 ## Instance Methods
 
 ### def __getobj__ -> object


### PR DESCRIPTION
open issue 全181件トリアージのクイックウィン第2弾(SEE ALSO・相互リンク)です。

## 変更内容

- Fixes #2258: `Object#object_id` の SEE に `[m:BasicObject#__id__]` を追加(逆方向のリンクは既存)
- Fixes #2960: `SimpleDelegator.new` の SEE 先だった `Delegator.new` は `#@if (version <= '1.8.6')` 内にしか記述がなく、現行対象バージョン(3.0〜4.1)では生成されないため、リンクを削除。実機でも `Delegator.method(:new).owner` が `Class`(独自定義なし)であることを確認
- Fixes #2168: `CSV#path` の「[m:IO#path] に委譲します」を `#@since 3.2` / `#@until 3.2` で分岐。`IO#path` は Ruby 3.2 で追加されたため(IO.md に `#@since 3.2` で収録済み)、3.0/3.1 では実装(`@io.path if @io.respond_to?(:path)`)に即した説明に変更し、3.2 以降のみ SEE リンクを保持

## 検証

- bitclust で Ruby 3.4 用・3.1 用の DB を実際にビルドし、`Delegator.new` が 3.4 に存在しないこと、`IO#path` が 3.1 に存在しないこと、`CSV#path` の説明が各バージョンで意図どおり描画されることを `bitclust lookup` で確認
- `#@since`/`#@until`/`#@end` の対応を機械チェック
