### PR TITLE
Object#singleton_method: 特異クラスに include/prepend したモジュールのメソッドも返す旨を反映 (3.4)

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -1401,6 +1401,11 @@ p me.call #=> 365
 オブジェクトの特異メソッド name をオブジェクト化した [c:Method] オブ
 ジェクトを返します。
 
+#@since 3.4
+特異クラスに include / prepend されたモジュールのインスタンスメソッド
+（例えば [m:Object#extend] で追加したモジュールのメソッド）も対象になります。
+#@end
+
 - **param** `name` -- メソッド名を[c:Symbol] または[c:String]で指定します。
 - **raise** `NameError` -- 定義されていないメソッド名を引数として与えると発生します。
 
@@ -1422,6 +1427,14 @@ m = k.singleton_method(:hi)    # => #<Method: #<Demo:0xf8b0c3c4 @iv=99>.hi>
 p m.call #=> "Hi, @iv = 99"
 m = k.singleton_method(:hello) # ~> NameError
 ```
+
+#@since 3.4
+```ruby title="例: extend で追加したモジュールのメソッド"
+o = Object.new
+o.extend(Module.new { def a = 1 })
+p o.singleton_method(:a).call # => 1
+```
+#@end
 
 - **SEE** [m:Module#instance_method], [c:Method], [m:BasicObject#__send__], [m:Object#send], [m:Kernel?.eval], [m:Object#method]
 


### PR DESCRIPTION
## 概要

Ruby 3.4 で `Object#singleton_method` が、レシーバの**特異クラスに include / prepend されたモジュール**（`Object#extend` で追加したものを含む）のインスタンスメソッドも返すようになりました（[Bug #20620](https://bugs.ruby-lang.org/issues/20620)）。従来はこれらを見つけられず `NameError` になっていました。マニュアルに未反映だったため追記します。

## 変更点（`manual/api/_builtin/Object.md`）

`Object#singleton_method` の項に `#@since 3.4` で次を追記しました。

- 特異クラスに include / prepend されたモジュールのメソッドも対象になる旨の説明。
- `extend` で追加したモジュールのメソッドを取得する例。

## 動作確認

実機で挙動を確認しました。

```ruby
o = Object.new
o.extend(Module.new { def a = 1 })
o.singleton_method(:a)
```

| バージョン | 結果 |
|---|---|
| 3.3.12 | `NameError: undefined singleton method 'a' for ...` |
| 3.4.10 / 4.0.6 | `Method` を返す（`.call #=> 1`） |

（`singleton_class.prepend` したモジュールのメソッドについても同様に、3.3 は `NameError`、3.4 以降は取得できることを確認しました。）

`BitClust::Preprocessor.read`（3.2 / 3.3 / 3.4 / 4.0、すべてエラーなし）でも、3.4 以降のみ追記内容が出力されることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
