### PR TITLE
Date#xmlschema の説明のタイポ修正

### DIFF
--- a/manual/api/date/Date.md
+++ b/manual/api/date/Date.md
@@ -889,7 +889,7 @@ ISO 8601 書式の文字列を返します (拡大表記 ('%Y-%m-%d') を使い�
 #%# exp
 ### def xmlschema -> String
 
-XML Scheme (date) による書式の文字列を返します。
+XML Schema (date) による書式の文字列を返します。
 
 ### def yday -> Integer
 


### PR DESCRIPTION
XML Scheme は正しくは XML Schema ですね。

このほかに schema を scheme と誤った例は見当たりませんでした。

scheme を schema と誤ったものは別 PR で。