### PR TITLE
NameError/NoMethodError の例の受け手表記を版で書き分け

### DIFF
--- a/manual/api/_builtin/NameError.md
+++ b/manual/api/_builtin/NameError.md
@@ -7,9 +7,13 @@ library: _builtin
 
 ```ruby title="例"
 bar
-#@since 3.4
-# => NameError: undefined local variable or method 'bar' for main:Object
-#@else
+#@if("3.4" <= version)
+# => NameError: undefined local variable or method 'bar' for main
+#@end
+#@if("3.3" <= version and version < "3.4")
+# => NameError: undefined local variable or method `bar' for main
+#@end
+#@if(version < "3.3")
 # => NameError: undefined local variable or method `bar' for main:Object
 #@end
 ```
@@ -47,9 +51,13 @@ p err.name  # => "foo"
 begin
   foobar
 rescue NameError => err
-#@since 3.4
-p err       # => #<NameError: undefined local variable or method 'foobar' for main:Object>
-#@else
+#@if("3.4" <= version)
+p err       # => #<NameError: undefined local variable or method 'foobar' for main>
+#@end
+#@if("3.3" <= version and version < "3.4")
+p err       # => #<NameError: undefined local variable or method `foobar' for main>
+#@end
+#@if(version < "3.3")
 p err       # => #<NameError: undefined local variable or method `foobar' for main:Object>
 #@end
   p err.name  # => :foobar
@@ -64,10 +72,15 @@ end
 begin
   foobar
 rescue NameError => err
-#@since 3.4
-p err       # => #<NameError: undefined local variable or method 'foobar' for main:Object>
-p err.to_s  # => "undefined local variable or method 'foobar' for main:Object"
-#@else
+#@if("3.4" <= version)
+p err       # => #<NameError: undefined local variable or method 'foobar' for main>
+p err.to_s  # => "undefined local variable or method 'foobar' for main"
+#@end
+#@if("3.3" <= version and version < "3.4")
+p err       # => #<NameError: undefined local variable or method `foobar' for main>
+p err.to_s  # => "undefined local variable or method `foobar' for main"
+#@end
+#@if(version < "3.3")
 p err       # => #<NameError: undefined local variable or method `foobar' for main:Object>
 p err.to_s  # => "undefined local variable or method `foobar' for main:Object"
 #@end

--- a/manual/api/_builtin/NoMethodError.md
+++ b/manual/api/_builtin/NoMethodError.md
@@ -7,10 +7,14 @@ library: _builtin
 
 ```ruby title="例"
 self.bar
-#@since 3.4
-# => -:1: undefined method 'bar' for #<Object:0x401a6c40> (NoMethodError)
-#@else
-# => -:1: undefined method `bar' for #<Object:0x401a6c40> (NoMethodError)
+#@if("3.4" <= version)
+# => -:1: undefined method 'bar' for main (NoMethodError)
+#@end
+#@if("3.3" <= version and version < "3.4")
+# => -:1: undefined method `bar' for main (NoMethodError)
+#@end
+#@if(version < "3.3")
+# => -:1: undefined method `bar' for main:Object (NoMethodError)
 #@end
 ```
 
@@ -18,10 +22,14 @@ self.bar
 
 ```ruby title="例"
 "".puts
-#@since 3.4
-# => -:1:in 'puts': private method 'puts' called for "":String (NoMethodError)
-#@else
-# => NoMethodError: private method `puts' called for "":String
+#@if("3.4" <= version)
+# => -:1:in '<main>': private method 'puts' called for an instance of String (NoMethodError)
+#@end
+#@if("3.3" <= version and version < "3.4")
+# => -:1:in `<main>': private method `puts' called for an instance of String (NoMethodError)
+#@end
+#@if(version < "3.3")
+# => -:1:in `<main>': private method `puts' called for "":String (NoMethodError)
 #@end
 ```
 
@@ -29,10 +37,14 @@ self.bar
 
 ```ruby title="例"
 bar
-#@since 3.4
-# => -:1: undefined local variable or method 'bar' for #<Object:0x401a6c40> (NameError)
-#@else
-# => -:1: undefined local variable or method `bar' for #<Object:0x401a6c40> (NameError)
+#@if("3.4" <= version)
+# => -:1: undefined local variable or method 'bar' for main (NameError)
+#@end
+#@if("3.3" <= version and version < "3.4")
+# => -:1: undefined local variable or method `bar' for main (NameError)
+#@end
+#@if(version < "3.3")
+# => -:1: undefined local variable or method `bar' for main:Object (NameError)
 #@end
 ```
 
@@ -76,13 +88,17 @@ rescue NoMethodError
   p $!.args
 end
 
-#@since 3.4
-# => #<NoMethodError: undefined method 'foobar' for main:Object>
-#@else
+#@if("3.4" <= version)
+# => #<NoMethodError: undefined method 'foobar' for main>
+#@end
+#@if("3.3" <= version and version < "3.4")
+# => #<NoMethodError: undefined method `foobar' for main>
+#@end
+#@if(version < "3.3")
 # => #<NoMethodError: undefined method `foobar' for main:Object>
 #@end
-:foobar
-[1, 2, 3]
+# => :foobar
+# => [1, 2, 3]
 ```
 
 ### def private_call? -> bool


### PR DESCRIPTION
#3170 の調査で判明した事実(エラーメッセージの受け手表記は **Ruby 3.3** で変更=[feature:18285]、コミット祖先関係で確認)の反映です。

NameError.md / NoMethodError.md の計7例は、既存の `#@since 3.4` 分岐(引用符のみの書き分け)だと **3.3 の表示と受け手の新旧が一致しない**ため、index.md と同じフラットな `#@if` で3分岐(3.0〜3.2 / 3.3 / 3.4+)にしました。

- 受け手表記: `for main:Object` → `for main`、`for "":String` → `for an instance of String`(3.3+)。
- あわせて修正: `self.bar` の例に残っていた 1.8 時代の受け手(`#<Object:0x401a6c40>`)を 3.0〜3.2 の実際の表記(`main:Object`)に。`"".puts` の例の 3.4 側フレーム表記(`in 'puts'` → 実測は `in '<main>'`)。`foobar` の例で**裸のままコードに混ざっていた出力2行**(`:foobar`・`[1, 2, 3]`)を `# =>` 注釈に。
- 3.4 の全出力は実測(`bar`・`self.bar`・`"".puts`・`p err`/`err.to_s`/`err.name`)、Preprocessor で 3.0/3.2/3.3/3.4 の出し分けを確認済み。

検証: 全 ruby ブロックの Ripper パース・3.4 scratch DB の全体パース OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
