### PR TITLE
Module#instance_methods 系4メソッドの SEE を相互リンク化する

### DIFF
--- a/manual/api/_builtin/Module.md
+++ b/manual/api/_builtin/Module.md
@@ -970,7 +970,7 @@ p Class.new.to_s    #=> "#<Class:0x00007fa5c40b41b0>"
 
 - **param** `inherited_too` -- false を指定するとそのモジュールで定義されているメソッドのみ返します。
 
-- **SEE** [m:Object#methods]
+- **SEE** [m:Object#methods], [m:Module#public_instance_methods], [m:Module#private_instance_methods], [m:Module#protected_instance_methods]
 
 ```ruby title="例1"
 class Foo
@@ -1052,7 +1052,7 @@ Kernel.public_instance_method(:p)         #   method `p' for module `Kernel' is 
 
 #@#noexample 参照先のModule#instance_methodsにサンプルが書かれているため
 
-- **SEE** [m:Object#public_methods], [m:Module#instance_methods]
+- **SEE** [m:Object#public_methods], [m:Module#instance_methods], [m:Module#private_instance_methods], [m:Module#protected_instance_methods]
 
 ### def private_instance_methods(inherited_too = true) -> [Symbol]
 
@@ -1061,7 +1061,7 @@ Kernel.public_instance_method(:p)         #   method `p' for module `Kernel' is 
 
 - **param** `inherited_too` -- false を指定するとそのモジュールで定義されているメソッドのみ返します。
 
-- **SEE** [m:Object#private_methods], [m:Module#instance_methods]
+- **SEE** [m:Object#private_methods], [m:Module#instance_methods], [m:Module#public_instance_methods], [m:Module#protected_instance_methods]
 
 ```ruby title="例"
 module Foo
@@ -1089,7 +1089,7 @@ p Bar.private_instance_methods(false) # => [:qux]
 
 #@#noexample 参照先のModule#instance_methodsにサンプルが書かれているため
 
-- **SEE** [m:Object#protected_methods], [m:Module#instance_methods]
+- **SEE** [m:Object#protected_methods], [m:Module#instance_methods], [m:Module#public_instance_methods], [m:Module#private_instance_methods]
 
 ### def private_class_method(*name) -> self
 ### def private_class_method(names) -> self


### PR DESCRIPTION
## 概要

[c:Module] の `instance_methods` 系4メソッドの SEE を相互リンク化します。
[rurema/doctree#2285](https://github.com/rurema/doctree/issues/2285) 対応。

## 背景

`manual/api/_builtin/Module.md` の `instance_methods` / `public_instance_methods` / `private_instance_methods` / `protected_instance_methods` は、互いに関連するメソッドですが SEE で兄弟メソッドへのリンクが一部欠けていました(例: `instance_methods` の SEE は `[m:Object#methods]` のみ)。

## 変更点

4メソッドの SEE に、欠けていた兄弟メソッドへのリンクを補い、相互に参照し合うようにしました(既存のリンクは保持)。

## 確認

追加した `[m:Module#...]` はすべて同ファイル内に実在するエントリです。scratch DB(3.4)で4エントリを real-DB render し、いずれも compileerror 0 件・リンクが解決することを実測しました。
