### PR TITLE
Thread#backtrace と URI::Generic#coerce の例に p を前置

### DIFF
--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -983,7 +983,7 @@ class C1
 end
 
 th = Thread.new {C1.new.m2; Thread.stop}
-th.backtrace
+p th.backtrace
 # => [
 #@since 3.4
 #      [0] "(irb):3:in 'sleep'",

--- a/manual/api/uri/Generic.md
+++ b/manual/api/uri/Generic.md
@@ -509,7 +509,7 @@ p uri.select(:userinfo, :host, :path)
 require 'uri'
 
 uri = URI.parse("http://my.example.com")
-uri.coerce("http://foo.com")
+p uri.coerce("http://foo.com")
 # => [#<URI::HTTP:0x00000000bcb028 URL:http://foo.com/>, #<URI::HTTP:0x00000000d92178 URL:http://my.example.com>]
 ```
 


### PR DESCRIPTION
次行 `# =>` 注釈への p 前置(#3169)の残り分です。#3169 で除外していた #3168 対象の15ファイルを、改良版ツール(継続行ガード入り)で走査しました。

- 候補11件のうち、**注釈が式の返り値である2件のみ**を適用: `Thread#backtrace`(バックトレース配列)と `URI::Generic#coerce`(変換ペアの配列)。
- 残り9件は見送り: `a.join`/`a.run`/`Process.wait`/`syscall` など6件は **print/puts の出力を注釈にした混合トランスクリプト**(p を付けると返り値のノイズが混ざる)、`test3(...)` の3件は **test3→test2→test1 と間接的に p 出力する例**(二重出力になる)のため。psych/yaml でツールが self-revert した6ブロックはヒアドキュメント終端の誤検知でブロック自体は健全と確認(対応不要)。

検証: Ripper パース・3.4 scratch DB の全体パース OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
