### PR TITLE
LocalJumpError: 要約に典型例(ブロックなしの yield)を追加

### DIFF
--- a/manual/api/_builtin/LocalJumpError.md
+++ b/manual/api/_builtin/LocalJumpError.md
@@ -3,9 +3,18 @@ library: _builtin
 ---
 # class LocalJumpError < StandardError
 
-ある [c:Proc] オブジェクトの作成元スコープがすでに終了しているとき、
+ブロックを伴わずに呼び出されたメソッドの中で yield を実行すると発生します。
+
+```ruby
+def call_block
+  yield 42
+end
+call_block  # => no block given (yield) (LocalJumpError)
+```
+
+また、ある [c:Proc] オブジェクトの作成元スコープがすでに終了しているとき、
 その [c:Proc] オブジェクト内で
-return, break, retry のいずれかを実行すると発生します。
+return, break, retry のいずれかを実行した場合にも発生します。
 
 [c:Proc] の例を参照してください。
 


### PR DESCRIPTION
#3184 対応。

LocalJumpError の要約が Proc 経由のケースしか説明していなかったため、rdoc(en)と同様に、最も典型的な「ブロックを伴わずに呼び出されたメソッド内での yield」のケースを例付きで先頭に追加しました。既存の Proc の説明は「また、〜した場合にも発生します」として維持しています。

検証: 例は Ruby 3.4/4.0 で実行しメッセージ(`no block given (yield)`)の一致を確認。3.4 scratch DB で当該ページの render error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
