### PR TITLE
ラベル付き参照の採用: 別名表記の括弧書きリンクを置き換え

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 0a7f6c7386f5a8587bba0b37d436fb79075276ab
+  revision: b4b4bf5819b709255380897ea94b325e69fdb84e
   specs:
     bitclust-core (1.5.0)
       drb

--- a/manual/api/openssl/Engine.md
+++ b/manual/api/openssl/Engine.md
@@ -209,5 +209,5 @@ engine をデフォルトに設定しないことを意味します。
 
 # class OpenSSL::Engine::EngineError < OpenSSL::OpenSSLError
 
-Engine([c:OpenSSL::Engine]) 関連のエラーが生じたときに発生する例外です。
+[`Engine`](c:OpenSSL::Engine) 関連のエラーが生じたときに発生する例外です。
 

--- a/manual/doc/news/2_1_0.md
+++ b/manual/doc/news/2_1_0.md
@@ -76,7 +76,7 @@
     - 拡張: [m:IO#write_nonblock] シンボルを返すためにキーワード引数 \`exception: false\` を受け付けるようになりました
 
   - [c:Kernel]
-    - 追加: Kernel#singleton_method([m:Object#singleton_method])
+    - 追加: [`Kernel#singleton_method`](m:Object#singleton_method)
 
   - [c:Module]
     - 追加: [m:Module#using], which activates refinements of the specified module only

--- a/manual/doc/news/2_3_0.md
+++ b/manual/doc/news/2_3_0.md
@@ -126,7 +126,7 @@
       [feature:11569]
 
   - [c:Queue] ([c:Thread::Queue])
-    - 終了を通知するために Queue#close([m:Thread::Queue#close]) を追加
+    - 終了を通知するために [`Queue#close`](m:Thread::Queue#close) を追加
       [feature:10600]
 
   - [c:Regexp]/[c:String]: Unicode のバージョンを 7.0.0 から 8.0.0 に更新

--- a/manual/doc/news/4_0_0.md
+++ b/manual/doc/news/4_0_0.md
@@ -99,7 +99,7 @@ since: "4.0"
 
 - [c:File]
   - 新規メソッド
-    - カーネルとファイルシステムが対応していれば、Linux でも statx システムコール([man:statx(2linux)])を介して [m:File::Stat#birthtime] が利用できるようになりました。[feature:21205]
+    - カーネルとファイルシステムが対応していれば、Linux でも [statx システムコール](man:statx(2linux))を介して [m:File::Stat#birthtime] が利用できるようになりました。[feature:21205]
 
 - [c:IO]
   - 変更されたメソッド


### PR DESCRIPTION
rurema/doctree#3347 レビューの「別 PR で他の部分も同様の括弧書きを変更してください」への対応です。

## 括弧書き別名表記の置き換え(3 箇所)

「別名(収録先リンク)」の形を manual/ 全体から機械抽出し(名前とリンク先のメソッド名/クラス名が一致するもののみ)、ラベル付き参照に置き換えました。該当は 3 箇所だけでした:

- news/2_1_0: `Kernel#singleton_method([m:Object#singleton_method])` → `` [`Kernel#singleton_method`](m:Object#singleton_method) ``
- news/2_3_0: `Queue#close([m:Thread::Queue#close])` → `` [`Queue#close`](m:Thread::Queue#close) ``
- openssl/Engine(EngineError の説明): `Engine([c:OpenSSL::Engine])` → `` [`Engine`](c:OpenSSL::Engine) ``

なお news/2_3_0 の見出し行 `[c:Queue] ([c:Thread::Queue])` のような「新旧両方のページへ別々にリンクする」形は別物なので対象外としています。

## statx の man リンク

rurema/bitclust#296 で `man:` がラベル付きリンクの宛先に使えるようになったので、news/4_0_0 の statx をレビューの suggestion の形 `[statx システムコール](man:statx(2linux))` に置き換えました。あわせて Gemfile.lock を b4b4bf5(#296 のマージコミット)に更新しています。

## 検証

- generate + check_links(3.4 / 4.0)でリンク切れ 0(bitclust は man: 対応ブランチを使用)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
