### PR TITLE
OpenSSL::Random.egd の説明をラベル付き参照で呼び出し形リンクにする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
-PATH
-  remote: ../bitclust
+GIT
+  remote: https://github.com/rurema/bitclust.git
+  revision: 0a7f6c7386f5a8587bba0b37d436fb79075276ab
   specs:
     bitclust-core (1.5.0)
       drb

--- a/manual/api/openssl/Random.md
+++ b/manual/api/openssl/Random.md
@@ -73,7 +73,7 @@ EGD(Entropy Gathering Daemon) からエントロピーを得、
 
 filename で指定した Unix domain socket から EGD に問い合わせ、
 255 バイト分のエントロピーを取得します。
-[m:OpenSSL::Random?.egd_bytes] に filename と 255 を渡して呼び出すのと同じです。
+[`OpenSSL::Random.egd_bytes(filename, 255)`](m:OpenSSL::Random?.egd_bytes) と同じです。
 
 - **param** `filename` -- EGD のソケットのファイル名
 - **raise** `OpenSSL::Random::RandomError` -- EGD からのエントロピー取得に失敗した場合に発生します。


### PR DESCRIPTION
rurema/bitclust#293 で入った `[ラベル](m:spec)` 記法の採用第 1 号です。

`OpenSSL::Random.egd` の説明は、もともと「`egd_bytes(filename, 255)` と同じ」という呼び出し形で書かれていましたが、参照リンク直後の括弧が Markdown リンクに化けるため #3336 で言い回しを変えて回避していました。新記法で呼び出し形のままリンクにできるようになったので、元の形に戻します。

```markdown
[`OpenSSL::Random.egd_bytes(filename, 255)`](m:OpenSSL::Random?.egd_bytes) と同じです。
```

## Gemfile.lock の修復について

あわせて Gemfile.lock を GIT ピン形式に戻し、bitclust をラベル付き参照対応の 0a7f6c7 に更新しています。

#3341 のコミットは「lock を 2447c8b に更新」のつもりでしたが、実際にはローカルの bundler が書き換えた PATH 形式(`remote: ../bitclust`)のままコミットしてしまっていました。CI では `../bitclust` が存在せず Gemfile のフォールバックで git ソース(master HEAD)を解決するため green のままでしたが、意図していたリビジョンのピンは効いていませんでした。復元した lock は最後の正常な GIT 形式(9b1b59d41 時点)と revision 行のみの差であることを確認済みです。

## 検証

- generate + check_links(3.4)でリンク切れ 0・コンパイルエラーなし(新記法の参照先も checklink の検証対象です)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
