### PR TITLE
Net::HTTP に gzip/deflate 自動展開の説明を追加する

### DIFF
--- a/manual/api/net/http/Net__HTTP.md
+++ b/manual/api/net/http/Net__HTTP.md
@@ -7,6 +7,19 @@ alias:
 
 HTTP のクライアントのためのクラスです。
 
+### gzip/deflate の自動展開
+
+Net::HTTP は、リクエストに Accept-Encoding ヘッダも Range ヘッダも
+指定されていない場合、自動的に
+`Accept-Encoding: gzip;q=1.0,deflate;q=0.6,identity;q=0.3` を付与します。
+このとき、応答の Content-Encoding が gzip や deflate であれば応答ボディは
+透過的に展開され、Content-Encoding ヘッダは取り除かれ、Content-Length は
+(存在すれば)展開後のサイズに更新されます。
+
+自分で Accept-Encoding ヘッダや Range ヘッダを指定した場合はこの自動展開は
+行われず、圧縮されたままのボディと Content-Encoding ヘッダがそのまま得られます。
+また、応答に Content-Range ヘッダが含まれる場合も展開は行われません。
+
 ## Class Methods
 
 ### def new(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil, no_proxy=nil) -> Net::HTTP


### PR DESCRIPTION
## 概要

[c:Net::HTTP] のクラス説明に、gzip/deflate の自動展開についての説明を追加します。
[rurema/doctree#332](https://github.com/rurema/doctree/issues/332) 対応。

## 背景

Net::HTTP は Ruby 2.0 以降、リクエストに `Accept-Encoding` ヘッダが未指定なら自動的にそれを付与し、応答が gzip/deflate で圧縮されていればボディを透過的に展開します。しかし doctree にはこの挙動の説明がありませんでした([c:Net::HTTPHeader] に `Accept-Encoding` の項目はありますが、自動展開そのものには触れていません)。

## 変更点

`manual/api/net/http/Net__HTTP.md` のクラス説明に「gzip/deflate の自動展開」節を追加しました。

- リクエストに `Accept-Encoding` ヘッダも `Range` ヘッダも未指定なら Net::HTTP が自動で `Accept-Encoding` を付与すること。
- 応答が gzip/deflate なら透過的に展開され、`Content-Encoding` は削除・`Content-Length` は(存在すれば)展開後サイズに更新されること。
- 自分で `Accept-Encoding` / `Range` を指定した場合、および応答に `Content-Range` が含まれる場合は自動展開が行われないこと。

## 確認

Ruby 3.4.8 の `net/http/generic_request.rb`・`net/http/response.rb` で確認しました。デフォルトの `Accept-Encoding` は `"gzip;q=1.0,deflate;q=0.6,identity;q=0.3"`(実機確認)。`generic_request.rb` は initheader に `accept-encoding` または `range` があると自動付与・自動展開を抑止します。`response.rb#inflater` は `decode_content` が真かつ `Content-Encoding` が gzip/deflate/x-gzip のときに `content-encoding` を削除して透過展開し(`Content-Range` 応答は展開しない)、`content-length` を(あれば)展開後サイズに更新します。2.0 以降の安定した挙動のため版ガードは付けていません。scratch DB(3.4)でのビルドも compileerror 0 件・当該節が見出しとして描画されること(phantom メソッドエントリが生じないこと)を実測しました。Range/Content-Range の例外は fable サブエージェント査読の指摘を反映したものです。
