### PR TITLE
動かない・誤解を招くサンプルコードを修正(Prime・Thread#status・JSON::State.from_state・caller)

### DIFF
--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -919,19 +919,28 @@ thr.safe_level              # => 1
 
 [m:Thread#alive?] が真を返すなら、このメソッドも真です。
 
-例:
-`````
-a = Thread.new { raise("die now") }
-b = Thread.new { Thread.stop }
-c = Thread.new { Thread.exit }
-d = Thread.new { sleep }
-d.kill                  #=> #<Thread:0x401b3678 aborting>
-a.status                #=> nil
-b.status                #=> "sleep"
-c.status                #=> false
-d.status                #=> "aborting"
+```ruby title="例"
 Thread.current.status   #=> "run"
-`````
+
+a = Thread.new { raise("die now") }
+sleep 0.1
+a.status                #=> nil
+
+b = Thread.new { Thread.stop }
+sleep 0.1
+b.status                #=> "sleep"
+
+c = Thread.new { Thread.exit }
+sleep 0.1
+c.status                #=> false
+
+d = Thread.new { sleep }
+sleep 0.1
+d.status                #=> "sleep"
+d.kill
+sleep 0.1
+d.status                #=> false
+```
 
 - **SEE** [m:Thread#alive?], [m:Thread#stop?]
 

--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -1330,39 +1330,9 @@ bar
 #   nil
 ```
 
-以下の関数は、caller の要素から [ファイル名, 行番号, メソッド名]
-を取り出して返します。
-
-```ruby title="例"
-def parse_caller(at)
-#@since 3.4
-  if /^(.+?):(\d+)(?::in '(.*)')?/ =~ at
-#@else
-  if /^(.+?):(\d+)(?::in `(.*)')?/ =~ at
-#@end
-    file = $1
-    line = $2.to_i
-    method = $3
-    [file, line, method]
-  end
-end
-
-def foo
-  p parse_caller(caller.first)
-end
-
-def bar
-  foo
-  p parse_caller(caller.first)
-end
-
-bar
-p parse_caller(caller.first)
-
-#=> ["-", 15, "bar"]
-#   ["-", 19, nil]
-#   nil
-```
+caller の要素から呼び出し元のファイル名や行番号、メソッド名を取り出したい場合は、
+文字列を正規表現でパースするより [m:Kernel?.caller_locations] を使うほうが適切です。
+詳しくは後述の caller_locations の項を参照してください。
 
 以下は、[m:$DEBUG] が真の場合に役に立つ debug 関数
 のサンプルです。

--- a/manual/api/json/JSON__State.md
+++ b/manual/api/json/JSON__State.md
@@ -85,9 +85,10 @@ require "json"
 
 json_state = JSON::State.from_state(indent: "\t")
 # JSON を出力する何らかの処理を実行する
-copy = JSON::State.from_state(json_state)
-copy.class  # => JSON::Ext::Generator::State
-copy.indent # => "\t"
+same = JSON::State.from_state(json_state)
+same.equal?(json_state) # => true
+same.class               # => JSON::Ext::Generator::State
+same.indent              # => "\t"
 ```
 
 ## Public Instance Methods


### PR DESCRIPTION
open issue 全181件トリアージのクイックウィン第4弾(サンプルコードの修正)です。

## 変更内容

- Fixes #2114: `Prime::PseudoPrimeGenerator#each_with_index` の例が `EratosthenesGenerator.new(10)` で ArgumentError になっていたのを引数なしに修正し、無限列挙に `break` を追加
- Fixes #2093: `Thread#status` の例を、1スレッドずつ状態を確認する形(issue コメントの okkez さんの改善例ベース)に置き換え。kill 直後の `"aborting"` は現行 Ruby では再現しないため、`sleep` を挟んで `false` になる決定的な出力のみを記載
- Fixes #2222: `JSON::State.from_state` の例の変数名 `copy` を `same` に変更し、`same.equal?(json_state) # => true` で同一オブジェクトが返ることを明示
- Fixes #2080: `caller` の出力を正規表現でパースする例(parse_caller)を削除し、`caller_locations` を使う旨の案内に置き換え

## 検証

- サンプルはすべて Ruby 3.4.8 で実行し、コメントの出力と一致することを確認
- 削除ブロック内にあった `#@since 3.4` 分岐ごと除去し、`#@since`/`#@end` の対応が崩れていないことを確認
