### PR TITLE
Exception#detailed_message を追加 (Ruby 3.2)

### DIFF
--- a/manual/api/_builtin/Exception.md
+++ b/manual/api/_builtin/Exception.md
@@ -291,3 +291,58 @@ end
 ```
 
 - **SEE** [m:Exception.to_tty?]
+
+#%since 3.2
+### def detailed_message(highlight: false, **opt) -> String
+
+例外のメッセージに情報を追加した文字列を返します。
+
+[m:Exception#message] との違いは、1 行目に例外クラス名が付くことです。
+highlight に true を指定すると、エスケープシーケンスによる文字装飾も付きます。
+
+[m:Exception#full_message] と違い、highlight の既定値は常に false です。
+[m:Exception.to_tty?] の値によって変わることはありません。
+
+- **param** `highlight` -- エスケープシーケンスによる文字装飾をつけるかどうかを
+                 指定します。
+
+- **param** `opt` -- 上書きしたメソッドが解釈するためのキーワード引数です。
+             このメソッド自身は解釈せず、知らないキーワードを渡しても
+             エラーになりません。
+
+```ruby
+begin
+  1 / 0
+rescue => e
+  p e.message                          # => "divided by 0"
+  p e.detailed_message                 # => "divided by 0 (ZeroDivisionError)"
+  p e.detailed_message(highlight: true)
+  # => "\e[1mdivided by 0 (\e[1;4mZeroDivisionError\e[m\e[1m)\e[m"
+end
+```
+
+Ruby が捕捉されなかった例外を報告するときに、このメソッドの返り値が使われます。
+[lib:did_you_mean] や error_highlight は、このメソッドを上書きして
+「もしかして」の候補やエラー箇所の指示を追加しています。
+そのため、実際に得られる文字列は読み込んでいるライブラリによって変わります。
+
+このメソッドを上書きする場合は、知らないキーワード引数を渡されても
+エラーにならないようにしてください。`highlight` のほか、`did_you_mean`、
+`error_highlight`、`syntax_suggest` などが渡される可能性があります。
+
+```ruby
+class MyError < StandardError
+  def detailed_message(highlight: false, **opt)
+    "custom: #{message}"
+  end
+end
+
+begin
+  raise MyError, "x"
+rescue => e
+  p e.detailed_message # => "custom: x"
+end
+```
+
+- **SEE** [m:Exception#message], [m:Exception#full_message]
+#%end


### PR DESCRIPTION
## 概要

[m:Exception#detailed_message] を追加しました。Ruby 3.2 で追加された、
例外のメッセージに例外クラス名などの情報を追加して返すメソッドです。

Ruby が捕捉されなかった例外を報告するときに使われる文字列を組み立てる
メソッドで、did_you_mean などが上書きして「もしかして」の候補を追加する
拡張点にもなっています。

## 登場バージョン

```
3.0.7 / 3.1.6: なし
3.2.11 以降:   あり
```

`#%since 3.2` で囲んでいます。3.1 のページに出ないことを DB で確認しました。

## 記述について

### full_message との違いを明示しました

同じ `highlight:` キーワードを持ちますが、既定値の決まり方が違います。

- `full_message` … [m:Exception.to_tty?] の返り値が既定
- `detailed_message` … 常に `false`

実機でも `$stderr` の状態によらず装飾なしの文字列が返ることを確認しました。
混同しやすいので本文に書いています。

### 上書きするときの注意を書きました

ri が "An overriding method must be tolerant of passed keyword arguments" と
強調している点です。`highlight` のほか `did_you_mean` / `error_highlight` /
`syntax_suggest` が渡される可能性があります。実際に上書きする例も付けました。

### error_highlight は平文にしました

`[lib:did_you_mean]` は収録済みですが、`error_highlight` と `syntax_suggest`
は未収録のため、リンクにすると切れます。収録されたらリンクに変える想定です。

## 検証

- 記載した例は 3.2 / 3.3 / 3.4 / 4.0 で実行し、出力が一致することを確認しました。
  エスケープシーケンス付きの出力も含めて全版で同一です。
  `NoMethodError` を使う例は版で文言が変わる (`for []:Array` →
  `for an instance of Array`、3.4 でクォート変更) ため避け、ライブラリによる
  拡張は説明で触れるに留めました。
- `rake check_links` は 3.1 / 3.2 / 4.0 のいずれも master と同数です
  (262 / 296 / 297)。
- `rake check_format` ほか lint 一式も通っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
