### PR TITLE
MatchData#begin/#end が名前付きキャプチャ名も受け取れることを追記する

### DIFF
--- a/manual/api/_builtin/MatchData.md
+++ b/manual/api/_builtin/MatchData.md
@@ -94,6 +94,32 @@ p $~.begin(4)   # => `begin': index 4 out of matches (IndexError)
 
 - **SEE** [m:MatchData#end]
 
+### def begin(name) -> Integer | nil
+
+name という名前付きグループの部分文字列先頭のオフセットを返します。
+
+name の名前付きグループがマッチしていなければ nil を返します。
+
+- **param** `name` -- 名前(シンボルか文字列)
+
+- **raise** `IndexError` -- 正規表現中で定義されていない name を指定した場合に発生します。
+
+```ruby title="例"
+/(?<year>\d{4})年(?<month>\d{1,2})月(?:(?<day>\d{1,2})日)?/ =~ "2021年1月"
+p $~.begin('year')    # => 0
+p $~.begin(:year)     # => 0
+p $~.begin('month')   # => 5
+p $~.begin(:month)    # => 5
+p $~.begin('day')     # => nil
+#@since 3.4
+p $~.begin('century') # => 'begin': undefined group name reference: century (IndexError)
+#@else
+p $~.begin('century') # => `begin': undefined group name reference: century (IndexError)
+#@end
+```
+
+- **SEE** [m:MatchData#end]
+
 ### def end(n) -> Integer | nil
 
 n 番目の部分文字列終端のオフセットを返します。
@@ -115,6 +141,32 @@ p $~.end(3)   # => nil
 p $~.end(4)   # => 'end': index 4 out of matches (IndexError)
 #@else
 p $~.end(4)   # => `end': index 4 out of matches (IndexError)
+#@end
+```
+
+- **SEE** [m:MatchData#begin]
+
+### def end(name) -> Integer | nil
+
+name という名前付きグループの部分文字列終端のオフセットを返します。
+
+name の名前付きグループがマッチしていなければ nil を返します。
+
+- **param** `name` -- 名前(シンボルか文字列)
+
+- **raise** `IndexError` -- 正規表現中で定義されていない name を指定した場合に発生します。
+
+```ruby title="例"
+/(?<year>\d{4})年(?<month>\d{1,2})月(?:(?<day>\d{1,2})日)?/ =~ "2021年1月"
+p $~.end('year')    # => 4
+p $~.end(:year)     # => 4
+p $~.end('month')   # => 6
+p $~.end(:month)    # => 6
+p $~.end('day')     # => nil
+#@since 3.4
+p $~.end('century') # => 'end': undefined group name reference: century (IndexError)
+#@else
+p $~.end('century') # => `end': undefined group name reference: century (IndexError)
 #@end
 ```
 


### PR DESCRIPTION
`MatchData#begin` / `#end` は整数のインデックスだけでなく、名前付きキャプチャの名前(シンボルか文字列)も受け取れます(#2018)。同ファイルの `offset(name)` / `byteoffset(name)` と同じ体裁で、`begin(name)` / `end(name)` のシグネチャ・説明・サンプルを追加しました。

- 未マッチの名前付きグループは `nil` を返す点、未定義の名前は `IndexError` になる点を明記。
- 例外メッセージのバッククォート→引用符の差(3.4〜)は、同ファイルの既存エントリと同じ `#@since 3.4`/`#@else` 分岐に合わせています。
- 挙動は Ruby 3.4 で確認済み。

fix #2018
