### PR TITLE
Set#join を追加

### DIFF
--- a/manual/api/_builtin/Set.md
+++ b/manual/api/_builtin/Set.md
@@ -266,6 +266,24 @@ set = Set['hello', 'world']
 p set.to_a # => ["hello", "world"]
 ```
 
+### def join(separator = nil) -> String
+
+各要素を文字列に変換し、separator を間に挟んで連結した文字列を返します。
+
+[m:Set#to_a] してから [m:Array#join] を呼ぶのと同じです。
+要素の順序は不定なので、連結される順序も不定です。
+
+- **param** `separator` -- 間に挟む文字列を指定します。nil を指定した場合と
+                 省略した場合は、間に何も挟まずに連結します。
+
+```ruby
+p Set[1, 2, 3].join       # => "123"
+p Set[1, 2, 3].join(", ") # => "1, 2, 3"
+p Set[].join(", ")        # => ""
+```
+
+- **SEE** [m:Array#join], [m:Set#to_a]
+
 ### def include?(o) -> bool
 ### def member?(o) -> bool
 ### def ===(o) -> bool

--- a/manual/api/set/Set.md
+++ b/manual/api/set/Set.md
@@ -200,6 +200,25 @@ set = Set['hello', 'world']
 p set.to_a # => ["hello", "world"]
 ```
 
+### def join(separator = nil) -> String
+
+各要素を文字列に変換し、separator を間に挟んで連結した文字列を返します。
+
+[m:Set#to_a] してから [m:Array#join] を呼ぶのと同じです。
+要素の順序は不定なので、連結される順序も不定です。
+
+- **param** `separator` -- 間に挟む文字列を指定します。nil を指定した場合と
+                 省略した場合は、間に何も挟まずに連結します。
+
+```ruby
+require 'set'
+p Set[1, 2, 3].join       # => "123"
+p Set[1, 2, 3].join(", ") # => "1, 2, 3"
+p Set[].join(", ")        # => ""
+```
+
+- **SEE** [m:Array#join], [m:Set#to_a]
+
 ### def include?(o) -> bool
 ### def member?(o) -> bool
 ### def ===(o) -> bool


### PR DESCRIPTION
## 概要

[m:Set#join] を追加しました。各要素を文字列に変換して連結するメソッドで、
[m:Set#to_a] してから [m:Array#join] を呼ぶのと同じものです。

`to_a` の直後に置きました。

## バージョンについて

`Set.md` は `since: "3.2"` で、その全範囲で `Set` が組み込みなので
`require "set"` は不要です。`join` 自体は 3.0 の set ライブラリにもあるため、
追加の版ゲートも要りません。

## 例に使わなかったもの

実機で調べて、版によって表示が変わるものは例から外しました。

### 入れ子の Set は 4.0 で表示が変わります

```
3.0〜3.4 : Set[1, Set[2, 3]].join(",") # => "1,#<Set: {2, 3}>"
4.0      :                             # => "1,Set[2, 3]"
```

### $, の扱いも 4.0 で変わります

`$,` を設定している場合、3.4 以前は区切りに使われますが 4.0 では無視されます。
`$,` については [m:Array#join] の項に「2.7 から非推奨」と既に書かれているため、
こちらでは触れていません。

## 検証

- 記載した例は 3.2 / 3.3 / 3.4 / 4.0 で実行し、出力が一致することを確認しました。
- `rake check_links` は 3.2 / 4.0 とも master と同数です (296 / 297)。
- `rake check_format` ほか lint 一式も通っています。

## 参考 (本 PR 対象外)

作業中に気づいた別件です。`Array#join` の項に旧記法が残っています。

```
Ruby 2.7 からは [[m:$,]] を nil 以外の値に変更することは非推奨になっており、
```

Markdown 移行後は `[m:$,]` が正しく、`[[m:$,]]` だと余分な角括弧が表示に残ります。
リンク自体は解決するので `rake check_links` には出ません。

`#%#` コメント行やコードフェンス内、`[[:alpha:]]` のような POSIX 文字クラスを
除いて調べたところ、残っているのは 5 箇所 / 3 ファイルでした
(`Array.md:1328,1329` の `[[m:$,]]`、`String.md:2281,2282` の `[[m:$;]]`、
`doc/news/2_7_0.md:263` の `[[feature:15575]]`)。別 PR にまとめて出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
