### PR TITLE
実行例の Proc/Thread の inspect 表記を 2.7 以降の形式に更新

### DIFF
--- a/manual/api/_builtin/Proc.md
+++ b/manual/api/_builtin/Proc.md
@@ -249,7 +249,7 @@ p Proc.new {
    true
 }.to_s
 
-# => "#<Proc:0x0x401a880c@-:3>"
+# => "#<Proc:0x401a880c -:3>"
 ```
 
 ### def curry         -> Proc

--- a/manual/api/_builtin/Signal.md
+++ b/manual/api/_builtin/Signal.md
@@ -69,8 +69,8 @@ end
 ```ruby title="例"
 p Signal.trap(:INT, "p true")     # => "DEFAULT"
 p Signal.trap(:INT) { p false }   # => "p true"
-p Signal.trap(:INT, proc{ p nil })  # => #<Proc:0x8e45ae0@-:2>
-p Signal.trap(:INT, "SIG_IGN")    # => #<Proc:0x8e45914@-:3>
+p Signal.trap(:INT, proc{ p nil })  # => #<Proc:0x8e45ae0 -:2>
+p Signal.trap(:INT, "SIG_IGN")    # => #<Proc:0x8e45914 -:3>
 p Signal.trap(:INT, "DEFAULT")    # => "IGNORE"
 p Signal.trap(:INT, "EXIT")       # => "DEFAULT"
 p Signal.trap(:INT, nil)          # => "EXIT"

--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -580,17 +580,17 @@ a = Thread.new{ Thread.stop; raise }
 a.report_on_exception = true
 a.report_on_exception   # => true
 a.run
-# => #<Thread:0x00007fc3f48c7908@(irb):1 run> terminated with exception (report_on_exception is true):
+# => #<Thread:0x00007fc3f48c7908 (irb):1 run> terminated with exception (report_on_exception is true):
 #    Traceback (most recent call last):
 #@since 3.4
 #    (irb):1:in 'block in irb_binding': unhandled exception
 #@else
 #    (irb):1:in `block in irb_binding': unhandled exception
 #@end
-#    #<Thread:0x00007fc3f48c7908@(irb):1 dead>
+#    #<Thread:0x00007fc3f48c7908 (irb):1 dead>
 b = Thread.new{ Thread.stop; raise }
 b.report_on_exception = false
-b.run   # => #<Thread:0x00007fc3f48aefc0@(irb):4 dead>
+b.run   # => #<Thread:0x00007fc3f48aefc0 (irb):4 dead>
 ```
 
 - **SEE** [m:Thread.report_on_exception]
@@ -906,7 +906,7 @@ c.join
 a = Thread.current
 a.inspect   # => "#<Thread:0x00007fdbaf07ddb0 run>"
 b = Thread.new{}
-b.inspect   # => "#<Thread:0x00007fdbaf8f7d10@(irb):3 dead>"
+b.inspect   # => "#<Thread:0x00007fdbaf8f7d10 (irb):3 dead>"
 ```
 
 ### def add_trace_func(pr) -> Proc
@@ -1140,7 +1140,7 @@ self の名前を name に設定します。
 a = Thread.new{}
 a.name = 'named'
 a.name      # => "named"
-a.inspect   # => "#<Thread:0x00007f85ac8721f0@named@(irb):1 dead>"
+a.inspect   # => "#<Thread:0x00007f85ac8721f0@named (irb):1 dead>"
 ```
 
 - **SEE** [m:Thread#name]

--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -2308,7 +2308,7 @@ untrace_var(:$v,block)
 $v = 'str'        #=> hookA."str",
 
 trace_var(:$v){|val| print "hookC.#{val.inspect}," }
-p untrace_var(:$v) #=> [#<Proc:0x02b68f58@..:9>, #<Proc:0x02b6978c@..:3>]
+p untrace_var(:$v) #=> [#<Proc:0x02b68f58 ..:9>, #<Proc:0x02b6978c ..:3>]
 $v = 'str'        # なにも出力されない
 ```
 

--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -289,7 +289,7 @@ IRB::Context オブジェクトを渡して実行します。
 ```console
 $ irb
 irb(main):001:0> IRB.conf[:IRB_RC] = lambda {|conf| conf.prompt_i = "> " }
-=> #<Proc:0x00002a95fa3fd8@(irb):2>
+=> #<Proc:0x00002a95fa3fd8 (irb):2 (lambda)>
 irb(main):002:0> irb
 >
 ```

--- a/manual/api/logger/Logger.md
+++ b/manual/api/logger/Logger.md
@@ -490,7 +490,7 @@ ltsv_formatter = proc { |severity, timestamp, progname, msg|
   "time:#{timestamp}\tlevel:#{severity}\tprogname:#{progname}\tmessage:#{msg}\n"
 }
 logger.formatter = ltsv_formatter
-p logger.formatter # => #<Proc:0x00007fa3048b8e00@/path/to/file:8>
+p logger.formatter # => #<Proc:0x00007fa3048b8e00 /path/to/file:8>
 logger.info("MyApp") { "test" }
 
 # => time:2019-05-09 22:13:56 +0900 level:INFO  progname:MyApp  message:test

--- a/manual/doc/spec/def.md
+++ b/manual/doc/spec/def.md
@@ -428,7 +428,7 @@ f("a", "b", "c", 2, 3, "foo", "bar", "baz", "x", "y", "z", k: 42, u: "unknown") 
   #   z: "z"
   #   k: 42
   #   kwrest: {:u=>"unknown"}
-  #   blk: #<Proc:0x007f7e7d8dd6c0@-:16>
+  #   blk: #<Proc:0x007f7e7d8dd6c0 -:16>
 ```
 
 ```ruby title="例: イテレータの定義"


### PR DESCRIPTION
#2142 対応。

Ruby 2.7 で `Proc#to_s`/`Proc#inspect`(および Thread の inspect)の位置情報の区切りが `@` からスペースに変わりました([feature:16101]、PR #1804 のレビュー指摘が発端)。対応バージョンは 3.0 以降のみなので、版分岐なしで旧表記が残る実行例を更新します。

- 対象7ファイル: `_builtin/Signal.md`・`_builtin/functions.md`(untrace_var)・`_builtin/Proc.md`・`_builtin/Thread.md`(5箇所)・`irb.md`・`logger/Logger.md`(issue の発端箇所)・`doc/spec/def.md`。
- **Thread の名前区切りの `@` は変更されていない**ため保持(`#<Thread:0x...@named (irb):1 dead>` — 実行して確認)。
- `irb.md` の例は lambda なので、現行 inspect が付ける `(lambda)` マーカーも補いました(実際の irb で確認)。`Proc.md` の例にあった `0x0x` タイポも修正。
- 変更は出力コメント・出力例のみで、コード本体は不変。`manual/doc/news/*` は当時の記録のため対象外。

スコープ外として残したもの: `TracePoint.md` の inspect 表記は 3.4 でさらに別の変更(`@` 全廃+引用符変更)が入っており、#2142 の範囲を超えるため未修正(フォローアップ候補)。`RubyVM::AbstractSyntaxTree::Node` の `@row:col` は現行も `@` のままで対象外。

検証: `git grep -E '0x[0-9a-fA-F]+@' manual/`(news 除く)の残存は Thread の名前区切り1件のみ(意図どおり)。3.4 scratch DB で touched エントリ render・compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
