### PR TITLE
Object#inspect: instance_variables_to_inspect フック (Ruby 4.0) を追記

### DIFF
--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -916,6 +916,27 @@ end
 p Bar.new.inspect                # => "#<Bar:0x0300c868 @bar=1>"
 ```
 
+#@since 4.0
+inspect をオーバーライドしていない場合、
+instance_variables_to_inspect を定義することで、inspect の出力に含める
+インスタンス変数を制御できます。このメソッドは、表示したいインスタンス変数名を
+[c:Symbol] の配列で返すようにします（デフォルトの実装は nil を返し、その場合は
+全てのインスタンス変数が表示されます）。パスワードなどの機密情報を持つ
+インスタンス変数を inspect の出力（ログなど）に含めたくない場合に利用できます。
+
+```ruby
+class Foo
+  def initialize
+    @a = 1
+    @password = "secret"
+    @b = 2
+  end
+  private def instance_variables_to_inspect = [:@a, :@b]
+end
+p Foo.new.inspect                # => "#<Foo:0x0300c868 @a=1, @b=2>"
+```
+#@end
+
 - **SEE** [m:Kernel?.p]
 
 ### def instance_variable_get(var) -> object | nil


### PR DESCRIPTION
## 概要

Ruby 4.0 から、`instance_variables_to_inspect` を定義することで、既定の [m:Object#inspect] 出力に含めるインスタンス変数を制御できるようになりました（[Feature #21219](https://bugs.ruby-lang.org/issues/21219)）。パスワードなどの機密情報を持つインスタンス変数を inspect の出力（ログなど）から除外する用途に使えます。マニュアルの `inspect` の項にこの記述がなかったため追記します。

## 変更内容

- `manual/api/_builtin/Object.md` の `inspect` の項に `#@since 4.0` で分岐する注記と例を追加。
  - `instance_variables_to_inspect` を定義すると、表示するインスタンス変数を Symbol の配列で指定できる旨を記載。
  - 既定の実装は `nil` を返し、その場合は全インスタンス変数が表示される旨も明記。

## 実機確認 (Ruby 4.0.6)

```ruby
class Foo
  def initialize
    @a = 1
    @password = "secret"
    @b = 2
  end
  private def instance_variables_to_inspect = [:@a, :@b]
end
p Foo.new
```

| Ruby | 出力 |
|---|---|
| 3.4 | `#<Foo:0x... @a=1, @password="secret", @b=2>`（フックは無視） |
| 4.0 | `#<Foo:0x... @a=1, @b=2>`（`@password` が除外される） |

補足: このフックは `Kernel` のメソッドで、arity 0・既定の戻り値は `nil` です。なお 4.0.6 時点では `pp` はこのフックを尊重しないため、`inspect` / `Kernel#p` の挙動として記述しています。

bitclust の preprocessor で、注記が 4.0 でのみ出力され、3.3 / 3.4 では出力されないことを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)