### PR TITLE
Pathname#rename が self を書き換えない旨を注記する

### DIFF
--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -676,6 +676,23 @@ File.rename(self.to_s, to) と同じです。
 
 #@#noexample File.renameの例を参照
 
+このメソッドはファイルシステム上のファイル名を変更しますが、レシーバの
+[c:Pathname] オブジェクトが保持しているパス文字列は変更されません。
+そのため、rename の呼び出し後も self は変更前のパスを指したままです。
+
+```ruby
+require 'pathname'
+path = Pathname.new("old")
+File.write("old", "")
+path.rename("new")
+path.to_s    # => "old"
+path.exist?  # => false
+Pathname.new("new").exist? # => true
+```
+
+新しいパスを指す [c:Pathname] オブジェクトが必要な場合は、
+Pathname.new(to) などとして新しく作成する必要があります。
+
 - **SEE** [m:File.rename]
 
 ### def stat -> File::Stat


### PR DESCRIPTION
## 概要

[m:Pathname#rename] が、ファイルをリネームしてもレシーバ自身のパス文字列を
書き換えないことを注記します。
[rurema/doctree#2252](https://github.com/rurema/doctree/issues/2252) 対応。

## 背景

`Pathname#rename(to)` は `File.rename(self.to_s, to)` と同じですが、リネーム後も
レシーバの [c:Pathname] オブジェクトが保持するパス文字列は変更されません
(self は変更前のパスを指したまま)。PR #1764 のレビューコメントで指摘されていた
挙動で、既存の説明では触れられていませんでした。

## 変更点

`rename` エントリに、self が更新されない旨の注記と、確認済みの例を追記しました。
新しいパスを指す Pathname が必要な場合は `Pathname.new(to)` などで作り直す必要がある、
という案内も併記しています。

## 確認

Ruby 3.4.8 で確認:

```
require 'pathname'; require 'tmpdir'
Dir.mktmpdir{|d| Dir.chdir(d){ File.write("old","x"); pn=Pathname.new("old"); p pn.rename("new"); p pn.to_s; p pn.exist?; p Pathname.new("new").exist? }}
# => 0
#    "old"       (self は書き換わらない)
#    false       (旧パスは消えている)
#    true        (新パスにファイルがある)
```

コードブロックは pathname.md の慣例に合わせてフェンス ```ruby にしています。
scratch DB でのビルドも compileerror 0 件、`[c:Pathname]` / `[m:File.rename]` リンクも解決を確認済み。
