### PR TITLE
Net::FTP.new の第2引数にオプションハッシュ形式を追記する

### DIFF
--- a/manual/api/net/ftp.md
+++ b/manual/api/net/ftp.md
@@ -76,19 +76,66 @@ FTP を実装したクラスです。
 
 ## Class Methods
 
+### def new(host = nil, options = {}) -> Net::FTP
 ### def new(host = nil, user = nil, passwd = nil, acct = nil) -> Net::FTP
 
 新しい Net::FTP のインスタンスを生成します。
 
 host が指定された場合、生成されたインスタンスに対して 
 [m:Net::FTP#connect] を呼び出し、
-さらに user が指定された場合は [m:Net::FTP#login] 
+さらにログインユーザ名が指定された場合は [m:Net::FTP#login] 
 を呼び出します。
 
+2 番目の引数には、後方互換のためログインに使うユーザ名を表す文字列を
+そのまま渡すこともできますが、各キーがシンボルであるオプションのハッシュを
+渡すこともできます。オプションのハッシュを渡した場合、3 番目・4 番目の
+引数(passwd、acct)は無視され、ユーザ名やパスワードはオプションの
+:username、:password で指定します。
+
 - **param** `host` -- 接続するホストを指定します。
-- **param** `user` -- ログインに使うユーザ名を指定します。
-- **param** `passwd` -- ログインに使うパスワードを指定します。
-- **param** `acct` -- ログイン後に送る ACCT コマンドのパラメータを指定します。
+
+- **param** `options` -- オプションをハッシュで指定します。各キーはシンボルです。
+
+- **`:port`**:
+ 接続するポート番号を指定します。デフォルトは 21 です。
+- **`:ssl`**:
+ 真を指定すると SSL(TLS)を使った接続を試みます。ハッシュを指定した場合は
+ [m:OpenSSL::SSL::SSLContext#set_params] にそのままパラメータとして渡されます。
+- **`:private_data_connection`**:
+ 真ならばデータ転送用のコネクションにも TLS を使います。
+ :ssl が真のときのデフォルトは true です。:ssl が偽のときに true を指定すると
+ [c:ArgumentError] が発生します。
+#@since 3.2
+- **`:implicit_ftps`**:
+ 真ならば接続の確立時点で TLS 接続を開始します(Implicit FTPS)。
+ デフォルトは false です。:ssl が偽のときに true を指定すると [c:ArgumentError] が発生します。
+#@end
+- **`:username`**:
+ ログインに使うユーザ名を指定します。
+- **`:password`**:
+ ログインに使うパスワードを指定します。
+- **`:account`**:
+ ログイン後に送る ACCT コマンドのパラメータを指定します。
+- **`:passive`**:
+ 真ならば接続をパッシブモードにします。デフォルトは true です
+ (既定値は [m:Net::FTP.default_passive=] で変更できます)。
+- **`:open_timeout`**:
+ 接続の確立を待つ秒数を指定します。デフォルトは nil (タイムアウトなし) です。
+- **`:read_timeout`**:
+ 1 ブロックの読み込みを待つ秒数を指定します。デフォルトは 60 です。
+- **`:ssl_handshake_timeout`**:
+ TLS のハンドシェイクを待つ秒数を指定します。デフォルトは nil です。
+#@since 3.1
+- **`:use_pasv_ip`**:
+ 真ならば PASV 応答に含まれる IP アドレスを使用します。偽の場合は制御コネクションと
+ 同じ IP アドレスを使用します。デフォルトは false です。
+#@end
+- **`:debug_mode`**:
+ 真ならば全ての通信内容を $stdout に出力します。デフォルトは false です。
+
+- **param** `user` -- ログインに使うユーザ名を指定します(後方互換のための位置引数です)。
+- **param** `passwd` -- ログインに使うパスワードを指定します(後方互換のための位置引数です)。
+- **param** `acct` -- ログイン後に送る ACCT コマンドのパラメータを指定します(後方互換のための位置引数です)。
 
 - **SEE** [m:Net::FTP.open]
 


### PR DESCRIPTION
## 概要

[m:Net::FTP.new] の第2引数にオプションハッシュ形式を追記します。
[rurema/doctree#347](https://github.com/rurema/doctree/issues/347) 対応。

## 背景

`manual/api/net/ftp.md` の Net::FTP.new は位置引数のみのシグネチャで、第2引数にオプションハッシュ(`:ssl` 等)を渡せることや、個々のオプションキーの説明がありませんでした。

## 変更点

- シグネチャに `def new(host = nil, options = {})` 形式を追加(後方互換の位置引数形式も残しています)。
- `:port` / `:ssl` / `:private_data_connection` / `:implicit_ftps` / `:username` / `:password` / `:account` / `:passive` / `:open_timeout` / `:read_timeout` / `:ssl_handshake_timeout` / `:use_pasv_ip` / `:debug_mode` の各キーを説明。
- 第2引数にハッシュを渡すと3番目・4番目の位置引数(passwd, acct)が無視される点も明記。
- 比較的新しい `:use_pasv_ip`(net-ftp 0.1.3〜= Ruby 3.1〜)と `:implicit_ftps`(net-ftp 0.2.0〜= Ruby 3.2〜)は、それぞれ `#@since 3.1` / `#@since 3.2` で版ガードしました(Ruby 3.0 同梱の net-ftp 0.1.1 には無いオプションです)。

## 確認

net-ftp 0.3.8 の `initialize(host = nil, user_or_options = {}, passwd = nil, acct = nil)` が `user_or_options.to_hash` でハッシュ判定し、失敗時のみ後方互換の位置引数処理にフォールバックすること(ハッシュ時は passwd/acct を参照しないこと)を確認しました。`:ssl` 未指定で `:private_data_connection` / `:implicit_ftps` を true にすると `ArgumentError` になることも実機確認しています。

版ガードは、`ruby/net-ftp` の各タグと `ruby/ruby` の各リリースを突き合わせて確認しました(3.0=net-ftp 0.1.1=両オプション無し / 0.1.3 で `:use_pasv_ip` 追加=3.1 / 0.2.0 で `:implicit_ftps` 追加=3.2)。scratch DB を 3.0 と 3.4 で作って `Net::FTP.new` を real-DB render し、3.0 では両オプションが出ず・3.4 では出ること、compileerror 0 件を実測しました。
