### PR TITLE
File.open/IO.new の newline オプションを記載する

### DIFF
--- a/manual/api/_builtin/File.md
+++ b/manual/api/_builtin/File.md
@@ -488,9 +488,9 @@ p File.link("testfile", "testlink") # => 0
 p IO.read("testlink")               # => "test"
 ```
 
-### def new(path, mode = "r", perm = 0666)                -> File 
-### def open(path, mode = "r", perm = 0666)               -> File 
-### def open(path, mode = "r", perm = 0666) {|file| ... } -> object
+### def new(path, mode = "r", perm = 0666, **opts)                -> File 
+### def open(path, mode = "r", perm = 0666, **opts)               -> File 
+### def open(path, mode = "r", perm = 0666, **opts) {|file| ... } -> object
 
 path で指定されるファイルをオープンし、[c:File] オブジェクトを生成して
 返します。
@@ -506,6 +506,8 @@ path が整数の場合はファイルディスクリプタとして扱い、そ
 - **param** `mode` -- モードを文字列か定数の論理和で指定します。[m:Kernel?.open] と同じです。
 
 - **param** `perm` -- ファイルを生成する場合のファイルのパーミッションを整数で指定します。[m:Kernel?.open] と同じです。
+
+- **param** `opts` -- キーワード引数でオープン時のオプションを指定します。指定できるオプションは [m:IO.new] を参照してください。
 
 - **raise** `Errno::EXXX` -- ファイルのオープンに失敗した場合に発生します。
 

--- a/manual/api/_builtin/IO.md
+++ b/manual/api/_builtin/IO.md
@@ -286,6 +286,12 @@ IO.new, IO.for_fd はブロックを受け付けません。
   - :textmode 真を渡すと mode の "t" と同じ意味になります。
   - :binmode 真を渡すと mode の "b" と同じ意味になります。
   - :autoclose 偽を渡すと close時/GCでのファイナライザ呼出時に fd を close しません。
+  - :newline 改行の変換方法を指定します。指定するとテキストモードになるため、
+    mode の "b" や :binmode と同時には指定できません(指定すると ArgumentError が発生します)。
+    :universal は読み込み時に "\r\n", "\r", "\n" のいずれの改行も "\n" に変換します。
+    :crlf は書き込み時に "\n" を "\r\n" に変換します。
+    :cr は書き込み時に "\n" を "\r" に変換します。
+    :lf は改行の変換を行いません。
 #@since 3.2
   - :path 文字列を渡すと、[m:IO#path] メソッドがその値を返すようになります。
 #@end


### PR DESCRIPTION
`newline:` オプション(改行変換の指定。Ruby 2.5 で追加)が未文書化だったので、`IO.new` のキーワード引数として記載し、`File.open`/`File.new` からは `IO.new` を参照する構成にしました(#952。maintainer znz 提案の集約方式、同ファイル `IO.foreach` の委譲記法に倣う)。

- **IO.md**: `IO.new` の option 一覧に `:newline` を追記。`:universal` は読み込み時に各種改行を `"\n"` に、`:crlf`/`:cr` は書き込み時に `"\n"` を `"\r\n"`/`"\r"` に変換、`:lf` は変換なし。バイナリモードとの併用は ArgumentError。
- **File.md**: `File.new`/`File.open` のシグネチャに `**opts` を追加し、「指定できるオプションは [[m:IO.new]] を参照」の param を追記(全リストは重複させない)。
- 2.5 で追加のため `#@since` ガード不要。挙動は Ruby 3.4.8 で実測確認。

fix #952
