### PR TITLE
制御構造の修飾子見出しにアンカーを追加(検索対応)

### DIFF
--- a/manual/doc/spec/control.md
+++ b/manual/doc/spec/control.md
@@ -75,7 +75,7 @@ $_ =~ リテラル
 
 であるかのように評価されます。
 
-#### if 修飾子
+#### if 修飾子 {#if_modifier}
 
 ```ruby title="例"
 print "debug\n" if $DEBUG
@@ -110,7 +110,7 @@ unless は if と反対で、条件式が偽の時に then 以下の
 式を評価します。unless 式にelsif を指定することはできませ
 ん。
 
-#### unless 修飾子
+#### unless 修飾子 {#unless_modifier}
 
 ```ruby title="例"
 print "stop\n" unless valid(passwd)
@@ -275,7 +275,7 @@ end
 while は nil を返します。また、引数を伴った break により
 while 式の戻り値をその値にすることもできます。
 
-#### while 修飾子
+#### while 修飾子 {#while_modifier}
 
 ```ruby title="例"
 sleep(60) while io_not_ready?
@@ -319,7 +319,7 @@ end
 until は nil を返します。また、引数を伴った break により
 until 式の戻り値をその値にすることもできます。
 
-#### until修飾子
+#### until修飾子 {#until_modifier}
 
 ```ruby title="例"
 print(f.gets) until f.eof?
@@ -667,7 +667,7 @@ end
 #    #<ZeroDivisionError: divided by 0>
 ```
 
-#### rescue修飾子
+#### rescue修飾子 {#rescue_modifier}
 
 ```ruby title="例"
 open("nonexistent file") rescue STDERR.puts "Warning: #$!"


### PR DESCRIPTION
rurema/bitclust#262(doc ページのアンカー付き見出しを検索インデックスに追加)のフォローアップです。制御構造のページでアンカーが無かった見出しに `{#id}` を付与し、検索でヒットするようにします。

- 追加した5つ(既存の snake_case 慣例に準拠・基本キーワードの既存アンカーとは区別): `{#if_modifier}`・`{#unless_modifier}`・`{#while_modifier}`・`{#until_modifier}`・`{#rescue_modifier}`
- if/unless/case/while/until/for/break/next/redo/retry/raise/begin/return/BEGIN/END は既にアンカーあり。def.md・call.md・literal.md・operator.md も全見出しアンカー済みで対応不要でした
- ensure・(修飾子でない)rescue は begin 節の本文中にあり独立見出しが無いため、構成変更なしにはアンカーを付けられず対象外としています
- 判断保留の報告: eval.md に多数のアンカー無しキーワード見出し(`#### if` 等 15 個程度)がありますが、control.md 等と重複する要約ページのため、検索ヒットが二重になることを避けて今回は見送りました(必要ならご指示ください)

検証: scratch DB(3.4)で render し `<h3 id='if_modifier'>` 等の出力を確認。SearchIndexGenerator の実行で5アンカー全てが重複なしの heading エントリとして載ることも確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
