### PR TITLE
サンプルコードの Rational()/Complex() をリテラル表記に統一

### DIFF
--- a/manual/api/_builtin/Integer.md
+++ b/manual/api/_builtin/Integer.md
@@ -540,8 +540,8 @@ other が Float、Rational、Complex の場合、普通の商を other と
 p 7 / 2 # => 3
 p 7 / -2 # => -4
 p 7 / 2.0 # => 3.5
-p 7 / Rational(2, 1) # => (7/2)
-p 7 / Complex(2, 0) # => ((7/2)+0i)
+p 7 / 2r # => (7/2)
+p 7 / (2+0i) # => ((7/2)+0i)
 
 begin
   2 / 0
@@ -568,7 +568,7 @@ div に対応する剰余メソッドは modulo です。
 p 7.div(2) # => 3
 p 7.div(-2) # => -4
 p 7.div(2.0) # => 3
-p 7.div(Rational(2, 1)) # => 3
+p 7.div(2r) # => 3
 
 begin
   2.div(0)

--- a/manual/api/_builtin/Numeric.md
+++ b/manual/api/_builtin/Numeric.md
@@ -604,8 +604,8 @@ p 1.0.quo(3)  #=> 0.3333333333333333
 p 1.quo(3.0)  #=> 0.3333333333333333
 p 1.quo(0.5)  #=> 2.0
 
-p Complex(1, 1).quo(1)  #=> ((1/1)+(1/1)*i)
-p 1.quo(Complex(1, 1))  #=> ((1/2)-(1/2)*i)
+p (1+1i).quo(1)  #=> ((1/1)+(1/1)*i)
+p 1.quo(1+1i)    #=> ((1/2)-(1/2)*i)
 ```
 
 - **SEE** [m:Numeric#fdiv]
@@ -622,7 +622,7 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 
 ```ruby title="例"
 p 1.fdiv(3)          #=> 0.3333333333333333
-p Complex(1, 1).fdiv 1 #=> (1.0+1.0i)
+p (1+1i).fdiv 1        #=> (1.0+1.0i)
 p 1.fdiv Complex(1, 1) #=> (0.5-0.5i)
 ```
 
@@ -731,10 +731,10 @@ p (-11).remainder(3.5)  #=> -0.5
 自身がゼロの時 nil を返し、非ゼロの時 self を返します。
 
 ```ruby title="例"
-p 10.nonzero?              #=> 10
-p 0.nonzero?               #=> nil
-p 0.0.nonzero?             #=> nil
-p Rational(0, 2).nonzero?  #=> nil
+p 10.nonzero?   #=> 10
+p 0.nonzero?    #=> nil
+p 0.0.nonzero?  #=> nil
+p 0r.nonzero?   #=> nil
 ```
 
 非ゼロの時に self を返すため、自身が 0 の時に他の処理をさせたい場合に以
@@ -754,7 +754,7 @@ self の絶対値が有限値の場合に true を、そうでない場合に fa
 
 ```ruby title="例"
 p 10.finite?                    # => true
-p Rational(3).finite?           # => true
+p 3r.finite?                    # => true
 
 p Float::INFINITY.finite?       # => false
 p Float::INFINITY.is_a?(Numeric)  # => true
@@ -780,7 +780,7 @@ self.to_i と同じです。
 
 ```ruby title="例"
 p (2+0i).to_int      # => 2
-p Rational(3).to_int # => 3
+p 3r.to_int          # => 3
 ```
 
 ### def zero?    -> bool
@@ -1020,7 +1020,7 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 p 10.real             # => 10
 p -10.real            # => -10
 p 0.1.real            # => 0.1
