### PR TITLE
Binding / Kernel: 番号指定パラメータがローカル変数として扱われなくなった旨を追記 (4.0)

### DIFF
--- a/manual/api/_builtin/Binding.md
+++ b/manual/api/_builtin/Binding.md
@@ -44,6 +44,9 @@ p get_binding("bye").eval("str + ' Fred'")   #=> "bye Fred"
 - **param** `symbol` -- ローカル変数名を [c:Symbol] オブジェクトで指定します。
 
 - **raise** `NameError` -- 引数 symbol で指定したローカル変数が未定義の場合に発生します。
+#@since 4.0
+- **raise** `NameError` -- 番号付きパラメータ（_1 など）を指定した場合に発生します。
+#@end
 
 ```ruby title="例"
 def foo
@@ -68,6 +71,9 @@ binding.eval("#{symbol}")
 - **param** `symbol` -- ローカル変数名を [c:Symbol] オブジェクトで指定します。
 
 - **param** `obj` -- 引数 symbol で指定したローカル変数に設定するオブジェクトを指定します。
+#@since 4.0
+- **raise** `NameError` -- 番号付きパラメータ（_1 など）を symbol に指定した場合に発生します。
+#@end
 
 ```ruby title="例"
 def foo
@@ -98,6 +104,9 @@ binding.eval("#{symbol} = #{obj}")
 そうでない場合に false を返します。
 
 - **param** `symbol` -- ローカル変数名を [c:Symbol] オブジェクトで指定します。
+#@since 4.0
+- **raise** `NameError` -- 番号付きパラメータ（_1 など）を指定した場合に発生します。
+#@end
 
 ```ruby title="例"
 def foo
@@ -127,6 +136,21 @@ def foo
   end
 end
 ```
+
+#@since 4.0
+番号付きパラメータ（_1 など）は 4.0 からローカル変数として扱われなくなり、
+返り値に含まれなくなりました。
+
+```ruby
+[1].each do
+  p _1                      # => 1
+  p binding.local_variables # => []（Ruby 3.4 以前は [:_1]）
+end
+```
+
+番号付きパラメータ自体は従来どおり参照できますが、4.0 からは
+[m:Binding#local_variables] の返り値には含まれません。
+#@end
 
 このメソッドは以下のコードと同様の動作をします。
 

--- a/manual/api/_builtin/Binding.md
+++ b/manual/api/_builtin/Binding.md
@@ -45,7 +45,7 @@ p get_binding("bye").eval("str + ' Fred'")   #=> "bye Fred"
 
 - **raise** `NameError` -- 引数 symbol で指定したローカル変数が未定義の場合に発生します。
 #@since 4.0
-- **raise** `NameError` -- 番号付きパラメータ（_1 など）を指定した場合に発生します。
+- **raise** `NameError` -- 番号指定パラメータ（_1 など）を指定した場合に発生します。
 #@end
 
 ```ruby title="例"
@@ -72,7 +72,7 @@ binding.eval("#{symbol}")
 
 - **param** `obj` -- 引数 symbol で指定したローカル変数に設定するオブジェクトを指定します。
 #@since 4.0
-- **raise** `NameError` -- 番号付きパラメータ（_1 など）を symbol に指定した場合に発生します。
+- **raise** `NameError` -- 番号指定パラメータ（_1 など）を symbol に指定した場合に発生します。
 #@end
 
 ```ruby title="例"
@@ -105,7 +105,7 @@ binding.eval("#{symbol} = #{obj}")
 
 - **param** `symbol` -- ローカル変数名を [c:Symbol] オブジェクトで指定します。
 #@since 4.0
-- **raise** `NameError` -- 番号付きパラメータ（_1 など）を指定した場合に発生します。
+- **raise** `NameError` -- 番号指定パラメータ（_1 など）を指定した場合に発生します。
 #@end
 
 ```ruby title="例"
@@ -138,7 +138,7 @@ end
 ```
 
 #@since 4.0
-番号付きパラメータ（_1 など）は 4.0 からローカル変数として扱われなくなり、
+番号指定パラメータ（_1 など）は 4.0 からローカル変数として扱われなくなり、
 返り値に含まれなくなりました。
 
 ```ruby
@@ -148,8 +148,7 @@ end
 end
 ```
 
-番号付きパラメータ自体は従来どおり参照できますが、4.0 からは
-[m:Binding#local_variables] の返り値には含まれません。
+番号指定パラメータ自体は従来どおり参照できます（[ref:d:spec/call#numbered_parameters]）。
 #@end
 
 このメソッドは以下のコードと同様の動作をします。

--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -2174,6 +2174,20 @@ yuyu = 0
 p local_variables #=> [:yuyu]
 ```
 
+#@since 4.0
+番号指定パラメータ（_1 など）は 4.0 からローカル変数として扱われなくなり、
+返り値に含まれなくなりました。
+
+```ruby
+[1].each do
+  p _1              # => 1
+  p local_variables # => []（Ruby 3.4 以前は [:_1]）
+end
+```
+
+番号指定パラメータ自体は従来どおり参照できます（[ref:d:spec/call#numbered_parameters]）。
+#@end
+
 - **SEE** [m:Kernel?.global_variables],[m:Object#instance_variables],[m:Module.constants],[m:Module#constants],[m:Module#class_variables]
 
 ### module_function def sub(pattern, replace)          -> String


### PR DESCRIPTION
## 概要

Ruby 4.0 から、番号指定パラメータ（`_1` など）はローカル変数として扱われなくなりました（[Bug #21049](https://bugs.ruby-lang.org/issues/21049)）。マニュアルの [c:Binding] および [m:Kernel.#local_variables] の各メソッドにこの記述がなかったため追記します。

## 変更内容

`#@since 4.0` で分岐する注記を追加。

**`manual/api/_builtin/Binding.md`**

- [m:Binding#local_variables] -- 返り値に番号指定パラメータを含めなくなった旨の説明と例。
- [m:Binding#local_variable_get] / [m:Binding#local_variable_set] / [m:Binding#local_variable_defined?] -- 番号指定パラメータを指定すると `NameError` が発生する旨を `- **raise**` として追記。

**`manual/api/_builtin/functions.md`**

- [m:Kernel.#local_variables] -- 返り値に番号指定パラメータを含めなくなった旨の説明と例（同じ Bug #21049）。

いずれも仕様への誘導として [ref:d:spec/call#numbered_parameters] を添えています。

## 実機確認

番号指定パラメータ（`_1`）を使うブロック内での挙動：

| | Ruby 3.3 / 3.4 | Ruby 4.0 |
|---|---|---|
| `Binding#local_variables` / `Kernel.#local_variables` | `[:_1]` を含む | 含まない（`[]`） |
| `Binding#local_variable_get(:_1)` | 値を返す | `NameError` |
| `Binding#local_variable_defined?(:_1)` | `true` | `NameError` |
| `Binding#local_variable_set(:_1, v)` | 設定できる | `NameError` |

エラーメッセージは `numbered parameter '_1' is not a local variable`。なお `defined?(_1)` は 4.0 でも `"local-variable"` を返すため、`defined?` 側は変更していません。

bitclust の preprocessor で 4.0 のみ出力・3.3 / 3.4 非表示を確認、`rake check_blank_lines` ほか lint もローカルで通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)