### PR TITLE
Dir: fchdir と for_fd を追加 (Ruby 3.3)

### DIFF
--- a/manual/api/_builtin/Dir.md
+++ b/manual/api/_builtin/Dir.md
@@ -135,7 +135,9 @@ p Dir.pwd                    #=> "/var/spool/mail"
 p Dir.chdir("~/.ssh")        # => Errno::ENOENT
 ```
 
+#@since 3.3
 - **SEE** [m:Dir.fchdir]
+#@end
 
 #@since 3.3
 ### def fchdir(fd)    -> 0
@@ -167,7 +169,7 @@ Dir.fchdir(dir.fileno)
 p Dir.pwd            # => "/usr"
 ```
 
-- **SEE** [m:Dir.chdir], [m:Dir#fileno]
+- **SEE** [m:Dir.chdir], [m:Dir#fileno], [m:Dir.for_fd]
 #@end
 
 ### def chroot(path)    -> 0
@@ -426,7 +428,7 @@ Dir.mktmpdir do |tmpdir|
 end
 ```
 
-- **SEE** [m:Dir#fileno], [m:Dir#path]
+- **SEE** [m:Dir#fileno], [m:Dir#path], [m:Dir.fchdir]
 #@end
 
 ### def exist?(file_name)    -> bool

--- a/manual/api/_builtin/Dir.md
+++ b/manual/api/_builtin/Dir.md
@@ -135,6 +135,41 @@ p Dir.pwd                    #=> "/var/spool/mail"
 p Dir.chdir("~/.ssh")        # => Errno::ENOENT
 ```
 
+- **SEE** [m:Dir.fchdir]
+
+#@since 3.3
+### def fchdir(fd)    -> 0
+### def fchdir(fd) { ... }    -> object
+
+カレントディレクトリを、整数のファイルディスクリプタ fd が指す
+ディレクトリに変更します。
+
+ファイルディスクリプタを UNIX ソケット経由で渡したり子プロセスに渡したりする
+場合、[m:Dir.chdir] の代わりに fchdir を使うと TOCTOU (time-of-check to
+time-of-use) 脆弱性を避けられます。
+
+ブロックを指定しない場合、カレントディレクトリを fd の指すディレクトリに変更し、
+0 を返します。
+
+ブロックを指定した場合、カレントディレクトリの変更はブロックの実行中に限られます。
+ブロックの実行結果を返します。
+
+- **param** `fd` -- ディレクトリを指すファイルディスクリプタを整数で指定します。
+
+- **raise** `Errno::EXXX` -- 失敗した場合に発生します。
+
+```ruby title="例"
+Dir.chdir("/var/spool/mail")
+p Dir.pwd            # => "/var/spool/mail"
+
+dir = Dir.new("/usr")
+Dir.fchdir(dir.fileno)
+p Dir.pwd            # => "/usr"
+```
+
+- **SEE** [m:Dir.chdir], [m:Dir#fileno]
+#@end
+
 ### def chroot(path)    -> 0
 
 ルートディレクトリを path に変更します。
@@ -361,6 +396,38 @@ Dir.mktmpdir do |tmpdir|
   end
 end
 ```
+
+#@since 3.3
+### def for_fd(fd)    -> Dir
+
+整数のディレクトリファイルディスクリプタ fd が指すディレクトリを表す、
+新しい [c:Dir] オブジェクトを返します。
+
+返される [c:Dir] オブジェクトには対応するパスがないため、
+[m:Dir#path] は nil を返します。
+
+このメソッドは POSIX 2008 で定義された fdopendir() を使用します。
+POSIX 非対応のプラットフォームでは実装されておらず、
+[c:NotImplementedError] が発生します。
+
+- **param** `fd` -- ディレクトリを指すファイルディスクリプタを整数で指定します。
+
+```ruby title="例"
+require 'tmpdir'
+
+Dir.mktmpdir do |tmpdir|
+  d0 = Dir.new(tmpdir)
+  d1 = Dir.for_fd(d0.fileno)
+
+  p d1.class  # => Dir
+  p d0.path   # => tmpdir のパス
+  p d1.path   # => nil
+  d0.close
+end
+```
+
+- **SEE** [m:Dir#fileno], [m:Dir#path]
+#@end
 
 ### def exist?(file_name)    -> bool
 


### PR DESCRIPTION
## 概要

Ruby 4.0 に存在するのにリファレンスに項目が無い [c:Dir] のメソッド 2 個を追加しました。
どちらも Ruby 3.3 で追加されたものです。

- `Dir.fchdir` — ファイルディスクリプタでカレントディレクトリを変更する
- `Dir.for_fd` — ファイルディスクリプタからパスを持たない [c:Dir] を作る

## 登場バージョン

実機で確認しました。どちらも 3.3 からです。

```
2.7.8 〜 3.2.11: なし
3.3.12 / 3.4.10 / 4.0.6: fchdir, for_fd
```

## 記述の根拠

- `Dir.fchdir` はブロックなしで 0 を、ブロックありでブロックの評価結果を返し、
  変更はブロック実行中に限られます。ブロック引数は nil だったため、シグネチャは
  `Dir.fchdir(fd) { ... }` としました (rdoc の call-seq に合わせています)。
  例はカレントディレクトリを変更するので、同ファイルの `Dir.chdir` の例と同じ
  `/var/spool/mail`・`/usr` のスタイルに揃えました。
- `Dir.for_fd` は POSIX の `fdopendir()` を使い、非 POSIX 環境では
  [c:NotImplementedError] になります。返る [c:Dir] はパスを持たず、
  [m:Dir#path] が nil を返すことを実機で確認しました。

```console
$ ruby -rtmpdir -e 'Dir.mktmpdir { |d| dir = Dir.new(d); p Dir.for_fd(dir.fileno).path }'
nil
```

## 検証

- `Dir.for_fd` の例は 3.3 / 3.4 / 4.0 で実行して出力を確認しました。
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_single_space_indent`
- `bitclust update --markdowntree=manual/api` を 3.1 / 3.2 / 3.3 / 3.4 / 4.0 で実行し、
  エラーが出ないこと、登録されるメソッドが **0 / 0 / 2 / 2 / 2 件**と 3.3 追加どおりに
  なることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
