### PR TITLE
Object#methods と Object#method に関連メソッドのまとめ表を追加

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -176,6 +176,24 @@ p obj.protected_methods(true) - Object.protected_instance_methods(true)
 [:protected_singleton, :protected_foo, :protected_parent]
 ```
 
+メソッド名一覧を取得するメソッド同士の対比は次のとおりです。[m:Object#methods] 系はレシーバ自身が応答できるメソッド（特異メソッドを含む）を対象にするのに対し、[m:Module#instance_methods] 系はクラス・モジュールが持つインスタンスメソッド（特異メソッドは含まない）を対象にします。
+
+| メソッド | 対象 | 含まれる可視性 | 特異メソッド |
+| --- | --- | --- | --- |
+| [m:Object#methods] | レシーバ | public, protected | 含む |
+| [m:Object#public_methods] | レシーバ | public | 含む |
+| [m:Object#private_methods] | レシーバ | private | 含む |
+| [m:Object#protected_methods] | レシーバ | protected | 含む |
+| [m:Object#singleton_methods] | レシーバ | public, protected | 特異メソッドのみ |
+| [m:Module#instance_methods] | self のインスタンス | public, protected | 含まない |
+| [m:Module#public_instance_methods] | self のインスタンス | public | 含まない |
+| [m:Module#private_instance_methods] | self のインスタンス | private | 含まない |
+| [m:Module#protected_instance_methods] | self のインスタンス | protected | 含まない |
+
+継承したメソッドを含めるかどうかなどを引数で制御できますが、引数の意味はメソッドごとに
+異なります（[m:Object#methods] は引数が false のとき特異メソッドのみを返します）。
+詳細は各メソッドの説明を参照してください。
+
 - **SEE** [m:Module#instance_methods],[m:Object#singleton_methods]
 
 ### def public_method(name) -> Method
@@ -1327,6 +1345,18 @@ me = -365.method(:abs)
 p me #=> #<Method: Integer#abs>
 p me.call #=> 365
 ```
+
+[c:Method]・[c:UnboundMethod] オブジェクトを取得するメソッドの対比は次のとおりです。
+
+| メソッド | 対象 | 可視性の制限 | 返り値 |
+| --- | --- | --- | --- |
+| [m:Object#method] | レシーバのメソッド（特異メソッドを含む） | なし | [c:Method] |
+| [m:Object#public_method] | レシーバのメソッド（特異メソッドを含む） | public のみ | [c:Method] |
+| [m:Object#singleton_method] | レシーバの特異メソッドのみ | なし | [c:Method] |
+| [m:Module#instance_method] | self のインスタンスメソッド | なし | [c:UnboundMethod] |
+| [m:Module#public_instance_method] | self のインスタンスメソッド | public のみ | [c:UnboundMethod] |
+
+[c:UnboundMethod] はレシーバに束縛されていない状態のメソッドオブジェクトです。[m:UnboundMethod#bind] でレシーバに束縛すると [c:Method] になり、逆に [m:Method#unbind] で [c:UnboundMethod] に戻せます。
 
 - **SEE** [m:Module#instance_method], [c:Method], [m:BasicObject#__send__], [m:Object#send], [m:Kernel?.eval], [m:Object#singleton_method]
 


### PR DESCRIPTION
#2285 対応。

「メソッド名一覧を取得するメソッド」「Method/UnboundMethod オブジェクトを取得するメソッド」の対比のまとめを、最も代表的な Object#methods と Object#method の節に表として追加します(issue 提案の Method/UnboundMethod 側にまとめページを作る方式ではなく、代表メソッドの節に集約する方式)。

- **Object#methods の節**: methods/public_methods/private_methods/protected_methods/singleton_methods と Module#instance_methods 系(4種)の対比表(対象・含まれる可視性・特異メソッドの有無)。引数の意味がメソッドごとに異なる旨の注意(methods は false のとき特異メソッドのみを返す)も明記。
- **Object#method の節**: method/public_method/singleton_method と Module#instance_method/public_instance_method の対比表(可視性の制限・返り値が Method か UnboundMethod か)、および UnboundMethod#bind / Method#unbind による相互変換の一文。

表の内容は Ruby 3.4 で実測して確認しています(method/instance_method は private/protected も取得可・public_method/public_instance_method は NameError・singleton_method は可視性を問わず特異メソッドのみ・methods(false)=singleton_methods(false) など)。

コミットには `fix #2285` を入れています(まとめ作成をもって解決とする想定です。issue を open のまま残す場合はマージ前にコミットメッセージの調整が必要です)。

検証: 3.4 scratch DB(markdowntree)で render し、GFM 表の `<table>` 出力・compile error 0 を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
