### PR TITLE
Array#rfind を追加 (Ruby 4.0)

### DIFF
--- a/manual/api/_builtin/Array.md
+++ b/manual/api/_builtin/Array.md
@@ -1627,6 +1627,42 @@ a.reverse_each {|x| print x, " " }
 
 - **SEE** [m:Array#each]
 
+#@since 4.0
+### def rfind(if_none_proc = nil) {|item| ... } -> object | nil
+### def rfind(if_none_proc = nil)               -> Enumerator
+
+各要素を逆順にブロックに渡して評価し、ブロックが真を返した最初の要素を返します。
+すなわち、ブロックが真を返す要素のうち最後のものを返します。
+
+ブロックが真を返す要素がなかった場合、if_none_proc を指定していればそれを
+呼び出した結果を返します。指定していなければ nil を返します。
+
+ブロックが与えられなかった場合は、自身と rfind から生成した
+[c:Enumerator] オブジェクトを返します。
+
+[m:Enumerable#find] と対になるメソッドで、`reverse_each.find` より効率的に
+同じ結果を得られます。
+
+- **param** `if_none_proc` -- ブロックが真を返す要素がなかった場合に呼び出される、
+                     call メソッドを持つオブジェクト([c:Proc] など)を指定します。
+
+```ruby title="例"
+a = [1, 2, 3, 4, 5, 6]
+
+p a.rfind {|item| item < 5 }   # => 4
+p a.find {|item| item < 5 }    # => 1  (先頭から探す)
+
+p a.rfind {|item| item > 100 } # => nil
+
+# 見つからないときに if_none_proc の結果を返す
+p [1, 2, 3, 4].rfind(proc { 0 }) {|item| item < -2 } # => 0
+
+p a.rfind                      # => #<Enumerator: [1, 2, 3, 4, 5, 6]:rfind>
+```
+
+- **SEE** [m:Enumerable#find], [m:Array#reverse_each], [m:Array#rindex]
+#@end
+
 ### def rindex(val)           -> Integer | nil
 ### def rindex {|item| ... }  -> Integer | nil
 ### def rindex                -> Enumerator


### PR DESCRIPTION
## 概要

Ruby 4.0 で [m:Array#rfind] が追加されましたが（[Feature #21678](https://bugs.ruby-lang.org/issues/21678)）、るりまに項目がありませんでした。`array.reverse_each.find` の効率的な代替として導入されたメソッドです。

## 登場バージョンの確認

実機で各バージョンの `Array.instance_methods(false)` を確認しました。

| Ruby | `Array#rfind` | `Enumerable#rfind` |
|---|---|---|
| 3.1 / 3.2 / 3.3 / 3.4 | なし | なし |
| **4.0** | **あり** | なし |
| 4.1-dev | あり | なし |

4.0 で追加されたため `#@since 4.0` で分岐しました。[c:Enumerable] 側には `rfind` は無く、**Array 専用**のメソッドです。

## 変更内容

`manual/api/_builtin/Array.md` に `rfind` の項目を追加しました。`reverse_each` の効率的な代替という位置づけのため、[m:Array#reverse_each] の直後に配置しています。

## 実機確認 (Ruby 4.0.6)

```ruby
a = [1, 2, 3, 4, 5, 6]

p a.rfind {|item| item < 5 }   # => 4
p a.find {|item| item < 5 }    # => 1  (先頭から探す)
p a.rfind {|item| item > 100 } # => nil
p [1, 2, 3, 4].rfind(proc { 0 }) {|item| item < -2 } # => 0
p a.rfind                      # => #<Enumerator: [1, 2, 3, 4, 5, 6]:rfind>
```

あわせて以下も確認しています。

- 走査順は末尾から先頭（`[6, 5, 4, 3, 2, 1]`）で、「ブロックが真を返す最後の要素」が返る。
- `a.reverse_each.find { ... }` と同じ結果になる。
- ブロックを省略すると [c:Enumerator] を返す。
- 引数 `if_none_proc` は、ブロックが真を返す要素が無かったときだけ呼ばれる。

bitclust の preprocessor で 4.0 でのみ出力され 3.3 / 3.4 では出力されないことを確認、`rake check_blank_lines` ほか lint も通過しています。

## 補足

同じ Feature #21678 で `Array#find` も「[m:Enumerable#find] の効率的なオーバーライド」として追加されていますが、こちらは挙動が Enumerable#find と同じで、るりまでも Enumerable#find として記載済みのため本 PR では触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)