### PR TITLE
Fix output for Complex#denominator  in documentation

### DIFF
--- a/manual/api/_builtin/Complex.md
+++ b/manual/api/_builtin/Complex.md
@@ -283,7 +283,7 @@ p Complex(1, 2).conj # => (1-2i)
 
 ```ruby title="例"
 p Complex('1/2+2/3i').denominator # => 6
-p Complex(3).numerator          # => 1
+p Complex(3).denominator          # => 1
 ```
 
 - **SEE** [m:Complex#numerator]


### PR DESCRIPTION
適当に RUN ボタンで動作確認をしていると、結果がコメントと違っていて、1.9 から 4.0 まですべて

```
6
(3+0i)
```

のようだったので、バージョン分岐なしで修正します。