### PR TITLE
rake: p 済みの例の注釈を inspect 表現に合わせる

### DIFF
--- a/manual/api/rake/FileUtils.md
+++ b/manual/api/rake/FileUtils.md
@@ -59,6 +59,6 @@ ruby %{-pe '$_.upcase!' <README}
 - **param** `path` -- 分割するパスを指定します。
 
 ```ruby title="例"
-p split_all("a/b/c") # =>  ['a', 'b', 'c']
+p split_all("a/b/c") # => ["a", "b", "c"]
 ```
 

--- a/manual/api/rake/Rake__FileList.md
+++ b/manual/api/rake/Rake__FileList.md
@@ -179,8 +179,8 @@ p FileList['lib/test/file', 'x/y'].gsub(/\//, "\\") # => ["lib\\test\\file", "x\
 task default: :test_rake_app
 task :test_rake_app do
   file_list = FileList['a.c', 'b.c']
-  p file_list.sub!(/\.c$/, '.o') # => ['a.o', 'b.o']
-  p file_list                  # => ['a.o', 'b.o']
+  p file_list.sub!(/\.c$/, '.o') # => ["a.o", "b.o"]
+  p file_list                  # => ["a.o", "b.o"]
 end
 ```
 

--- a/manual/api/rake/String.md
+++ b/manual/api/rake/String.md
@@ -51,8 +51,8 @@ p "hoge.tar.gz".ext(".bz2")  # => "hoge.tar.bz2"
 %d は数値のプレフィクスを取ることができます。
 
 ```ruby title="例"
-p 'a/b/c/d/file.txt'.pathmap("%2d")  # => 'a/b'
-p 'a/b/c/d/file.txt'.pathmap("%-2d") # => 'c/d'
+p 'a/b/c/d/file.txt'.pathmap("%2d")  # => "a/b"
+p 'a/b/c/d/file.txt'.pathmap("%-2d") # => "c/d"
 ```
 
 また、%d, %p, %f, %n, %x, %X には単純な文字列置換を行うための


### PR DESCRIPTION
#2229(クローズ済み)/#3147 のフォローアップ(独立 issue なし)。

#3147 の本文でフォローアップ候補として挙げていた、「既に `p` している例なのに `# =>` 注釈がシングルクォートのまま inspect 表現と食い違っている」3ファイル5行を修正します。

- `rake/FileUtils.md`: `p split_all("a/b/c") # => ["a", "b", "c"]`(余分な空白も整理)
- `rake/Rake__FileList.md`: `FileList#sub!` の例2行 → `["a.o", "b.o"]`
- `rake/String.md`: `pathmap("%2d")`/`("%-2d")` の2行 → `"a/b"`/`"c/d"`

いずれも rake 13.4.2 で実測した出力と一致することを確認済み。

検証: 3.4 scratch DB で該当エントリ render・compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
