### PR TITLE
bitclust を dynamic include 表示対応(#249)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 65468f3d8f86231b5bb702ddba4a051f4fbf0269
+  revision: a1e43a5aee2959c8451e65ae31987ad842603a90
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
#2338 対応(rurema/bitclust#249 マージの反映)。

bitclust 側で dynamic include(`# reopen` + front matter `include:`)されたモジュールのメソッドをクラスページに表示できるようになった(rurema/bitclust#248 → #249)ため、Gemfile.lock の bitclust を該当マージコミット(a1e43a5)にバンプします。

これにより json の to_json(Array/Hash/String/Integer/Float/NilClass/TrueClass/FalseClass/Object)、open-uri の OpenURI::OpenRead#open/read(URI::HTTP/URI::FTP)、rake の RakeFileUtils の各メソッドが、対象クラスのページに「動的includeで追加されるメソッド」として(by ライブラリ名)付きで表示されます(bitclust 側で doctree 実データ・4テンプレートの表示を検証済み)。サイトへの反映は次の生成からです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
