### PR TITLE
do ... end ブロックでも begin なしで rescue が書けることを制御構造に追記

### DIFF
--- a/manual/doc/spec/control.md
+++ b/manual/doc/spec/control.md
@@ -652,6 +652,21 @@ begin式全体の評価値は、本体／rescue節／else節のうち
 などの定義文では、それぞれ
 begin なしで rescue, ensure 節を定義でき、これにより例外を処理できます。
 
+また、`do ... end` 形式のブロックでも、Ruby 2.6 から begin なしで
+rescue, else, ensure 節を書けるようになりました([feature:12906])。
+`{ }` 形式のブロックではこの書き方はできません。
+
+```ruby title="例"
+[1, 2, 0].each do |item|
+  p 10 / item
+rescue ZeroDivisionError => e
+  p e
+end
+# => 10
+#    5
+#    #<ZeroDivisionError: divided by 0>
+```
+
 #### rescue修飾子
 
 ```ruby title="例"


### PR DESCRIPTION
#3007 への対応です。制御構造の begin 節に、`do ... end` 形式のブロックでも begin なしで rescue/else/ensure 節を書けること(Ruby 2.6 から、Feature #12906)を追記し、実測済みの例を1つ添えました。`{ }` 形式のブロックでは書けないことも明記しています(`{ }` で SyntaxError になることは 3.4.8 で実測)。

定義文(class/module/def)で begin なしの rescue が書ける旨の既存説明の直後に置き、NEWS(2.5.0)には記載済みだった内容を本文側に反映しました。

検証: 例の出力は Ruby 3.4.8 で実測。scratch DB(3.4)で spec/control の compile error 数が master と同数(15)であることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
