### PR TITLE
Thread.DEBUG を const から def に修正 (fix #3289)

### DIFF
--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -259,7 +259,7 @@ a.join
 
 - **SEE** [m:Thread#run], [m:Thread#wakeup]
 
-### const DEBUG -> Integer
+### def DEBUG -> Integer
 
 スレッドのデバッグレベルを返します。
 
@@ -267,7 +267,7 @@ a.join
 それ以外の場合は、スレッドのデバッグログを標準出力に出力します。
 初期値は 0 です。
 使用するためには、THREAD_DEBUG を -1 にして Ruby をコンパイルする必要が
-あります。
+あります。通常配布されている Ruby では利用できません。
 
 ```ruby title="例"
 p Thread.DEBUG # => 0
@@ -282,7 +282,7 @@ p Thread.DEBUG # => 0
 val が 真 のときは Integer に変換してから設定します。
 偽 のときは 0 を設定します。
 使用するためには、THREAD_DEBUG を -1 にして Ruby をコンパイルする必要が
-あります。
+あります。通常配布されている Ruby では利用できません。
 
 ```ruby title="例"
 p Thread.DEBUG # => 0


### PR DESCRIPTION
fix #3289

issue #3289 で相談した `Thread.DEBUG` / `Thread.DEBUG=` について、方針をいただいたので対応します。

## 変更内容

- **`### const DEBUG` → `### def DEBUG` に修正**(点2)。RD からの変換のときに誤って `const` になっていたものを、本来のクラスメソッドに直しました。例・SEE・セッター `Thread.DEBUG=` がいずれも `Thread.DEBUG` というメソッド呼び出しの形で書かれており、`def` が実態に合います。
- **デバッグビルド専用である旨を明記**(点1・案 b)。`Thread.DEBUG` / `Thread.DEBUG=` の両方に「通常配布されている Ruby では利用できません」を追記しました(実測した全 19 版とも、標準ビルドでは存在しないことを確認済み)。エントリ自体は残しています。

## 確認

- `### const DEBUG` は元々 `## Class Methods` セクション配下にあったため bitclust はすでにクラスメソッド(kind=s)として描画しており、`def` への修正で描画結果は変わりません(bitclust ミニ描画で master と DEBUG 見出しがバイト一致・`[m:Thread.DEBUG]` / `[m:Thread.DEBUG=]` の参照も従来どおり解決・compileerror なしを確認)。今回の差分は追記した 1 文のみです。
- `rake check_blank_lines` / `check_indent_in_samplecode` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
