### PR TITLE
bitclust を「追加されるメソッド」表示対応(#253)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: a1e43a5aee2959c8451e65ae31987ad842603a90
+  revision: ccf2062f290a954387dc767131056a55310bdaf1
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
rurema/bitclust#253(statichtml/epub のクラスページに reopen で追加されたメソッドを表示)のマージの反映です。

Gemfile.lock の bitclust を該当マージコミット(ccf2062)にバンプします。これにより docs.ruby-lang.org のクラスページに、これまで表示されていなかった reopen 直書きのメソッド(csv の Array#to_csv/String#parse_csv、shellwords の Array#shelljoin、rake の Kernel#task/desc/file など)が「追加されるメソッド」として表示されるようになります(bitclust 側で doctree 実データの表示・非対象クラスの不変を検証済み)。サイトへの反映は次の生成からです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
