### PR TITLE
raise 系: backtrace に Thread::Backtrace::Location の配列を渡せる旨を反映 (3.4)

### DIFF
--- a/manual/api/_builtin/Exception.md
+++ b/manual/api/_builtin/Exception.md
@@ -145,7 +145,11 @@ end
 バックトレース情報に errinfo を設定し、設定されたバックトレース
 情報を返します。
 
+#@since 3.4
+- **param** `errinfo` -- nil、[c:String]、[c:String] の配列、あるいは [c:Thread::Backtrace::Location] の配列のいずれかを指定します。
+#@else
 - **param** `errinfo` -- nil、[c:String] あるいは [c:String] の配列のいずれかを指定します。
+#@end
 
 ```ruby title="例"
 begin

--- a/manual/api/_builtin/Fiber.md
+++ b/manual/api/_builtin/Fiber.md
@@ -191,7 +191,11 @@ message 引数を渡した場合、message 引数をメッセージとした Run
 
 - **param** `message` -- 例外のメッセージとなる文字列です。
 - **param** `exception` -- 発生させる例外です。
+#@since 3.4
+- **param** `backtrace` -- 例外発生時のスタックトレースです。文字列の配列、または [c:Thread::Backtrace::Location] の配列で指定します。
+#@else
 - **param** `backtrace` -- 例外発生時のスタックトレースです。文字列の配列で指定します。
+#@end
 
 ```ruby title="例"
 f = Fiber.new { Fiber.yield }

--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -2375,6 +2375,10 @@ error_type として例外ではないクラスやオブジェクトを指定し
 - **param** `message` -- 例外のメッセージとなる文字列です。
 - **param** `backtrace` -- 例外発生時のスタックトレースで、[m:Kernel?.caller] の戻り値と同じ
   形式で指定しなければいけません。
+#@since 3.4
+  Ruby 3.4 からは、[m:Kernel?.caller_locations] の戻り値と同じ
+  [c:Thread::Backtrace::Location] の配列も指定できます。
+#@end
 - **param** `cause` -- 現在の例外([m:$!])の代わりに [m:Exception#cause] に設定する例外を指定します。
   [c:Exception] オブジェクトまたは nil を指定できます。
 - **raise** `TypeError` -- exception メソッドが例外オブジェクトを返さなかった場合に発生します。


### PR DESCRIPTION
## 概要

Ruby 3.4 で、例外のバックトレースを指定する各メソッドが、文字列の配列に加えて **`Thread::Backtrace::Location` の配列**（`caller_locations` の戻り値）も受け付けるようになりました（[Feature #13557](https://bugs.ruby-lang.org/issues/13557)）。マニュアルに未反映だったため追記します。

対象: `Exception#set_backtrace` / `Kernel#raise` / `Thread#raise` / `Fiber#raise`

## 変更点

各メソッドの backtrace（`errinfo` / `backtrace`）引数の説明に `#@since 3.4` で「`Thread::Backtrace::Location` の配列も指定できる」旨を追記しました。

- `manual/api/_builtin/Exception.md`（`Exception#set_backtrace`）
- `manual/api/_builtin/functions.md`（`Kernel.#raise`）
- `manual/api/_builtin/Fiber.md`（`Fiber#raise`）

`Thread#raise` は `traceback` 引数の説明が「[[m:Kernel?.raise]] を参照してください」と委譲しているため、`Kernel#raise` の更新でカバーされます（Thread.md は変更していません）。

## 動作確認

実機で挙動を確認しました（`caller_locations(0)` は `Thread::Backtrace::Location` の配列）。

| 呼び出し | 3.3.12 | 3.4.10 / 4.0.6 |
|---|---|---|
| `e.set_backtrace(caller_locations)` | `TypeError: backtrace must be Array of String` | 成功（`backtrace` は文字列で返る） |
| `raise(RuntimeError, "y", caller_locations)` | `TypeError: backtrace must be Array of String` | 成功 |

`BitClust::Preprocessor.read`（3.2 / 3.3 / 3.4 / 4.0、すべてエラーなし）でも、3.4 以降のみ `Thread::Backtrace::Location` の配列の記述が追加されることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
