### PR TITLE
bitclust を e936dba(メソッド単位 since/until バッジ一式)に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 232e986b5022cbfbedf8a1fb22ae5b19c738912b
+  revision: e936dba2cf25c1098de19f3fb9a77dba8b28a62b
   specs:
     bitclust-core (1.5.0)
       drb


### PR DESCRIPTION
## 概要

bitclust の lock を 232e986 → e936dba に更新します。メソッド単位バージョンバッジ一式(rurema/bitclust#132 の PR #270〜#273)を取り込みます。

- 名前別 since/until スキーマ(#270)・`methodsince` 算出サブコマンド(#271)・署名へのバッジ表示(#272)・`{: since="X"}` / `{: until="X"}` メソッド属性(#273)
- bitclust の VERSION は 1.5.0 のままなので、lock は revision 行 1 行のみの更新です

## 効果と注意

- 生成パイプライン(generated-documents)は bitclust master を直接 clone するため、本 lock とは独立です。この更新は **doctree の CI** と、**原稿で `{: since="X"}` / `{: until="X"}` 属性を使えるようにする**ためのものです(旧リビジョンでは未知属性としてビルドエラーになります)。

refs rurema/bitclust#132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
