### PR TITLE
トップページのライブラリ見出しを整理(fix #2665)

### DIFF
--- a/manual/doc/index.md
+++ b/manual/doc/index.md
@@ -86,11 +86,9 @@ Ruby の文法:
   - [d:spec/regexp]
   - [d:spec/lambda_proc]
 
-#### 組み込みライブラリ
-  - [lib:_builtin]
-
-#### 標準添付ライブラリ
+#### ライブラリ
   - [lib:/]
+    - [lib:_builtin]
 
 #### C API
   - [f:/]


### PR DESCRIPTION
fix #2665

## 変更内容

- `manual/doc/index.md` のトップページ目次で、「組み込みライブラリ」「標準添付ライブラリ」の2見出しに分かれていた項目を、「ライブラリ」の1見出しにまとめました。
  - `[lib:/]`(ライブラリ一覧)を見出し直下に配置
  - `[lib:_builtin]`(組み込みライブラリ)をその子項目としてネストして配置

変更前:
```
#### 組み込みライブラリ
  - [lib:_builtin]

#### 標準添付ライブラリ
  - [lib:/]
```

変更後:
```
#### ライブラリ
  - [lib:/]
    - [lib:_builtin]
```

`[lib:/]` はビルトインも含む全ライブラリの索引ページ「ライブラリ一覧」を指すリンクで、これを「標準添付ライブラリ」という見出しの下に置くと、用語集の定義(標準添付ライブラリー = ライブラリーのうち組み込みではないもの)と矛盾していました。scivola さんが issue 内で提案した、見出しを1つにまとめて組み込みライブラリをネストする形で解消します。リンクテキストは `[lib:...]` 記法が自動生成する既存の日本語ラベル(「ライブラリ一覧」「組み込みライブラリ」)をそのまま使用しており、手動のラベル指定は行っていません。

## 参照

fix #2665

scivola さんの提案([lib:/] を「ライブラリ」の1見出しにまとめ、[lib:_builtin] をその子項目にする)に基づく変更です。

## 検証

### ネスト vs フラットリストの判断

`manual/doc/news/*.md` など既存ファイルで `  - [c:...]` の下に `    - [m:...]` を4スペースインデントでネストする慣例が広く使われていることを確認した上で、同じ2/4スペースインデント規約でネストリストを実装しました。実際にネイティブの Markdown コンパイラ(`BitClust::MDCompiler`、`RDCompiler` のサブクラス)で当該ページをコンパイルし、`<ul><li>...<ul><li>...</ul></li></ul>` という正しい入れ子の HTML が生成されることを確認したため、フラットリストへのフォールバックは不要と判断しました。

### 実施した検証

- `manual/api` を md_root として一時ディレクトリに `BitClust::MethodDatabase` を構築(`update_by_markdowntree` + `copy_doc` で `manual/doc/index.md` も doc エントリとして登録)し、バージョン `3.0.0` の DB を作成
- 日本語メッセージカタログ(`bitclust/data/bitclust/catalog/ja_JP.UTF-8`)をロードした `BitClust::MDCompiler` で `index` doc ページ本文をコンパイルし、実際の HTML を取得
- `BitClust::Preprocessor.process` で `manual/doc/index.md` をバージョン `3.0.0` と `4.1.0` の両方で前処理し、エラーなく処理できること、新しい見出し「#### ライブラリ」が出力に含まれ、旧見出し「組み込みライブラリ」「標準添付ライブラリ」が残っていないことを確認
- 編集箇所周辺の `#@since`/`#@until`/`#@if`/`#@end` のバランスに影響がないことを確認(この行範囲には版分岐ディレクティブは存在しません)

### コンパイル結果(該当部分の実際の HTML)

```html
<h2 >ライブラリ</h2>
<ul>
<li><a href="dummy/library/">ライブラリ一覧</a><ul>
<li><a href="dummy/library/_builtin">組み込みライブラリ</a></li>
</ul>
</li>
</ul>
<h2 >C API</h2>
<ul>
<li><a href="dummy/function/">関数一覧</a></li>
</ul>
```

(`<h2>` は検証スクリプトで見出しレベルの基準を1に設定した場合の出力で、本番の実際のレベルとは異なりますが、`#### C API` など他の同階層の見出しと同じレベルで出力されており、ネスト構造以外に影響がないことが確認できます。`href` の `dummy/` 接頭辞は検証用の `URLMapper` のダミー実装によるものです。)
