### PR TITLE
Enumerable#to_set: 引数渡しの deprecated (4.0) と Set の表示形式を反映

### DIFF
--- a/manual/api/_builtin/Enumerable.md
+++ b/manual/api/_builtin/Enumerable.md
@@ -1623,6 +1623,12 @@ Ruby 2.7 以前は SortedSet が定義されていました)。
 引数 args およびブロックは、集合オブジェクトを生成するための new
 メソッドに渡されます。
 
+#@since 4.0
+Ruby 4.0 から、引数 klass や args を渡す呼び出しは deprecated です。
+引数を渡すと「passing arguments to Enumerable#to_set is deprecated」という
+警告を出力します（ブロックのみを渡す呼び出しは deprecated ではありません）。
+#@end
+
 - **param** `klass` -- 生成する集合クラスを指定します。
 - **param** `args` -- 集合クラスのオブジェクト初期化メソッドに渡す引数を指定します。
 - **param** `block` -- 集合クラスのオブジェクト初期化メソッドに渡すブロックを指定します。
@@ -1630,12 +1636,23 @@ Ruby 2.7 以前は SortedSet が定義されていました)。
 
 ```ruby
 p [30, 10, 20].to_set
+#@since 4.0
+#=> Set[30, 10, 20]
+#@else
 #=> #<Set: {30, 10, 20}>
+#@end
 MySet = Class.new(Set)
 p [30, 10, 20].to_set(MySet)
-#=> #<MySet: {10, 20, 30}>
+#@since 4.0
+# warning: passing arguments to Enumerable#to_set is deprecated
+#@end
+#=> #<MySet: {30, 10, 20}>
 p [30, 10, 20].to_set {|num| num / 10}
+#@since 4.0
+#=> Set[3, 1, 2]
+#@else
 #=> #<Set: {3, 1, 2}>
+#@end
 ```
 
 - **SEE** [m:Set.new]


### PR DESCRIPTION
## 概要

Ruby 4.0 の変更 2 件を [m:Enumerable#to_set] に反映します。

- 引数（`klass` / `args`）を渡す呼び出しが deprecated になりました（[Feature #21390](https://bugs.ruby-lang.org/issues/21390)）。
- [m:Set#inspect] の表示が `Set[...]` 形式になった（[Feature #21389](https://bugs.ruby-lang.org/issues/21389)）ため、例の出力が旧形式のままになっていました。

## 変更内容

`manual/api/_builtin/Enumerable.md` の `to_set` の項（`#@since 3.2` ブロック内）に `#@since 4.0` の分岐を追加。

- 引数を渡す呼び出しが deprecated である旨と、出力される警告文を追記。ブロックのみを渡す呼び出しは対象外である点も明記しました。
- 例の出力を `#@since 4.0` / `#@else` で出し分け（`Set[30, 10, 20]` / `#<Set: {30, 10, 20}>`）。
- 引数付き呼び出しの例には、4.0 で警告が出ることをコメントで示しました。

## 実機確認

| | Ruby 3.3 / 3.4 | Ruby 4.0 |
|---|---|---|
| `[30, 10, 20].to_set` | `#<Set: {30, 10, 20}>` | `Set[30, 10, 20]` |
| `[30, 10, 20].to_set(MySet)` | `#<MySet: {30, 10, 20}>` | 警告 + `#<MySet: {30, 10, 20}>` |
| `[30, 10, 20].to_set {\|num\| num / 10}` | `#<Set: {3, 1, 2}>` | `Set[3, 1, 2]` |

補足として確認した点:

- **警告は `Warning[:deprecated]` に依存しません**。既定でも出力され、`-W0` のときだけ抑止されます（`_id2ref` 等の deprecated 警告とは挙動が異なります）。そのため注記でも「Warning[:deprecated] が真のとき」という条件は付けていません。
- **Set のサブクラスは従来どおり `#<MySet: {...}>` 形式**のままです（`Set[...]` になるのは Set 自身のみ）。そのため該当行はバージョン分岐していません。

## 既存の記述の誤りをあわせて修正

例の `to_set(MySet)` の出力が `#<MySet: {10, 20, 30}>` となっていましたが、実際は入力順のまま `#<MySet: {30, 10, 20}>` です（3.3 / 3.4 / 4.0 いずれでも確認）。SortedSet が存在した頃の名残と思われるため、あわせて修正しました。

## 関連

`Set#inspect` 自体（`Set.md` の例やマニュアル各所に残る旧形式の Set 出力例）の横断修正は範囲が広いため、本 PR には含めず別途対応する想定です。なお NEWS では `Set#to_set` も同じ Feature #21390 の対象ですが、当マニュアルに `Set#to_set` の項目は無いため対象外としました。

bitclust の preprocessor で 3.3 / 3.4 と 4.0 それぞれ意図した分岐が出力されることを確認、`rake check_blank_lines` ほか lint もローカルで通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)