### PR TITLE
IO::Buffer: 状態問い合わせの 10 メソッドを追加

### DIFF
--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -369,3 +369,118 @@ p buf.size  # => 4
 ```
 
 - **SEE** [m:IO::Buffer#transfer], [m:IO::Buffer#null?]
+
+### def empty? -> bool
+
+バッファの大きさが 0 の場合に true を返します。
+
+大きさ 0 のバッファは、[m:IO::Buffer.new] に 0 を渡すか、
+空文字列から [m:IO::Buffer.for] で作った場合などにできます。
+
+```ruby
+p IO::Buffer.new(0).empty? # => true
+p IO::Buffer.new(4).empty? # => false
+```
+
+### def null? -> bool
+
+バッファがどのメモリ領域も指していない場合に true を返します。
+
+[m:IO::Buffer#free] で解放したバッファ、[m:IO::Buffer#transfer] で所有権を手放した
+バッファ、および最初からメモリ領域を確保していないバッファがこれにあたります。
+
+```ruby
+p IO::Buffer.new(0).null? # => true
+
+buf = IO::Buffer.new(4)
+p buf.null? # => false
+buf.free
+p buf.null? # => true
+```
+
+- **SEE** [m:IO::Buffer#free], [m:IO::Buffer#transfer]
+
+### def valid? -> bool
+
+バッファがアクセス可能な場合に true を返します。
+
+別のバッファや文字列の一部を参照している([m:IO::Buffer#slice] で作った)バッファは、
+参照元が解放されたり別のアドレスに再確保されたりすると、アクセスできなくなります。
+
+### def internal? -> bool
+
+バッファが内部(internal)バッファである場合に true を返します。
+
+内部バッファは、バッファ自身が確保したメモリ領域を参照します。
+文字列などの外部のメモリやファイルのマッピングとは結び付いていません。
+[m:IO::Buffer.new] で作られるバッファは既定で内部バッファです。
+
+```ruby
+p IO::Buffer.new(4).internal? # => true
+```
+
+- **SEE** [m:IO::Buffer#external?]
+
+### def external? -> bool
+
+バッファが外部(external)バッファである場合に true を返します。
+
+外部バッファは、バッファ自身が確保・マップしたのではないメモリ領域を参照します。
+[m:IO::Buffer.for] で作ったバッファは、文字列のメモリを外部参照します。
+外部バッファは大きさを変更できません。
+
+```ruby
+p IO::Buffer.for("test").external? # => true
+p IO::Buffer.new(4).external?      # => false
+```
+
+- **SEE** [m:IO::Buffer#internal?]
+
+### def readonly? -> bool
+
+バッファが読み取り専用の場合に true を返します。
+
+読み取り専用のバッファは、[m:IO::Buffer#set_value] や [m:IO::Buffer#set_string]、
+[m:IO::Buffer#copy] などで変更できません。
+[m:IO::Buffer.for] で作ったバッファや、読み取り専用のファイルから作ったバッファが
+これにあたります。
+
+```ruby
+p IO::Buffer.for("test").readonly? # => true
+p IO::Buffer.new(4).readonly?      # => false
+```
+
+### def mapped? -> bool
+
+バッファがマップ(mapped)バッファである場合に true を返します。
+
+マップバッファは、仮想メモリ機構でマップされたメモリ領域を参照します。
+[m:IO::Buffer.new] に [m:IO::Buffer::MAPPED] を指定した場合や、
+大きさが [m:IO::Buffer::PAGE_SIZE] 以上の場合は匿名のマップになります。
+[m:IO::Buffer.map] で作った場合はファイルに紐づいたマップになります。
+
+### def locked? -> bool
+
+バッファがロックされている場合に true を返します。
+
+ロックされたバッファは大きさの変更や解放ができず、
+さらにロックを取得することもできません。
+システムコールでバッファを使っている間に、そのバッファが移動しないことを
+保証するための仕組みです。
+
+#@since 3.2
+### def shared? -> bool
+
+バッファが共有(shared)バッファである場合に true を返します。
+
+共有バッファは、他のプロセスと共有できるメモリ領域を参照します。
+そのため、このプロセスで変更しなくても内容が変わることがあります。
+#@end
+
+#@since 3.3
+### def private? -> bool
+
+バッファがプライベート(private)バッファである場合に true を返します。
+
+プライベートバッファに加えた変更は、元になったファイルのマッピングには反映されません。
+#@end

--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -448,12 +448,23 @@ p IO::Buffer.new(4).external?      # => false
 #@# set_value / for を収録したらリンクに戻す
 読み取り専用のバッファは、`IO::Buffer#set_value` や [m:IO::Buffer#set_string]、
 [m:IO::Buffer#copy] などで変更できません。
-`IO::Buffer.for` で作ったバッファや、読み取り専用のファイルから作ったバッファが
-これにあたります。
+
+`IO::Buffer.for` にブロックを渡さずに作ったバッファは、元の文字列が freeze
+されているかどうかによらず、常に読み取り専用になります。内部で作った文字列の
+複製をバッファの元として使うためです。
+ブロックを渡した場合は元の文字列のメモリを直接参照するため、
+その文字列が freeze されている場合にだけ読み取り専用になります。
+読み取り専用のファイルから作ったバッファも読み取り専用です。
 
 ```ruby
-p IO::Buffer.for("test").readonly? # => true
-p IO::Buffer.new(4).readonly?      # => false
+# ブロックを渡さない場合は、元の文字列が freeze されていなくても読み取り専用
+p IO::Buffer.for("test").readonly?                  # => true
+
+# ブロックを渡した場合は元の文字列に従う
+p IO::Buffer.for("test") { |buf| buf.readonly? }    # => false
+p IO::Buffer.for("test".freeze) { |buf| buf.readonly? } # => true
+
+p IO::Buffer.new(4).readonly?                       # => false
 ```
 
 ### def mapped? -> bool

--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -10,7 +10,8 @@ include:
 Ruby 3.1 で導入されました。
 
 [c:String] を経由せずにメモリ領域を扱えるため、コピーを避けた入出力
-(zero-copy IO)を実現するために使われます。主に [c:Fiber::Scheduler] の
+(zero-copy IO)を実現するために使われます。主に
+[Fiber::Scheduler](https://docs.ruby-lang.org/en/4.0/Fiber/Scheduler.html) の
 実装のような、低レベルな入出力を扱う場面で利用します。
 
 バッファは以下のいずれかの方法で確保されたメモリ領域を指します。
@@ -78,7 +79,8 @@ OS のページサイズをバイト数で表した値です。
 バッファがロックされていることを表すフラグです。
 
 ロックされている間はバッファの解放やリサイズができません。
-[m:IO::Buffer#locked] を参照してください。
+バッファがロックされているかどうかは [m:IO::Buffer#locked?] で調べられます。
+#@# locked を収録したら、ブロックの間ロックする IO::Buffer#locked への言及も足す
 
 ### const PRIVATE -> Integer
 
@@ -118,7 +120,7 @@ p IO::Buffer::HOST_ENDIAN == IO::Buffer::LITTLE_ENDIAN # => true
 size バイトの、0 で埋められた新しいバッファを作成して返します。
 
 既定では内部(internal)バッファ、すなわち Ruby が直接確保したメモリ領域に
-なります。ただし size が OS 依存の [m:IO::Buffer::PAGE_SIZE] より大きい場合は、
+なります。ただし size が OS 依存の [m:IO::Buffer::PAGE_SIZE] 以上の場合は、
 仮想メモリ機構(Unix では匿名 mmap、Windows では VirtualAlloc)を用いて
 確保されます。flags に [m:IO::Buffer::MAPPED] を指定すると、
 size によらず後者の方法で確保されます。
@@ -299,7 +301,8 @@ p buf.get_string # => "\x00AA\x00"
 変更後の大きさによっては、メモリ領域が別の場所に確保しなおされ、
 内容がそこへコピーされます。
 
-[m:IO::Buffer.for] で作った外部バッファや、ロックされたバッファは大きさを変更できません。
+#@# for を収録したらリンクに戻す
+`IO::Buffer.for` で作った外部バッファや、ロックされたバッファは大きさを変更できません。
 
 - **param** `size` -- 変更後の大きさをバイト数で指定します。
 - **raise** `IO::Buffer::AccessError` -- 大きさを変更できないバッファに対して呼び出した場合に発生します。
@@ -374,8 +377,9 @@ p buf.size  # => 4
 
 バッファの大きさが 0 の場合に true を返します。
 
+#@# for を収録したらリンクに戻す
 大きさ 0 のバッファは、[m:IO::Buffer.new] に 0 を渡すか、
-空文字列から [m:IO::Buffer.for] で作った場合などにできます。
+空文字列から `IO::Buffer.for` で作った場合などにできます。
 
 ```ruby
 p IO::Buffer.new(0).empty? # => true
@@ -426,7 +430,8 @@ p IO::Buffer.new(4).internal? # => true
 バッファが外部(external)バッファである場合に true を返します。
 
 外部バッファは、バッファ自身が確保・マップしたのではないメモリ領域を参照します。
-[m:IO::Buffer.for] で作ったバッファは、文字列のメモリを外部参照します。
+#@# for を収録したらリンクに戻す
+`IO::Buffer.for` で作ったバッファは、文字列のメモリを外部参照します。
 外部バッファは大きさを変更できません。
 
 ```ruby
@@ -440,9 +445,10 @@ p IO::Buffer.new(4).external?      # => false
 
 バッファが読み取り専用の場合に true を返します。
 
-読み取り専用のバッファは、[m:IO::Buffer#set_value] や [m:IO::Buffer#set_string]、
+#@# set_value / for を収録したらリンクに戻す
+読み取り専用のバッファは、`IO::Buffer#set_value` や [m:IO::Buffer#set_string]、
 [m:IO::Buffer#copy] などで変更できません。
-[m:IO::Buffer.for] で作ったバッファや、読み取り専用のファイルから作ったバッファが
+`IO::Buffer.for` で作ったバッファや、読み取り専用のファイルから作ったバッファが
 これにあたります。
 
 ```ruby
@@ -457,7 +463,8 @@ p IO::Buffer.new(4).readonly?      # => false
 マップバッファは、仮想メモリ機構でマップされたメモリ領域を参照します。
 [m:IO::Buffer.new] に [m:IO::Buffer::MAPPED] を指定した場合や、
 大きさが [m:IO::Buffer::PAGE_SIZE] 以上の場合は匿名のマップになります。
-[m:IO::Buffer.map] で作った場合はファイルに紐づいたマップになります。
+#@# map を収録したらリンクに戻す
+`IO::Buffer.map` で作った場合はファイルに紐づいたマップになります。
 
 ### def locked? -> bool
 


### PR DESCRIPTION
## 概要

[c:IO::Buffer] の状態を問い合わせる 10 メソッドを追加しました。
#3278 / #3295 / #3301 の続きです。

`empty?` / `null?` / `valid?` / `internal?` / `external?` / `readonly?` /
`mapped?` / `locked?` / `shared?` / `private?`

レビューを受けて、同じファイル内のリンク切れの解消と、`IO::Buffer.new` の
説明の誤り (1 バイトのずれ) の修正も含んでいます。

## 登場バージョン

実機で確認したところ、8 個は `IO::Buffer` が導入された Ruby 3.1 からありますが、
2 個は後の版で追加されていました。`#@since` で分岐しています。

```
3.1.6:  8/10  （shared? private? が無い）
3.2.11: 9/10  （private? が無い）
3.3.12: 10/10
3.4.10: 10/10
4.0.6:  10/10
```

- `shared?` … 3.2 から
- `private?` … 3.3 から

## readonly? は Ruby 本体の rdoc も直しました

rdoc には「Frozen strings and read-only files create read-only buffers.」と
だけ書かれていましたが、`IO::Buffer.for` に**ブロックを渡さない場合は、元の
文字列が freeze されていなくても常に読み取り専用**になります。これが一番よく
あるケースなのに説明が抜けていたため、Ruby 本体にも修正を送り、
ruby/ruby#18062 としてマージされました。

るりま側もこの区別を説明する形にしています (3.1.6 / 3.2.11 / 3.4.10 / 4.0.6 で
同じ挙動を確認)。

```console
$ ruby -e 'p IO::Buffer.for("test").readonly?'
true
$ ruby -e 'p(IO::Buffer.for("test") { |buf| buf.readonly? })'
false
$ ruby -e 'p(IO::Buffer.for("test".freeze) { |buf| buf.readonly? })'
true
$ ruby -e 'p IO::Buffer.new(4).readonly?'
false
```

ブロックなしの場合は内部で作った文字列の複製をバッファの元として使うため
(`rb_io_buffer_type_for` がその経路で `RB_IO_BUFFER_READONLY` を無条件に渡す)、
元の文字列が freeze されているかどうかによらず読み取り専用になります。

## 未収録 API へのリンクは平文にしました (レビュー対応)

`IO::Buffer` は段階的に追加している途中で、まだ収録していないメソッドを
参照している箇所がありました。リンクにすると存在しない URL を指してしまうため、
収録する回まではコードスパンにし、戻し忘れないよう `#@#` コメントを添えています。

| 参照 | 対応 |
|------|------|
| `IO::Buffer#set_value` | 平文にした |
| `IO::Buffer.map` | 平文にした |
| `IO::Buffer.for` | 平文にした (4 箇所。うち 2 箇所は #3301 由来) |
| `IO::Buffer#locked` | `locked?` への案内に書き換えた (#3295 由来) |
| `Fiber::Scheduler` | rdoc へのリンクにした (#3299 と同じ扱い) |

## IO::Buffer.new の PAGE_SIZE の境界を修正しました (レビュー対応)

`IO::Buffer.new` の説明が「size が `PAGE_SIZE` **より大きい**場合」となって
いましたが、実装は `>=` です。

```c
    if (size >= RUBY_IO_BUFFER_PAGE_SIZE) {
```

```console
$ ruby -e 'ps = IO::Buffer::PAGE_SIZE; p [IO::Buffer.new(ps - 1).mapped?, IO::Buffer.new(ps).mapped?]'
[false, true]
```

3.1.6 / 3.2.11 / 3.3.12 / 3.4.10 / 4.0.6 のいずれも同じ結果で、「`PAGE_SIZE`
**以上**の場合」に修正しました。

## 例について

例に使ったコードは 3.1 / 3.2 / 3.3 / 4.0 で実行し、すべて同じ出力になることを
確認しました。

`valid?` / `mapped?` / `locked?` / `shared?` / `private?` は、簡潔で安定した例を
作るのが難しい（ファイルのマッピングや slice の無効化などが必要になる）ため、
説明のみとしています。

## 検証

- `rake check_format` / `check_blank_lines` / `check_indent_in_samplecode` /
  `check_single_space_indent`
- `bitclust update --markdowntree=manual/api` を 3.1 / 3.2 / 3.3 / 4.0 で実行し、
  エラーが出ないこと、登録されるメソッドが **8 / 9 / 10 / 10 件**と
  上記の追加バージョンどおりになることを確認しました。
- `IO__Buffer.md` 由来の全エントリについて `[m:...]` / `[c:...]` を DB と
  突き合わせ、リンク切れが 0 件であることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
