### PR TITLE
文字列・シンボルリテラルのエンコーディングを説明する

### DIFF
--- a/manual/doc/spec/literal.md
+++ b/manual/doc/spec/literal.md
@@ -114,6 +114,17 @@ p "foo" "bar"
 
 文字列式は評価されるたびに毎回新しい文字列オブジェクトを生成します。
 
+文字列リテラルから生成される文字列オブジェクトのエンコーディングは、スクリプトエンコー
+ディング(ソースファイルのエンコーディング。マジックコメント `# encoding:` で指定でき、
+指定がなければ UTF-8)になります。
+
+```ruby
+# encoding: utf-8
+p "あ".encoding # => #<Encoding:UTF-8>
+```
+
+[m:String#encoding]、[c:Encoding] を参照してください。
+
 #### バックスラッシュ記法 {#backslash}
 
 文字列中でバックスラッシュ(環境によっては￥記号で表示されます)の後に記
@@ -596,6 +607,20 @@ p %s{foo-bar} #=> :"foo-bar"
 
 シンボルは常に一意のオブジェクトで、(式展開を含んでいてもその結果が同
 じ文字列であれば)何度評価されても同じオブジェクトを返します。
+
+シンボルのエンコーディングは、ASCII文字のみからなる場合はUS-ASCII、そうでなければ
+スクリプトエンコーディングになります。文字列リテラルは中身がASCII文字のみでも常にス
+クリプトエンコーディングになる([ref:string]参照)のに対し、シンボルはASCII文字のみ
+の場合にUS-ASCIIになる点が異なります。
+
+```ruby
+# encoding: utf-8
+p :abc.encoding  # => #<Encoding:US-ASCII>
+p :あ.encoding    # => #<Encoding:UTF-8>
+p "abc".encoding # => #<Encoding:UTF-8> (Symbolと異なりASCII文字のみでもスクリプトエンコーディングになる)
+```
+
+[m:Symbol#encoding]、[m:String#encoding]、[c:Encoding] を参照してください。
 
 ほとんどのシンボルはGC可能です。
 


### PR DESCRIPTION
文字列リテラル・シンボルの節にエンコーディングの記述がなかったので追記しました(#767。正規表現・文字リテラルの節には既に記載あり)。

- **文字列リテラル**: 生成される文字列のエンコーディングはスクリプトエンコーディング(ソースファイルのエンコーディング。`# encoding:` で指定、既定 UTF-8)。
- **シンボル**: ASCII 文字のみなら US-ASCII、そうでなければスクリプトエンコーディング。文字列リテラル(ASCII のみでもスクリプトエンコーディング)との違いも明記。
- 例は Ruby 3.4.8 で実測(`"あ".encoding`=UTF-8・`:abc.encoding`=US-ASCII・`:"あ".encoding`=UTF-8)。`[[m:String#encoding]]`/`[[m:Symbol#encoding]]`/`[[c:Encoding]]` へリンク。real-DB render で compileerror ゼロ確認。

fix #767
