### PR TITLE
Pathname#lutime を追加 (Ruby 3.2)

### DIFF
--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -762,6 +762,23 @@ File.utime(atime, mtime, self.to_s) と同じです。
 
 - **SEE** [m:File.utime]
 
+#@since 3.2
+### def lutime(atime, mtime) -> Integer
+
+File.lutime(atime, mtime, self.to_s) と同じです。
+
+[m:Pathname#utime] と違い、シンボリックリンクそのものの時刻を変更します
+（リンク先をたどりません）。
+
+- **param** `atime` -- 最終アクセス時刻を [c:Time] か、起算時からの経過秒数を数値で指定します。
+
+- **param** `mtime` -- 更新時刻を [c:Time] か、起算時からの経過秒数を数値で指定します。
+
+#@#noexample File.lutime の例を参照
+
+- **SEE** [m:File.lutime], [m:Pathname#utime]
+#@end
+
 ### def basename(suffix = "") -> Pathname
 
 Pathname.new(File.basename(self.to_s, suffix)) と同じです。


### PR DESCRIPTION
## 概要

[m:Pathname#lutime] がるりまに未収録でした。`File.lutime(atime, mtime, self.to_s)` と同じで、[m:Pathname#utime] と違い**シンボリックリンクそのものの時刻を変更します**（リンク先をたどりません）。

## 登場バージョンの確認

| Ruby | `Pathname#lutime` |
|---|---|
| 2.7 / 3.1 | なし |
| **3.2 以降** | **あり** |

3.2 で追加されたため `#@since 3.2` で分岐しました。

## 変更内容

`manual/api/pathname.md` に `lutime` の項目を [m:Pathname#utime] の直後に追加しました。既存の [m:Pathname#utime] / [m:Pathname#lchmod] と同じ「`File.xxx` と同じです」＋ `#@#noexample`（参照先の例を見てもらう）の書式に合わせています。

## 実機確認 (Ruby 4.0.6)

シンボリックリンクを実際に作り、`lutime` と `utime` の違いを確認しました。

```ruby
File.write("target.txt", "x")
File.symlink("target.txt", "link.txt")
link = Pathname.new("link.txt")

link.lutime(Time.at(0), Time.at(0))
File.lstat("link.txt").mtime  # => 1970-01-01 (リンク自身が変わる)
File.stat("target.txt").mtime # => 変わらない

link.utime(Time.at(86400), Time.at(86400))
File.stat("target.txt").mtime # => 1970-01-02 (リンク先が変わる)
```

bitclust の preprocessor で 3.2 以降でのみ出力され 3.1 では出力されないことを確認、`rake check_blank_lines` ほか lint も通過しています。

## `Pathname#path` について（本 PR には含めていません）

未収録メソッドを調べた際に `Pathname#path`（4.0 で追加）も候補に挙がりましたが、**意図的に文書化されていないメソッド**だったため見送りました。

Ruby 本体では `:stopdoc:` で囲まれたうえで `protected` に指定されています。

```ruby
# :stopdoc:

attr_reader :path
protected :path

# :startdoc:
```

実際に外部から呼ぶと `NoMethodError`（`protected method 'path' called`）になり、`Pathname#==` や `Pathname#+` の内部実装でのみ使われています。`ri` にもドキュメントがありません。そのため、るりまでも記載しないのが適切と判断しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)