### PR TITLE
未収録の組み込みクラスのドキュメントを追加する

### DIFF
--- a/manual/api/_builtin/IO__EAGAINWaitReadable.md
+++ b/manual/api/_builtin/IO__EAGAINWaitReadable.md
@@ -1,0 +1,17 @@
+---
+library: _builtin
+include:
+  - IO::WaitReadable
+---
+# class IO::EAGAINWaitReadable < Errno::EAGAIN
+
+[m:IO#read_nonblock] などのノンブロッキング I/O が読み込み待ちの状態で
+`EAGAIN` を検出したときに発生する例外です。
+
+[c:Errno::EAGAIN] のサブクラスであり [c:IO::WaitReadable] を include して
+いるため、`rescue IO::WaitReadable` と `rescue Errno::EAGAIN` のどちらでも
+捕捉できます。同様の例外を発生させるたびに [m:Object#extend] するのでは
+なく、あらかじめ [c:IO::WaitReadable] を include したこの専用クラスの
+インスタンスを生成することで実現されています。
+
+- **SEE** [c:IO::WaitReadable], [m:IO#read_nonblock]

--- a/manual/api/_builtin/IO__EAGAINWaitWritable.md
+++ b/manual/api/_builtin/IO__EAGAINWaitWritable.md
@@ -1,0 +1,17 @@
+---
+library: _builtin
+include:
+  - IO::WaitWritable
+---
+# class IO::EAGAINWaitWritable < Errno::EAGAIN
+
+[m:IO#write_nonblock] などのノンブロッキング I/O が書き込み待ちの状態で
+`EAGAIN` を検出したときに発生する例外です。
+
+[c:Errno::EAGAIN] のサブクラスであり [c:IO::WaitWritable] を include して
+いるため、`rescue IO::WaitWritable` と `rescue Errno::EAGAIN` のどちらでも
+捕捉できます。同様の例外を発生させるたびに [m:Object#extend] するのでは
+なく、あらかじめ [c:IO::WaitWritable] を include したこの専用クラスの
+インスタンスを生成することで実現されています。
+
+- **SEE** [c:IO::WaitWritable], [m:IO#write_nonblock]

--- a/manual/api/_builtin/IO__EINPROGRESSWaitReadable.md
+++ b/manual/api/_builtin/IO__EINPROGRESSWaitReadable.md
@@ -1,0 +1,17 @@
+---
+library: _builtin
+include:
+  - IO::WaitReadable
+---
+# class IO::EINPROGRESSWaitReadable < Errno::EINPROGRESS
+
+ノンブロッキングな I/O 処理が読み込み待ちの状態で `EINPROGRESS` を検出
+したときに発生する例外です。
+
+[c:Errno::EINPROGRESS] のサブクラスであり [c:IO::WaitReadable] を include
+しているため、`rescue IO::WaitReadable` と `rescue Errno::EINPROGRESS` の
+どちらでも捕捉できます。同様の例外を発生させるたびに [m:Object#extend]
+するのではなく、あらかじめ [c:IO::WaitReadable] を include したこの専用
+クラスのインスタンスを生成することで実現されています。
+
+- **SEE** [c:IO::WaitReadable], [c:IO::EINPROGRESSWaitWritable]

--- a/manual/api/_builtin/IO__EINPROGRESSWaitWritable.md
+++ b/manual/api/_builtin/IO__EINPROGRESSWaitWritable.md
@@ -1,0 +1,17 @@
+---
+library: _builtin
+include:
+  - IO::WaitWritable
+---
+# class IO::EINPROGRESSWaitWritable < Errno::EINPROGRESS
+
+[m:Socket#connect_nonblock] などのノンブロッキングな接続処理が完了を
+待っている状態で `EINPROGRESS` を検出したときに発生する例外です。
+
+[c:Errno::EINPROGRESS] のサブクラスであり [c:IO::WaitWritable] を include
+しているため、`rescue IO::WaitWritable` と `rescue Errno::EINPROGRESS` の
+どちらでも捕捉できます。同様の例外を発生させるたびに [m:Object#extend]
+するのではなく、あらかじめ [c:IO::WaitWritable] を include したこの専用
+クラスのインスタンスを生成することで実現されています。
+
+- **SEE** [c:IO::WaitWritable], [m:Socket#connect_nonblock]

--- a/manual/api/_builtin/Process__Waiter.md
+++ b/manual/api/_builtin/Process__Waiter.md
@@ -1,0 +1,18 @@
+---
+library: _builtin
+---
+# class Process::Waiter < Thread
+
+[m:Process?.detach] が返す、子プロセスの終了を監視するスレッドを表す
+クラスです。
+
+[c:Thread] のサブクラスであり、監視している子プロセスのプロセス ID を
+保持しています。
+
+- **SEE** [m:Process?.detach]
+
+## Instance Methods
+
+### def pid -> Integer
+
+監視している子プロセスのプロセス ID を返します。

--- a/manual/api/_builtin/Random.md
+++ b/manual/api/_builtin/Random.md
@@ -1,5 +1,7 @@
 ---
 library: _builtin
+include:
+  - Random::Formatter
 ---
 # class Random < Object
 

--- a/manual/api/_builtin/Random__Formatter.md
+++ b/manual/api/_builtin/Random__Formatter.md
@@ -1,0 +1,22 @@
+---
+library: _builtin
+---
+# module Random::Formatter
+
+生成した乱数を 16 進文字列や base64 文字列、UUID など、人が扱いやすい
+形式の文字列に整形するためのメソッド群を提供するモジュールです。
+
+このモジュールは [c:Random] に include され、[c:SecureRandom] には
+extend されています。ただし、以下の整形用メソッドが定義されるのは
+`require "random/formatter"` を読み込んだとき(`require "securerandom"`
+でも読み込まれます)です。読み込むと、[c:Random] のインスタンスと
+[c:SecureRandom] の両方でこれらのメソッドが使えるようになります。
+
+  - random_bytes
+  - hex
+  - base64
+  - urlsafe_base64
+  - alphanumeric
+  - uuid など
+
+これらのメソッドの詳しい説明は [c:SecureRandom] を参照してください。

--- a/manual/api/securerandom.md
+++ b/manual/api/securerandom.md
@@ -1,5 +1,7 @@
 ---
 type: library
+extend:
+  - Random::Formatter
 ---
 安全な乱数発生器のためのインターフェースを提供するライブラリです。
 HTTP のセッションキーなどに適しています。


### PR DESCRIPTION
#617 チェックリストの残り6クラスのページを追加しました。BitClust は `manual/api/` 以下の `.md` をファイル存在で認識するため、新規ファイル追加だけで登録されます(`IO.md` 等の既存ファイル編集は不要。scratch DB へのビルドで登録・メタデータを確認済み)。

- `Process::Waiter`(`Thread` のサブクラス、`Process.detach` が返す監視スレッド)
- `Random::Formatter`(`Random` に include・`SecureRandom` に extend される整形メソッド群のモジュール。整形メソッド(hex/base64/uuid 等)は `require "random/formatter"`(または `"securerandom"`)読み込み後に定義される点を明記)
- `IO::EAGAINWaitReadable` / `EAGAINWaitWritable` / `EINPROGRESSWaitReadable` / `EINPROGRESSWaitWritable`(`Errno::EAGAIN`/`EINPROGRESS` のサブクラスで `IO::WaitReadable`/`WaitWritable` を include したノンブロッキング I/O 用の例外クラス)

あわせて `Random.md` に include、`securerandom.md` に extend の front matter を追加。

fix #617
