### PR TITLE
ドキュメントの加筆3件(help/envvars/JSON)

### DIFF
--- a/manual/api/json/JSON.md
+++ b/manual/api/json/JSON.md
@@ -239,6 +239,12 @@ JSON.generate([1, 2, { name: "tanaka", age: 19 }], json_state)
 
 与えられた JSON 形式の文字列を Ruby オブジェクトとしてロードして返します。
 
+[m:JSON?.parse] との違いは、load は信頼できる入力源を読み込むための簡易メソッドである点です。
+source には JSON 形式の文字列だけでなく、to_str, to_io, read のいずれかに応答するオブジェクト
+(File などの IO や、パスを表すオブジェクトなど) も指定でき、その内容を読み込んだ上で
+内部的に [m:JSON?.parse] を呼び出します。また、[m:JSON?.parse] とはデフォルトのオプション
+(特に create_additions) が異なります。
+
 proc として手続きオブジェクトが与えられた場合は、読み込んだオブジェクトを
 引数にその手続きを呼び出します。
 

--- a/manual/doc/help.md
+++ b/manual/doc/help.md
@@ -40,6 +40,12 @@ CGI#[](name) -> String | [String]
 x オブジェクトと nil で成功・失敗を表す場合は「x | nil」が
 使われています。
 
+### 参考
+
+このマニュアルの読み方をもっとやさしく学びたい方は、
+伊藤淳一 著『[Rubyの公式リファレンスが読めるようになる本](https://zenn.dev/jnchito/books/how-to-read-ruby-reference)』
+(web book、無料) も参考にしてください。
+
 ### お問い合わせ
 
 間違いを見付けた場合は

--- a/manual/doc/spec/envvars.md
+++ b/manual/doc/spec/envvars.md
@@ -100,3 +100,24 @@ ruby: invalid switch in RUBYOPT: -y (RuntimeError)
 - **`RUBY_GC_*`**:
 
   [ref:c:GC#tuning_gc] を参照。
+
+- **`RUBY_THREAD_VM_STACK_SIZE`**:
+
+  スレッド生成時に使用される VM スタックのサイズをバイト数で指定します。
+
+- **`RUBY_THREAD_MACHINE_STACK_SIZE`**:
+
+  スレッド生成時に使用されるマシンスタックのサイズをバイト数で指定します。
+
+- **`RUBY_FIBER_VM_STACK_SIZE`**:
+
+  Fiber 生成時に使用される VM スタックのサイズをバイト数で指定します。
+
+- **`RUBY_FIBER_MACHINE_STACK_SIZE`**:
+
+  Fiber 生成時に使用されるマシンスタックのサイズをバイト数で指定します。
+
+  これらのスタックサイズ関連の環境変数は実装依存であり、Ruby のバージョンによって
+  変更される可能性があります。値を小さくすることでより多くの Fiber や Thread を
+  同時に実行できるようになる場合がありますが、[c:SystemStackError] やセグメンテー
+  ション違反が発生しやすくなります。


### PR DESCRIPTION
分類C の小規模な加筆3件。

- **#2604** `doc/help.md`: 伊藤淳一 著『Rubyの公式リファレンスが読めるようになる本』(無料 web book)への参考リンクを `### 参考` 節に追加。著者本人が issue で提示した文言・URL を使用。
- **#2641** `doc/spec/envvars.md`: スタックサイズ関連の環境変数 `RUBY_THREAD_VM_STACK_SIZE` / `RUBY_THREAD_MACHINE_STACK_SIZE` / `RUBY_FIBER_VM_STACK_SIZE` / `RUBY_FIBER_MACHINE_STACK_SIZE` を追加(znz コメントの方針。`man ruby` の STACK SIZE 節に準拠。`RUBY_YJIT_ENABLE` は対象外)。**既定バイト値は 32/64bit で異なるため意図的に省略しています。要否をご判断ください。**
- **#2646** `api/json/JSON.md`: `JSON.load` の説明に `JSON.parse` との違い(信頼できる入力前提・IO/File 等も受け付け内部で parse を呼ぶ・既定オプションが異なる)を追記。

fix #2604
fix #2641
fix #2646
