### PR TITLE
Enumerator::Product と Enumerator.product を追加 (Ruby 3.2)

### DIFF
--- a/manual/api/_builtin/Enumerator.md
+++ b/manual/api/_builtin/Enumerator.md
@@ -159,6 +159,36 @@ p unknown.size  # => nil
 
 #@end
 
+#@since 3.2
+### def product(*enums) -> Enumerator::Product
+### def product(*enums) { |elts| ... } -> nil
+
+与えた [c:Enumerable] なオブジェクトの直積(デカルト積)を列挙する Enumerator を作って返します。
+
+[m:Enumerator::Product.new] と同じです。
+ブロックを与えた場合は、各要素の配列をブロックに渡して繰り返し、nil を返します。
+
+- **param** `enums` -- 直積を取る [c:Enumerable] なオブジェクトを指定します。
+
+```ruby
+e = Enumerator.product(1..3, [4, 5])
+p e.to_a # => [[1, 4], [1, 5], [2, 4], [2, 5], [3, 4], [3, 5]]
+p e.size # => 6
+```
+
+```ruby title="例: ブロックを与えた場合"
+Enumerator.product(1..2, ["a", "b"]) do |i, s|
+  p [i, s]
+end
+# => [1, "a"]
+#    [1, "b"]
+#    [2, "a"]
+#    [2, "b"]
+```
+
+- **SEE** [c:Enumerator::Product]
+#@end
+
 ## Methods
 
 ### def +(enum) -> Enumerator::Chain

--- a/manual/api/_builtin/Enumerator__Product.md
+++ b/manual/api/_builtin/Enumerator__Product.md
@@ -1,0 +1,93 @@
+---
+library: _builtin
+since: "3.2"
+---
+# class Enumerator::Product < Enumerator
+
+複数の [c:Enumerable] なオブジェクトの直積(デカルト積)を列挙するためのクラス。
+
+このクラスのオブジェクトは [m:Enumerator.product] から作られます。
+
+各要素は、与えたオブジェクトの数と同じ大きさの配列になります。
+右側のオブジェクトほど内側のループになり、最後のオブジェクトが最も速く進みます。
+
+```ruby title="例"
+e = Enumerator::Product.new(1..2, ["a", "b"])
+e.each do |i, s|
+  p [i, s]
+end
+# => [1, "a"]
+#    [1, "b"]
+#    [2, "a"]
+#    [2, "b"]
+```
+
+## Class Methods
+
+### def new(*enums) -> Enumerator::Product
+
+与えた [c:Enumerable] なオブジェクトの直積を列挙する Enumerator を作って返します。
+
+- **param** `enums` -- 直積を取る [c:Enumerable] なオブジェクトを指定します。
+
+```ruby title="例"
+e = Enumerator::Product.new(1..3, [4, 5])
+p e.to_a # => [[1, 4], [1, 5], [2, 4], [2, 5], [3, 4], [3, 5]]
+p e.size # => 6
+```
+
+- **SEE** [m:Enumerator.product]
+
+## Instance Methods
+
+### def each { |*args| ... } -> self
+### def each -> Enumerator
+
+各オブジェクトの直積の要素を、配列としてブロックに渡して繰り返します。
+
+各オブジェクトに対しては each ではなく each_entry を呼び出します。
+そのため、N 個のオブジェクトの直積は、各繰り返しでちょうど N 要素の配列になります。
+
+オブジェクトを1つも与えずに作った場合は、空の引数リストでブロックを1回だけ呼びます。
+
+ブロックを渡さない場合は [c:Enumerator] を返します。
+
+```ruby title="例"
+e = Enumerator::Product.new(1..2, ["a", "b"])
+e.each do |i, s|
+  p [i, s]
+end
+# => [1, "a"]
+#    [1, "b"]
+#    [2, "a"]
+#    [2, "b"]
+```
+
+### def inspect -> String
+
+self を人間が読みやすい形式の文字列にして返します。
+
+```ruby title="例"
+e = Enumerator::Product.new(1..3, [4, 5])
+p e.inspect # => "#<Enumerator::Product: [1..3, [4, 5]]>"
+```
+
+### def rewind -> self
+
+列挙状態を巻き戻します。
+
+self が持つ各オブジェクトに対して、逆順で rewind メソッドを呼びます。
+ただし rewind メソッドを持たないオブジェクトに対しては呼びません。
+
+### def size -> Integer | Float::INFINITY | nil
+
+直積の要素数を返します。
+
+各オブジェクトのサイズの積を返します。
+サイズが分からないオブジェクトが含まれる場合は nil を、
+無限に続くオブジェクトが含まれる場合は [m:Float::INFINITY] を返します。
+
+```ruby title="例"
+p Enumerator::Product.new(1..3, [4, 5]).size    # => 6
+p Enumerator::Product.new(1.., [4, 5]).size     # => Infinity
+```


