### PR TITLE
例外注釈を # ~> 書式に統一(第1弾)

### DIFF
--- a/manual/api/_builtin/IO.md
+++ b/manual/api/_builtin/IO.md
@@ -2051,7 +2051,7 @@ File.open("testfile") do |f|
     p f.readbyte  # => 49
     p f.readbyte  # => 50
     p f.readbyte  # => 51
-    f.readbyte  # => 例外発生
+    f.readbyte  # ~> EOFError
   rescue => e
     e.class # => EOFError
   end

--- a/manual/api/_builtin/IO.md
+++ b/manual/api/_builtin/IO.md
@@ -2053,7 +2053,7 @@ File.open("testfile") do |f|
     p f.readbyte  # => 51
     f.readbyte  # ~> EOFError
   rescue => e
-    e.class # => EOFError
+    p e.class # => EOFError
   end
 end
 ```

--- a/manual/api/_builtin/UncaughtThrowError.md
+++ b/manual/api/_builtin/UncaughtThrowError.md
@@ -9,7 +9,7 @@ since: "2.2.0"
 
 ```ruby
 throw "foo", "bar"
-# => (例外発生) UncaughtThrowError: uncaught throw "foo"
+# ~> UncaughtThrowError: uncaught throw "foo"
 ```
 
 ## Instance Methods

--- a/manual/api/pstore.md
+++ b/manual/api/pstore.md
@@ -71,7 +71,7 @@ db.transaction do
 end
   
 db.transaction(true) do |pstore|
-  pstore["root"] = 'aaa' # => ここで例外発生
+  pstore["root"] = 'aaa' # ~> PStore::Error
 end
 ```
 
@@ -127,7 +127,7 @@ end
 db.transaction(true) do |pstore|
   pstore.fetch("root")        # => [[1, 1.5], 2, 3, 4]
   pstore.fetch("root", 'aaa') # => [[1, 1.5], 2, 3, 4]
-  pstore.fetch("not_root")    # => 例外発生
+  pstore.fetch("not_root")    # ~> PStore::Error
 end
 ```
 

--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -189,7 +189,7 @@ Psych.safe_load(yaml, permitted_classes: [Date])
 x = []
 x << x
 yaml = Psych.dump x
-Psych.safe_load yaml                # => 例外発生
+Psych.safe_load yaml                # ~> Psych::AliasesNotEnabled
 p Psych.safe_load yaml, aliases: true # => エイリアスが読み込まれる
 ```
 

--- a/manual/api/rake/Rake__InvocationChain.md
+++ b/manual/api/rake/Rake__InvocationChain.md
@@ -10,7 +10,7 @@ a = Rake::InvocationChain::EMPTY
 b = a.append('task_a').append('task_b')
 p b.to_s  # => "TOP => task_a => task_b"
   
-a.append('task_a').append('task_b').append('task_a') # => 例外発生
+a.append('task_a').append('task_b').append('task_a') # ~> RuntimeError
 ```
 
 ## Public Instance Methods


### PR DESCRIPTION
#2128 で決めた例外注釈の書式 `# ~>`(PR #3195 でガイドライン化)を既存サンプルへ適用する第1弾です。

- `grep "例外発生"` で見つかる 15 件を全件精査し、「その行の式を評価すると例外が発生する」ことを示す注釈 **6 件**を `# ~> 例外クラス名` に変換(pstore 2件・psych・IO#readbyte・Rake::InvocationChain#append・UncaughtThrowError)。例外クラスは全件実測で確認
- 除外 9 件は「例外発生時の…」のような説明文中の用法(コード注釈ではない)

`# => 〜Error` 形式など grep に掛からない残りの表記は、フォローアップの第2弾候補です。

検証: scratch DB(3.4)+statichtml 全生成で compileerror 0(master 同数)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
