### PR TITLE
Rational#**: 巨大な計算結果の旧挙動 (INFINITY/NaN) を Ruby 3.4 で併記

### DIFF
--- a/manual/api/_builtin/Rational.md
+++ b/manual/api/_builtin/Rational.md
@@ -64,6 +64,29 @@ p r ** 2.0           # => 0.5625
 p r ** Rational(1, 2)  # => 0.866025403784439
 ```
 
+#@until 3.4
+計算結果の分母・分子が巨大になりすぎるとき、警告を出したうえで Float::INFINITY（基数によっては NaN）を返します。
+
+```ruby title="計算を放棄して Float::INFINITY を返す例"
+p Rational(2) ** 100000000
+# => warning: in a**b, b may be too big
+#    Infinity
+```
+
+判定の閾値は変わりえます。
+#@end
+
+#@since 3.4
+計算結果の分母・分子が巨大すぎるときは ArgumentError が発生します。
+
+```ruby title="計算結果が巨大すぎる例"
+p Rational(2) ** 10000000000000000000
+# => exponent is too large (ArgumentError)
+```
+
+判定の閾値は変わりえます。
+#@end
+
 ### def +(other) -> Rational | Float
 
 和を計算します。


### PR DESCRIPTION
## 概要

[m:Rational#**] は Ruby 3.4 から、計算結果の分母・分子が巨大になる場合でも可能な限り [c:Rational] を計算し、極端に巨大なときは `ArgumentError`（`exponent is too large`）を発生するようになりました。新しい `ArgumentError` の記述（`- **raise**`）は既に反映済みでしたが、**3.3 以前の挙動**（警告を出したうえで `Float::INFINITY` / `NaN` を返す）の記述がありませんでした。

姉妹メソッドの [m:Integer#**] は旧挙動（`#@until 3.4`）と新挙動（`#@since 3.4`）を併記しているため、これに倣って揃えます。

## 変更内容

`manual/api/_builtin/Rational.md` の `**` に、[m:Integer#**] と同じ構造で以下を追加。

- `#@until 3.4` -- 巨大な結果のとき警告つきで `Float::INFINITY`（基数によっては `NaN`）を返す旧挙動。
- `#@since 3.4` -- 巨大すぎるときは `ArgumentError` が発生する新挙動。

## 実機確認

| 式 | Ruby 3.3 | Ruby 3.4 / 4.0 |
|---|---|---|
| `Rational(2) ** 100000000` | 警告 + `Infinity` | 巨大な `Rational`（約3000万桁） |
| `Rational(3, 2) ** 100000000` | `NaN` | 巨大な `Rational` |
| `Rational(2) ** 10000000000000000000` | `Infinity` | `ArgumentError: exponent is too large` |

3.3 での警告メッセージは `in a**b, b may be too big` で、[m:Integer#**] と同一です。

`rake check_blank_lines` / `check_indent_in_samplecode` / `check_single_space_indent` をローカルで実行し、いずれもパスすることを確認済みです。bitclust の preprocessor で、旧挙動が 3.3 以前のみ・新挙動が 3.4 以降のみ出力されることも確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)