### PR DESCRIPTION
## 概要

Ruby 4.0 に存在するのにリファレンスに項目が無かった [c:Enumerator::Product] と
[m:Enumerator.product] を追加しました。どちらも Ruby 3.2 で追加された公開 API です。

- `Enumerator::Product` (新規ファイル) — `new` と `each` / `inspect` / `rewind` / `size`
- `Enumerator.product` (`Enumerator.md` に追加) — `Enumerator::Product.new` と同じもの

## Enumerator.product も同じ PR で追加しました (レビュー対応)

当初は `Enumerator::Product` だけを追加していましたが、クラスの説明と `new` の
`- **SEE**` から参照している `[m:Enumerator.product]` が doctree に未定義で
リンク切れになるとのご指摘をいただき、この PR で `Enumerator.md` にも追加しました。
Ruby 3.2 で追加されたメソッドなので `#@since 3.2` で囲んでいます。

説明は `[m:Enumerator::Product.new] と同じです` として、参照先の内容を複製しない
形にしました。

### ブロックを渡した場合の返り値を rdoc と変えています

`enumerator.c` の call-seq は次のようになっています。

```c
 *   Enumerator.product(*enums) -> enumerator
 *   Enumerator.product(*enums) { |elts| ... } -> enumerator
```

しかし実装はブロックがあるとき `nil` を返します。

```c
    if (!NIL_P(block)) {
        enum_product_run(obj, block);
        return Qnil;
    }
```

rdoc の本文も「ブロックを渡した場合は nil を返す」と説明しており、実機でも `nil` が返ります。
call-seq 側の誤りと考えられるため、るりまは実機に合わせて `-> nil` としました。

```console
$ ruby -e 'p(Enumerator.product(1..2, ["a", "b"]) { })'
nil
```

## Enumerator::Producer は非対応にしました

対になる `Enumerator::Producer` も未収録でしたが、Ruby 本体の `enumerator.c` で

```c
/* :nodoc: Producer */
rb_cEnumProducer = rb_define_class_under(rb_cEnumerator, "Producer", rb_cObject);
```

と `:nodoc:` 指定された内部実装クラスで、ri にもドキュメントがありません
(`Enumerator.produce` が返すのは通常の [c:Enumerator] で、Producer は表に出ません)。
:nodoc: のものは収録しない方針に従い、こちらは収録せずトラッカーで非対応としました。

## 登場バージョン

```
2.7.8 〜 3.1.6: なし
3.2.11 以降:    Enumerator::Product / Enumerator.product
```

3.1.6 では `Enumerator.product` は `NoMethodError` (`Did you mean? produce`) になります。

## 記述の根拠(実機で確認)

- 各オブジェクトには `each` ではなく `each_entry` が呼ばれ、N 個のオブジェクトの
  直積は各繰り返しでちょうど N 要素の配列になります。
- 引数なしで作った場合は空の引数リストでブロックを1回呼びます。
- `size` は各オブジェクトのサイズの積を返し、無限を含む場合は [m:Float::INFINITY]、
  分からない場合は nil を返します。

```console
$ ruby -e 'p Enumerator::Product.new(1.., [4, 5]).size'
Infinity
```

- `Enumerator.product` の返り値は `Enumerator::Product` です。

```console
$ ruby -e 'p Enumerator.product(1..2, ["a", "b"]).class'
Enumerator::Product
```

## 検証

- サンプルコードは 3.2 / 3.3 / 3.4 / 4.0 で実行して出力を確認しました。
- `rake check_format` / `check_blank_lines` / `check_indent_in_samplecode` /
  `check_single_space_indent`
- `bitclust update --markdowntree=manual/api` を 3.1 / 3.2 / 3.3 / 4.0 で実行し、
  エラーが出ないこと、3.1 では未登録・3.2 以降でクラスと 5 項目が登録されることを
  確認しました。
- `Enumerator.product` も同様に、4.0 の DB では `bitclust lookup --method='Enumerator.product'`
  で引けること、3.1 の DB では `no such method` になることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
