### PR TITLE
トップレベルからのクラス変数アクセスは RuntimeError になることを反映

### DIFF
--- a/manual/doc/spec/variables.md
+++ b/manual/doc/spec/variables.md
@@ -185,10 +185,10 @@ p Foo.a1        #=> :a
 def Foo.a2
   p @@a
 end
-Foo.a2          #=> NameError になります。
+Foo.a2          # ~> RuntimeError: class variable access from toplevel
 
 class << Foo
-  p @@a         #=> NameError になります。
+  p @@a         # ~> RuntimeError: class variable access from toplevel
 end
 ```
 


### PR DESCRIPTION
`# ~>` 統一第2弾(#3227)の調査で見つかった既存バグの修正です。変数と定数のページで、トップレベルからのクラス変数アクセスを「NameError になります」と記述していますが、実際は `RuntimeError: class variable access from toplevel` です。

- 挙動境界の調査: NEWS-3.0.0 に "accessing a class variable from the toplevel scope is now a RuntimeError"(Bug #14541)と明記されており、ちょうどるりまの最古サポート版(3.0)からの挙動のため、バージョンガード無しの無条件修正です(3.4.8・4.0.1 で実メッセージも実測)
- 該当2箇所の注釈を `# ~> RuntimeError: class variable access from toplevel` に修正

検証: scratch DB(3.4)で render し compile error 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
