### PR TITLE
Object#eql? の説明を Hash 限定に読めないように修正

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -68,8 +68,9 @@ p a <=> b # => nil
 
 ### def eql?(other) -> bool
 
-オブジェクトと other が等しければ真を返します。[c:Hash] で二つのキー
-が等しいかどうかを判定するのに使われます。
+オブジェクトと other が等しければ真を返します。[c:Hash] のキー比較
+をはじめ、[m:Array#uniq] や [c:Set] など、要素の同値性を判定する
+さまざまな場面で [m:Object#hash] とともに使われます。
 
 このメソッドは各クラスの性質に合わせて再定義すべきです。
 多くの場合、 == と同様に同値性の判定をするように再定義されていますが、
@@ -91,7 +92,7 @@ p(4.eql?(4)) #=> true
 p(4.eql?(4.0)) #=> false
 ```
 
-- **SEE** [m:Object#hash],[m:Object#equal?],[m:Object#==]
+- **SEE** [m:Object#hash],[m:Object#equal?],[m:Object#==],[m:Array#uniq],[c:Set]
 
 ### def equal?(other) -> bool
 


### PR DESCRIPTION
#2269 への対応です。Object#eql? の説明が「Hash で二つのキーが等しいかどうかを判定するのに使われます」と Hash 限定に読める問題を修正します。

- Hash のキー比較をはじめ、Array#uniq や Set など、要素の同値性を判定するさまざまな場面で hash とともに使われることを明記
- SEE に Array#uniq と Set を追加

issue のコメント欄で整理された各メソッドの利用実態(uniq や tally が hash + eql? を使うことなど)は、Array.md・Enumerable.md・set.md 側には既に反映済みで、本 PR は残っていた大元の Object#eql? の文言を直すものです。Hash 側への詳しい説明の集約(znz さん案)は、必要になれば別途検討します。

検証: scratch DB(3.4)で render し compile error 0 を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
