### PR TITLE
IPAddr の「要約」を改善

### DIFF
--- a/manual/api/ipaddr.md
+++ b/manual/api/ipaddr.md
@@ -6,7 +6,7 @@ IPアドレスを扱うライブラリです。
 
 # class IPAddr < Object
 
-IP アドレスを扱うのためのクラスです。
+IP アドレスを表すクラスです。IPv4 と IPv6 のどちらのアドレスも表せます。
 
 ```ruby title="例"
 require 'ipaddr'


### PR DESCRIPTION
* クラスなので「〜を扱う」を「〜を表す」に
* IPv4, IPv6 両方に対応することを追記