### PR TITLE
Ractor: 例外クラス 6 個と shareable_proc / shareable_lambda を追加

### DIFF
--- a/manual/api/_builtin/Ractor.md
+++ b/manual/api/_builtin/Ractor.md
@@ -102,6 +102,41 @@ obj が shareable である場合、true を返します。
 
 - **param** `obj` -- Shareable であるか判定したいオブジェクトを指定します。
 
+#@since 4.0
+### def shareable_proc { ... } -> Proc
+
+与えられたブロックから shareable な [c:Proc] を作成して返します。
+
+通常の [c:Proc] は shareable ではないため、他の Ractor に渡せません。
+このメソッドで作成した [c:Proc] は shareable になるため、複数の Ractor から
+利用できます。
+
+```ruby
+pr = Ractor.shareable_proc { 42 }
+p Ractor.shareable?(pr) # => true
+p pr.lambda?            # => false
+
+p Ractor.shareable?(proc { 42 }) # => false （通常の Proc は shareable ではない）
+
+# 他の Ractor に渡して呼び出せる
+p Ractor.new(pr) {|p| p.call }.value # => 42
+```
+
+- **SEE** [m:Ractor.shareable_lambda], [m:Ractor.make_shareable]
+
+### def shareable_lambda { ... } -> Proc
+
+[m:Ractor.shareable_proc] と同じですが、lambda である [c:Proc] を返します。
+
+```ruby
+l = Ractor.shareable_lambda { 42 }
+p Ractor.shareable?(l) # => true
+p l.lambda?            # => true
+```
+
+- **SEE** [m:Ractor.shareable_proc]
+#@end
+
 #@since 3.4
 ### def store_if_absent(key) { ... } -> object
 

--- a/manual/api/ractor/ClosedError.md
+++ b/manual/api/ractor/ClosedError.md
@@ -1,0 +1,27 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::ClosedError < StopIteration
+
+閉じられた Ractor のポートに対して送受信を行おうとした場合に発生します。
+
+[c:StopIteration] のサブクラスであるため、[m:Kernel?.loop] の中で発生した
+場合はループを終了させます。他の Ractor に関する例外と異なり、
+[c:Ractor::Error] のサブクラスではないことに注意してください。
+
+```ruby
+r = Ractor.new do
+  Ractor.current.close
+  Ractor.receive # ここで Ractor::ClosedError が発生する
+end
+
+begin
+  r.value
+rescue Ractor::RemoteError => e
+  # 他の Ractor で発生した例外は Ractor::RemoteError に包まれて伝わる
+  p e.cause.class # => Ractor::ClosedError
+end
+```
+
+- **SEE** [c:Ractor], [c:StopIteration]

--- a/manual/api/ractor/ClosedError.md
+++ b/manual/api/ractor/ClosedError.md
@@ -12,12 +12,20 @@ since: "3.0"
 
 ```ruby
 r = Ractor.new do
+#@since 4.0
   Ractor.current.close
+#@else
+  Ractor.current.close_incoming
+#@end
   Ractor.receive # ここで Ractor::ClosedError が発生する
 end
 
 begin
+#@since 4.0
   r.value
+#@else
+  r.take
+#@end
 rescue Ractor::RemoteError => e
   # 他の Ractor で発生した例外は Ractor::RemoteError に包まれて伝わる
   p e.cause.class # => Ractor::ClosedError

--- a/manual/api/ractor/Error.md
+++ b/manual/api/ractor/Error.md
@@ -1,0 +1,12 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::Error < RuntimeError
+
+[c:Ractor] に関する例外の基底クラスです。
+
+[c:Ractor::IsolationError]、[c:Ractor::MovedError]、[c:Ractor::RemoteError]、
+[c:Ractor::UnsafeError] はいずれもこのクラスのサブクラスです。
+
+- **SEE** [c:Ractor]

--- a/manual/api/ractor/IsolationError.md
+++ b/manual/api/ractor/IsolationError.md
@@ -1,0 +1,13 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::IsolationError < Ractor::Error
+
+shareable にできないオブジェクトを shareable にしようとした場合に発生します。
+
+```ruby
+Ractor.make_shareable(proc { }) # ~> Ractor::IsolationError
+```
+
+- **SEE** [c:Ractor], [m:Ractor.make_shareable]

--- a/manual/api/ractor/IsolationError.md
+++ b/manual/api/ractor/IsolationError.md
@@ -6,8 +6,14 @@ since: "3.0"
 
 shareable にできないオブジェクトを shareable にしようとした場合に発生します。
 
+#@since 3.1
+
 ```ruby
 Ractor.make_shareable(proc { }) # ~> Ractor::IsolationError
 ```
+
+#@else
+#@#noexample 3.0 では Ractor.make_shareable に Proc を渡しても例外にならないため
+#@end
 
 - **SEE** [c:Ractor], [m:Ractor.make_shareable]

--- a/manual/api/ractor/MovedError.md
+++ b/manual/api/ractor/MovedError.md
@@ -1,0 +1,20 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::MovedError < Ractor::Error
+
+他の Ractor に移動(move)されたオブジェクトにアクセスした場合に発生します。
+
+[m:Ractor#send] に `move: true` を指定してオブジェクトを送ると、送った側では
+そのオブジェクトが [c:Ractor::MovedObject] に置き換わり、以後アクセスできなく
+なります。
+
+```ruby
+s = +"hello"
+r = Ractor.new { Ractor.receive }
+r.send(s, move: true)
+s.upcase # ~> Ractor::MovedError
+```
+
+- **SEE** [c:Ractor], [c:Ractor::MovedObject], [m:Ractor#send]

--- a/manual/api/ractor/RemoteError.md
+++ b/manual/api/ractor/RemoteError.md
@@ -1,0 +1,28 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::RemoteError < Ractor::Error
+
+他の Ractor で発生した例外を、その結果を待っている Ractor に伝えるために
+発生します。
+
+もとの例外は [m:Exception#cause] で取得できます。
+
+```ruby
+r = Ractor.new { raise "boom" }
+begin
+  r.value
+rescue Ractor::RemoteError => e
+  p e.message      # => "thrown by remote Ractor."
+  p e.cause.message # => "boom"
+end
+```
+
+## Instance Methods
+
+### def ractor -> Ractor
+
+例外が発生した Ractor を返します。
+
+- **SEE** [c:Ractor]

--- a/manual/api/ractor/RemoteError.md
+++ b/manual/api/ractor/RemoteError.md
@@ -12,9 +12,13 @@ since: "3.0"
 ```ruby
 r = Ractor.new { raise "boom" }
 begin
