### PR TITLE
Symbol#to_s / #id2name: 返り値の破壊的変更が Ruby 3.4 で警告になる旨を追記 (3.4)

### DIFF
--- a/manual/api/_builtin/Symbol.md
+++ b/manual/api/_builtin/Symbol.md
@@ -149,6 +149,19 @@ p :foo.id2name  # => "foo"
 p :foo.id2name.intern == :foo  # => true
 ```
 
+#@since 3.4
+返り値の文字列を破壊的に変更すると、Warning[:deprecated] が真のとき
+「この文字列は将来のバージョンで freeze される」という趣旨の警告が出る
+ようになりました。将来のバージョンでは返り値が freeze される予定です。
+freeze された文字列が必要なときは [m:Symbol#name] を使用してください。
+
+```ruby
+s = :foo.to_s
+s << "bar"
+# warning: string returned by :foo.to_s will be frozen in the future
+```
+#@end
+
 - **SEE** [m:String#intern]
 - **SEE** [m:Symbol#name]
 ### def name -> String


### PR DESCRIPTION
## 概要

Ruby 3.4 から、[m:Symbol#to_s]（および別名の [m:Symbol#id2name]）が返す文字列を破壊的に変更すると、`Warning[:deprecated]` が真のとき「将来のバージョンで freeze される」という趣旨の deprecated 警告が出るようになりました（[Feature #20350](https://bugs.ruby-lang.org/issues/20350)）。マニュアルの `to_s` の項にはこの記述がなかったため追記します。

## 変更内容

- `manual/api/_builtin/Symbol.md` の `id2name` / `to_s` の項に `#@since 3.4` で分岐する注記を追加。
  - 返り値を破壊的に変更すると警告が出ること、将来 frozen 化される予定であることを記載。
  - freeze された文字列が必要な場合の代替として [m:Symbol#name] への案内を追加。

## 実機確認

| Ruby | 破壊的変更時の警告 (`-w` / `-W:deprecated`) | `to_s.frozen?` |
|---|---|---|
| 3.3 | なし | false |
| 3.4 / 4.0 | `string returned by :foo.to_s will be frozen in the future` | false |

```ruby
s = :foo.to_s
s << "bar"
# warning: string returned by :foo.to_s will be frozen in the future
```

bitclust の preprocessor で、注記が 3.4 / 4.0 でのみ出力され、3.2 / 3.3 では出力されないことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)