### PR TITLE
Refinement: target と refined_class を追加

### DIFF
--- a/manual/api/_builtin/Refinement.md
+++ b/manual/api/_builtin/Refinement.md
@@ -9,6 +9,51 @@ refine のブロックの中の self のクラスです。
 [m:Refinement#import_methods]で他のモジュールからメソッドを
 インポートできます。
 
+#%since 3.2
+## Instance Methods
+
+#%since 3.3
+### def target -> Class | Module
+
+`self` が refine の対象にしているクラスまたはモジュールを返します。
+
+```ruby
+module M
+  refine String do
+  end
+end
+
+p M.refinements[0].target # => String
+```
+
+- **SEE** [m:Module#refinements], [m:Module#refine]
+
+#%end
+#%until 3.4
+### def refined_class -> Class
+
+`self` が refine の対象にしているクラスを返します。
+
+#%since 3.3
+Ruby 3.3 で deprecated になり、Ruby 3.4 で削除されました。
+[m:Refinement#target] を使ってください。
+`-W:deprecated` を指定すると警告が出ます。
+#%end
+
+```ruby
+module M
+  refine String do
+  end
+end
+
+p M.refinements[0].refined_class # => String
+```
+
+- **SEE** [m:Module#refinements], [m:Module#refine]
+
+#%end
+#%end
+
 ## Private Instance Methods
 
 ### def import_methods(*modules) -> self


### PR DESCRIPTION
## 概要

[c:Refinement] のインスタンスメソッド 2 つを追加しました。

- `Refinement#target` (3.3 以降)
- `Refinement#refined_class` (3.2 / 3.3 のみ)

`Refinement.md` には `import_methods` しか収録されていなかったため、
**refine の対象を取得する手段がどの版のページにも載っていませんでした**。

## 版ごとの状況 (実機で確認)

```
3.1.6  : どちらも無し
3.2.11 : refined_class のみ
3.3.12 : refined_class と target の両方
3.4.10 : target のみ (refined_class は削除)
4.0.6  : target のみ
```

`refined_class` は 3.2 で追加され、3.3 で deprecated になり、3.4 で削除
されました。3.3 で `-W:deprecated` を付けると警告が出ます。

```console
$ ruby -W:deprecated -e 'module M; refine(String){}; end; M.refinements[0].refined_class'
-e:1: warning: Refinement#refined_class is deprecated and will be removed in Ruby 3.4; use Refinement#target instead
```

3.2 では警告は出ません。そのため deprecated の注記自体も `#%since 3.3` で
囲んでいます。

## 版の出し分け

`## Instance Methods` 全体を `#%since 3.2` で囲み、その中で

- `target` を `#%since 3.3`
- `refined_class` を `#%until 3.4`
- `refined_class` の deprecated の注記をさらに `#%since 3.3`

としています。版ごとに DB を生成して、意図どおりであることを確認しました。

| 版 | target | refined_class |
|----|--------|---------------|
| 3.1 | なし | なし |
| 3.2 | なし | あり |
| 3.3 | あり | あり |
| 3.4 / 4.0 | あり | なし |

## 検証

- 例は 3.2 / 3.3 / 3.4 / 4.0 で実行し、いずれも `String` を返すことを確認しました。
- `rake check_links` は 3.2 / 3.3 / 4.0 のいずれも master と同数です
  (296 / 295 / 297)。`refined_class` から `[m:Refinement#target]` への参照が
  3.2 で切れていないことも含めて確認しています。
- `rake check_format` ほか lint 一式も通っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
