### PR TITLE
ページ名から「(super・ブロック付き・yield)」を削除

### DIFF
--- a/manual/doc/spec/call.md
+++ b/manual/doc/spec/call.md
@@ -1,4 +1,4 @@
-# メソッド呼び出し(super・ブロック付き・yield)
+# メソッド呼び出し
 
   - [ref:super]
   - [ref:block]


### PR DESCRIPTION
ページ名が長すぎ，これが入っている必要もなく[^a]，かつ他ページの本文中にここへのサイト内リンクが含まれていると読みづらいため。

[^a]: これは単にこのページ内に super やブロック付き呼び出しや yield についても書かれていることを示しているだけでしょう。