### PR TITLE
Process::Status#& / #>>: Ruby 4.0 での削除を反映

### DIFF
--- a/manual/api/_builtin/Process__Status.md
+++ b/manual/api/_builtin/Process__Status.md
@@ -98,12 +98,17 @@ other が数値の場合、self.to_i との比較が行われます。こ
 
 - **param** `other` -- 自身と比較したいオブジェクトを指定します。
 
+#@until 4.0
 ### def &(other)    -> Integer
 
 self.to_i & other と同じです。
 このメソッドは後方互換性のためにあります。
+#@since 3.3
+このメソッドは Ruby 3.3 から deprecated であり、Ruby 4.0 で削除されました。
+#@end
 
 - **param** `other` -- 自身との & 演算をしたい整数を指定します。
+#@end
 
 ### def pid    -> Integer
 
@@ -176,9 +181,13 @@ signaled? が真の場合プロセスを終了させたシグナル番号を、
 このメソッドはシステムに依存します。サポートしないプラットフォー
 ムでは常に false を返します。
 
+#@until 4.0
 ### def >>(num)    -> Integer
 
 self.to_i >> num と同じです。
+#@since 3.3
+このメソッドは Ruby 3.3 から deprecated であり、Ruby 4.0 で削除されました。
+#@end
 
 - **param** `num` -- 整数を指定します。
 
@@ -188,6 +197,7 @@ p Process.wait     #=> 26563
 p $?.to_i          #=> 25344
 p $? >> 8          #=> 99
 ```
+#@end
 
 ### def success?    -> bool
 


### PR DESCRIPTION
## 概要

`Process::Status#&` と `Process::Status#>>` は Ruby 3.3 で deprecated となり、Ruby 4.0 で削除されました（[Bug #19868](https://bugs.ruby-lang.org/issues/19868)）。この変更を反映します。

実機 Ruby 4.0.5 でも `$?.respond_to?(:&)` / `$?.respond_to?(:>>)` はいずれも `false`（メソッドが存在しない）ことを確認しています。

## 変更点（`manual/api/_builtin/Process__Status.md`）

- 両メソッドの定義全体を `#@until 4.0` で囲み、Ruby 4.0 以降のリファレンスには掲載されないようにしました。
- 3.3 以降向けに `#@since 3.3` で「Ruby 3.3 から deprecated であり、Ruby 4.0 で削除されました」という注記を追加しました（3.0〜3.2 では従来どおり注記なし）。

## 動作確認

`BitClust::Preprocessor.read` で各バージョンを展開し、次を確認しました（すべてエラーなし）。

| バージョン | `#&` / `#>>` の掲載 | deprecated 注記 |
|---|---|---|
| 3.2 | あり | なし（従来どおり） |
| 3.3 / 3.4 | あり | あり |
| 4.0 / 4.1 | なし（削除） | なし |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
