### PR TITLE
Kernel.#lambda: 非リテラルブロックが Ruby 3.3 で ArgumentError になる旨を反映

### DIFF
--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -2516,11 +2516,19 @@ eval('raise RuntimeError', binding, 'XXX.rb', 4)
 
 また、lambda に & 引数を渡すのは推奨されません。& 引数ではなくてブロック記法で記述する必要があります。
 
+#@since 3.3
+& 引数(リテラルでないブロック)を渡して lambda を呼び出すと、[c:ArgumentError]
+「the lambda method requires a literal block」が発生します。
+#@else
 & 引数を渡した lambda は Warning[:deprecated] = true のときに警告メッセージ
 「warning: lambda without a literal block is deprecated; use the proc without lambda instead」
 を出力します。
+#@end
 
 - **raise** `ArgumentError` -- ブロックを省略した呼び出しを行ったときに発生します。
+#@since 3.3
+- **raise** `ArgumentError` -- & 引数(リテラルでないブロック)を渡して呼び出したときに発生します。
+#@end
 
 ```ruby title="例"
 def foo &block


### PR DESCRIPTION
## 概要

`lambda` に `&` 引数（リテラルでないブロック）を渡した場合の挙動が Ruby 3.3 で変わりました。Ruby 3.2 までは `Warning[:deprecated]` 下で警告を出しつつブロックをそのまま返していましたが、Ruby 3.3 からは `ArgumentError`（`the lambda method requires a literal block`）を発生します（[Feature #19777](https://bugs.ruby-lang.org/issues/19777)）。

マニュアルは旧来の「警告を出力します」という記述のままだったため修正します。

## 変更点（`manual/api/_builtin/functions.md` の `Kernel.#lambda`）

- 挙動の説明を `#@since 3.3` で分岐し、3.3 以降は「`ArgumentError` が発生する」旨に更新（3.2 以前の警告の記述は `#@else` に温存）。
- 3.3 以降向けに、`&` 引数を渡したときの `ArgumentError` を `- **raise**` の一覧にも追加。

## 動作確認

実機で挙動を確認しました（`def foo(&b); lambda(&b); end; foo { 1 }`、`-W:deprecated`）。

| バージョン | 非リテラル `&` ブロック |
|---|---|
| 3.1.6 / 3.2.11 | ⚠️ 警告「lambda without a literal block is deprecated ...」を出し、`lambda?` は `false`（例外なし） |
| 3.3.12 / 3.4.10 / 4.0.6 | `ArgumentError: the lambda method requires a literal block` |

`BitClust::Preprocessor.read` で各バージョンを展開した結果（すべてエラーなし）:

| バージョン | 挙動の記述 |
|---|---|
| 3.0 / 3.2 | 従来どおり「警告を出力」 |
| 3.3 / 3.4 / 4.0 | 「`ArgumentError` が発生」＋ raise 一覧に追記 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
