### PR TITLE
OpenURI.open_uri のオプションに :encoding の説明を追加する

### DIFF
--- a/manual/api/open-uri/OpenURI.md
+++ b/manual/api/open-uri/OpenURI.md
@@ -36,6 +36,7 @@ options には [c:Hash] を与えます。理解するハッシュの
  - :ssl_verify_mode
  - :ftp_active_mode
  - :redirect
+ - :encoding
 です。
 「:content_length_proc」と「:progress_proc」はプログレスバーに
 利用されることを想定しています。
@@ -120,6 +121,17 @@ sio = OpenURI.open_uri('http://www.example.com',
 
  HTTP と FTP の間のリダイレクトもこれで指定します。
 
+- **`:encoding`**:
+ 取得した内容の外部エンコーディングを指定します。
+ "euc-jp" のような文字列か [c:Encoding] オブジェクトを与えます。
+ 指定すると、返り値の StringIO オブジェクトの外部エンコーディングが
+ その値に設定されます。指定しなかった場合は Content-Type ヘッダの
+ charset に基づいて設定されます。いずれの場合も内容の変換(transcode)は
+ 行われず、エンコーディングが設定されるだけです。
+
+ 同じ指定を mode 引数の文字列("r:euc-jp" のように)で行うこともできますが、
+ mode と :encoding の両方でエンコーディングを指定すると
+ [c:ArgumentError] が発生します。
 
 - **param** `name` -- オープンしたいリソースを文字列で与えます。
 


### PR DESCRIPTION
## 概要

[m:OpenURI.open_uri] のオプションに `:encoding` の説明を追記します。
[rurema/doctree#731](https://github.com/rurema/doctree/issues/731) 対応。

## 背景

`manual/api/open-uri/OpenURI.md` の open_uri が理解するオプションキーの一覧・詳細説明に `:encoding` が欠けていました。

## 変更点

理解するキーの一覧に `:encoding` を追加し、`:proxy` 等と同様の詳細説明ブロックを追加しました。取得内容の外部エンコーディングを指定するオプションで、mode 引数の文字列(`"r:euc-jp"` 等)と `:encoding` の両方で指定すると `[c:ArgumentError]` になる点も明記しました。

## 確認

Ruby 3.4.8 の `lib/open-uri.rb` で、`Options` に `:encoding => nil` があり、`options[:encoding]` が `Encoding.find` され `io.set_encoding(encoding)` で適用されること、mode 由来のエンコーディングと二重指定で `ArgumentError "encoding specified twice"` になることを確認しました。scratch DB(3.4)でのビルドも compileerror 0 件です。