-p Rational(2, 3).real # => (2/3)
+p (2/3r).real         # => (2/3)
 ```
 
 - **SEE** [m:Numeric#imag]、[m:Complex#real]
@@ -1035,7 +1035,7 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 p 10.real?             # => true
 p -10.real?            # => true
 p 0.1.real?            # => true
-p Rational(2, 3).real? # => true
+p (2/3r).real?         # => true
 ```
 
 - **SEE** [m:Numeric#integer?]、[m:Complex#real?]
@@ -1064,7 +1064,7 @@ Numeric のサブクラスは、このメソッドを適切に再定義しなけ
 p 1.to_c            # => (1+0i)
 p -1.to_c           # => (-1+0i)
 p 1.0.to_c          # => (1.0+0i)
-p Rational(1, 2).to_c # => ((1/2)+0i)
+p (1/2r).to_c       # => ((1/2)+0i)
 ```
 
 Numeric のサブクラスは、このメソッドを適切に再定義しなければなりません。
@@ -1079,5 +1079,5 @@ Complex(0, self) を返します。
 p 10.i           # => (0+10i)
 p -10.i          # => (0-10i)
 p (0.1).i        # => (0+0.1i)
-p Rational(1, 2).i # => (0+(1/2)*i)
+p (1/2r).i       # => (0+(1/2)*i)
 ```

--- a/manual/api/bigdecimal/util.md
+++ b/manual/api/bigdecimal/util.md
@@ -93,8 +93,8 @@ nFig 桁まで計算を行います。
 ```ruby
 require "bigdecimal"
 require "bigdecimal/util"
-p Rational(1, 3).to_d(3)  # => 0.333e0
-p Rational(1, 3).to_d(10) # => 0.3333333333e0
+p (1/3r).to_d(3)  # => 0.333e0
+p (1/3r).to_d(10) # => 0.3333333333e0
 ```
 
 # reopen Integer

--- a/manual/api/date/Date.md
+++ b/manual/api/date/Date.md
@@ -498,7 +498,7 @@ p Date.new(2001, 2, 3) <=> Date.new(2001, 2, 4) # => -1
 p Date.new(2001, 2, 3) <=> Date.new(2001, 2, 3) # => 0
 p Date.new(2001, 2, 3) <=> Date.new(2001, 2, 2) # => 1
 p Date.new(2001, 2, 3) <=> Object.new           # => nil
-p Date.new(2001, 2, 3) <=> Rational(4903887, 2) # => 0
+p Date.new(2001, 2, 3) <=> 4903887/2r           # => 0
 ```
 
 - **param** `other` -- 日付オブジェクトまたは数値

--- a/manual/api/json/add/complex.md
+++ b/manual/api/json/add/complex.md
@@ -30,7 +30,7 @@ JSON のオブジェクトから [c:Complex] のオブジェクトを生成し�
 
 ```ruby title="例"
 require 'json/add/complex'
-p Complex(2, 3).to_json # => "{\"json_class\":\"Complex\",\"r\":2,\"i\":3}"
+p (2+3i).to_json # => "{\"json_class\":\"Complex\",\"r\":2,\"i\":3}"
 ```
 
 - **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/rational.md
+++ b/manual/api/json/add/rational.md
@@ -30,7 +30,7 @@ JSON のオブジェクトから [c:Rational] のオブジェクトを生成し�
 
 ```ruby title="例"
 require 'json/add/rational'
-p Rational(1, 3).to_json # => "{\"json_class\":\"Rational\",\"n\":1,\"d\":3}"
+p (1/3r).to_json # => "{\"json_class\":\"Rational\",\"n\":1,\"d\":3}"
 ```
 
 - **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/matrix/Matrix.md
+++ b/manual/api/matrix/Matrix.md
@@ -818,9 +818,9 @@ Complexオブジェクトを要素に持つ場合は虚部が0でも偽を返し
 ```ruby title="例"
 require 'matrix'
 p Matrix[[1, 0], [0, 1]].real? # => true
-p Matrix[[Complex(0, 1), 0], [0, 1]].real? # => false
+p Matrix[[1i, 0], [0, 1]].real? # => false
 # 要素が実数であっても Complex オブジェクトなら偽を返す。
-p Matrix[[Complex(1, 0), 0], [0, 1]].real? # => false
+p Matrix[[1+0i, 0], [0, 1]].real? # => false
 ```
 
 ### def regular? -> bool
@@ -1008,10 +1008,10 @@ p m.to_a # => [[1, 2, 3], [10, 15, 20], [-1, -2, 1.5]]
 
 ```ruby title="例"
 require 'matrix'
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]]
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]]
   # => 1+2i   i  0
   #       1   2  3
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]].conjugate
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]].conjugate
   # => 1-2i  -i  0
   #       1   2  3
 ```
@@ -1023,10 +1023,10 @@ p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]].conjugate
 
 ```ruby title="例"
 require 'matrix'
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]]
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]]
 #  => 1+2i  i  0
 #        1  2  3
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]].imaginary
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]].imaginary
 #  =>   2i  i  0
 #        0  0  0
 ```
@@ -1036,10 +1036,10 @@ p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]].imaginary
 
 ```ruby title="例"
 require 'matrix'
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]]
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]]
 #  => 1+2i  i  0
 #        1  2  3
