### PR TITLE
Module#autoload? の inherit 引数と Time#inspect の秒未満表示を反映(#2071 残課題)

### DIFF
--- a/manual/api/_builtin/Module.md
+++ b/manual/api/_builtin/Module.md
@@ -388,11 +388,14 @@ p Foo::Bar
 
 - **SEE** [m:Kernel?.autoload]
 
-### def autoload?(const_name) -> String | nil
+### def autoload?(const_name, inherit = true) -> String | nil
 autoload 定数がまだ定義されてない(ロードされていない) ときにそのパス名を返します。
 また、ロード済みなら nil を返します。
 
 - **param** `const_name` -- [c:String] または [c:Symbol] で指定します。
+
+- **param** `inherit` -- false にすると、スーパークラスや include したモジュールで
+       定義された autoload を検索対象にしません。
 
 - **SEE** [m:Kernel?.autoload?]
 
@@ -403,6 +406,18 @@ autoload?(:Date) # => "date"
 Date
 autoload?(:Date) # => nil
 autoload?(:Foo) # => nil
+```
+
+```ruby title="例: inherit引数"
+class Parent
+  autoload :Foo, "foo"
+end
+
+class Child < Parent
+end
+
+Child.autoload?(:Foo)        # => "foo"
+Child.autoload?(:Foo, false) # => nil
 ```
 
 ### def class_variables(inherit = true) -> [Symbol]

--- a/manual/api/_builtin/Time.md
+++ b/manual/api/_builtin/Time.md
@@ -925,12 +925,12 @@ p t.strftime("%Y-%m-%d %H:%M:%S UTC")  # => "2000-01-01 18:04:05 UTC"
 
 戻り値の文字エンコーディングは [m:Encoding::US_ASCII] です。
 
-#@since 2.7.0
 ### def inspect     -> String
 
 時刻を文字列に変換した結果を返します。
 
-[m:Time#to_s] とは異なりナノ秒まで含めて返します。
+[m:Time#to_s] とは異なり、秒未満の端数が 0 でない場合はその値も含めて返します。
+端数が 0 の場合は [m:Time#to_s] と同じ結果になります。
 
 ```ruby
 t = Time.now
@@ -939,10 +939,13 @@ t.strftime "%Y-%m-%d %H:%M:%S.%N %z"  #=> "2012-11-10 18:16:12.261257655 +0100"
 
 t.utc.inspect                          #=> "2012-11-10 17:16:12.261257655 UTC"
 t.strftime "%Y-%m-%d %H:%M:%S.%N UTC"  #=> "2012-11-10 17:16:12.261257655 UTC"
+
+t2 = Time.at(0.1r)
+t2.inspect                                # => "1970-01-01 09:00:00.1 +0900"
+t2.strftime("%Y-%m-%d %H:%M:%S.%N %z")    # => "1970-01-01 09:00:00.100000000 +0900"
 ```
 
 戻り値の文字エンコーディングは [m:Encoding::US_ASCII] です。
-#@end
 
 ### def hash -> Integer
 


### PR DESCRIPTION
Ruby 2.7 NEWS フォローアップ(#2071)のクローズ時に残課題とした2点を反映します。

## 変更内容

- `manual/api/_builtin/Module.md`: `Module#autoload?` に Ruby 2.7 で追加された第二引数 `inherit`(デフォルト `true`)を反映
  - シグネチャを `def autoload?(const_name, inherit = true) -> String | nil` に更新(サポート対象は全バージョン 3.0 以降のため版分岐なしで反映)
  - `inherit` のパラメータ説明を追加(`const_defined?` の既存の書き方に合わせた文面)
  - スーパークラスで `autoload` されている定数について、`inherit` が `true`(デフォルト)だとパスを返し、`false` だと `nil` を返す例を追加(upstream の C ドキュメントの例を踏襲)
- `manual/api/_builtin/Time.md`: `Time#inspect` を `Time#to_s` から分離して独立したメソッドとして記述
  - Ruby 2.7 で `to_s` から分離された経緯を踏まえ、`#@since 2.7.0` の版分岐(サポート対象では常に真のため死んだ分岐)を除去し、無条件のエントリに変更
  - 「ナノ秒まで含めて返します」という不正確な記述(実際は秒未満が 0 の場合は `to_s` と同じ出力になる)を、実際の挙動に合わせて修正
  - `Time.at(0.1r)` を使った具体例を追加(秒未満が非ゼロの場合に表示される例)

## 参照

#2071 のクローズ時に残課題とした2点(`Module#autoload?` の `inherit` 引数、`Time#inspect` の秒未満精度表示)を反映するものです。

refs #2071

## 検証

- `BitClust::Preprocessor.process` で `Module.md`・`Time.md` をそれぞれバージョン `3.0.0` と `4.1.0` で前処理し、エラーが発生しないこと、シグネチャ・追加した例・`inspect` エントリが期待どおり出力に含まれることを確認しました(`ruby -I bitclust/lib` でスクリプトを実行)。
- 追加したサンプルコードの出力は、ローカルの Ruby 3.4.8 で実際に実行して確認しました。
  - `Child.autoload?(:Foo)` => `"foo"`、`Child.autoload?(:Foo, false)` => `nil`
  - `Time.at(0.1r).inspect` => `"1970-01-01 09:00:00.1 +0900"`
  - `Time.at(0.1r).strftime("%Y-%m-%d %H:%M:%S.%N %z")` => `"1970-01-01 09:00:00.100000000 +0900"`
- 編集箇所周辺の `#@since`/`#@until`/`#@end` の対応が崩れていないことを目視と簡易スクリプトで確認しました。
