### PR TITLE
Math.expm1 / Math.log1p を追加 (Ruby 4.0)

### DIFF
--- a/manual/api/_builtin/Math.md
+++ b/manual/api/_builtin/Math.md
@@ -341,6 +341,41 @@ p Math.exp(-Float::INFINITY)  # => 0.0
 
 - **SEE** [man:exp(3)], [m:Math?.log]
 
+#@since 4.0
+### module_function def expm1(x) -> Float
+
+e の x 乗から 1 を引いた値、すなわち `exp(x) - 1` を返します（e は自然対数の底）。
+
+x が 0 に近いとき、[m:Math?.exp] の結果から 1 を引くと桁落ちによって精度が
+失われますが、このメソッドはそれを避けて計算します。
+
+- **param** `x` -- 実数
+
+- **raise** `TypeError` -- x に数値以外を指定した場合に発生します。
+
+- **raise** `RangeError` -- x に実数以外の数値を指定した場合に発生します。
+
+```ruby title="例"
+p Math.expm1(0)    # => 0.0
+p Math.expm1(-1.0) # => -0.6321205588285577
+p Math.expm1(0.5)  # => 0.6487212707001282
+```
+
+```ruby title="例: 0 に近い値での精度"
+p Math.exp(1e-16) - 1 # => 0.0     （桁落ちして 0 になる）
+p Math.expm1(1e-16)   # => 1.0e-16
+```
+
+x に負の無限大を渡した場合は -1.0 を返します。
+
+```ruby title="例: 無限大を渡す"
+p Math.expm1(-Float::INFINITY) # => -1.0
+p Math.expm1(Float::INFINITY)  # => Infinity
+```
+
+- **SEE** [man:expm1(3)], [m:Math?.exp], [m:Math?.log1p]
+#@end
+
 ### module_function def frexp(x) -> [Float, Integer]
 
 実数 x の仮数部と指数部の配列を返します。
@@ -457,6 +492,40 @@ p Math.log10(10**100) # => 100.0
 ```
 
 - **SEE** [m:Math?.log], [m:Math?.log2]
+
+#@since 4.0
+### module_function def log1p(x) -> Float
+
+1 に x を足した値の自然対数、すなわち `log(x + 1)` を返します。
+
+x が 0 に近いとき、1 に x を足してから [m:Math?.log] を取ると桁落ちによって
+精度が失われますが、このメソッドはそれを避けて計算します。
+
+- **param** `x` -- -1 以上の実数
+
+- **raise** `TypeError` -- x に数値以外を指定した場合に発生します。
+
+- **raise** `RangeError` -- x に実数以外の数値を指定した場合に発生します。
+
+- **raise** `Math::DomainError` -- x に -1 未満の実数を指定した場合に発生します。
+
+```ruby title="例"
+p Math.log1p(0)             # => 0.0
+p Math.log1p(Math::E - 1)   # => 1.0
+p Math.log1p(-1.0)          # => -Infinity
+```
+
+```ruby title="例: 0 に近い値での精度"
+p Math.log(1 + 1e-16) # => 0.0     （桁落ちして 0 になる）
+p Math.log1p(1e-16)   # => 1.0e-16
+```
+
+```ruby title="例: 定義域外"
+Math.log1p(-2.0) # ~> Math::DomainError
+```
+
+- **SEE** [man:log1p(3)], [m:Math?.log], [m:Math?.expm1]
+#@end
 
 ### module_function def sqrt(x) -> Float
 


### PR DESCRIPTION
## 概要

Ruby 4.0 で [m:Math.#expm1] と [m:Math.#log1p] が追加されましたが（[Feature #21527](https://bugs.ruby-lang.org/issues/21527)）、るりまに項目がありませんでした。

`x` が 0 に近いときの桁落ちを避けて `exp(x) - 1` / `log(x + 1)` を計算するメソッドで、C の `expm1(3)` / `log1p(3)` に対応します。

## 登場バージョンの確認

| Ruby | `Math.expm1` / `Math.log1p` |
|---|---|
| 3.1 / 3.2 / 3.3 / 3.4 | なし |
| **4.0 / 4.1-dev** | **あり** |

4.0 で追加されたため `#@since 4.0` で分岐しました。

## 変更内容

`manual/api/_builtin/Math.md` に 2 メソッドを追加しました。既存の並びに合わせて `expm1` は [m:Math.#exp] の直後、`log1p` は [m:Math.#log10] の直後に配置しています。

このメソッドの存在意義である「桁落ちを避けられる」点が伝わるよう、対比できる例を添えました。

```ruby
p Math.exp(1e-16) - 1 # => 0.0     （桁落ちして 0 になる）
p Math.expm1(1e-16)   # => 1.0e-16

p Math.log(1 + 1e-16) # => 0.0     （桁落ちして 0 になる）
p Math.log1p(1e-16)   # => 1.0e-16
```

## Ruby 本体の rdoc の誤りについて

Ruby 本体の rdoc（`ri Math.expm1`）は `expm1(-INFINITY)` の結果を **`0.0`** と記載していますが、実機で確認したところ正しくは **`-1.0`** でした。

```
$ ruby -e 'p Math.expm1(-Float::INFINITY)'
-1.0
```

`exp(-∞) - 1 = 0 - 1 = -1` なので `-1.0` が正しく、rdoc 側の誤記と思われます（[m:Math.#exp] が `-Infinity` に対して `0.0` を返すため、そちらと混同したのかもしれません）。本 PR では実機の結果に合わせて `-1.0` と記述しています。

なお、この件は ruby/ruby 側にも修正 PR を出しました（[ruby/ruby#18032](https://github.com/ruby/ruby/pull/18032)）。あわせて全 7 例を実機照合したところ、`expm1(1.0)` にも誤りが見つかりました。記載は `1.718281828459045` ですが実際は `1.7182818284590453` で、記載値は `Math.exp(1.0) - 1` の結果と一致します。つまり `Math.expm1` が避けるための桁落ちが、その `Math.expm1` の例で起きていました。本 PR の例では正しい値を使っています。`Math.log1p` の例は 4 件とも正しいことも確認済みです。

## 実機確認 (Ruby 4.0.6)

記載した例の出力はすべて実機でそのまま実行し、一致を確認しました。`Math.log1p(-2.0)` が `Math::DomainError` になることも確認しています。

bitclust の preprocessor で 4.0 でのみ出力され 3.3 / 3.4 では出力されないことを確認、`rake check_blank_lines` ほか lint も通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
