### PR TITLE
rake: サンプルコードの値を p で出力するように変更

### DIFF
--- a/manual/api/rake/Rake__FileList.md
+++ b/manual/api/rake/Rake__FileList.md
@@ -45,14 +45,14 @@ file_list.include %w( math.c lib.h *.o )
 
 例:
 `````
-FileList['a.c', 'b.c'].exclude("a.c") # => ['b.c']
-FileList['a.c', 'b.c'].exclude(/^a/)  # => ['b.c']
+p FileList['a.c', 'b.c'].exclude("a.c") # => ["b.c"]
+p FileList['a.c', 'b.c'].exclude(/^a/)  # => ["b.c"]
 
 # If "a.c" is a file, then ...
-FileList['a.c', 'b.c'].exclude("a.*") # => ['b.c']
+p FileList['a.c', 'b.c'].exclude("a.*") # => ["b.c"]
 
 # If "a.c" is not a file, then ...
-FileList['a.c', 'b.c'].exclude("a.*") # => ['a.c', 'b.c']
+p FileList['a.c', 'b.c'].exclude("a.*") # => ["a.c", "b.c"]
 `````
 
 ### def clear_exclude -> self
@@ -165,7 +165,7 @@ FileList['a.c', 'b.c'].sub(/\.c$/, '.o')  => ['a.o', 'b.o']
 
 例:
 ``````
