### PR TITLE
bitclust を 6558619(インラインコードスタイル・title エイリアスほか)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 1311707cba1d8984a62ebadf608e6eb7479266be
+  revision: 6558619b383e9816d904d6075018e335c5e1ca51
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
bitclust の参照 revision を 6558619(PR #258〜#261 マージ後の master)に更新します。次回の生成から本番に反映される内容:

- インラインコード(`code`/`tt`)の背景色スタイル(rurema/bitclust#258、#246 対応)
- Windows のドライブレター付き DB パス修正(#259、#238 対応)
- statichtml の `--sitemap-baseurl` オプション(#260、#130 対応。generated-documents 側の対応 PR は本 PR のマージ後にマージしてください)
- メソッドページの title へのエイリアス列挙(#261、rurema/doctree#2748 対応)

Gemfile.lock の revision 行のみの更新です(従来のバンプ PR と同形式)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
