### PR TITLE
ObjectSpace._id2ref: Ruby 4.0 で deprecated になった旨を追記

### DIFF
--- a/manual/api/_builtin/ObjectSpace.md
+++ b/manual/api/_builtin/ObjectSpace.md
@@ -11,6 +11,23 @@ library: _builtin
 
 オブジェクト ID([m:BasicObject#__id__])からオブジェクトを得ます。
 
+#@since 4.0
+このメソッドは Ruby 4.0 から deprecated です。Warning[:deprecated] が真のとき
+「ObjectSpace._id2ref is deprecated」という警告を出力します。
+将来のバージョンでは削除される予定です。
+
+オブジェクト ID からオブジェクトを引く必要がある場合は、[m:Object#object_id]
+をキーとして [c:ObjectSpace::WeakMap] にオブジェクトを保持しておく方法があります。
+
+```ruby
+map = ObjectSpace::WeakMap.new
+a = "hoge"
+map[a.object_id] = a
+p map[a.object_id] # => "hoge"
+```
+
+#@end
+
 - **param** `id` -- 取得したいオブジェクトの ID を整数で指定します。
 
 - **raise** `RangeError` -- 対応するオブジェクトが存在しなければ発生します。


### PR DESCRIPTION
## 概要

Ruby 4.0 から [m:ObjectSpace.#_id2ref] は deprecated になりました（[Feature #15408](https://bugs.ruby-lang.org/issues/15408)）。マニュアルの `_id2ref` の項にこの記述がなかったため追記します。

## 変更内容

`manual/api/_builtin/ObjectSpace.md` の `_id2ref` の項に `#@since 4.0` で分岐する注記を追加。

- Ruby 4.0 から deprecated であり、`Warning[:deprecated]` が真のとき `ObjectSpace._id2ref is deprecated` の警告が出る旨。
- 将来のバージョンで削除される予定である旨。
- 代替として [m:Object#object_id] をキーに [c:ObjectSpace::WeakMap] へオブジェクトを保持する方法（Feature #15408 で案内されている方法）と、その例。

## 実機確認

| Ruby | 動作 | `-W:deprecated` 時の警告 |
|---|---|---|
| 3.3 / 3.4 | 動作する | なし |
| 4.0 | 動作する | `warning: ObjectSpace._id2ref is deprecated` |
| 4.1-dev (master) | **削除済み**（`ObjectSpace.respond_to?(:_id2ref)` が `false`、`NoMethodError`） | - |

削除は 4.1-dev では既に入っていますが、未リリースのため今回は「将来のバージョンでは削除される予定です」という表現に留めています。4.1 リリース後に版を確定させる形が良いかと思います。

なお未定義の ID に対する `RangeError` は 3.3 / 3.4 / 4.0 で変わらないため（メッセージが `is not id value` → `is not an id value` に変わっただけ）、既存の `- **raise**` の記述はそのままにしています。

## ご相談

代替として [c:ObjectSpace::WeakMap] を挙げていますが、当マニュアルの [c:ObjectSpace::WeakMap] のページには「主に [c:WeakRef] クラスの内部で使用されるため、[lib:weakref] ライブラリ経由で使用してください」と書かれています。一方 Feature #15408 では WeakMap を公式 API として `object_id` をキーに使う方法が案内されており、`_id2ref` の用途（ID からの逆引き）にはこちらが直接の代替になります。この書き方で問題ないか、あるいは表現を調整すべきかご意見いただけると助かります。

bitclust の preprocessor で 4.0 のみ出力・3.3 / 3.4 非表示を確認、`rake check_blank_lines` ほか lint もローカルで通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)