### PR TITLE
Ruby 3.0 で削除された Thread.exclusive のエントリを削除(#1451)

### DIFF
--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -255,26 +255,6 @@ a.join
 
 - **SEE** [m:Thread#run], [m:Thread#wakeup]
 
-#@since 1.9.1
-### def exclusive { ... }  -> object
-#@# 1.8 以前は ../thread.rb にあります。
-VM グローバルの Mutex をロックし、ブロックを実行します。
-
-このクラスメソッドの挙動は 1.8 以前とは違います。
-#@since 2.6.0
-Thread.exclusive は VM グローバルの Mutex の
-#@else
-Thread.exclusive は VM グローバルの [m:Thread::MUTEX_FOR_THREAD_EXCLUSIVE] の
-#@end
-synchronize を呼び出しているだけで、Thread.exclusive していないスレッドは動きます。
-#@since 2.3.0
-[c:Thread::Mutex] や [c:Monitor] などの他の排他制御の方法を検討してください。
-#@else
-[c:Mutex] や [c:Monitor] などの他の排他制御の方法を検討してください。
-#@end
-
-#@#noexample deprecated
-
 ### const DEBUG -> Integer
 
 スレッドのデバッグレベルを返します。
@@ -307,8 +287,6 @@ Thread.DEBUG # => 1
 ```
 
 - **SEE** [m:Thread.DEBUG]
-
-#@end
 
 #@since 2.0.0
 #@# 参考: [[ruby-dev:45341]]
@@ -1266,15 +1244,4 @@ a.inspect   # => "#<Thread:0x00007f85ac8721f0@named@(irb):1 dead>"
 ```
 
 - **SEE** [m:Thread#name]
-#@end
-
-## Constants
-
-#@if("1.9.1" <= version and version < "2.6.0")
-### const MUTEX_FOR_THREAD_EXCLUSIVE -> Mutex
-
-[m:Thread.exclusive]用の[c:Mutex]オブジェクトです。
-#@since 2.4.0
-(private constant です。)
-#@end
 #@end

--- a/manual/api/_builtin/ThreadGroup.md
+++ b/manual/api/_builtin/ThreadGroup.md
@@ -21,10 +21,11 @@ puts "all threads finished"
 ```
 
 対象の Thread が Thread を起こす可能性がある場合
-([m:Thread.exclusive]参照)
+([c:Thread::Mutex] 参照)
 
 ```````
-Thread.exclusive do
+mutex = Thread::Mutex.new
+mutex.synchronize do
   (ThreadGroup::Default.list - [Thread.current]).each {|th| th.join}
 end
 ```````


### PR DESCRIPTION
#1451 のフォローアップです。`Thread.exclusive` はサポート対象バージョン(3.0以降)には存在しないため、ドキュメントからエントリを削除します。

## 変更内容

- `manual/api/_builtin/Thread.md`
  - `Thread.exclusive` のメソッドエントリ(`#@since 1.9.1` ゲートで囲まれていた `### def exclusive { ... } -> object` の記述一式)を削除
  - 内部定数 `MUTEX_FOR_THREAD_EXCLUSIVE` のエントリ(`#@if("1.9.1" <= version and version < "2.6.0")` ゲート、常にサポート対象では偽)を削除。このクラスの `## Constants` セクションはこの定数のみだったため、見出しごと削除
- `manual/api/_builtin/ThreadGroup.md`
  - サンプルコード中の `[m:Thread.exclusive]参照` および `Thread.exclusive do ... end` の用例を、非推奨メッセージが案内していた代替である `Thread::Mutex` を使う形(`Thread::Mutex.new` + `#synchronize`)に置き換え

## 参照

refs #1451

`Thread.exclusive` は Ruby 2.3 で非推奨警告("...use Mutex")が入り、2.4〜2.7 では警告文言が "...use Thread::Mutex" に変わりました。Ruby 3.0.0 で prelude.rb から削除され、メソッド自体が存在しなくなっています(v3_0_0 の prelude.rb には定義がないことを確認済み、また手元の Ruby 3.4 でも `Thread.respond_to?(:exclusive)` が `false` であることを確認済み)。本リポジトリのサポート対象は 3.0 以降のみのため、このエントリはどのバージョンに対しても該当しない内容でした。

## 検証

- 削除した行範囲(編集前の `manual/api/_builtin/Thread.md` の行番号)
  - `Thread.exclusive` メソッドエントリ本体: 259〜276 行目(`### def exclusive { ... } -> object` から `#@#noexample deprecated` を含む空行まで)
  - これを囲んでいた `#@since 1.9.1` ゲート: 開始行 258、対応する `#@end` は 311 行目(間に `### const DEBUG` / `### def DEBUG=` を含んでいたため、ゲート行のみ削除しメソッド本体は残置)
  - `MUTEX_FOR_THREAD_EXCLUSIVE` の `#@if(...)` ブロックと `## Constants` 見出し: 1249〜1258 行目(ファイル末尾)
  - ディレクティブのネストは行単位でスタックを組んで機械的に対応関係を確認し、`#@since 1.9.1` の対応 `#@end` が直後ではなく `DEBUG`/`DEBUG=` を挟んだ後ろにあることを確認した上で削除範囲を決めています。
- `grep -rn 'Thread\.exclusive\|MUTEX_FOR_THREAD_EXCLUSIVE' manual/` を `manual/` 全体に対して実行し、`Thread.md` 以外に `ThreadGroup.md` 内のサンプルコード2箇所(参照リンクと用例)がヒットすることを確認し、両方修正しました。修正後は再度同じ grep がヒット0件であることを確認済みです。
- `BitClust::Preprocessor.process` で `Thread.md`・`ThreadGroup.md` をバージョン `3.0.0` と `4.1.0` の両方で前処理し、エラーが発生しないこと、出力に "exclusive" という文字列が(大文字小文字を問わず)一切含まれないことを確認しました。
- `#@since`/`#@until`/`#@if`/`#@end` の対応が全体でバランスしていることを、行単位のスタックチェックスクリプトで確認しました(開いたまま残るディレクティブ0件)。
- `BitClust::MethodDatabase` を一時ディレクトリに作成し `update_by_markdowntree` でバージョン `3.0.0` の DB を構築、`RDCompiler#compile_method` で `Thread`/`ThreadGroup` の全エントリをコンパイルしてエラーが増えていないことを確認しました(`Thread#raise`・`ThreadGroup#enclose` の2件はサンプル出力に起因する既存のコンパイルエラーで、`origin/master` でも同様に発生することを確認済み・本変更とは無関係)。