-p Matrix[[Complex(1,2), Complex(0,1), 0], [1, 2, 3]].real
+p Matrix[[1+2i, 1i, 0], [1, 2, 3]].real
 #  =>    1  0  0
 #        1  2  3
 ```
@@ -1067,7 +1067,7 @@ require 'matrix'
 a1 = [1, 2]
 a2 = [-1.25, 2.2]
 m = Matrix[a1, a2]
-r = Rational(1, 2)
+r = 1/2r
 p m.coerce(r) #=> [#<Matrix::Scalar:0x832df18 @value=(1/2)>, Matrix[[1, 2], [-1.25, 2.2]]]
 ```
 
@@ -1206,7 +1206,7 @@ p Matrix[[1,2], [3,4]].hadamard_product(Matrix[[1,2], [3,2]]) # => Matrix[[1, 4]
 ```ruby
 require 'matrix'
 
-p Matrix[[0, -2, Complex(1, 3)], [2, 0, 5], [-Complex(1, 3), -5, 0]].antisymmetric? # => true
+p Matrix[[0, -2, 1+3i], [2, 0, 5], [-(1+3i), -5, 0]].antisymmetric? # => true
 p Matrix.empty.antisymmetric? # => true
 
 p Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]].antisymmetric? # => false

--- a/manual/api/matrix/Vector.md
+++ b/manual/api/matrix/Vector.md
@@ -267,7 +267,7 @@ self の各要素を数 other で割ったベクトルを返します。
 ```ruby title="例"
 require 'matrix'
 p Vector[3, 4].norm # => 5.0
-p Vector[Complex(0, 1), 0].norm # => 1.0
+p Vector[1i, 0].norm # => 1.0
 ```
 
 - **SEE** [m:Vector#normalize]


### PR DESCRIPTION
#810 で SampleCodeGuideline に追加した「リテラルで簡潔に書けるオブジェクトはリテラルで書く」原則(PR #3195)の既存サンプルへの適用です。

- `Rational(...)`・`Complex(...)` の呼び出し 29 件(8 ファイル: Integer・Numeric・bigdecimal/util・date 2件・json の add 2件・matrix 2件)をリテラル表記に変更。全件で等値と `# =>` 出力の一致を実測し、コメントの桁も再調整
- **除外**(ガイドラインの「生成方法自体を説明する例」ほか): Rational()/Complex()/Regexp.new/Hash.[] 自身のエントリ、Regexp のオプション定数の対応を教える例、mathn(2.5 で削除済み)、cmath(until ガードで実測不可)、フラット引数の `Hash[...]`(リテラル化不可)、news 系

副産物の報告: Numeric.md の `1.fdiv Complex(1, 1)` の例(626 行付近)は変更前から Ruby 3.4.8 で RangeError になる既存バグです(本 PR では対象外・別途対応候補)。

検証: scratch DB(3.4)+statichtml 全生成で compileerror 0(master 同数)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
