### PR TITLE
Proc#parameters: 引数名を持たない引数の表現 (Ruby 4.0 の変更) を追記

### DIFF
--- a/manual/api/_builtin/Proc.md
+++ b/manual/api/_builtin/Proc.md
@@ -406,6 +406,25 @@ Proc オブジェクトが引数を取らなければ空の配列を返します
               扱ったときの引数の情報を返します。
 #@end
 
+分割代入を使った `|(a, b)|` のように引数名を持たない引数の場合は、引数の種類を表す
+Symbol だけの 1 要素の配列になります。
+#@since 4.0
+これは必須の引数でもオプショナルな引数でも同様です。
+#@else
+ただし、オプショナルな引数の場合は引数名が nil の 2 要素の配列になります。
+#@end
+
+```ruby title="引数名を持たない引数の例"
+p lambda { |(a, b)| }.parameters  # => [[:req]]
+#@since 4.0
+p proc { |(a, b)| }.parameters    # => [[:opt]]
+p proc { |x, (a, b)| }.parameters # => [[:opt, :x], [:opt]]
+#@else
+p proc { |(a, b)| }.parameters    # => [[:opt, nil]]
+p proc { |x, (a, b)| }.parameters # => [[:opt, :x], [:opt, nil]]
+#@end
+```
+
   ```ruby title="例"
   prc = lambda{|x, y=42, *other, k_x:, k_y: 42, **k_other, &b|}
   prc.parameters #=> [[:req, :x], [:opt, :y], [:rest, :other], [:keyreq, :k_x], [:key, :k_y], [:keyrest, :k_other], [:block, :b]]


### PR DESCRIPTION
## 概要

Ruby 4.0 から [m:Proc#parameters] は、引数名を持たないオプショナルな引数を `[:opt, nil]` ではなく `[:opt]` で返すようになりました（[Bug #20974](https://bugs.ruby-lang.org/issues/20974)）。必須の引数が以前から `[:req]` を返していたのと表現が揃った形です。

## 変更内容

`manual/api/_builtin/Proc.md` の `parameters` の項に追記しました。

現在のマニュアルは「各配列の要素は引数の種類に対応した Symbol と、引数名を表す Symbol の **2 要素**です」とだけ書かれており、**引数名を持たない引数で 1 要素になるケース自体が未記載**でした。そこで、

- 引数名を持たない引数（分割代入 `|(a, b)|` で生じる）は、引数の種類だけの 1 要素の配列になること
- `#@since 4.0` / `#@else` で、4.0 以降は必須・オプショナルとも 1 要素になること／3.4 以前はオプショナルのみ引数名が nil の 2 要素になること

を、それぞれの例つきで追記しています。

## 実機確認

| 式 | Ruby 3.3 / 3.4 | Ruby 4.0 |
|---|---|---|
| `proc { \|(a, b)\| }.parameters` | `[[:opt, nil]]` | `[[:opt]]` |
| `proc { \|x, (a, b)\| }.parameters` | `[[:opt, :x], [:opt, nil]]` | `[[:opt, :x], [:opt]]` |
| `lambda { \|(a, b)\| }.parameters` | `[[:req]]` | `[[:req]]`（変化なし） |

なお、読み込み済みの組み込みメソッドを全走査して `Method#parameters` / `UnboundMethod#parameters` 側で `[:opt, nil]` を返すものを探しましたが該当は無く、影響するのは分割代入を使った Proc のケースでした。そのため [m:Method#parameters] / [m:UnboundMethod#parameters] 側は変更していません。

bitclust の preprocessor で 3.3 / 3.4 と 4.0 それぞれ意図した分岐が出力されることを確認、`rake check_blank_lines` ほか lint もローカルで通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)