-FileList['lib/test/file', 'x/y'].gsub(/\//, "\\") # => ['lib\\test\\file', 'x\\y']
+p FileList['lib/test/file', 'x/y'].gsub(/\//, "\\") # => ["lib\\test\\file", "x\\y"]
 ``````
 
 ### def sub!(pattern, replace) -> self
@@ -261,7 +261,7 @@ task :test_rake_app do
   p file_list.egrep(/line/) # => 7
 
   file_list.egrep(/.*/) do |filename, count, line|
-    "filename = #{filename}, count = #{count}, line = #{line}"
+    p "filename = #{filename}, count = #{count}, line = #{line}"
   end
 end
 

--- a/manual/api/rake/String.md
+++ b/manual/api/rake/String.md
@@ -66,14 +66,14 @@ p 'a/b/c/d/file.txt'.pathmap("%-2d") # => 'c/d'
 中括弧、コンマ、セミコロンはパターンと置換文字列に使用しないでください。
 
 ```ruby title="例"
-"src/org/onestepback/proj/A.java".pathmap("%{^src,bin}X.class")
+p "src/org/onestepback/proj/A.java".pathmap("%{^src,bin}X.class")
 #=> "bin/org/onestepback/proj/A.class"
 ```
 
 置換文字列に '*' を指定した場合は、置換文字列を計算するためにブロックを評価します。
 
 ```ruby title="例"
-"/path/to/file.TXT".pathmap("%X%{.*,*}x") { |ext| ext.downcase }
+p "/path/to/file.TXT".pathmap("%X%{.*,*}x") { |ext| ext.downcase }
 #=> "/path/to/file.txt"
 ```
 

--- a/manual/api/rake/packagetask.md
+++ b/manual/api/rake/packagetask.md
@@ -65,7 +65,7 @@ require:
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.name # => "sample"
+  p package_task.name # => "sample"
 end
 ```
 
@@ -80,9 +80,9 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.name # => "sample"
+  p package_task.name # => "sample"
   package_task.name = "update"
-  package_task.name # => "update"
+  p package_task.name # => "update"
 end
 ```
 
@@ -96,7 +96,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar # => false
+  p package_task.need_tar # => false
 end
 ```
 
@@ -111,9 +111,9 @@ gzip した tar ファイル (tgz) を作成するかどうかを設定します
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar # => false
+  p package_task.need_tar # => false
   package_task.need_tar = true
-  package_task.need_tar # => true
+  p package_task.need_tar # => true
 end
 ```
 
@@ -127,7 +127,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar_bz2 # => false
+  p package_task.need_tar_bz2 # => false
 end
 ```
 
@@ -142,9 +142,9 @@ bzip2 した tar ファイル (tar.bz2) を作成するかどうかを設定し�
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar_bz2 # => false
+  p package_task.need_tar_bz2 # => false
   package_task.need_tar_bz2 = true
-  package_task.need_tar_bz2 # => true
+  p package_task.need_tar_bz2 # => true
 end
 ```
 
@@ -158,7 +158,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar_gz # => false
+  p package_task.need_tar_gz # => false
 end
 ```
 
@@ -173,9 +173,9 @@ gzip した tar ファイル (tar.gz) を作成するかどうかを設定しま
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_tar_gz # => false
+  p package_task.need_tar_gz # => false
   package_task.need_tar_gz = true
-  package_task.need_tar_gz # => true
+  p package_task.need_tar_gz # => true
 end
 ```
 
@@ -189,7 +189,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_zip # => false
+  p package_task.need_zip # => false
 end
 ```
 
@@ -204,9 +204,9 @@ zip ファイル (tgz) を作成するかどうかを設定します。
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.need_zip # => false
+  p package_task.need_zip # => false
   package_task.need_zip = true
-  package_task.need_zip # => true
+  p package_task.need_zip # => true
 end
 ```
 
@@ -219,7 +219,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.package_dir # => "pkg"
+  p package_task.package_dir # => "pkg"
 end
 ```
 
@@ -234,9 +234,9 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.package_dir # => "pkg"
+  p package_task.package_dir # => "pkg"
   package_task.package_dir = "package"
-  package_task.package_dir # => "package"
+  p package_task.package_dir # => "package"
 end
 ```
 
@@ -249,7 +249,7 @@ end
 require 'rake/packagetask'
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.package_dir_path # => "pkg/sample-1.0.0"
+  p package_task.package_dir_path # => "pkg/sample-1.0.0"
 end
 ```
 
@@ -265,9 +265,9 @@ IO.write("test1.rb", "test")
 IO.write("test2.rb", "test")
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.package_files # => []
+  p package_task.package_files # => []
   package_task.package_files.include("*.rb")
-  package_task.package_files # => ["test1.rb", "test2.rb"]
+  p package_task.package_files # => ["test1.rb", "test2.rb"]
 end
 ```
 
@@ -285,9 +285,9 @@ IO.write("test1.rb", "test")
 IO.write("test2.rb", "test")
 
 Rake::PackageTask.new("sample", "1.0.0") do |package_task|
-  package_task.package_files # => []
+  p package_task.package_files # => []
   package_task.package_files = FileList.new("test1.rb", "test2.rb")
-  package_task.package_files # => ["test1.rb", "test2.rb"]
+  p package_task.package_files # => ["test1.rb", "test2.rb"]
 end
 ```
 


### PR DESCRIPTION
#2229 対応。

Rakefile にコピペして実行しても何も出力されない例(`# =>` 注釈のみの式)を、`p` で実際に出力するように変更します。

- 対象の洗い出し: `# =>` 注釈を持つ rake 配下 15ファイルを全て確認。うち11ファイルは既に全例が `p`/`pp`/`puts` 済みで変更不要でした。
- 変更したのは `Rake__FileList.md`(6行)・`String.md`(pathmap 2行)・`packagetask.md`(23行)の計31行。
- `p` の出力は inspect 表現になるため、注釈の引用符もあわせて修正(`['b.c']` → `["b.c"]` など)。値は rake 13.4.2 で実測して確認。
- スキップ(理由付き): 例外が発生する例(`p` が無意味)、代入だけの行、`rake -T` のシェル出力の書き起こし、`puts` 済みの副作用出力の注釈。

フォローアップ候補(この PR では未対応・既に `p` 済みの行のため): 注釈がシングルクォートのまま inspect 表現と食い違っている既存箇所が数件あります(`FileUtils.md:62`・`Rake__FileList.md:182-183`・`String.md:54-55`)。

検証: 3.4 scratch DB render(FileList#exclude/#egrep/#gsub・PackageTask#name/#package_files・String#pathmap)で compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
