### PR TITLE
リンク URL を修正

### DIFF
--- a/manual/api/cgi.md
+++ b/manual/api/cgi.md
@@ -190,7 +190,7 @@ value = cgi.accept_charset      # ENV["HTTP_ACCEPT_CHARSET"]
   - HTTP_USER_AGENT
 
 CGI に関連する環境変数に関しては
-[url:http://www.w3.org/CGI/] も参照してください。
+[url:https://www.w3.org/CGI/] も参照してください。
 
 #### 標準出力に HTTP ヘッダと HTML を出力する
 

--- a/manual/api/prettyprint.md
+++ b/manual/api/prettyprint.md
@@ -44,7 +44,7 @@ Christian Lindig, Strictly Pretty, March 2000,
 [url:http://www.st.cs.uni-sb.de/~lindig/papers/pretty/strictly-pretty.html]
 
 Philip Wadler, A prettier printer, March 1998,
-[url:http://homepages.inf.ed.ac.uk/wadler/topics/language-design.html#prettier]
+[url:https://homepages.inf.ed.ac.uk/wadler/topics/language-design.html#prettier]
 
 # class PrettyPrint < Object
 

--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -10,7 +10,7 @@ category: FileFormat
 ### 概要
 
 Psych を用いると YAML のパースと出力ができます。
-これらの機能は libyaml [url:http://pyyaml.org/wiki/LibYAML] を用いて
+これらの機能は libyaml [url:https://pyyaml.org/wiki/LibYAML] を用いて
 実装されています。さらに Ruby の大半のオブジェクトと YAML フォーマットの
 データの間を相互に変換できます。
 

--- a/manual/api/psych/Psych__Nodes__Alias.md
+++ b/manual/api/psych/Psych__Nodes__Alias.md
@@ -3,7 +3,7 @@ library: psych
 ---
 # class Psych::Nodes::Alias < Psych::Nodes::Node
 
-YAML の alias [url:http://yaml.org/spec/1.1/#alias] を表すクラス。
+YAML の alias [url:https://yaml.org/spec/1.1/#alias] を表すクラス。
 
 anchor で別の YAML の要素を指します。
 
@@ -28,7 +28,7 @@ alias が指す先の anchor を返します。
 ### def anchor=(val)
 alias が指す先の anchor を変更します。
 
-- **param** `val` -- 設定する anchor 
+- **param** `val` -- 設定する anchor
 - **SEE** [m:Psych::Nodes::Alias#anchor],
      [m:Psych::Nodes::Alias.new]
 

--- a/manual/api/psych/Psych__Nodes__Mapping.md
+++ b/manual/api/psych/Psych__Nodes__Mapping.md
@@ -3,7 +3,7 @@ library: psych
 ---
 # class Psych::Nodes::Mapping < Psych::Nodes::Node
 
-YAML の mapping [url:http://yaml.org/spec/1.1/#mapping] を表すクラスです。
+YAML の mapping [url:https://yaml.org/spec/1.1/#mapping] を表すクラスです。
 
 Psych::Nodes::Mapping は 0 個以上の子ノードを持つことができます。
 子ノードの個数は偶数でなければなりません。
@@ -21,7 +21,7 @@ ast = Psych.parse(<<EOS)
 x: y
 u: v
 EOS
-  
+
 p ast.root.children.map{|v| v.value } # => ["x", "y", "u", "v"]
 ```
 
@@ -101,7 +101,7 @@ mapping の style を返します。
 ### def style=(sty)
 mapping の style を設定します。
 
-- **param** `sty` -- 設定する style 
+- **param** `sty` -- 設定する style
 
 - **SEE** [m:Psych::Nodes::Mapping#style],
      [m:Psych::Nodes::Mapping.new]

--- a/manual/api/psych/Psych__Nodes__Scalar.md
+++ b/manual/api/psych/Psych__Nodes__Scalar.md
@@ -2,7 +2,7 @@
 library: psych
 ---
 # class Psych::Nodes::Scalar < Psych::Nodes::Node
-YAML の scalar [url:http://yaml.org/spec/1.1/#id858081] を表すクラスです。
+YAML の scalar [url:https://yaml.org/spec/1.1/#id858081] を表すクラスです。
 
 これは AST の葉にあたるノードであり、子ノードを持ちません。
 
@@ -56,7 +56,7 @@ scalar に付加された anchor を返します。
 - **SEE** [m:Psych::Nodes::Scalar#anchor=],
      [m:Psych::Nodes::Scalar.new]
 
-### def anchor=(a) 
+### def anchor=(a)
 scalar に付加された anchor を変更します。
 
 - **param** `a` -- 設定する anchor

--- a/manual/api/psych/Psych__Nodes__Sequence.md
+++ b/manual/api/psych/Psych__Nodes__Sequence.md
@@ -2,7 +2,7 @@
 library: psych
 ---
 # class Psych::Nodes::Sequence < Psych::Nodes::Node
-YAML sequence [url:http://yaml.org/spec/1.1/#sequence/syntax] を表すクラスです。
+YAML sequence [url:https://yaml.org/spec/1.1/#sequence/syntax] を表すクラスです。
 
 YAML sequence とは基本的にはリスト、配列です。以下のような例が考えられます。
 ```yaml
@@ -25,7 +25,7 @@ YAML sequence には anchor を付加できます。
 
 
 tag を付けることもできます。この例では
-[m:Psych::Nodes::Sequence#tag] は "tag:yaml.org,2002:seq" 
+[m:Psych::Nodes::Sequence#tag] は "tag:yaml.org,2002:seq"
 (!seq はこの tag の別名)を返します。
 ```yaml
 %YAML 1.1
@@ -119,7 +119,7 @@ sequence の style を返します。
 ### def style=(sty)
 sequence の style を設定します。
 
-- **param** `sty` -- 設定する style 
+- **param** `sty` -- 設定する style
 
 - **SEE** [m:Psych::Nodes::Sequence#style],
      [m:Psych::Nodes::Sequence.new]

--- a/manual/api/yaml.md
+++ b/manual/api/yaml.md
@@ -266,7 +266,7 @@ YAML Specification
 YAML4R
 
  - [url:http://yaml4r.sourceforge.net/]
- - [url:http://yaml4r.sourceforge.net/cookbook/]([url:http://yaml.org/YAML_for_ruby.html])
+ - [url:http://yaml4r.sourceforge.net/cookbook/]([url:https://yaml.org/YAML_for_ruby.html])
  - [url:http://yaml4r.sourceforge.net/doc/]
 
 Rubyist Magazine: [url:https://magazine.rubyist.net/]

--- a/manual/doc/platform/GNU.md
+++ b/manual/doc/platform/GNU.md
@@ -12,4 +12,4 @@ GNU is Not Unix なので、敬意を表して [d:platform/Unix] の括りから
 探してみたら、[ruby-dev:6712], [ruby-dev:14603] にパッチの投稿
 がある。きっと今でも動くに違いない。情報求む。
 
-[url:http://www.gnu.org/] 参照
+[url:https://www.gnu.org/] 参照


### PR DESCRIPTION
リンク URL で，http → https とリダイレクトされるものを https に修正しました。
一部のファイルではコミット時に「余計な行末スペースの削除」も行なっています。

なお，URL にフラグメント（`#hoge` の類）が含まれる場合，リンク先でそれが存在するかどうかまではチェックしていません。