### PR TITLE
WEBrick::Cookie の不適切な参照先 URL を削除

### DIFF
--- a/manual/api/webrick/cookie.md
+++ b/manual/api/webrick/cookie.md
@@ -8,9 +8,6 @@ require:
 Cookie を表すクラスです。[rfc:2109] に準拠しています。
 RFC2109 は [rfc:2965] により破棄されましたが、WEBrick::Cookie クラスは RFC2965 に対応していません。
 
- - <http://www.studyinghttp.net/translations#RFC2965>  
- - <http://www.studyinghttp.net/cookies> 
-
 ## Class Methods
 
 ### def new(name, value)    -> WEBrick::Cookie


### PR DESCRIPTION
studyinghttp.net は現在，オンラインカジノのサイトです