### PR TITLE
JSON::State: 実体が JSON::Ext::Generator::State である旨を明記

### DIFF
--- a/manual/api/json/JSON__State.md
+++ b/manual/api/json/JSON__State.md
@@ -8,6 +8,10 @@ alias:
 Ruby オブジェクトから JSON 形式の文字列を生成する間、
 JSON 形式の文字列を生成するための設定を保持しておくために使用するクラスです。
 
+実体は [c:JSON::Ext::Generator::State] であり、JSON::State はそれを指す別名(定数)です。
+そのため、生成したインスタンスの `class` メソッドや `inspect` の結果には
+`JSON::Ext::Generator::State` と表示されます。
+
 ## Singleton Methods
 
 ### def new(options = {}) -> JSON::State


### PR DESCRIPTION
#1564 対応。

issue コメントでの sho-h さんの方針(pure には変更できないので構造は今のまま、短い説明で alias に触れる)に沿って、`JSON::State` のページ冒頭に「実体は [c:JSON::Ext::Generator::State] であり、JSON::State はそれを指す別名(定数)である」旨と、そのため `class` や `inspect` の結果には JSON::Ext::Generator::State が現れることを追記します。front matter の `alias:` 構造や既存のコード例は変更しません。

実測(Ruby 3.4.8・json 2.20.0): `JSON::State.equal?(JSON::Ext::Generator::State)` が true、`JSON::State.name` は "JSON::Ext::Generator::State"。json gem の `lib/json/common.rb` でも `const_set :State, generator::State` を確認。`JSON::Pure` は現行 gem に存在しないため歴史的経緯には触れていません。

検証: 3.4 scratch DB render で compile error 0・[c:JSON::Ext::Generator::State] リンクが alias として解決されることを確認。

フォローアップ候補(この PR では未対応): 同ファイルに英語のまま残っている説明が複数あります(`quirks_mode` 系・`buffer_initial_length` 系・`[]`/`[]=`・`generate` など約10箇所)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
