### PR TITLE
FloatDomainError の説明を rdoc に従って訂正

### DIFF
--- a/manual/api/_builtin/FloatDomainError.md
+++ b/manual/api/_builtin/FloatDomainError.md
@@ -3,6 +3,16 @@ library: _builtin
 ---
 # class FloatDomainError < RangeError
 
-正負の無限大や NaN (Not a Number) を [c:Bignum] に変換しようとしたり、
-NaN との比較を行ったときに発生します。
-#%# NaN は、p 0.0/0 #=> NaN で得られます。[[c:Float]]参照
+正負の無限大や NaN (Not a Number) を、それに対応していない数値クラスに変換しようとしたとき発生します。
+
+```ruby title="FloatDomainErrorが発生する例"
+# Integer には正負の無限大や NaN に対応する値が無い
+Float::INFINITY.to_i    # ~> FloatDomainError
+(-Float::INFINITY).to_i # ~> FloatDomainError
+Float::NAN.to_i         # ~> FloatDomainError
+
+# Rational には正負の無限大や NaN に対応する値が無い
+Float::INFINITY.to_r    # ~> FloatDomainError
+(-Float::INFINITY).to_r # ~> FloatDomainError
+Float::NAN.to_r         # ~> FloatDomainError
+```


### PR DESCRIPTION
* rdoc には「NaN との比較を行ったとき」の記述がなく，実際 NaN は他の値と比較可能なので，この記述を削除
* コメントの豆知識（NaN の作り方）は不要と思い削除
* サンプルコードを付加

なお，この修正により，`[c:Bignum]` のリンク切れは解消します（#3324 が 1 件減る）。