### PR TITLE
メソッドの引数に指定できない式の一覧から not を外し、パーサによる差異を補足

### DIFF
--- a/manual/doc/spec/program.md
+++ b/manual/doc/spec/program.md
@@ -96,7 +96,7 @@ end
 
 以下のような式はそのままではメソッドの引数にできません。
 
-- `and`, `or`, `not` 演算子による演算子式
+- `and`, `or` 演算子による演算子式
 - `if`, `unless`, `while`, `until`, `rescue` 修飾子の付いた式
 
 ```text title="SyntaxError になる書き方"
@@ -111,6 +111,8 @@ p("当たり" if rand(10).zero?)
 p((true and nil))
 p(("当たり" if rand(10).zero?))
 ```
+
+なお、`not` 演算子による式は、Ruby 3.3 以前のデフォルトパーサ(parse.y)ではメソッドの引数にできませんが、Ruby 3.4 以降のデフォルトパーサ(Prism)では引数に指定できます。
 
 ### プログラムの終り {#terminate}
 


### PR DESCRIPTION
#3106 で追加された「メソッドの引数に指定できない式」の一覧に `not` が含まれていますが、`not` だけは Ruby 3.4 以降でデフォルトになった Prism パーサではメソッドの引数に指定できます。マニュアルは 3.0〜4.1 が対象なので、`and` / `or` と同列に「指定できない」と書くと 3.4 以降で不正確になります。

Ruby 3.4.8 で実測した挙動:

| 式                | parse.y(3.3 以前のデフォルト) | Prism(3.4 以降のデフォルト) |
| ----------------- | ----------------------------- | ---------------------------- |
| `p(true and nil)` | SyntaxError                   | SyntaxError                  |
| `p(true or nil)`  | SyntaxError                   | SyntaxError                  |
| `p(not true)`     | SyntaxError                   | **有効**(`false` を返す)   |

```
$ ruby --parser=parse.y -c -e 'p(not true)'
-e:1: syntax error, unexpected 'true', expecting '('
$ ruby --parser=prism   -e 'p(not true)'
false
```

## 変更内容

- 一覧から `not` を外す(`and` / `or` は両パーサ・全バージョンで SyntaxError なので残す)。
- 括弧でのグルーピング例の後ろに、`not` の扱いがパーサによって異なる旨の注記を1文追加。

「SyntaxError になる書き方」の例(`p(true and nil)`)は両パーサ・全バージョンで SyntaxError のままなので変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
