### PR TITLE
bitclust を 1311707(invalid 属性・先頭空行修正ほか)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: ccf2062f290a954387dc767131056a55310bdaf1
+  revision: 1311707cba1d8984a62ebadf608e6eb7479266be
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
bitclust を 1311707(PR #255/#256/#257 マージ後の master)に更新します。本番の生成 HTML に以下がまとめて反映されます:

- **コードブロックの `invalid` 属性対応**(rurema/bitclust#251)— #3190 で付け替えた ```` ```ruby invalid ```` ブロック(SyntaxError の例など13箇所)が Rouge で色付けされるようになります。
- **コードブロック先頭の余計な空行の解消**(rurema/bitclust#254)— 全コードブロックの `<code>` 直後の改行が無くなります。
- **Kernel のモジュール関数の rdoc リンク修正**(rurema/bitclust#237)— Kernel.#trace_var などの rdoc リンクが `method-i-*` になります。

検証: 新 bitclust で `ruby invalid` ブロックが `<pre class="highlight ruby"><code><span ...>`(色付け+先頭空行なし)で描画されることをローカルで実測。doctree の 3.4 scratch DB 構築・全対象ページの render error 0 も #3190 の検証時に確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
