### PR TITLE
bitclust を 232e986(CommonMark 準拠化ほか)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 50fb413f0f183edd9198b78e721b730ee61ff317
+  revision: 232e986b5022cbfbedf8a1fb22ae5b19c738912b
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
bitclust の参照 revision を 232e986(PR #266〜#269 マージ後の master)に更新します。次の内容が CI と次回の生成から有効になります。

- リスト継続行インデントの CommonMark 準拠化(#266)と、N 連バッククォートコードスパン対応(#269)— rurema/doctree#3232 のレビュー対応の実装側
- 和欧文間を空ける text-autospace(#267)
- CC BY ロゴの体裁修正(#268)

Gemfile.lock の revision 行のみの更新です。マージ後、#3247(gsub 系のコードスパン化)がマージ可能になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
