### PR TITLE
variables.md: トップレベルのクラス変数アクセスが RuntimeError になることを明記

### DIFF
--- a/manual/doc/spec/variables.md
+++ b/manual/doc/spec/variables.md
@@ -161,6 +161,13 @@ end
 クラス変数は、その場所を囲むもっとも内側の(特異クラスでない) class 式
 または module 式のボディをスコープとして持ちます。
 
+class 式にも module 式にも囲まれていないトップレベルでクラス変数を参照・
+代入すると、例外 [c:RuntimeError] が発生します。
+
+```ruby
+@@foo = 1   # ~> RuntimeError: class variable access from toplevel
+```
+
 #%# https://blade.ruby-lang.org/ruby-list/39212
 
 ```ruby


### PR DESCRIPTION
fix #3344

spec/variables.md のクラス変数のスコープの説明は「class 式または module 式のボディをスコープとして持つ」ことだけを述べており、その外(トップレベル)でのアクセスがどうなるかが書かれていませんでした。トップレベルでの参照・代入が例外 RuntimeError になることを本文と最小の例で追記します。

- この挙動は Ruby 3.0 からで、サポート対象の全バージョンで同じため、バージョンディレクティブは付けていません
- 同節の既存のコード例 2 箇所にも `RuntimeError: class variable access from toplevel` は現れますが、いずれも特異クラス・特異メソッド定義経由の間接的な例で、本文には記述がありませんでした

🤖 Generated with [Claude Code](https://claude.com/claude-code)
