### PR TITLE
TCPSocket.new/open: 3.0〜3.3 でも resolv_timeout を受理することを記載

### DIFF
--- a/manual/api/socket/TCPSocket.md
+++ b/manual/api/socket/TCPSocket.md
@@ -38,8 +38,8 @@ s.close
 ### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
 #@end
 #@until 3.4
-### def open(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
-### def new(host, service, local_host=nil, local_service=nil, connect_timeout: nil) -> TCPSocket
+### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
+### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
 #@end
 
 host で指定したホストの service で指定したポートと接続したソケッ
@@ -54,8 +54,10 @@ host で指定したホストの service で指定したポートと接続した
 - **param** `service` --        /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
 - **param** `local_host` --     ホスト名、またはインターネットアドレスを示す文字列を指定します。
 - **param** `local_service` --  /etc/services (または NIS) に登録されているサービス名かポート番号を指定します。
-#@if (version >= "3.4")
+#@since 3.4
 - **param** `resolv_timeout` -- 名前解決のタイムアウトを秒数で指定します。
+#@else
+- **param** `resolv_timeout` -- 指定してもエラーにはなりませんが、無視されます。名前解決のタイムアウトとして追加されました([feature:17134])が、対応する実装は Ruby 3.0 のリリース前に取り消され([bug:17220])、Ruby 3.4 で改めて有効になりました。
 #@end
 - **param** `connect_timeout` -- 接続確立のタイムアウトを秒数で指定します。
 #@if (version >= "4.0")


### PR DESCRIPTION
#2980 対応。

TCPSocket.new/open の `resolv_timeout` は [Feature #17134](https://bugs.ruby-lang.org/issues/17134) により Ruby 3.0 から受理されますが、getaddrinfo_a を使う実装が 3.0 リリース前に [Bug #17220](https://bugs.ruby-lang.org/issues/17220) で revert されたため、3.0〜3.3 では指定しても(エラーにならず)無視されます。ビルド依存ではなく無条件です。3.4 の Happy Eyeballs v2 実装で改めて有効になりました。

- `#@until 3.4` のシグネチャに `resolv_timeout: nil` を追加(tcp_init のキーワード順に合わせ `connect_timeout` の前)。
- param 説明を `#@since 3.4`(従来の「名前解決のタイムアウトを秒数で指定します。」)/`#@else`(受理されるが無視される旨+経緯のリンク)で書き分け。経緯のリンクは `[feature:17134]`/`[bug:17220]` 記法を使用。

一次情報: v3_0_0/v3_3_0 の ext/socket/tcpsocket.c(`rb_get_kwargs` で resolv_timeout を受理)・ext/socket/ipsocket.c(受理した resolv_timeout を一切参照しない)、revert コミット 5d8bcc4870(v3.0.0 タグより前)、v3_0_0 の NEWS.md(connect_timeout のみ記載・resolv_timeout の記載なし)、v3_4_0 の ipsocket.c(HEv2 で使用)。

検証: 3.0/3.4 の scratch DB で render し、3.0 では「無視されます」注記・3.4 では従来説明+fast_fallback が出ること、compile error 0 を確認済み(Preprocessor でも 3.0/3.3/3.4/4.0 の gating を実測)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
