### PR TITLE
Object#initialize_clone に freeze キーワード引数を追記する

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -1823,14 +1823,21 @@ check obj.clone
 
 - **SEE** [m:Object#initialize_clone], [m:Object#initialize_dup]
 
-### def initialize_clone(obj) -> object
+### def initialize_clone(obj, freeze: nil) -> object
 
 [m:Object#clone] がオブジェクトを複製する際に呼び出すメソッドです。
 
-デフォルトでは [m:Object#initialize_copy] を呼び出します。
+デフォルトの実装は freeze キーワード引数を無視して [m:Object#initialize_copy] を
+呼び出し、self を返します。複製したオブジェクトを freeze するかどうかは、
+このメソッドの呼び出し元である [m:Object#clone] が判断します。
+
+freeze キーワード引数には、[m:Object#clone] に渡された freeze の値がそのまま渡されます。
+clone と dup で挙動を変えたいなどの理由でこのメソッドを再定義する場合は、
+freeze キーワード引数を受け取り、super へそのまま渡すようにしてください。
 
 initialize_clone という名前のメソッドは自動的に private に設定されます。
 
+- **param** `freeze` -- [m:Object#clone] に渡された freeze の値(true, false, nil のいずれか)が渡されます。
 - **SEE** [m:Object#initialize_copy], [m:Object#initialize_dup]
 
 ### def initialize_dup(obj) -> object


### PR DESCRIPTION
## 概要

[c:Object]#initialize_clone のシグネチャに `freeze:` キーワード引数を追記します。
[rurema/doctree#2967](https://github.com/rurema/doctree/issues/2967) 対応。

## 背景

Ruby 3.0.0 以降、[m:Object#clone] は `freeze:` キーワード引数を
[m:Object#initialize_clone] へそのまま渡します(bug:14266 / feature:16175、
`manual/doc/news/3_0_0.md` に記載)。`clone` 側の記載は既に `freeze:` に対応済みでしたが、
`initialize_clone` 側はシグネチャ・説明ともに `freeze:` が漏れていました。

## 変更点

- シグネチャを `initialize_clone(obj)` → `initialize_clone(obj, freeze: nil)` に変更。
- `clone` 側と同じ文言で `freeze` パラメータの説明を追記。

3.0 は doctree のサポート下限バージョンであり、`clone` エントリも `freeze:` を
`#@since` ガード無しで記載しているため、本エントリでもガードは付けていません。

## 確認

Ruby 3.4.8 で、`clone(freeze:)` が `initialize_clone` に `freeze:` を転送することを確認済み
(サブクラスで `initialize_clone(other, freeze: nil)` を override し、`clone(freeze: true/false/なし)`
それぞれで受け取る値と `frozen?` を確認)。scratch DB でのビルドも compileerror 0 件。
