### PR TITLE
String.new: capacity の説明を実装に即して修正

### DIFF
--- a/manual/api/_builtin/String.md
+++ b/manual/api/_builtin/String.md
@@ -195,9 +195,7 @@ p String.try_convert(/re/)    # => nil
 ```
 
 ### def new(string = "")                -> String
-#@# capacityのデフォルトのサイズは STR_BUF_MIN_SIZE。string.c 参照。
-### def new(string = "", encoding: string.encoding, capacity: 63) -> String
-### def new(string = "", encoding: string.encoding, capacity: string.bytesize) -> String
+### def new(string = "", encoding: string.encoding, capacity: Integer) -> String
 
 string と同じ内容の新しい文字列を作成して返します。
 引数を省略した場合は空文字列を生成して返します。
@@ -212,8 +210,12 @@ string と同じ内容の新しい文字列を作成して返します。
                 指定することで、なんども文字列連結する
                 (そしてreallocがなんども呼ばれる)ときの
                 パフォーマンスが改善されるかもしれません。
-                省略した場合、引数stringのバイト数が127未満であれば127、
-                それ以上であればstring.bytesizeになります。
+                capacity を指定しても文字列の内容や
+                [m:String#bytesize] が変わるわけではありません。
+                内部バッファの実際の確保方法は実装依存です。
+                特に短い文字列はオブジェクトに直接埋め込まれる表現に
+                なって独立したバッファを持たないなど、指定が反映され
+                ない場合もあります。
 - **return** --         引数 string と同じ内容の文字列オブジェクト
 
 ```ruby title="例"


### PR DESCRIPTION
#2794 対応。

String.new の `capacity` の「省略した場合、引数stringのバイト数が127未満であれば127、それ以上であればstring.bytesizeになります」という説明は実態と異なるため、実装に即した記述に修正します。

- **説明文**: capacity は内部バッファのサイズ指定であり文字列の内容や bytesize は変えないこと、内部バッファの実際の確保方法は実装依存で、短い文字列はオブジェクトに直接埋め込まれる表現になって独立したバッファを持たないなど指定が反映されない場合があること、を記載。
- **シグネチャ**: 擬似デフォルト `capacity: 63` / `capacity: string.bytesize` は実際には起こらない(issue 報告者も削除を提案)ため、既存慣例([m:Array#sample] の `random: Random` と同形式)に合わせて `capacity: Integer` に置き換え。あわせて古い内部コメント(`STR_BUF_MIN_SIZE`)も削除。

一次情報: v3_0_0〜v3_2_1 の string.c(`rb_str_init`: 指定時は 63 に切り上げ+常に非 embed)と v3_3_0 以降の `rb_str_s_new`(下限なし・VWA で embed になり得る)を確認。省略時はどのバージョンでも embed か shared 表現になり「127 や string.bytesize の capa」にはならないため、この修正自体に版分岐は不要と判断。Ruby 3.4.8 の `ObjectSpace.dump` でも実測(embedded/shared/capacity キーの有無)。

検証: 3.4 scratch DB render で compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
