### PR TITLE
Ractor: 3.4 で追加された 4 メソッドに #@since 3.4 を付ける

### DIFF
--- a/manual/api/_builtin/Ractor.md
+++ b/manual/api/_builtin/Ractor.md
@@ -18,6 +18,7 @@ Ractor を生成して、ブロックの評価を開始します。
             コピーできない値であった場合は例外が発生します。
 - **param** `name` -- Ractor の名前を指定します。
 
+#@since 3.4
 ### def [](sym) -> object | nil
 
 このメソッドを呼び出した Ractor の Ractor-local storage の sym に対応するデータを取り出します。
@@ -30,6 +31,7 @@ sym に対応するデータがなければ nil を返します。
 
 - **param** `sym` -- Ractor-local storage のキーを指定します。
 - **param** `val` -- 格納するデータを指定します。
+#@end
 
 ### def count -> Integer
 
@@ -43,9 +45,11 @@ sym に対応するデータがなければ nil を返します。
 
 main Ractor（プログラムの実行が開始された Ractor）を返します。
 
+#@since 3.4
 ### def main? -> bool
 
 このメソッドを呼び出した Ractor が main Ractor であるとき、true を返します。
+#@end
 
 ### def make_shareable(obj, copy: false) -> object
 
@@ -98,6 +102,7 @@ obj が shareable である場合、true を返します。
 
 - **param** `obj` -- Shareable であるか判定したいオブジェクトを指定します。
 
+#@since 3.4
 ### def store_if_absent(key) { ... } -> object
 
 このメソッドを呼び出した Ractor の Ractor-local storage の key データがない場合、
@@ -105,6 +110,7 @@ obj が shareable である場合、true を返します。
 格納した値を返します。
 
 - **param** `key` -- Ractor-local storage のキーを指定します。
+#@end
 
 #@until 4.0
 ### def yield(obj, move: false) -> object


### PR DESCRIPTION
refs #3269

Ractor.[] / Ractor.[]= / Ractor.main? / Ractor.store_if_absent は Ruby 3.4 で追加されたメソッドですが、バージョンゲートが無いため 3.0〜3.3 の版ページにも掲載され、since バッジも「Ruby 3.0 から」と誤表示されています(例: https://docs.ruby-lang.org/ja/3.0/method/Ractor/s/=5b=5d.html )。

#3269 を受けて行った全数調査(#3274 の `tools/method-versions/`、詳細は `mismatch-report.md` の frozen-db-contamination 節)で見つかった「ライブ版側のゲート漏れ」4 件です。実測(`matrix.tsv`)で 4 メソッドとも初出が 3.4 であることを確認しています。

## 変更内容

`manual/api/_builtin/Ractor.md` の該当 4 エントリを `#@since 3.4`〜`#@end` で囲みます(隣接する `[]`/`[]=` は 1 ブロック)。これにより:

- 3.0〜3.3 の版ページから記載が消える
- since バッジは自動計算で「Ruby 3.4 から」になる(明示 `{: since=}` は不要)

## 確認

- bitclust preprocessor で 3.0〜3.3 は非表示・3.4/4.0/4.1 は表示になることを確認
- `rake check_blank_lines` / `check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
