### PR TITLE
gethostbyname/gethostbyaddr が deprecated である旨を注記する

### DIFF
--- a/manual/api/socket/Socket.md
+++ b/manual/api/socket/Socket.md
@@ -216,6 +216,8 @@ Socket.getnameinfo([nil, 21,'127.0.0.1'])
 
 ### def gethostbyaddr(host, type = Socket::AF_INET) -> Array
 
+このメソッドは deprecated です。[m:Addrinfo#getnameinfo] を使用してください。
+
 sockaddr 構造体をパックした文字列からホスト情報を返します。
 ホスト情報の構造は [m:Socket.gethostbyname] と同じです。
 type には、アドレスタイプ(デフォルトは
@@ -228,6 +230,8 @@ Socket::AF_INET)を指定します。
 - **raise** `SocketError` -- [man:gethostbyaddr(3)] の呼び出しにエラーがあった場合に発生します。
 
 ### def gethostbyname(host) -> Array
+
+このメソッドは deprecated です。[m:Addrinfo.getaddrinfo] を使用してください。
 
 ホスト名または IP アドレス(指定方法に関しては
 [ref:lib:socket#host_format]を参照)

--- a/manual/api/socket/TCPSocket.md
+++ b/manual/api/socket/TCPSocket.md
@@ -67,6 +67,8 @@ host で指定したホストの service で指定したポートと接続した
 
 ### def gethostbyname(host) -> Array
 
+このメソッドは deprecated です。[m:Addrinfo.getaddrinfo] を使用してください。
+
 ホスト名または IP アドレス (整数または"127.0.0.1"
 のような文字列)からホストの情報を返します。ホスト情報は、ホ
 スト名、ホストの別名の配列、ホストのアドレスタイプ、ホストの


### PR DESCRIPTION
## 概要

deprecated である以下のメソッドに、その旨と代替メソッドへの案内を追記します。
[rurema/doctree#738](https://github.com/rurema/doctree/issues/738) 対応。

- [m:Socket.gethostbyname] → [m:Addrinfo.getaddrinfo]
- [m:Socket.gethostbyaddr] → [m:Addrinfo#getnameinfo]
- [m:TCPSocket.gethostbyname] → [m:Addrinfo.getaddrinfo]

## 背景

これらは Ruby 本体で deprecated 扱いになっており、呼び出すと代替メソッドの使用を促す警告が出ますが、
doctree の該当エントリには deprecated である旨の記載がありませんでした。
Issue コメントの整理どおり、`Socket.getaddrinfo` は対象外としています。

## 確認

Ruby 3.4.8 で各メソッドの警告文を確認済み:

```
$ ruby -rsocket -e 'Socket.gethostbyname("localhost")'
warning: Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.
$ ruby -rsocket -e 'Socket.gethostbyaddr([127,0,0,1].pack("C4"))'
warning: Socket.gethostbyaddr is deprecated; use Addrinfo#getnameinfo instead.
$ ruby -rsocket -e 'TCPSocket.gethostbyname("localhost")'
warning: TCPSocket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.
```

代替メソッドは警告文どおり、`gethostbyname` が `Addrinfo.getaddrinfo`、
`gethostbyaddr` が `Addrinfo#getnameinfo` である点を反映しています。
記法は本コードベースの deprecated 注記の慣例(独立した SEE 節を作らず、
「このメソッドは deprecated です。[...] を使用してください。」の一文にリンクを埋め込む)に合わせました。
scratch DB でのビルドも compileerror 0 件、3 本の `[m:Addrinfo...]` リンクの解決も確認済み。
