### PR TITLE
CONTRIBUTING.md に Ruby コミュニティの行動規範への言及を追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,12 @@ Ruby でプログラミングができるとサンプルの検証などもでき
 * 既に上がっている Issue へのコメント
 * ブログや勉強会などで「るりま」を紹介する
 
+## 行動規範
+
+本プロジェクトは Ruby コミュニティの
+[行動規範](https://www.ruby-lang.org/ja/conduct/)
+（[Code of Conduct](https://www.ruby-lang.org/en/conduct/)）に従います。
+
 ## 各バージョンの対応方針
 
 以下の方針で対応します。


### PR DESCRIPTION
#2086 への対応です。issue で提案されていた軽量案のとおり、CONTRIBUTING.md に Ruby コミュニティの行動規範(ruby-lang.org/ja/conduct/)への言及を追加します。プロジェクト独自の CoC 文書は作らず、リンクのみです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
