### PR TITLE
Thread: リンク切れと、3.1 以降で動かないサンプルコードを修正

### DIFF
--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -442,7 +442,7 @@ flag = false # スレッド停止
 
 ### 使い方
 
-例:[c:Thread#raise] 発生のタイミングを制御する例
+例:[m:Thread#raise] 発生のタイミングを制御する例
 
 ```ruby
 th = Thread.new do
@@ -465,24 +465,24 @@ th.raise "stop"
 [c:RuntimeError] を無視(延期)している間はリソースの割り当てや ensure
 節でリソースの解放を安全に行う事ができます。
 
-#### TimeoutError 対策
+#### Timeout::Error 対策
 
-例:[c:TimeoutError] 発生のタイミングを制御する例
+例:[c:Timeout::Error] 発生のタイミングを制御する例
 
 ```ruby
 require 'timeout'
-Thread.handle_interrupt(TimeoutError => :never) {
-  timeout(10){
-    # TimeoutError => :never の指定により、ここでは TimeoutError が発生しない。
-    Thread.handle_interrupt(TimeoutError => :on_blocking) {
-      # :on_blocking な処理は TimeoutError が発生し得る。
+Thread.handle_interrupt(Timeout::Error => :never) {
+  Timeout.timeout(10){
+    # Timeout::Error => :never の指定により、ここでは Timeout::Error が発生しない。
+    Thread.handle_interrupt(Timeout::Error => :on_blocking) {
+      # :on_blocking な処理は Timeout::Error が発生し得る。
     }
-    # TimeoutError => :never の指定により、ここでは TimeoutError が発生しない。
+    # Timeout::Error => :never の指定により、ここでは Timeout::Error が発生しない。
   }
 }
 ```
 
-この例を ensure 節での [c:TimeoutError] 発生に応用する事でリソースリー
+この例を ensure 節での [c:Timeout::Error] 発生に応用する事でリソースリー
 クに備える事ができます。[m:Timeout?.timeout] はスレッドを使って実装さ
 れているため、Thread.handle_interrupt による制御が有効です。
 


### PR DESCRIPTION
## 概要

`Thread.md` に以前からあったリンク切れ 2 種類 (3 箇所) を直しました。
調べたところ、片方はリンクだけでなく**サンプルコード自体が Ruby 3.1 以降で
動かない**状態だったため、あわせて修正しています。

#3313 で「リンク切れの記法ミスとタイポ」をまとめて直しましたが、`Thread.md` は
当時 #3308 と競合するため外していました。#3308 がマージされたので別途出します。

## 1. `[c:Thread#raise]` → `[m:Thread#raise]`

メソッドを `[c:]` (クラス参照) で書いている記法ミスです。
bitclust の `[c:...]` はリンク先の存在確認をしないため、静かにリンク切れに
なっていました (#3313 で znz さんに教えていただいた挙動です)。

## 2. `[c:TimeoutError]` → `[c:Timeout::Error]` (2 箇所)

`TimeoutError` は Ruby 3.1 で削除されており、実在するのは `Timeout::Error` だけです。
るりまにも `Timeout::Error` のページしかありません。

## 3. サンプルコードが 3.1 以降で動かない

「TimeoutError 対策」節のサンプルは `TimeoutError` と `timeout(10)` を使って
いましたが、どちらも 3.1 で削除されています。

```console
$ ruby -e 'require "timeout"; Thread.handle_interrupt(TimeoutError => :never) { }'
-e:1:in '<main>': uninitialized constant TimeoutError (NameError)

$ ruby -e 'require "timeout"; timeout(1) { }'
-e:1:in '<main>': undefined method 'timeout' for main (NoMethodError)
```

実機で確認した版ごとの状況です。

```
2.7.8 / 3.0.7: 動く (Object#timeout is deprecated, use Timeout.timeout instead の警告つき)
3.1.6 以降:    NameError / NoMethodError
```

`Timeout::Error` / `Timeout.timeout` に置き換えました。この形は 2.7.8 / 3.0.7 /
3.1.6 / 3.4.10 / 4.0.6 のすべてで動くので、版分岐は不要です。

あわせて見出し「TimeoutError 対策」も「Timeout::Error 対策」に揃えました。

## 検証

- 置き換え後のサンプルを 2.7 / 3.0 / 3.1 / 3.4 / 4.0 で実行し、すべて例外が
  出ないことを確認しました。
- `rake check_format` / `check_blank_lines` / `check_indent_in_samplecode` /
  `check_single_space_indent`
- `Thread.md` 由来の全エントリの `[m:...]` / `[c:...]` を DB と突き合わせ、
  3.0 / 4.0 のいずれもリンク切れ 0 件になりました (修正前は 2 件)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
