### PR TITLE
IO::Buffer: ビット演算の 8 メソッドを追加

### DIFF
--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -825,3 +825,85 @@ p IO::Buffer.new(4).readonly?                       # => false
 
 プライベートバッファに加えた変更は、元になったファイルのマッピングには反映されません。
 #%end
+
+#%since 3.2
+### def &(mask) -> IO::Buffer
+### def |(mask) -> IO::Buffer
+### def ^(mask) -> IO::Buffer
+
+バッファの各バイトと mask の各バイトのビット演算(AND / OR / XOR)を行い、
+結果を格納した新しいバッファを返します。
+
+返されるバッファの大きさは元のバッファと同じです。
+mask が元のバッファより短い場合は、mask を先頭から繰り返し使います。
+
+- **param** `mask` -- マスクを [c:IO::Buffer] で指定します。
+
+- **raise** `IO::Buffer::MaskError` -- mask の大きさが 0 の場合に発生します。
+
+```ruby
+# 4 バイトのマスクが 10 バイトに繰り返し適用される
+buf = IO::Buffer.for("1234567890") & IO::Buffer.for("\xFF\x00\x00\xFF")
+p buf.size                                              # => 10
+p buf.get_string.bytes.map {|b| "%02x" % b }.join(" ")  # => "31 00 00 34 35 00 00 38 39 00"
+```
+
+- **SEE** [m:IO::Buffer#and!], [m:IO::Buffer#or!], [m:IO::Buffer#xor!]
+
+### def ~ -> IO::Buffer
+
+バッファの各バイトのビットを反転した、新しいバッファを返します。
+
+返されるバッファの大きさは元のバッファと同じです。
+
+```ruby
+buf = ~IO::Buffer.for("1234567890")
+p buf.size                                              # => 10
+p buf.get_string.bytes.map {|b| "%02x" % b }.join(" ")  # => "ce cd cc cb ca c9 c8 c7 c6 cf"
+```
+
+- **SEE** [m:IO::Buffer#not!]
+
+### def and!(mask) -> self
+### def or!(mask) -> self
+### def xor!(mask) -> self
+
+[m:IO::Buffer#&] などと同じビット演算を、新しいバッファを作らずに
+自身に対して行います。`self` を返します。
+
+mask が自身より短い場合は、mask を先頭から繰り返し使います。
+
+- **param** `mask` -- マスクを [c:IO::Buffer] で指定します。
+
+- **raise** `IO::Buffer::MaskError` -- mask の大きさが 0 の場合に発生します。
+
+- **raise** `IO::Buffer::AccessError` -- 読み取り専用のバッファに対して
+             呼び出した場合に発生します。
+
+```ruby
+# IO::Buffer.for はブロックを渡さないと読み取り専用になるので、dup で複製する
+buf = IO::Buffer.for("1234567890").dup
+buf.and!(IO::Buffer.for("\xFF\x00\x00\xFF"))
+p buf.get_string.bytes.map {|b| "%02x" % b }.join(" ")  # => "31 00 00 34 35 00 00 38 39 00"
+
+IO::Buffer.for("1234").and!(IO::Buffer.for("\xFF")) # ~> IO::Buffer::AccessError
+```
+
+- **SEE** [m:IO::Buffer#&], [m:IO::Buffer#|], [m:IO::Buffer#^]
+
+### def not! -> self
+
+[m:IO::Buffer#~] と同じビット反転を、新しいバッファを作らずに
+自身に対して行います。`self` を返します。
+
+- **raise** `IO::Buffer::AccessError` -- 読み取り専用のバッファに対して
+             呼び出した場合に発生します。
+
+```ruby
+buf = IO::Buffer.for("1234567890").dup
+buf.not!
+p buf.get_string.bytes.map {|b| "%02x" % b }.join(" ")  # => "ce cd cc cb ca c9 c8 c7 c6 cf"
+```
+
+- **SEE** [m:IO::Buffer#~]
+#%end


### PR DESCRIPTION
## 概要

[c:IO::Buffer] のビット演算の 8 メソッドを追加しました。
#3278 / #3295 / #3301 / #3305 / #3318 / #3327 の続きです。

`&` / `|` / `^` / `~` / `and!` / `or!` / `xor!` / `not!`

説明がほぼ同じものはまとめ、4 エントリで表現しています
(`&` `|` `^` で 1 つ、`~` で 1 つ、`and!` `or!` `xor!` で 1 つ、`not!` で 1 つ)。

## 登場バージョン

```
3.1.6:       8 つとも無し
3.2.11 以降: 8 つとも有り
```

`#%since 3.2` で囲んでいます。3.1 のページに出ないことを DB で確認しました。

## ri に無い挙動を補いました

実機で確認して追記した点です。

| 内容 | ri |
|------|-----|
| 空のマスクを渡すと `IO::Buffer::MaskError` | 記載なし |
| 読み取り専用に破壊版で `IO::Buffer::AccessError` | 記載なし |
| 破壊版の返り値は `self` | `-> io_buffer` とだけ |
| マスクが短い場合は繰り返し適用 | 記載あり |

`IO::Buffer::MaskError` は #3295 で収録した例外クラスですが、発生条件が
どこにも書かれていませんでした。これで繋がります。

## ri の例のサイズ表示について

`&` の例は結果を `#<IO::Buffer 0x...+4 INTERNAL>` と表示していますが、実際は
元と同じ 10 バイトです (`|` `^` `~` の例は `+10` で正しい)。

```console
$ ruby -e 'p((IO::Buffer.for("1234567890") & IO::Buffer.for("\xFF\x00\x00\xFF")).size)'
10
```

例をそのまま写さず、`p buf.size # => 10` を明示しました。
本体側の修正も ruby/ruby#18087 で出しています。

## 破壊版の例で dup している理由

`IO::Buffer.for` はブロックを渡さないと読み取り専用になるため、破壊版を
呼ぶには複製が要ります (#3305 で明確化した挙動です)。例のコメントに理由を
書きました。

## 検証

- 記載した例は 3.2 / 3.3 / 3.4 / 4.0 で実行し、出力が一致することを確認しました。
- `rake check_links` はいずれの版も master と同数です
  (3.1: 225 / 3.2: 256 / 4.0: 257)。
- `rake check_format` ほか lint 一式も通っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
