### PR TITLE
Module#name の名前が最初の定数代入で確定することを明記

### DIFF
--- a/manual/api/_builtin/Module.md
+++ b/manual/api/_builtin/Module.md
@@ -57,19 +57,18 @@ mod
 
 ブロックを与えた場合も生成したモジュールを返します。
 
-このメソッドで生成されたモジュールは、
-最初に名前が必要になったときに名前が決定します。
-モジュールの名前は、
-そのモジュールが代入されている定数名のいずれかです。
+このメソッドで生成された直後のモジュールは無名で、
+最初にいずれかの定数に代入された時点で名前が確定します
+([m:Module#name] を参照)。
 
 ```ruby title="例"
 m = Module.new
 p m               # => #<Module 0lx40198a54>
 p m.name          # => nil   # まだ名前は未定
 Utils = m
-# m.name          # ここで m.name を呼べば m の名前は "Utils" に確定する
+p m.name          # => "Utils"   # 最初に代入された定数名で確定する
 Helpers = m
-p m.name          # "Utils" か "Helpers" のどちらかに決まる
+p m.name          # => "Utils"   # 一度確定した名前は変わらない
 ```
 
 ### def used_modules -> [Module]
@@ -939,6 +938,12 @@ p t.foo()              #=> 1
 「::」を使って表示した名前のことです。
 クラスパスの例としては「CGI::Session」「Net::HTTP」が挙げられます。
 
+[m:Module.new] や [m:Class.new] で生成した直後の無名のモジュール /
+クラスは、最初にいずれかの定数に代入された時点で名前が確定します。
+一度確定した名前は、その定数を remove_const で取り除いたり、
+そのモジュール / クラスを別の定数へ代入し直したりしても変わりません。
+返り値の文字列は freeze されています。
+
 - **return** -- 名前のないモジュール / クラスに対しては、name は nil を、それ以外はオブジェクト ID の文字列を返します。
 
 ```ruby title="例"
@@ -961,6 +966,15 @@ p Module.new.name   #=> nil
 p Class.new.name    #=> nil
 p Module.new.to_s   #=> "#<Module:0x00007f90b09112c8>"
 p Class.new.to_s    #=> "#<Class:0x00007fa5c40b41b0>"
+
+# 名前は最初に代入された定数で確定し、以後は変わらない
+c = Class.new
+p c.name         #=> nil
+Foo = c
+p c.name         #=> "Foo"
+Bar = c
+p c.name         #=> "Foo"
+p c.name.frozen? #=> true
 ```
 
 ### def instance_methods(inherited_too = true) -> [Symbol]


### PR DESCRIPTION
#2148 への対応です。Module#name の値が定数への最初の代入時に確定する挙動(Ruby 2.7 から、[Feature #16150]。NEWS 2.7.0 で裏取り済み)がどこにも書かれていなかったため、Module#name と Module.new の両方に追記します。

- **Module#name**: 無名モジュール/クラスは最初にいずれかの定数に代入された時点で名前が確定し、以後 remove_const や別定数への再代入でも変わらないこと、返り値が freeze されていることを明記+実測例を追加
- **Module.new**: 既存の説明「最初に名前が必要になったときに名前が決定します」は 2.6 以前の挙動のため修正。既存の例の「"Utils" か "Helpers" のどちらかに決まる」という記述も現在の挙動と矛盾するため、実測に基づく出力(最初の代入で "Utils" に確定し変わらない)に修正しました
- るりまの対応範囲(3.0〜)では全版がこの挙動のため、バージョン分岐はありません

挙動は全て Ruby 3.4.8 で実測(nil → "Foo" → 再代入後も "Foo"、frozen? => true、remove_const 後も不変)。

検証: scratch DB(3.4)で Module#name・Module.new を render し compile error 0 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
