### PR TITLE
旧環境の実行例トランスクリプトを現行 Ruby の出力に更新

### DIFF
--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -225,13 +225,15 @@ irb(main):004:0> x = "OK"          # ローカル変数 x を定義
 irb(main):005:0> x                 # x を表示
 => "OK"
 irb(main):006:0> irb               # サブ irb を起動
+Multi-irb commands are deprecated and will be removed in IRB 2.0.0. Please use workspace commands instead.
+If you have any use case for multi-irb, please leave a comment at https://github.com/ruby/irb/issues/653
 irb#1(main):001:0> x               # x を表示
 #@since 3.4
-NameError: undefined local variable or method 'x' for main:Object
-        from (irb#1):1:in 'Kernel#binding'
+(irb#1):1:in '<top (required)>': undefined local variable or method 'x' for main (NameError)
+        from <internal:kernel>:168:in 'Kernel#loop'
 #@else
-NameError: undefined local variable or method `x' for main:Object
-        from (irb#1):1:in `Kernel#binding'
+(irb#1):1:in `<top (required)>': undefined local variable or method `x' for main (NameError)
+        from <internal:kernel>:187:in `loop'
 #@end
 ```
 
@@ -239,6 +241,11 @@ NameError: undefined local variable or method `x' for main:Object
 「irb」でサブ irb を起動すると、
 ローカル変数 x が見えなくなっています。
 これが「独立した環境」の意味です。
+
+なお、「irb」コマンドによるサブ irb の起動(multi-irb)は非推奨となっており、
+将来の IRB 2.0.0 で削除される予定です。
+今後は後述の「irb で使用可能なコマンド一覧」にある workspace 関連のコマンド
+(`cws`、`pushws` など)の利用が推奨されています。
 
 ### サブ irb の設定 {#configure_sub_irb}
 
@@ -592,9 +599,9 @@ foo = 0
 ```irb
 irb(main):001:0> eval "foo"
 #@since 3.4
-NameError (undefined local variable or method 'foo' for main:Object)
+NameError (undefined local variable or method 'foo' for main)
 #@else
-NameError (undefined local variable or method `foo' for main:Object)
+NameError (undefined local variable or method `foo' for main)
 #@end
 irb(main):002:0> foo = 0
 ```

--- a/manual/api/optparse/optparse-tut.md
+++ b/manual/api/optparse/optparse-tut.md
@@ -81,27 +81,11 @@ p argv
 ```console
 ruby ./sample.rb -c
 #@since 3.4
-/usr/local/lib/ruby/1.9/optparse.rb:1428:in 'complete': invalid option: -c (OptionParser::InvalidOption)
-        from /usr/local/lib/ruby/1.9/optparse.rb:1426:in 'catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1426:in 'complete'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1287:in 'order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in 'catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in 'order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1336:in 'permute!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1363:in 'parse!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1356:in 'parse'
-        from ./sample.rb:9
+./sample.rb:7:in '<main>': invalid option: -c (OptionParser::InvalidOption)
+./sample.rb:7:in '<main>': invalid option: c (OptionParser::InvalidOption)
 #@else
-/usr/local/lib/ruby/1.9/optparse.rb:1428:in `complete': invalid option: -c (OptionParser::InvalidOption)
-        from /usr/local/lib/ruby/1.9/optparse.rb:1426:in `catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1426:in `complete'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1287:in `order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in `catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in `order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1336:in `permute!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1363:in `parse!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1356:in `parse'
-        from ./sample.rb:9
+./sample.rb:7:in `<main>': invalid option: -c (OptionParser::InvalidOption)
+./sample.rb:7:in `<main>': invalid option: c (OptionParser::InvalidOption)
 #@end
 ```
 
@@ -187,21 +171,9 @@ ruby sample.rb -a foo bar -b baz
 ```console
 ruby ./sample.rb -a
 #@since 3.4
-/usr/local/lib/ruby/1.9/optparse.rb:455:in 'parse': missing argument: -a (OptionParser::MissingArgument)
-        from /usr/local/lib/ruby/1.9/optparse.rb:1295:in 'order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in 'catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in 'order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1336:in 'permute!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1363:in 'parse!'
-        from ./sample.rb:7
+./sample.rb:7:in '<main>': missing argument: -a (OptionParser::MissingArgument)
 #@else
-/usr/local/lib/ruby/1.9/optparse.rb:455:in `parse': missing argument: -a (OptionParser::MissingArgument)
-        from /usr/local/lib/ruby/1.9/optparse.rb:1295:in `order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in `catch'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1256:in `order!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1336:in `permute!'
-        from /usr/local/lib/ruby/1.9/optparse.rb:1363:in `parse!'
-        from ./sample.rb:7
+./sample.rb:7:in `<main>': missing argument: -a (OptionParser::MissingArgument)
 #@end
 ```
 

--- a/manual/api/rexml/validation/relaxng.md
+++ b/manual/api/rexml/validation/relaxng.md
@@ -25,7 +25,7 @@ relaxng_schema = <<RELAXNG
       </optional>
     </element>
   </zeroOrMore>
-<element>
+</element>
 RELAXNG
 
 xml = <<XML
@@ -46,28 +46,28 @@ parser = REXML::Parsers::TreeParser.new(xml)
 parser.add_listener(validator)
 parser.parse
 #@since 3.4
-# ~> /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/validation/validation.rb:22:in 'validate': Validation error.  Expected: :start_element(  ) or :start_element( card ) from < Z.2 #:start_element( card ), :start_element( name ), :text(  ), :end_element(  ), :start_element( email ), :text(  ), :end_element(  ), < O.3 #:start_element( note ), :text(  ), :end_element(  ) >, :end_element(  ) >  but got :text(  (REXML::Validation::ValidationException)
+# ~> /path/to/gems/rexml-3.4.4/lib/rexml/validation/validation.rb:21:in 'REXML::Validation::Validator#validate': Validation error.  Expected: :end_element(  ) or :start_element( card ) from < Z.2 #:start_element( card ), :start_element( name ), :text(  ), :end_element(  ), :start_element( email ), :text(  ), :end_element(  ), < O.3 #:start_element( note ), :text(  ), :end_element(  ) >, :end_element(  ) >  but got :text(  (REXML::Validation::ValidationException)
 #@else
-# ~> /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/validation/validation.rb:22:in `validate': Validation error.  Expected: :start_element(  ) or :start_element( card ) from < Z.2 #:start_element( card ), :start_element( name ), :text(  ), :end_element(  ), :start_element( email ), :text(  ), :end_element(  ), < O.3 #:start_element( note ), :text(  ), :end_element(  ) >, :end_element(  ) >  but got :text(  (REXML::Validation::ValidationException)
+# ~> /path/to/gems/rexml-3.3.9/lib/rexml/validation/validation.rb:21:in `validate': Validation error.  Expected: :end_element(  ) or :start_element( card ) from < Z.2 #:start_element( card ), :start_element( name ), :text(  ), :end_element(  ), :start_element( email ), :text(  ), :end_element(  ), < O.3 #:start_element( note ), :text(  ), :end_element(  ) >, :end_element(  ) >  but got :text(  (REXML::Validation::ValidationException)
 #@end
 # ~>    )
 #@since 3.4
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/validation/relaxng.rb:122:in 'receive'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:185:in 'block (2 levels) in pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:184:in 'each'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:184:in 'block in pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:183:in 'tap'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:183:in 'pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/treeparser.rb:22:in 'parse'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/validation/relaxng.rb:123:in 'REXML::Validation::RelaxNG#receive'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/parsers/baseparser.rb:251:in 'block (2 levels) in REXML::Parsers::BaseParser#pull'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/parsers/baseparser.rb:250:in 'Array#each'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/parsers/baseparser.rb:250:in 'block in REXML::Parsers::BaseParser#pull'
+# ~> 	from <internal:kernel>:91:in 'Kernel#tap'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/parsers/baseparser.rb:249:in 'REXML::Parsers::BaseParser#pull'
+# ~> 	from /path/to/gems/rexml-3.4.4/lib/rexml/parsers/treeparser.rb:21:in 'REXML::Parsers::TreeParser#parse'
 # ~> 	from -:41:in '<main>'
 #@else
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/validation/relaxng.rb:122:in `receive'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:185:in `block (2 levels) in pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:184:in `each'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:184:in `block in pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:183:in `tap'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/baseparser.rb:183:in `pull'
-# ~> 	from /home/ohai/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/rexml/parsers/treeparser.rb:22:in `parse'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/validation/relaxng.rb:123:in `receive'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/parsers/baseparser.rb:245:in `block (2 levels) in pull'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/parsers/baseparser.rb:244:in `each'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/parsers/baseparser.rb:244:in `block in pull'
+# ~> 	from <internal:kernel>:90:in `tap'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/parsers/baseparser.rb:243:in `pull'
+# ~> 	from /path/to/gems/rexml-3.3.9/lib/rexml/parsers/treeparser.rb:21:in `parse'
 # ~> 	from -:41:in `<main>'
 #@end
 ```

--- a/manual/api/timeout/Timeout.md
+++ b/manual/api/timeout/Timeout.md
@@ -79,33 +79,52 @@ Socket などは DNSの名前解決に時間がかかった場合割り込めま
 その処理を Ruby で実装しなおすか C 側で Ruby
 のスレッドを意識してあげる必要があります。
 
-以下の例では、gethostbyname(およそ0.6秒処理に時間がかかっている) が終了した直後((A)の箇所)で Timeout::Error 例外があがっています。
+以下の例では、Fiddle 経由で libc の sleep(3) を直接呼び出しています。
+Ruby の sleep と異なり GVL を解放しないため Timeout からの割り込みを受け付けず、
+この呼び出し(1秒かかっている)が終了した直後((A)の箇所)で Timeout::Error 例外があがっています。
 
 ```text title="例 timeout が割り込めない"
 require 'timeout'
-require 'socket'
+require 'fiddle'
+
+libc = Fiddle.dlopen(nil)
+c_sleep = Fiddle::Function.new(libc['sleep'], [Fiddle::TYPE_INT], Fiddle::TYPE_INT)
 
 t = 0.1
 start = Time.now
 begin
   Timeout.timeout(t) {
-    p TCPSocket.gethostbyname("www.ruby-lang.org")
+    p c_sleep.call(1)
     # (A)
   }
 ensure
   p Time.now - start
 end
 # 実行例
-=> ["helium.ruby-lang.org", [], 2, "210.251.121.214"]
-   0.689331
-   /usr/local/lib/ruby/1.6/timeout.rb:37: execution expired (Timeout::Error)
+=> 1.000757509
 #@since 3.4
-         from -:6:in 'timeout'
+   /path/to/gems/timeout-0.6.0/lib/timeout.rb:40:in 'Timeout::Error.handle_timeout': execution expired (Timeout::Error)
+        from /path/to/gems/timeout-0.6.0/lib/timeout.rb:304:in 'Timeout.timeout'
+        from -:10:in '<main>'
+   -:11:in 'Fiddle::Function#call': execution expired (Timeout::ExitException)
+        from -:11:in 'block in <main>'
+        from /path/to/gems/timeout-0.6.0/lib/timeout.rb:295:in 'block in Timeout.timeout'
+        from /path/to/gems/timeout-0.6.0/lib/timeout.rb:38:in 'Timeout::Error.handle_timeout'
+        from /path/to/gems/timeout-0.6.0/lib/timeout.rb:304:in 'Timeout.timeout'
+        from -:10:in '<main>'
 #@else
-         from -:6:in `timeout'
+   /path/to/gems/timeout-0.4.1/lib/timeout.rb:43:in `rescue in handle_timeout': execution expired (Timeout::Error)
+        from /path/to/gems/timeout-0.4.1/lib/timeout.rb:40:in `handle_timeout'
+        from /path/to/gems/timeout-0.4.1/lib/timeout.rb:195:in `timeout'
+        from -:10:in `<main>'
+   -:11:in `call': execution expired (Timeout::ExitException)
+        from -:11:in `block in <main>'
+        from /path/to/gems/timeout-0.4.1/lib/timeout.rb:186:in `block in timeout'
+        from /path/to/gems/timeout-0.4.1/lib/timeout.rb:41:in `handle_timeout'
+        from /path/to/gems/timeout-0.4.1/lib/timeout.rb:195:in `timeout'
+        from -:10:in `<main>'
 #@end
-         from -:6
-# gethostbyname が0.1秒かからない場合は例外が発生しないので
+# c_sleep.call の秒数が t より短い場合は例外が発生しないので
 # その場合は、t に小さい数値(0.000001のような)に変える。
 ```
 


### PR DESCRIPTION
#3151 のフォローアップ。Ruby 1.9〜2.0 時代のパスや現存しない内部フレームを含む実行例の書き起こし4ファイルを、実際に再現した現行の出力へ置き換えます(前回は引用符の版分岐のみでした)。

- **optparse チュートリアル(2箇所)**: 現行 optparse は `ParseError.filter_backtrace` で内部フレームを除去するため単一フレームに(1.9 時代の9段の内部スタックはもはや出ない)。invalid option は cause 連鎖で2行になる実挙動も反映。3.3/3.4/4.0 で実測し、残る差は引用符のみのため `#@since 3.4`/`#@else` は維持。
- **rexml RelaxNG**: 例の**スキーマ自体のバグ(`<element>` の閉じタグ欠落)を修正**した上で実行し、ValidationException の実出力に更新(3.4 はフレームのクラス修飾付き)。パスは `/path/to/gems/...` の慣例表記。rexml 3.3.9/3.4.4 で実測。
- **Timeout**: 「割り込めない処理」の例を DNS 依存(現行では再現しない)から **Fiddle 経由の libc sleep(3) 直接呼び出し**(GVL を解放しないため本当に割り込めない)に変更。現行 timeout gem の cause 連鎖(Timeout::ExitException)込みの実出力に更新(timeout 0.4.1/0.6.0 で実測)。
- **irb(2箇所)**: サブ irb の例を pty 駆動での実トランスクリプトに更新。**multi-irb が非推奨(IRB 2.0.0 で削除予定)**である警告と、workspace コマンド(`cws`/`pushws` 等)への誘導の一文を追加。eval の例はインストール方法依存のフレームを避け、メッセージのみ現行化(受け手表記は Ruby 3.3 からの「for main」)。

報告事項(この PR では未対応): NameError/NoMethodError の受け手表記「for main:Object」→「for main」の変更は **Ruby 3.3 境界**(コミットの祖先関係で確認)。`_builtin/NameError.md`・`NoMethodError.md` にも同じ古い表記が残っており、#3168 マージ後のフォローアップ候補です。

検証: 3.4 scratch DB の全体パース OK(変更ブロックは console/text の書き起こしが中心)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
