### PR TITLE
Thread.ignore_deadlock/= と Rational.convert を正しいメソッド種別の位置に移動

### DIFF
--- a/manual/api/_builtin/Rational.md
+++ b/manual/api/_builtin/Rational.md
@@ -486,6 +486,17 @@ p Rational(0.5).to_s # => "1/2"
 
 ## Private Instance Methods
 
+### def marshal_dump -> Array
+
+[m:Marshal?.load] のためのメソッドです。
+Rational::compatible#marshal_load で復元可能な配列を返します。
+
+[注意] Rational::compatible は通常の方法では参照する事ができません。
+
+#@# #6625 を参照。
+
+## Private Singleton Methods
+
 ### def convert(*arg) -> Rational
 
 引数を有理数([c:Rational])に変換した結果を返します。
@@ -495,12 +506,3 @@ p Rational(0.5).to_s # => "1/2"
 [m:Kernel?.Rational] の本体です。
 
 - **SEE** [m:Kernel?.Rational]
-
-### def marshal_dump -> Array
-
-[m:Marshal?.load] のためのメソッドです。
-Rational::compatible#marshal_load で復元可能な配列を返します。
-
-[注意] Rational::compatible は通常の方法では参照する事ができません。
-
-#@# #6625 を参照。

--- a/manual/api/_builtin/Rational.md
+++ b/manual/api/_builtin/Rational.md
@@ -493,7 +493,7 @@ Rational::compatible#marshal_load で復元可能な配列を返します。
 
 [注意] Rational::compatible は通常の方法では参照する事ができません。
 
-#@# #6625 を参照。
+#@# https://bugs.ruby-lang.org/issues/6625 を参照。
 
 ## Private Singleton Methods
 

--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -70,6 +70,36 @@ Traceback (most recent call last):
 
 - **param** `newstate` -- スレッド実行中に例外発生した場合、その内容を報告するかどうかを true か false で指定します。
 
+#@since 3.0
+### def ignore_deadlock -> bool
+
+デッドロック検知を無視する機能のon/offを返します。
+
+デフォルト値はfalseで、デッドロックが検知されます。
+
+#@#noexample Thread.ignore_deadlock=を参照
+
+- **SEE** [m:Thread.ignore_deadlock=]
+
+### def ignore_deadlock=(bool)
+
+デッドロック検知を無視する機能をon/offします。デフォルト値はfalseです。
+
+trueを渡すとデッドロックを検知しなくなります。
+
+```ruby
+Thread.ignore_deadlock = true
+queue = Thread::Queue.new
+
+trap(:SIGUSR1){queue.push "Received signal"}
+
+# ignore_deadlockがfalseだとエラーが発生する
+puts queue.pop
+```
+
+- **SEE** [m:Thread.ignore_deadlock]
+#@end
+
 ### def current    -> Thread
 
 現在実行中のスレッド(カレントスレッド)を返します。
@@ -643,34 +673,6 @@ th1.kill
 p Thread.current.group == ThreadGroup::Default
 # => true
 ```
-
-### def ignore_deadlock -> bool
-
-デッドロック検知を無視する機能のon/offを返します。
-
-デフォルト値はfalseで、デッドロックが検知されます。
-
-#@#noexample Thread#ignore_deadlock=を参照
-
-- **SEE** [m:Thread#ignore_deadlock=]
-
-### def ignore_deadlock=(bool)
-
-デッドロック検知を無視する機能をon/offします。デフォルト値はfalseです。
-
-trueを渡すとデッドロックを検知しなくなります。
-
-```ruby
-Thread.ignore_deadlock = true
-queue = Thread::Queue.new
-
-trap(:SIGUSR1){queue.push "Received signal"}
-
-# ignore_deadlockがfalseだとエラーが発生する
-puts queue.pop
-```
-
-- **SEE** [m:Thread#ignore_deadlock]
 
 ### def join           -> self
 ### def join(limit)    -> self | nil


### PR DESCRIPTION
実装はクラス(特異)メソッドなのに、インスタンスメソッドのセクションに記載されているエントリ 3 件を正しい位置に移動します。#3269 を受けた全数調査(#3274 の `tools/method-versions/`、`mismatch-report.md` の DOC_ONLY 分析)で見つかったものです。

## 変更内容

- **Thread.ignore_deadlock / Thread.ignore_deadlock=**(`manual/api/_builtin/Thread.md`)
  `## Instance Methods` 配下に記載されていましたが、実 Ruby に存在するのは特異メソッドのみです(Ruby 3.0 で追加。本文の例ももともと `Thread.ignore_deadlock = true` とクラスメソッド呼び出しで書かれていました)。`## Class Methods` セクション(report_on_exception= の後)へ移動し、あわせて `#@since 3.0` ゲートを追加、相互参照の `Thread#...` を `Thread....` に修正しました。移動により URL は `/method/Thread/i/ignore_deadlock` → `/method/Thread/s/ignore_deadlock` に変わります(他ファイルからの参照はありません)。
- **Rational.convert**(`manual/api/_builtin/Rational.md`)
  `## Private Instance Methods` 配下に記載されていましたが、実体は private な特異メソッドです([m:Kernel.#Rational] の本体。実測では 1.9.1 以降の全版で private 特異として存在)。新設の `## Private Singleton Methods` セクション(Random.md に前例あり)へ本文無変更で移動しました。他ファイルからの参照はありません。

## 対象外としたもの

同じ調査で見つかった `Thread.DEBUG` / `Thread.DEBUG=`(`### const DEBUG` が `## Class Methods` 配下にある既知の構造問題)は、**通常ビルドの Ruby には全 19 実測版で一度も存在しない**(THREAD_DEBUG 付きカスタムビルド限定)という記載内容自体の問題があるため、本 PR では触らず別途 issue で扱うのが良さそうです。

## 確認

- 実測(`tools/method-versions/matrix.tsv`): Thread s ignore_deadlock/= は 3.0 から、Rational s convert は 1.9.1 から(private)。インスタンス側はいずれの版にも存在しません
- `rake check_blank_lines` / `check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
