### PR TITLE
Binding#implicit_parameters 系 3 メソッドを追加 (Ruby 4.0)

### DIFF
--- a/manual/api/_builtin/Binding.md
+++ b/manual/api/_builtin/Binding.md
@@ -149,6 +149,7 @@ end
 ```
 
 番号指定パラメータ自体は従来どおり参照できます（[ref:d:spec/call#numbered_parameters]）。
+[c:Binding] から番号指定パラメータを扱うには [m:Binding#implicit_parameters] を使用してください。
 #@end
 
 このメソッドは以下のコードと同様の動作をします。
@@ -158,6 +159,88 @@ binding.eval("local_variables")
 ```
 
 #@# #8779 を参照。
+#@since 4.0
+### def implicit_parameters -> [Symbol]
+
+self のスコープで定義されている番号指定パラメータおよび it パラメータの名前を
+[c:Symbol] の配列で返します。定義されていない場合は空の配列を返します。
+
+これらは [m:Binding#local_variables] の返り値には含まれません。
+
+```ruby
+[42].each do
+  it
+  p binding.implicit_parameters # => [:it]
+end
+
+{ k: 42 }.each do
+  _2
+  p binding.implicit_parameters # => [:_1, :_2]
+end
+
+# どちらも使っていない場合
+p binding.implicit_parameters   # => []
+```
+
+- **SEE** [m:Binding#implicit_parameter_get], [m:Binding#implicit_parameter_defined?], [m:Binding#local_variables]
+
+### def implicit_parameter_get(symbol) -> object
+
+引数 symbol で指定した番号指定パラメータまたは it パラメータの値を返します。
+
+- **param** `symbol` -- 番号指定パラメータまたは it パラメータの名前を [c:Symbol] で指定します。
+
+- **raise** `NameError` -- 指定した名前が番号指定パラメータでも it パラメータでもない場合に発生します。
+
+- **raise** `NameError` -- 指定したパラメータが self のスコープで定義されていない場合に発生します。
+
+```ruby
+[42].each do
+  it
+  p binding.implicit_parameter_get(:it) # => 42
+end
+
+{ k: 42 }.each do
+  _2
+  p binding.implicit_parameter_get(:_1) # => :k
+  p binding.implicit_parameter_get(:_2) # => 42
+end
+```
+
+- **SEE** [m:Binding#implicit_parameters], [m:Binding#implicit_parameter_defined?]
+
+### def implicit_parameter_defined?(symbol) -> bool
+
+引数 symbol で指定した番号指定パラメータまたは it パラメータが self のスコープで
+定義されている場合に true を、そうでない場合に false を返します。
+
+定義されていない場合に false を返すのは、symbol が番号指定パラメータまたは
+it パラメータの名前である場合だけです。それ以外の名前を指定した場合は
+[c:NameError] が発生します。
+
+- **param** `symbol` -- 番号指定パラメータまたは it パラメータの名前を [c:Symbol] で指定します。
+
+- **raise** `NameError` -- 指定した名前が番号指定パラメータでも it パラメータでもない場合に発生します。
+
+```ruby
+[42].each do
+  it
+  p binding.implicit_parameter_defined?(:it) # => true
+  p binding.implicit_parameter_defined?(:_1) # => false
+end
+
+{ k: 42 }.each do
+  _2
+  p binding.implicit_parameter_defined?(:_1) # => true
+  p binding.implicit_parameter_defined?(:_3) # => false
+  p binding.implicit_parameter_defined?(:it) # => false
+end
+```
+
+- **SEE** [m:Binding#implicit_parameters], [m:Binding#implicit_parameter_get]
+
+#@end
+
 ### def receiver -> object
 
 保持するコンテキスト内での self を返します。


### PR DESCRIPTION
## 概要

Ruby 4.0 で以下の 3 メソッドが追加されましたが（[Bug #21049](https://bugs.ruby-lang.org/issues/21049)）、るりまに項目がありませんでした。

- [m:Binding#implicit_parameters]
- [m:Binding#implicit_parameter_get]
- [m:Binding#implicit_parameter_defined?]

番号指定パラメータと `it` パラメータにアクセスするためのメソッドです。

**同じ Bug #21049 で `Binding#local_variables` が番号指定パラメータを含まなくなり、`local_variable_get` などが番号指定パラメータを拒否するようになりました**（[#3264](https://github.com/rurema/doctree/pull/3264) で反映済み）。この 3 メソッドはその代替 API にあたるため、あわせて追加します。

## 登場バージョンの確認

| Ruby | 3 メソッドの有無 |
|---|---|
| 3.3 / 3.4 | なし |
| **4.0 / 4.1-dev** | **あり** |

4.0 で追加されたため `#@since 4.0` で分岐しました。

## 変更内容

`manual/api/_builtin/Binding.md` に 3 メソッドの項目を [m:Binding#local_variables] の直後に追加しました。

あわせて、#3264 で追加した `local_variables` の 4.0 注記から `implicit_parameters` への導線を 1 文追加しています。「番号指定パラメータは `local_variables` に含まれない」とだけ書かれていると、**ではどう取得するのかが分からない**ためです。

## 実機確認 (Ruby 4.0.6)

```ruby
[42].each do
  it
  p binding.implicit_parameters          # => [:it]
  p binding.implicit_parameter_get(:it)  # => 42
end

{ k: 42 }.each do
  _2
  p binding.implicit_parameters          # => [:_1, :_2]
  p binding.implicit_parameter_get(:_1)  # => :k
end
```

記載した例の出力はすべて実機でそのまま実行し、一致を確認しました。

### `implicit_parameter_defined?` の挙動に注意点があります

未定義のときに `false` を返すのは、**引数が番号指定パラメータまたは `it` パラメータの名前である場合だけ**です。それ以外の名前（通常のローカル変数名など）を渡すと `NameError` になります。

```ruby
b = binding
x = 1
b.implicit_parameter_defined?(:_1)  # => false
b.implicit_parameter_defined?(:x)   # ~> NameError: 'x' is not an implicit parameter
```

紛らわしいため、この点は本文にも明記しました。`implicit_parameter_get` も同様に、名前が不正な場合と未定義の場合の 2 通りで `NameError` が発生します（メッセージは異なります）。

bitclust の preprocessor で 4.0 でのみ 3 項目が出力され 3.3 / 3.4 では出力されないことを確認、`rake check_blank_lines` ほか lint も通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)