### PR TITLE
Thread::Queue#pop の nonblock 例を SizedQueue と統一

### DIFF
--- a/manual/api/thread/Queue.md
+++ b/manual/api/thread/Queue.md
@@ -159,6 +159,7 @@ begin
   q.pop(true)
 rescue => e
   p e
+  p e.message
 end
 
 # => resource1


### PR DESCRIPTION
#3181 の補足で報告されていた、[m:Thread::Queue#pop] と [m:Thread::SizedQueue#pop] の `nonblock = true` の例の不整合を解消します。

## 内容

両者の例はほぼ同じ内容ですが、出力コメントに `# => "queue empty"` の行があるのに、[m:Thread::Queue#pop] 側にはそれを出力する `p e.message` の呼び出しが無く、[m:Thread::SizedQueue#pop] 側にだけ `p e.message` がある、という食い違いがありました。

[m:Thread::SizedQueue#pop] に合わせて、[m:Thread::Queue#pop] の rescue 節にも `p e.message` を追加して統一します。

```ruby
rescue => e
  p e
  p e.message   # ← 追加
end
```

## 確認

- `q.pop(true)` が空キューに対して `ThreadError`(メッセージ `"queue empty"`)を発生させることを 3.4.10 / 4.0.6 で実測確認しました(出力コメントの `# => "queue empty"` と一致)。
- bitclust のミニ描画(4.0)で compileerror なし・例が正しく描画されることを確認しました。
- `rake check_blank_lines` / `check_indent_in_samplecode` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
