### PR TITLE
Net::HTTP: body 付きリクエストの Content-Type 自動設定廃止 (4.0) を反映

### DIFF
--- a/manual/api/net/http/Net__HTTP.md
+++ b/manual/api/net/http/Net__HTTP.md
@@ -769,9 +769,16 @@ POST で送ります。
 ブロックに与えます。このとき戻り値の HTTPResponse オブジェクトは有効な body を
 持ちません。
 
+#@since 4.0
+POST する場合にはヘッダに Content-Type: を指定する必要があります。
+Ruby 4.0 から、header に指定しなかった場合に Content-Type を
+"application/x-www-form-urlencoded" として補う挙動は削除されました。
+指定しなかった場合、Content-Type ヘッダは送信されません。
+#@else
 POST する場合にはヘッダに Content-Type: を指定する必要があります。
 もし header に指定しなかったならば、 Content-Type として
 "application/x-www-form-urlencoded" を用います。
+#@end
 
 dest は時代遅れの引数です。利用しないでください。
 dest を指定した場合には
@@ -894,9 +901,16 @@ header が nil
 接続を維持した状態で [c:Net::HTTPResponse]
 オブジェクトをブロックに渡します。
 
+#@since 4.0
+POST する場合にはヘッダに Content-Type: を指定する必要があります。
+Ruby 4.0 から、header に指定しなかった場合に Content-Type を
+"application/x-www-form-urlencoded" として補う挙動は削除されました。
+指定しなかった場合、Content-Type ヘッダは送信されません。
+#@else
 POST する場合にはヘッダに Content-Type: を指定する必要があります。
 もし header に指定しなかったならば、 Content-Type として
 "application/x-www-form-urlencoded" を用います。
+#@end
 
 - **param** `path` -- POST先のエンティティのパスを文字列で指定します。
 - **param** `data` -- POSTするデータを与えます。


### PR DESCRIPTION
## 概要

Ruby 4.0 から、body を持つリクエスト（POST / PUT 等）で `Content-Type` が明示されていないときに `application/x-www-form-urlencoded` を補う挙動が削除されました。指定しなかった場合は `Content-Type` ヘッダ自体が送信されません。

出典は NEWS-4.0.0 の Net::HTTP の項で、そこで参照されているのが [ruby/net-http#205](https://github.com/ruby/net-http/issues/205)（"Do not supply a default content type."）です。この変更は net-http gem 側で行われたため、bugs.ruby-lang.org には対応するチケットがありません。

マニュアルには「もし header に指定しなかったならば、Content-Type として "application/x-www-form-urlencoded" を用います」という記述が残っていたため、バージョンで出し分けます。

## 変更内容

`manual/api/net/http/Net__HTTP.md` の以下 2 箇所を `#@since 4.0` / `#@else` で分岐。

- [m:Net::HTTP#post]
- [m:Net::HTTP#request_post]

4.0 以降は「header に指定しなかった場合に補う挙動は削除された」「指定しなかった場合 Content-Type ヘッダは送信されない」と記述し、3.4 以前は従来の文言をそのまま残しています。

なお [m:Net::HTTP#patch] にも同じ説明がありますが、元々 `#@#` でコメントアウトされていて出力されないため対象外としました。

## 実機確認

ローカルの `TCPServer` に対して body 付き POST を送り、サーバ側で受信したリクエストヘッダをそのまま captured した結果です。

```ruby
req = Net::HTTP::Post.new("/")
req.body = "a=1&b=2"
Net::HTTP.start("127.0.0.1", port) { |h| h.request(req) }
```

| Ruby | 送信された Content-Type |
|---|---|
| 3.3 / 3.4 | `Content-Type: application/x-www-form-urlencoded` |
| 4.0 | **ヘッダなし**（Content-Type 行自体が送られない） |

## 変更しなかった箇所

[m:Net::HTTPHeader#set_form_data]（および `net/http.md` の `application/x-www-form-urlencoded` の記述）は、4.0 でも従来どおり Content-Type を明示的に設定することを確認したため、変更していません。

```
set_form_data 後の Content-Type : "application/x-www-form-urlencoded"  # 3.4 / 4.0 とも同じ
```

bitclust の preprocessor で、3.3 / 3.4 では旧文言が 2 箇所・4.0 では新文言が 2 箇所出力されることを確認、`rake check_blank_lines` ほか lint もローカルで通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)