### PR TITLE
Set#compare_by_identity / compare_by_identity? のエントリを追加

### DIFF
--- a/manual/api/_builtin/Set.md
+++ b/manual/api/_builtin/Set.md
@@ -99,6 +99,48 @@ p s2 # => #<Set: {10, 20, 30}>
 
 - **SEE** [m:Object#clone]
 
+### def compare_by_identity -> self
+
+集合の要素の一致判定をオブジェクトの同一性で判定するように変更します。
+
+デフォルトでは、要素の内容が [m:Object#eql?] で等しければ同じ要素とみなされますが、より厳密に
+[m:Object#object_id] が一致しているかどうかを条件とするように self を変更します。
+
+self が変化する破壊的メソッドです。
+
+- **return** -- self を返します。
+
+```ruby title="例"
+s1 = Set["a", "b"]
+a  = "a"
+
+p s1.compare_by_identity? # => false
+p s1.include?(a)          # => true
+
+s1.compare_by_identity
+
+p s1.compare_by_identity? # => true
+p s1.include?(a)          # => false
+p s1.include?("a")        # => false
+```
+
+- **SEE** [m:Set#compare_by_identity?], [m:Hash#compare_by_identity]
+
+### def compare_by_identity? -> bool
+
+集合が要素の一致判定をオブジェクトの同一性を用いて行っているならば真を返します。
+
+```ruby title="例"
+s1 = Set["a", "b"]
+p s1.compare_by_identity? # => false
+
+s1.compare_by_identity
+
+p s1.compare_by_identity? # => true
+```
+
+- **SEE** [m:Set#compare_by_identity], [m:Hash#compare_by_identity?]
+
 ### def size -> Integer
 ### def length -> Integer
 

--- a/manual/api/set/Set.md
+++ b/manual/api/set/Set.md
@@ -74,6 +74,50 @@ p s2 # => #<Set: {10, 20, 30}>
 
 - **SEE** [m:Object#clone]
 
+### def compare_by_identity -> self
+
+集合の要素の一致判定をオブジェクトの同一性で判定するように変更します。
+
+デフォルトでは、要素の内容が [m:Object#eql?] で等しければ同じ要素とみなされますが、より厳密に
+[m:Object#object_id] が一致しているかどうかを条件とするように self を変更します。
+
+self が変化する破壊的メソッドです。
+
+- **return** -- self を返します。
+
+```ruby title="例"
+require 'set'
+s1 = Set["a", "b"]
+a  = "a"
+
+p s1.compare_by_identity? # => false
+p s1.include?(a)          # => true
+
+s1.compare_by_identity
+
+p s1.compare_by_identity? # => true
+p s1.include?(a)          # => false
+p s1.include?("a")        # => false
+```
+
+- **SEE** [m:Set#compare_by_identity?], [m:Hash#compare_by_identity]
+
+### def compare_by_identity? -> bool
+
+集合が要素の一致判定をオブジェクトの同一性を用いて行っているならば真を返します。
+
+```ruby title="例"
+require 'set'
+s1 = Set["a", "b"]
+p s1.compare_by_identity? # => false
+
+s1.compare_by_identity
+
+p s1.compare_by_identity? # => true
+```
+
+- **SEE** [m:Set#compare_by_identity], [m:Hash#compare_by_identity?]
+
 ### def size -> Integer
 ### def length -> Integer
 


### PR DESCRIPTION
#2970 への対応です。`Set#compare_by_identity` と `Set#compare_by_identity?` のエントリがどちらの Set ページにも無かったため追加します。

## 内容

- 機能は Ruby 2.4 で追加(Feature #12210)されており、るりまの対応範囲(3.0〜4.1)の全域に存在するため、バージョンガードは不要です
- `manual/api/_builtin/Set.md`(3.2 以降)と `manual/api/set/Set.md`(3.2 未満)の両方に追加。set 側の例には `require 'set'` を付けています
- 記述は Hash の同名エントリを雛形にし、SEE で `Hash#compare_by_identity` / `Hash#compare_by_identity?` と相互参照
- 例の出力は Ruby 3.4.8 で実測(`compare_by_identity` の返り値が self であること、識別子ベース比較への切り替わりを含む)

## 検証

- scratch DB(3.4 と 3.0)で両ファイルのエントリを render し、compile error 0・SEE リンク解決を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
