### PR TITLE
Enumerator::Generator のドキュメントを追加

### DIFF
--- a/manual/api/_builtin/Enumerator.md
+++ b/manual/api/_builtin/Enumerator.md
@@ -489,7 +489,3 @@ p (1..100).drop_while.size # => nil
 ```
 
 - **SEE** [m:Enumerator.new]
-
-#@# 以下のクラスはユーザが直接触れるべきではないのでドキュメントは
-#@# 書かない
-#@# = class Enumerator::Generator

--- a/manual/api/_builtin/Enumerator__Generator.md
+++ b/manual/api/_builtin/Enumerator__Generator.md
@@ -1,0 +1,18 @@
+---
+library: _builtin
+---
+# class Enumerator::Generator < Object
+
+[m:Enumerator.new] で内部的に使われるクラスで、直接使うものではありません。
+
+
+## Instance Methods
+
+### def each(*args) { ... } -> object
+
+[m:Enumerator.new] で使われるメソッドです。
+
+新しく生成した [c:Enumerator::Yielder] オブジェクトを先頭に、それ以降に引数 args
+を続けたものを引数として、[m:Enumerator.new] に渡したブロックを実行します。
+ブロックの実行結果をそのまま返します。
+


### PR DESCRIPTION
#1141 対応(Enumerator::Generator 分。Yielder は #2273 で追加済み)。

- `Enumerator::Generator` のページを新規追加しました。クラス説明は Yielder と同じ粒度で「Enumerator.new で内部的に使われるクラスで、直接使うものではありません」とし、`each` の説明(新しく生成した Yielder を先頭に、each への引数を続けたものを引数として Enumerator.new に渡したブロックを実行し、結果を返す)は ruby v3_4_0 の enumerator.c の `generator_each` 実装で確認した事実のみを記載しています。
- `Enumerator.md` 末尾の「ユーザが直接触れるべきではないのでドキュメントは書かない」コメントは、Yielder 追加(#2273)以降実態と合っていないため削除しました。

検証: 3.4/3.0 の scratch DB で markdowntree update(パース OK)し、`Enumerator::Generator#each` とクラス説明の render で compile error 0・body 非空を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
