### PR TITLE
Gem::Specification.stubs / stubs_for を追加

### DIFF
--- a/manual/api/rubygems/specification.md
+++ b/manual/api/rubygems/specification.md
@@ -695,6 +695,37 @@ YAML 形式の gemspec を正しくフォーマットします。
 
 必須属性のリストを返します。
 
+### def stubs -> Array
+
+インストールされている全ての Gem の情報を、Gem::StubSpecification（gemspec ファイルの内容を遅延読み込みする軽量なスタブオブジェクト）の配列として返します。
+
+[m:Gem::Specification.list] とは異なり、gemspec ファイルの内容を実際に読み込まずにスタブを生成するため、高速に動作します。
+
+```ruby title="例"
+p Gem::Specification.stubs.first(3).map(&:class)
+# => [Gem::StubSpecification, Gem::StubSpecification, Gem::StubSpecification]
+
+p Gem::Specification.stubs.first.name
+# => "abbrev"
+```
+
+- **SEE** [m:Gem::Specification.list], [m:Gem::Specification.stubs_for]
+
+### def stubs_for(name) -> Array
+
+指定した名前を持つ Gem の Gem::StubSpecification の配列を返します。
+
+[m:Gem::Specification.stubs] と同様、gemspec ファイルの内容を遅延読み込みするスタブオブジェクトを返すため高速に動作します。
+
+- **param** `name` -- Gem の名前を文字列で指定します。
+
+```ruby title="例"
+p Gem::Specification.stubs_for("abbrev").map(&:name)
+# => ["abbrev"]
+```
+
+- **SEE** [m:Gem::Specification.stubs]
+
 
 ## Constants
 


### PR DESCRIPTION
#2006 対応(残り分)。

issue の2つの指摘のうち、廃止クラス(Gem::GemPathSearcher/Gem::SourceIndex)の掲載は既に解消済みで、残っていた `Gem::Specification.stubs` の未掲載を解消します。

- `Gem::Specification.stubs` と `Gem::Specification.stubs_for(name)` を Singleton Methods に追加(既存の `list` の書式に準拠)。
- gemspec を実際に読み込まず軽量なスタブとして列挙するため高速、という `list` との違いを明記。
- 返り値の `Gem::StubSpecification` は doctree に未文書化のため、`[c:]` リンクにせず地の文で説明(リンク切れ回避)。返り値表記は既存慣例に合わせ `-> Array`。
- 挙動・例は Ruby 3.4.8(rubygems 3.6.9)で実測(v3_4_0 の lib/rubygems/specification.rb のシグネチャとも突き合わせ)。

rubygems ドキュメント全体の現行 API への追従は別途大きな作業として残りますが、issue #2006 が具体的に挙げていた項目はこれで両方解消です。

検証: 3.4 scratch DB で両エントリ render・compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
