### PR TITLE
Float#rationalize の eps 省略時の説明を修正

### DIFF
--- a/manual/api/_builtin/Float.md
+++ b/manual/api/_builtin/Float.md
@@ -529,22 +529,29 @@ p 0.5.numerator         # => 1
 p 0.5.to_r    # => (1/2)
 ```
 
+- **SEE** [m:Float#rationalize]
+
 ### def rationalize      -> Rational
 ### def rationalize(eps) -> Rational
 
-自身から eps で指定した許容誤差の範囲に収まるような [c:Rational] を返
-します。
+自身から eps で指定した許容誤差の範囲に収まるような、できるだけ簡潔
+な [c:Rational] を返します。
 
-eps を省略した場合は誤差が最も小さくなるような [c:Rational] を返しま
-す。
+eps を省略した場合は、self の浮動小数点数としての精度に基づいて許容
+誤差が自動的に決定され、その範囲に収まる簡潔な [c:Rational] を返し
+ます。そのため [m:Float#to_r] が返す厳密な値とは異なります。誤差の
+ない厳密な値が必要な場合は [m:Float#to_r] を使ってください。
 
 - **param** `eps` -- 許容する誤差
 
 ```ruby title="例"
 p 0.3.rationalize        # => (3/10)
+p 0.3.to_r               # => (5404319552844595/18014398509481984)
 p 1.333.rationalize      # => (1333/1000)
 p 1.333.rationalize(0.01)  # => (4/3)
 ```
+
+- **SEE** [m:Float#to_r]
 
 ### def next_float -> Float
 


### PR DESCRIPTION
#2138 への対応です。Float#rationalize の「eps を省略した場合は誤差が最も小さくなるような Rational を返します」は誤りです(誤差ゼロの厳密値を返す Float#to_r と異なる値を返すため)。scivola さんも 2026-07-11 に誤りである旨を再確認しています。

- eps 省略時は「浮動小数点数としての精度に基づいて許容誤差が自動的に決定され、その範囲に収まる簡潔な Rational を返す」という趣旨の表現に修正(rdoc の "chosen automatically" 相当の穏当な表現)
- 厳密な値が必要な場合は Float#to_r を使う旨を明記し、例に `0.3.rationalize`(→ 3/10)と `0.3.to_r`(→ 5404319552844595/18014398509481984)の対比を追加(いずれも実測)
- to_r と rationalize に相互 SEE を追加

自動決定される許容誤差の正確なアルゴリズム(連分数近似)への深入りは、rdoc 同様行っていません。

検証: scratch DB(3.4)で render し compile error 0 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
