### PR TITLE
Pathname#fnmatch の誤記述修正と WEBrick::HTTPUtils.escape_form のドキュメント追加

### DIFF
--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -646,8 +646,8 @@ File.lchown(owner, group, self.to_s) と同じです。
 ### def fnmatch(pattern, *args) -> bool
 File.fnmatch(pattern, self.to_s, *args) と同じです。
 
-- **param** `pattern` -- パターンを文字列で指定します。ワイルドカードとして `*`, `?`, `[]` が使用できま
-               す。[m:Dir.glob] とは違って `{}` や `**/` は使用できません。
+- **param** `pattern` -- パターンを文字列で指定します。ワイルドカードとして `*`,
+               `**`, `?`, `[]`, `{}` が使用できます。詳細は [m:File.fnmatch] を参照してください。
 
 - **param** `args` -- [m:File.fnmatch] を参照してください。
 
@@ -665,8 +665,8 @@ path.fnmatch("TEST*", File::FNM_CASEFOLD)   # => true
 ### def fnmatch?(pattern, *args) -> bool
 File.fnmatch?(pattern, self.to_s, *args) と同じです。
 
-- **param** `pattern` -- パターンを文字列で指定します。ワイルドカードとして `*`, `?`, `[]` が使用できま
-               す。[m:Dir.glob] とは違って `{}` や `**/` は使用できません。
+- **param** `pattern` -- パターンを文字列で指定します。ワイルドカードとして `*`,
+               `**`, `?`, `[]`, `{}` が使用できます。詳細は [m:File.fnmatch] を参照してください。
 
 - **param** `args` -- [m:File.fnmatch] を参照してください。
 

--- a/manual/api/webrick/httputils/HTTPUtils.md
+++ b/manual/api/webrick/httputils/HTTPUtils.md
@@ -123,11 +123,33 @@ unreserved = num + lowalpha + upalpha + mark
 #@#--- parse_qvalues(value)
 #@#todo
 
-#@#--- escape_form(str)
-#@#todo
+### module_function def escape_form(str) -> String
 
-#@#--- unescape_form(str)
-#@#todo
+与えられた文字列を application/x-www-form-urlencoded 形式の文字列に変換します。
+スペースは `+` に変換されます。
+
+- **param** `str` -- 文字列を指定します。
+
+`````
+require 'webrick'
+p WEBrick::HTTPUtils.escape_form('foo bar+baz')  # => "foo+bar%2Bbaz"
+`````
+
+- **SEE** [m:WEBrick::HTTPUtils?.unescape_form]
+
+### module_function def unescape_form(str) -> String
+
+[m:WEBrick::HTTPUtils?.escape_form] で変換された文字列を元の文字列に戻します。
+`+` はスペースに変換されます。
+
+- **param** `str` -- 文字列を指定します。
+
+`````
+require 'webrick'
+p WEBrick::HTTPUtils.unescape_form('foo+bar%2Bbaz')  # => "foo bar+baz"
+`````
+
+- **SEE** [m:WEBrick::HTTPUtils?.escape_form]
 
 #@#--- _make_regex!(str)
 #@#todo


### PR DESCRIPTION
open issue 全181件トリアージのクイックウィン第7弾(リンク切れ・未文書化 API)です。

## 変更内容

- Fixes #3034: `Pathname#fnmatch` / `#fnmatch?` の param 説明「`{}` や `**/` は使用できません」を、`*`, `**`, `?`, `[]`, `{}` が使用できる旨+ `[m:File.fnmatch]` への参照に修正(File 側の記述と整合)
- Fixes #3033: `WEBrick::HTTPUtils.escape_form` / `.unescape_form` のコメントアウト(`#@#---`/`#@#todo`)を解除し、既存の escape 系メソッドと同じ体裁で説明・param・サンプル・SEE を追加。これにより `manual/api/uri/URI.md` からの `[m:WEBrick::HTTPUtils?.escape_form]` のリンク切れが解消

#2964(OptionParser の `opt.heading=`)もこのバッチで調査しましたが、manual にも凍結ソース refm にも過去の履歴にも `heading=` の記述は存在せず(あるのは `banner=(heading)` のみ)、doctree 側に誤りが見当たらないため PR には含めていません(issue へ事実確認のコメントを返す想定です)。

## 検証

- `Pathname#fnmatch` の `**`/`{}` の挙動を Ruby 3.4.8 で実行確認、escape_form/unescape_form のサンプル出力を webrick 1.9.2 で実行確認
- 一時 bitclust DB から statichtml(3.4)をフル生成し、変更ページの相互リンク解決と生成 HTML 全体で brokenlink 0 件を確認
