### PR TITLE
Range#reverse_each: 始端なし範囲(beginless)の反復に対応した旨を追記 (3.3)

### DIFF
--- a/manual/api/_builtin/Range.md
+++ b/manual/api/_builtin/Range.md
@@ -425,6 +425,10 @@ Range#each は各要素の succ メソッドを使用してイテレーション
 
 内部で各要素を保持した配列を作ります。ただし、端点が [c:Integer] である場合は、配列を作らないように最適化が行われています。
 
+始端を持たない範囲(beginless range)であっても、終端が [c:Integer] であれば、
+終端から下降しながら反復できます。この場合は要素が無限に生成されるため、
+`first` や `take` で打ち切るか、ブロック内で break してください。
+
 ブロックを省略した場合は、各要素を逆順に辿る
 [c:Enumerator] を返します。
 
@@ -436,6 +440,9 @@ p (1..3).reverse_each # => #<Enumerator: ...>
 # => 3
 #    2
 #    1
+# 始端を持たない範囲は終端から下降しながら反復する(無限に生成される)
+p (..5).reverse_each.first(3) # => [5, 4, 3]
+
 (1..).reverse_each { |v| p v } # raises: TypeError: can't iterate from NilClass
 ```
 


### PR DESCRIPTION
## 概要

Ruby 3.3 で `Range#reverse_each` が、終端が `Integer` の**始端なし範囲（beginless range、例: `(..5)`）**を、終端から下降しながら反復できるようになりました（[Feature #18515](https://bugs.ruby-lang.org/issues/18515)）。マニュアルの `Range#reverse_each` の項に未記載だったため追記します。

（同じ 3.3 の変更で、**終端なし範囲（endless range、例: `(1..)`）で `TypeError` になる**件（[Feature #18551](https://bugs.ruby-lang.org/issues/18551)）は既に反映済みです。）

## 変更点（`manual/api/_builtin/Range.md`）

`Range#reverse_each` の項（既存の `#@since 3.3` ブロック内）に以下を追記しました。

- 始端なし範囲でも終端が `Integer` なら反復できること、要素が無限に生成されるため `first` / `take` / `break` で打ち切る旨の説明。
- 例 `p (..5).reverse_each.first(3) # => [5, 4, 3]`。

## 動作確認

実機で挙動を確認しました（`break` で先頭3件を取得）。

| 呼び出し | 3.2.11 | 3.3.12 / 4.0.6 |
|---|---|---|
| `(..5).reverse_each`（beginless） | `TypeError`（未対応） | `[5, 4, 3, …]` |
| `(...5).reverse_each` | `TypeError` | `[4, 3, 2, …]` |
| `(1..).reverse_each`（endless） | ハング（無限に配列生成） | `TypeError`（反映済み） |

`BitClust::Preprocessor.read`（3.2 / 3.3 / 3.4 / 4.0、すべてエラーなし）でも、エントリ全体が `#@since 3.3` のため 3.2 では非掲載、3.3 以降で追記内容が出力されることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
