### PR TITLE
Encoding#replicate: Ruby 3.3 での削除を反映

### DIFF
--- a/manual/api/_builtin/Encoding.md
+++ b/manual/api/_builtin/Encoding.md
@@ -211,13 +211,16 @@ p Encoding::UTF_8.ascii_compatible?   #=> true
 p Encoding::UTF_16BE.ascii_compatible?  #=> false
 ```
 
+#@until 3.3
 ### def replicate(name) -> Encoding
 
 レシーバのエンコーディングを複製(replicate)します。
 複製されたエンコーディングは元のエンコーディングと同じバイト構造を持たなければなりません。
 name という名前のエンコーディングが既に存在する場合は [c:ArgumentError] を発生します。
 
-Ruby 3.2 から非推奨となり、Ruby 3.3 で削除予定です。
+#@since 3.2
+このメソッドは Ruby 3.2 から deprecated であり、Ruby 3.3 で削除されました。
+#@end
 
 ```ruby
 encoding = Encoding::UTF_8.replicate("REPLICATED_UTF-8")     #=> #<Encoding:REPLICATED_UTF-8>
@@ -226,6 +229,7 @@ p "\u3042".force_encoding(Encoding::UTF_8).valid_encoding?   #=> true
 p "\u3042".force_encoding(encoding).valid_encoding?          #=> true
 p "\u3042".force_encoding(Encoding::SHIFT_JIS).valid_encoding? #=> false
 ```
+#@end
 
 ## Constants
 


### PR DESCRIPTION
## 概要

`Encoding#replicate` は Ruby 3.2 で deprecated となり、Ruby 3.3 で削除されました（[Feature #18949](https://bugs.ruby-lang.org/issues/18949)）。マニュアルには「Ruby 3.3 で削除**予定**です」という将来形の記述のまま項目が残っており、3.3 以降のリファレンスにも掲載されていたため修正します。

## 変更点（`manual/api/_builtin/Encoding.md`）

- メソッド定義全体を `#@until 3.3` で囲み、Ruby 3.3 以降のリファレンスには掲載されないようにしました。
- 「Ruby 3.2 から非推奨となり、Ruby 3.3 で削除予定です。」を、`#@since 3.2` で「このメソッドは Ruby 3.2 から deprecated であり、Ruby 3.3 で削除されました。」に更新しました（3.0 / 3.1 では従来どおり注記なし）。

## 動作確認

実機で挙動を確認しました。

| バージョン | `respond_to?(:replicate)` | 実行 | `-W:deprecated` |
|---|---|---|---|
| 3.1.6 | `true` | 複製成功 | 警告なし |
| 3.2.11 | `true` | 複製成功 | ⚠️「Encoding#replicate is deprecated and will be removed in Ruby 3.3」 |
| 3.3.12 / 4.0.6 | `false` | `NoMethodError` | （メソッドなし） |

`BitClust::Preprocessor.read` で各バージョンを展開した結果（すべてエラーなし）:

| バージョン | `#replicate` の掲載 | deprecated 注記 |
|---|---|---|
| 3.0 / 3.1 | あり | なし（従来どおり） |
| 3.2 | あり | あり |
| 3.3 / 3.4 / 4.0 | なし（削除） | なし |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
