### PR TITLE
Hash#each: Ruby 3.0 でのブロック引数の一貫化を記載

### DIFF
--- a/manual/api/_builtin/Hash.md
+++ b/manual/api/_builtin/Hash.md
@@ -928,6 +928,31 @@ each_pair は each のエイリアスです。
 p({:a=>1, :b=>2}.each_pair)  # => #<Enumerator: {:a=>1, :b=>2}:each_pair>
 ```
 
+Ruby 3.0 から、ブロックには常に `[key, value]` という2要素の配列が1つの引数として
+yield されるようになりました。通常のブロックでは `{|k, v| ... }` のように複数の仮引数を
+書けば配列が自動的に分解されるため、これまでと同様にキーと値を別々の引数として
+受け取れます。
+
+一方、`&` を使って lambda や [c:Method] オブジェクトをブロックとして渡す場合は
+この自動分解が行われません。そのため、2引数の lambda（`->(k, v) { ... }`）を渡すコードは、
+Ruby 2.7 までは動作していましたが、Ruby 3.0 以降は [c:ArgumentError] になります。
+1引数で配列として受け取るか、`->((k, v)) { ... }` のように仮引数を括弧で囲んで
+分解してください。
+
+```ruby title="例"
+# Ruby 2.7 まではこの書き方でも動作していましたが、Ruby 3.0 以降は ArgumentError になります
+{foo: 100}.each(&->(k, v) { p [k, v] })
+# => ArgumentError
+
+# 1引数で配列として受け取る
+{foo: 100}.each(&->(pair) { p pair })
+#=> [:foo, 100]
+
+# 仮引数を括弧で囲んで分解する
+{foo: 100}.each(&->((k, v)) { p [k, v] })
+#=> [:foo, 100]
+```
+
 - **SEE** [m:Hash#each_key],[m:Hash#each_value]
 
 ### def each_key {|key| ... } -> self


### PR DESCRIPTION
#2756 対応。

Ruby 3.0 の Hash#each の一貫化([Bug #12706](https://bugs.ruby-lang.org/issues/12706): ブロックには常に `[key, value]` の2要素配列が1つの引数として yield される)により、`&` で渡した2引数 lambda が ArgumentError になる件を `each`/`each_pair` の説明に追記します。

- 通常のブロックは複数の仮引数を書けば自動分解されるため従来どおり、という整理も明記。
- lambda に加えて Method オブジェクトでも同様であることを実測し、あわせて言及。
- 回避方法(1引数で配列として受け取る・`->((k, v))` のように仮引数を括弧で囲んで分解)を例付きで記載。

一次情報: v3_0_0 の NEWS.md の該当記述(`Hash#each consistently yields a 2-element array`)、およびローカル Ruby 3.4 での実測(2引数 lambda が ArgumentError、回避2形式の出力一致)。

検証: 3.4 scratch DB で `Hash#each` を render し compile error 0 を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