+#@since 4.0
   r.value
+#@else
+  r.take
+#@end
 rescue Ractor::RemoteError => e
-  p e.message      # => "thrown by remote Ractor."
+  p e.message       # => "thrown by remote Ractor."
   p e.cause.message # => "boom"
 end
 ```

--- a/manual/api/ractor/UnsafeError.md
+++ b/manual/api/ractor/UnsafeError.md
@@ -1,0 +1,9 @@
+---
+library: _builtin
+since: "3.0"
+---
+# class Ractor::UnsafeError < Ractor::Error
+
+Ractor 内で安全に実行できない操作を行おうとした場合に発生します。
+
+- **SEE** [c:Ractor]


### PR DESCRIPTION
## 概要

[c:Ractor] の例外クラスと、Ruby 4.0 で追加されたメソッドが未収録でした。まとめて追加します。

## 例外クラス 6 個（いずれも 3.0 から存在）

| クラス | 継承 |
|---|---|
| [c:Ractor::Error] | `RuntimeError`（他の Ractor 例外の基底） |
| [c:Ractor::IsolationError] | `Ractor::Error` |
| [c:Ractor::MovedError] | `Ractor::Error` |
| [c:Ractor::RemoteError] | `Ractor::Error`（`#ractor` を持つ） |
| [c:Ractor::UnsafeError] | `Ractor::Error` |
| [c:Ractor::ClosedError] | **`StopIteration`** |

**`Ractor::ClosedError` だけ `Ractor::Error` のサブクラスではなく `StopIteration` を継承しています。** そのため [m:Kernel?.loop] の中で発生するとループを終了させます。紛らわしいので本文にも明記しました。

既存の [c:Ractor::Port] / [c:Ractor::MovedObject] に倣い、`manual/api/ractor/` 配下の個別ファイルとし、版指定は front matter の `since:` で行っています。

## メソッド 2 個（Ruby 4.0 で追加）

- [m:Ractor.shareable_proc]
- [m:Ractor.shareable_lambda]

実機で 3.4 には存在せず 4.0 で追加されたことを確認し、`#@since 4.0` で分岐しました。

```ruby
pr = Ractor.shareable_proc { 42 }
p Ractor.shareable?(pr)          # => true
p Ractor.shareable?(proc { 42 }) # => false （通常の Proc は shareable ではない）
p Ractor.new(pr) {|p| p.call }.value # => 42
```

## 例について

発生条件はすべて実機で確認しました。特に 2 点、実際の挙動に合わせています。

**`ClosedError` の例** — 単純に書くと子 Ractor 内で発生した例外が [c:Ractor::RemoteError] に包まれて伝わるため、`ClosedError` が直接見えません。`e.cause` で取り出す形にして、実際の見え方が分かるようにしました。

```ruby
r = Ractor.new do
  Ractor.current.close
  Ractor.receive # ここで Ractor::ClosedError が発生する
end

begin
  r.value
rescue Ractor::RemoteError => e
  p e.cause.class # => Ractor::ClosedError
end
```

**`RemoteError` の例** — もとの例外を [m:Exception#cause] で取得できることを実機で確認して記載しています。

## 確認したこと

- bitclust のデータベース生成を **3.0 / 3.4 / 4.0** で実行し、エラーが出ないことを確認しました。
- 例外 6 個が 3.0 で登録されること、`shareable_proc` が 3.4 では登録されず 4.0 でのみ登録されることを、生成したデータベースへの照会で確認しました。
- `rake check_blank_lines` ほか lint も通過しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)