### PR TITLE
メソッドシグネチャを実装に追従(CSV.instance・GC の immediate_mark・Net::HTTP#max_retries・SystemCallError.new)

### DIFF
--- a/manual/api/_builtin/GC.md
+++ b/manual/api/_builtin/GC.md
@@ -241,11 +241,7 @@ GC.enable    # => true
 GC.enable    # => false
 ```
 
-#@since 2.1.0
-### def start(full_mark: true, immediate_sweep: true) -> nil
-#@else
-### def start -> nil
-#@end
+### def start(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
 
 ガーベージコレクトを開始します。
 
@@ -258,9 +254,11 @@ GC.enable    # => false
 
 nil を返します。
 
-#@since 2.1.0
 - **param** `full_mark` -- マイナー GC を動作させる場合は false を、そうでない場
                  合は true を指定します。
+
+- **param** `immediate_mark` -- mark を遅らせる(Lazy Mark を行う)場合は false
+                       を、そうでない場合は true を指定します。
 
 - **param** `immediate_sweep` -- sweep を遅らせる(Lazy Sweep を行う)場合は false
                        を、そうでない場合は true を指定します。
@@ -268,7 +266,6 @@ nil を返します。
 注意: これらのキーワード引数は Ruby の実装やバージョンによって異なりま
 す。将来のバージョンとの互換性も保証されません。また、Ruby の実装がサポー
 トしていない場合はキーワード引数を指定しても無視される可能性があります。
-#@end
 
 ```ruby title="例"
 GC.count  # => 3
@@ -483,7 +480,7 @@ SEGV が起きるでしょう。
 
 ## Instance Methods
 
-### def garbage_collect(full_mark: true, immediate_sweep: true) -> nil
+### def garbage_collect(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
 
 ガーベージコレクトを開始します。
 
@@ -498,6 +495,9 @@ nil を返します。
 
 - **param** `full_mark` -- マイナー GC を動作させる場合は false を、そうでない場
                  合は true を指定します。
+
+- **param** `immediate_mark` -- mark を遅らせる(Lazy Mark を行う)場合は false
+                       を、そうでない場合は true を指定します。
 
 - **param** `immediate_sweep` -- sweep を遅らせる(Lazy Sweep を行う)場合は false
                        を、そうでない場合は true を指定します。

--- a/manual/api/_builtin/SystemCallError.md
+++ b/manual/api/_builtin/SystemCallError.md
@@ -25,7 +25,7 @@ p SystemCallError.new("message")
     # => #<SystemCallError: unknown error - message>
 `````
 
-### def new(error_message, errno) -> SystemCallError
+### def new(error_message, errno, location = nil) -> SystemCallError
 ### def new(errno) -> SystemCallError
 整数 errno に対応する [c:Errno::EXXX] オブジェクトを生成して返します。
 
@@ -38,8 +38,12 @@ p SystemCallError.new("message")
 
 エラーコードの取り得る値および意味はシステムに依存します。詳しくは [c:Errno::EXXX] を参照してください。
 
+location と error_message を両方指定した場合、エラーが発生した場所を表す
+情報としてエラーメッセージに location が付加されます。
+
 - **param** `error_message` -- エラーメッセージを表す文字列
 - **param** `errno` -- システム依存のエラーコード
+- **param** `location` -- エラーが発生した場所を表す文字列
 - **raise** `TypeError` -- errno を整数に変換できないときに発生します。
 
 例:
@@ -51,6 +55,8 @@ p SystemCallError.new(2)
     # => #<Errno::ENOENT: No such file or directory>
 p SystemCallError.new(256)
     # => #<SystemCallError: Unknown error 256>
+p SystemCallError.new("message", 2, "location")
+    # => #<Errno::ENOENT: No such file or directory @ location - message>
 `````
 
 ### def ===(other) -> bool

--- a/manual/api/csv/CSV.md
+++ b/manual/api/csv/CSV.md
@@ -521,8 +521,8 @@ CSV.generate_line(taro, col_sep: '|') # => "1|taro|tanaka|20\n"
 
 - **SEE** [m:CSV.new]
 
-### def instance(data = $stdout, options = Hash.new) -> CSV
-### def instance(data = $stdout, options = Hash.new){|csv| ... } -> object
+### def instance(data = $stdout, **options) -> CSV
+### def instance(data = $stdout, **options){|csv| ... } -> object
 
 このメソッドは [m:CSV.new] のように [c:CSV] のインスタンスを返します。
 しかし、返される値は [m:Object#object_id] と与えられたオプションを

--- a/manual/api/net/http/Net__HTTP.md
+++ b/manual/api/net/http/Net__HTTP.md
@@ -591,6 +591,31 @@ Windows では Net::WriteTimeout は発生しません。
 - **SEE** [m:Net::HTTP#open_timeout], [m:Net::HTTP#read_timeout], [m:Net::HTTP#write_timeout]
 #@end
 
+### def max_retries -> Integer
+冪等なリクエストが失敗した場合に再試行する最大回数を返します。
+
+デフォルトは 1 です。
+
+- **SEE** [m:Net::HTTP#max_retries=]
+
+### def max_retries=(times)
+冪等なリクエストが [c:Net::ReadTimeout]、[c:IOError]、[c:EOFError]、
+[c:Errno::ECONNRESET]、[c:Errno::ECONNABORTED]、[c:Errno::EPIPE]、
+[c:OpenSSL::SSL::SSLError]、[c:Timeout::Error] のいずれかで失敗した場合に
+再試行する最大回数を設定します。
+
+デフォルトは 1 です。
+
+- **param** `times` -- 再試行する最大回数を 0 以上の整数で指定します。
+             負の値を指定した場合は [c:ArgumentError] が発生します。
+
+```ruby title="例"
+http = Net::HTTP.new(hostname)
+http.max_retries = 2   # => 2
+http.max_retries       # => 2
+```
+
+- **SEE** [m:Net::HTTP#max_retries]
 
 ### def keep_alive_timeout -> Integer
 以前のリクエストで使ったコネクションの再利用(keep-alive)を許可する秒数を


### PR DESCRIPTION
open issue 全181件トリアージのクイックウィン第3弾(シグネチャの実装追従)です。

## 変更内容

- Fixes #2941: `CSV.instance` のシグネチャを `options = Hash.new` から `**options` に修正(csv gem の実装はキーワード引数)
- Fixes #1097: `GC.start` / `GC#garbage_collect` に `immediate_mark` キーワード引数と param 説明を追加(`GC.method(:start).parameters` で実在を確認)。`immediate_mark` は 2.2.0 で追加([Feature #10137] incremental GC)のため、シグネチャを 2.1.0 対応と主張することになる既存の `#@since 2.1.0` 分岐は削除(対象バージョン 3.0〜4.1 では常に真の分岐であり、前処理結果は全対象バージョンで不変なことを確認済み)
- Fixes #1170: `Net::HTTP#max_retries` / `#max_retries=` を追記(再試行対象の例外一覧・デフォルト1・負数は ArgumentError)。2.5 で追加され対象バージョン(3.0〜4.1)では常に存在するため分岐なし
- Fixes #2055: `SystemCallError.new` の3番目の引数 location を追記(エラーメッセージに `@ location` として付加される実行例つき)

## 検証

- 手元の Ruby 3.4.8 で各シグネチャ・サンプル出力を実行確認
- `#@since`/`#@end` の対応・行末空白のチェック、`bundle exec rake check_indent_in_samplecode` exit 0
