### PR TITLE
net/http のサンプルを追加

### DIFF
--- a/manual/api/net/http.md
+++ b/manual/api/net/http.md
@@ -42,6 +42,16 @@ res = Net::HTTP.start(url.host, url.port) {|http|
 puts res.body
 ```
 
+```ruby title="例5: パラメータ付きで GET する"
+require 'net/http'
+require 'uri'
+
+url = URI.parse('http://www.example.com/search')
+url.query = URI.encode_www_form('q'=>'ruby', 'max'=>'50')
+res = Net::HTTP.get_response(url)
+puts res.body
+```
+
 #### フォームの情報を送信する (POST)
 
 ```ruby title="例"

--- a/manual/api/net/http/Net__HTTPHeader.md
+++ b/manual/api/net/http/Net__HTTPHeader.md
@@ -385,6 +385,17 @@ req['Content-Range'] = "bytes 1-500/1000"
 p req.range_length # => 500
 ```
 
+1 以外から始まる範囲の場合は、末尾の値との差分に 1 を足した値になります。
+
+```ruby title="例"
+require 'net/http'
+
+uri = URI.parse('http://www.example.com/index.html')
+req = Net::HTTP::Get.new(uri.request_uri)
+req['Content-Range'] = "bytes 200-699/1000"
+p req.range_length # => 500
+```
+
 ### def delete(key) -> [String] | nil
 key ヘッダフィールドを削除します。
 


### PR DESCRIPTION
分類C。net/http のサンプル追加2件。

- **#2453** `net/http.md`: クエリパラメータ付きで GET する使用例(例5、`URI.encode_www_form`)を例4 の後に追加。
- **#2129** `Net::HTTPHeader#range_length`: 開始位置が 1 以外の `Content-Range`(`bytes 200-699/1000` → 500)の例を追加し、返り値が末尾値そのものではなく `last - first + 1` であることを明示。

fix #2453
fix #2129
