### PR TITLE
RubyVM::MJIT に until: 3.3 を追加(3.3 での削除を反映)

### DIFF
--- a/manual/api/_builtin/RubyVM__MJIT.md
+++ b/manual/api/_builtin/RubyVM__MJIT.md
@@ -1,10 +1,23 @@
 ---
 library: _builtin
 since: "2.6.0"
+until: "3.3"
 ---
 # module RubyVM::MJIT
 
-Ruby の JIT 関連のモジュールです。
+Ruby の JIT (Just-in-time compiler) 関連のモジュールです。
+
+Ruby 2.6 で実験的機能として導入された MJIT (Method-based JIT) コンパイラを制御します。
+コマンドラインオプション `--jit`(3.0)/`--mjit`(3.1 以降)で有効化します。
+
+MJIT は Ruby 3.3 で削除され、このモジュールも同時に削除されました。
+3.3 以降は YJIT(`RubyVM::YJIT`)や RJIT が JIT コンパイラとして提供されています。
+
+なお、開発版の Ruby では 2021 年 1 月から 12 月にかけての一時期、
+このモジュールが `RubyVM::JIT` にリネームされていたことがありますが
+([feature:17490])、Ruby 3.1.0 のリリース前に `RubyVM::MJIT` へ
+戻されており、`RubyVM::JIT` という名前が正式リリースに存在したことは
+ありません。
 
 ## Singleton Methods
 


### PR DESCRIPTION
#3164 対応。調査の結果、issue の前提と実態が異なっていたため、対応内容を報告します。

## 調査結果: RubyVM::JIT は正式リリースに存在しない

- `RubyVM::MJIT` → `RubyVM::JIT` のリネームは 2021-01 に開発版へ入りましたが([feature:17490])、**3.1.0 リリース前の 2021-12 に `RubyVM::MJIT` へ差し戻し・`RubyVM::JIT` 定数も削除**されています。v3_1_0 の vm.c は `rb_define_module_under(rb_cRubyVM, "MJIT")` のみであることを確認しました。
- 参照ブランチ(znz/doctree の RubyVM__JIT)はリネームコミット直後(2021-01-15)の状態を追ったもので、その後の差し戻しで前提が消えた形です。
- したがって `RubyVM::JIT` のページは作成しません。

## 実際に見つかったバグの修正

既存の `RubyVM__MJIT.md` は `since: "2.6.0"` のみで `until` が無く、**MJIT が削除された 3.3 以降の版にも RubyVM::MJIT のページが表示され続けていました**(3.4 の DB に登録されることを実測確認)。

- front matter に `until: "3.3"` を追加(3.0〜3.2 のみ表示)。
- 冒頭の説明を加筆: MJIT の導入(2.6)・有効化オプション(3.0 は `--jit`、3.1 以降は `--mjit`。NEWS-3.1.0 で確認)・3.3 での削除と後継(YJIT/RJIT)・`RubyVM::JIT` リネームが正式リリースに存在しない経緯。

## 検証

- 3.2/3.3/3.4 の scratch DB を **init からの再構築**で作成し、3.2=登録・3.3/3.4=非表示の境界を実測(bitclust update は差分更新のため、front matter のゲート変更は init からの作り直しでないと反映されない点に注意)。
- 3.2 DB 全体(約1.1万エントリ)を MDCompiler(gfm)で総レンダリングしエラー 0。
- `RubyVM::JIT` への参照が manual/ に無いことを grep で確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
