### PR TITLE
IO::Buffer クラスのリファレンスを追加（最小構成）

### DIFF
--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -1,0 +1,127 @@
+---
+library: _builtin
+since: "3.3"
+include:
+  - Comparable
+---
+# class IO::Buffer < Object
+
+メモリ領域を直接読み書きするための低レベルなバッファを表すクラスです。
+
+[c:String] を経由せずにメモリ領域を扱えるため、コピーを避けた入出力
+(zero-copy IO)を実現するために使われます。主に [c:Fiber::Scheduler] の
+実装のような、低レベルな入出力を扱う場面で利用します。
+
+バッファは以下のいずれかの方法で確保されたメモリ領域を指します。
+
+  - 内部(internal) -- Ruby が確保したメモリ領域。[m:IO::Buffer.new] で作られます。
+  - 外部(external) -- [c:String] など、Ruby の他のオブジェクトが持つメモリ領域。
+  - マップ(mapped) -- 仮想メモリ機構(Unix の mmap など)で確保されたメモリ領域。
+
+このクラスは実験的な機能です。
+利用すると「IO::Buffer is experimental and both the Ruby and C interface may
+change in the future!」という警告が出力されます。
+将来のバージョンで Ruby と C の双方のインターフェースが変更される可能性があります。
+
+```ruby
+buf = IO::Buffer.new(8)
+p buf.size          # => 8
+
+buf.set_string("Ruby")
+p buf.get_string    # => "Ruby\x00\x00\x00\x00"
+p buf.get_string(0, 4)  # => "Ruby"
+```
+
+## Class Methods
+
+### def new(size = IO::Buffer::DEFAULT_SIZE, flags = 0) -> IO::Buffer
+
+size バイトの、0 で埋められた新しいバッファを作成して返します。
+
+既定では内部(internal)バッファ、すなわち Ruby が直接確保したメモリ領域に
+なります。ただし size が OS 依存の [m:IO::Buffer::PAGE_SIZE] より大きい場合は、
+仮想メモリ機構(Unix では匿名 mmap、Windows では VirtualAlloc)を用いて
+確保されます。flags に [m:IO::Buffer::MAPPED] を指定すると、
+size によらず後者の方法で確保されます。
+
+- **param** `size` -- 確保するバッファのバイト数を整数で指定します。
+             省略した場合は [m:IO::Buffer::DEFAULT_SIZE] になります。
+
+- **param** `flags` -- バッファの確保方法を [m:IO::Buffer::MAPPED] などの定数で指定します。
+
+```ruby
+buf = IO::Buffer.new(4)
+p buf.size       # => 4
+p buf.internal?  # => true
+p buf.get_string # => "\x00\x00\x00\x00"
+```
+
+## Instance Methods
+
+### def size -> Integer
+
+バッファのバイト数を返します。
+
+```ruby
+p IO::Buffer.new(8).size # => 8
+```
+
+### def get_string(offset = 0, length = nil, encoding = Encoding::BINARY) -> String
+
+バッファの内容を [c:String] として取り出して返します。
+
+- **param** `offset` -- 読み出しを開始する位置をバッファの先頭からのバイト数で指定します。
+
+- **param** `length` -- 読み出すバイト数を指定します。省略した場合は offset から
+               バッファの終端までを読み出します。
+
+- **param** `encoding` -- 返す文字列のエンコーディングを指定します。
+                 省略した場合は [m:Encoding::BINARY] になります。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファのバイト数を超える場合に発生します。
+
+```ruby
+buf = IO::Buffer.new(8)
+buf.set_string("Ruby")
+
+p buf.get_string        # => "Ruby\x00\x00\x00\x00"
+p buf.get_string(0, 4)  # => "Ruby"
+p buf.get_string(1, 3)  # => "uby"
+
+p buf.get_string(0, 4).encoding                   # => #<Encoding:BINARY (ASCII-8BIT)>
+p buf.get_string(0, 4, Encoding::UTF_8).encoding  # => #<Encoding:UTF-8>
+
+buf.get_string(0, 99)   # ~> ArgumentError
+```
+
+- **SEE** [m:IO::Buffer#set_string]
+
+### def set_string(string, offset = 0, length = nil, source_offset = 0) -> Integer
+
+文字列 string の内容をバッファに書き込みます。書き込んだバイト数を返します。
+
+- **param** `string` -- 書き込む内容を [c:String] で指定します。
+
+- **param** `offset` -- 書き込みを開始する位置をバッファの先頭からのバイト数で指定します。
+
+- **param** `length` -- 書き込むバイト数を指定します。省略した場合は string 全体を書き込みます。
+
+- **param** `source_offset` -- string のどの位置から読み出すかをバイト数で指定します。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファのバイト数を超える場合に発生します。
+
+- **raise** `IO::Buffer::AccessError` -- 書き込みできないバッファに対して呼び出した場合に発生します。
+
+```ruby
+buf = IO::Buffer.new(8)
+
+p buf.set_string("Ruby")   # => 4
+p buf.get_string           # => "Ruby\x00\x00\x00\x00"
+
+buf.set_string("XY", 6)
+p buf.get_string           # => "Ruby\x00\x00XY"
+
+IO::Buffer.new(2).set_string("TOOLONG") # ~> ArgumentError
+```
+
+- **SEE** [m:IO::Buffer#get_string]

--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -1,12 +1,13 @@
 ---
 library: _builtin
-since: "3.3"
+since: "3.1"
 include:
   - Comparable
 ---
 # class IO::Buffer < Object
 
 メモリ領域を直接読み書きするための低レベルなバッファを表すクラスです。
+Ruby 3.1 で導入されました。
 
 [c:String] を経由せずにメモリ領域を扱えるため、コピーを避けた入出力
 (zero-copy IO)を実現するために使われます。主に [c:Fiber::Scheduler] の
@@ -23,6 +24,8 @@ include:
 change in the future!」という警告が出力されます。
 将来のバージョンで Ruby と C の双方のインターフェースが変更される可能性があります。
 
+この警告は `Warning[:experimental] = false` を指定すると抑止できます。
+
 ```ruby
 buf = IO::Buffer.new(8)
 p buf.size          # => 8
@@ -31,6 +34,28 @@ buf.set_string("Ruby")
 p buf.get_string    # => "Ruby\x00\x00\x00\x00"
 p buf.get_string(0, 4)  # => "Ruby"
 ```
+
+## Constants
+
+### const DEFAULT_SIZE -> Integer
+
+[m:IO::Buffer.new] で size を省略した場合に使われる既定のバイト数です。
+
+値は環境依存です。
+
+### const PAGE_SIZE -> Integer
+
+OS のページサイズをバイト数で表した値です。
+
+[m:IO::Buffer.new] は、size がこの値より大きい場合に仮想メモリ機構を用いて
+バッファを確保します。
+
+値は環境依存です。
+
+### const MAPPED -> Integer
+
+バッファを仮想メモリ機構(Unix では匿名 mmap、Windows では VirtualAlloc)で
+確保することを表すフラグです。[m:IO::Buffer.new] の flags に指定します。
 
 ## Class Methods
 


### PR DESCRIPTION
## 概要

[c:IO::Buffer] は Ruby 3.1 で追加されたクラスですが、るりまには**クラスページ自体が存在せず丸ごと未収録**でした（言及は `manual/doc/news/3_1_0.md` の導入アナウンス1行のみ）。

そこで `manual/api/_builtin/IO__Buffer.md` を新規に追加します。全 66 項目あるため、**まず最小構成で出して方針を確認**し、以降を順次追加していく形にしています。

## 今回含めた範囲

クラス概要（実験的機能である旨・internal / external / mapped の説明）と、中核となる API です。「バッファを作る → 大きさを知る → 書く → 読む」で一通り完結する組み合わせにしました。

- [m:IO::Buffer.new]
- [m:IO::Buffer#size]
- [m:IO::Buffer#get_string]
- [m:IO::Buffer#set_string]
- 定数 `DEFAULT_SIZE` / `PAGE_SIZE` / `MAPPED`（本文から参照しているため同時に収録）

残りはクラスメソッド `for` / `map` / `string` / `size_of`、低レベル IO の `read` / `write` / `pread` / `pwrite`、ビット演算系、残りの定数と例外クラス 5 などです。

## 対象バージョン

front matter に `since: "3.1"` を指定しました。**今回の範囲は Ruby 3.1 でもそのまま動作するため、`#@since` による分岐は 1 つも必要ありません。**

実機 3.1.6 で全例を逐語実行し、出力・エンコーディング・例外クラス・定数値（`DEFAULT_SIZE=65536` など）・`Comparable` の include まで 4.0.6 と一致することを確認しています。唯一の差異は `ArgumentError` のメッセージ文言（3.1: `exceeds buffer size!` / 4.0: `is bigger than the buffer size!`）ですが、例外クラスは同じで、本 PR の例は例外クラスのみを示しているため影響ありません。

将来 `IO::Buffer.string`（3.3 で追加）や `#private?`（3.3 で追加）を追加する際に、その 2 項目だけ `#@since` を付ければ済みます。

## 実験的機能について

[c:IO::Buffer] は Ruby 4.0 時点でも実験的機能で、利用すると既定でも次の警告が出ます。

```
warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!
```

ページ冒頭でこの旨と、`Warning[:experimental] = false` で抑止できることを明記しています。

## 確認したこと

- 例の出力はすべて実機（Ruby 3.1.6 / 4.0.6）でそのまま実行し、記載と一致することを確認しました。
- front matter の `since: "3.1"` が 3.0 を除外し 3.1 以降で生成されることを、bitclust の判定ロジックで確認しました。
- 本文から参照している定数 3 つを同時に収録し、リンク切れが無いことを確認しています。
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_single_space_indent` / `check_filename_case_conflicts` はいずれも通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)