### PR TITLE
参照リンク切れを検査する rake check_links を追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 838a5614ecfefa2e81feb04bcf9e103311e0be16
+  revision: 3c9999411372b350a4ae0e55c2de669390cadc10
   specs:
     bitclust-core (1.5.0)
       drb

--- a/Rakefile
+++ b/Rakefile
@@ -191,6 +191,33 @@ end
 desc "Generate static html"
 multitask :statichtml => CI_VERSIONS.map {|version| "statichtml:#{version}" }
 
+# 参照リンク切れの検査(bitclust checklink)。[c:]/[m:]/[lib:]/[d:]/[f:]
+# 参照の指す先が同じ版の DB に存在するかを、実際の描画経路で検証する。
+# 既知のリンク切れが残っているため default タスクにはまだ入れていない
+# (棚卸しが済んでゼロになったら default 入りさせて回帰を防ぐ)
+def check_links(version)
+  check_bitclust_version!
+  db = "/tmp/db-#{version}"
+  generate_database(version) unless File.exist?(db)
+  puts "check links of #{version}"
+  # capi は generate_database で同じ prefix に構築されるので [f:] も検証する
+  succeeded = system("bundle", "exec", "bitclust", "--database=#{db}",
+                     "checklink", "--capi-database=#{db}")
+  raise "Broken links found in #{version} (see above)" unless succeeded
+end
+
+namespace :check_links do
+  ALL_VERSIONS.each do |version|
+    desc "Check broken cross references of #{version}"
+    task version do
+      check_links(version)
+    end
+  end
+end
+
+desc "Check broken cross references (CI versions)"
+task :check_links => CI_VERSIONS.map {|version| "check_links:#{version}" }
+
 desc "Create index"
 task :create_index do
   links = []


### PR DESCRIPTION
## 概要

bitclust に追加された `checklink` サブコマンド(bitclust 側 PR 参照)を使って参照リンク切れを検査する `rake check_links` を追加します。`[c:]` / `[m:]` / `[lib:]` / `[d:]` / `[f:]` 参照の指す先が同じ版の DB に存在するかを、実際の描画経路で検証します(コードスパン・フェンス内の参照風テキストは対象外)。

```
rake check_links          # CI 対象全版
rake check_links:4.1      # 特定の版のみ(DB が無ければ生成する)
```

capi DB は `generate_database` で同じ prefix に構築されるため、`[f:]` 参照も同時に検証します。

## default タスクに入れていない理由

現行の manual/ には既知のリンク切れが残っています(4.1 版で 303 件。別 issue で棚卸し予定)。ゼロになった時点で default 入りさせて、新規のリンク切れ混入を CI で防ぐ想定です。

## 前提

bitclust 側の checklink PR のマージ(+Gemfile.lock の更新)が先です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
