### PR TITLE
prism ライブラリの収録(第一弾: Prism モジュールと ParseResult)

### DIFF
--- a/manual/api/prism.md
+++ b/manual/api/prism.md
@@ -1,0 +1,327 @@
+---
+type: library
+since: "3.3"
+category: Text
+---
+Ruby プログラムを解析するための、エラー耐性のあるパーサライブラリです。
+
+prism は Ruby 3.3 で default gem として導入され、Ruby 3.4 以降は
+CRuby 本体が Ruby プログラムをコンパイルする際に使われるデフォルトの
+パーサの実装になっています(3.3 の時点では `ruby --parser=prism`
+オプションで試験的に切り替えられる位置づけでした)。
+
+設計上の目標として、構文エラーがあっても可能な限り解析を継続する
+「エラー耐性(error tolerant)」を重視しており、エディタや IDE、linter
+といった、エラーを含む可能性があるコードも解析する必要があるツールから
+利用しやすくなっています。また C99 で実装された移植性の高いライブラリ
+(libprism)でもあり、CRuby 以外の Ruby 処理系やツール、他言語の
+バインディングからも利用できます。
+
+構文解析の結果得られる構文木の各ノードは `Prism::Node` のサブクラス
+(150 種類以上)として表現されますが、個々のノードクラスの詳細はこの
+リファレンスでは扱いません。ノードクラスも含めた完全な API については
+公式ドキュメントを参照してください。
+
+- プロジェクトページ: <https://github.com/ruby/prism>
+- リファレンス(YARD): <https://www.rubydoc.info/gems/prism>
+- ドキュメントサイト: <https://ruby.github.io/prism/>
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("1 + 2")
+p result.class          # => Prism::ParseResult
+p result.value.class    # => Prism::ProgramNode
+p result.success?       # => true
+```
+
+# module Prism
+
+Ruby プログラムの構文解析・字句解析を行うためのモジュール関数を
+提供するモジュールです。文字列を直接解析する [m:Prism?.parse] や
+[m:Prism?.lex] の他、ファイルを指定して解析する [m:Prism?.parse_file]
+などが用意されています。
+
+解析結果は多くの場合 [c:Prism::ParseResult] のインスタンスとして
+返されます。詳細は [c:Prism::ParseResult] を参照してください。
+
+## Module Functions
+
+### module_function def parse(source, **options) -> Prism::ParseResult
+
+Ruby プログラムのソースコード文字列 `source` を構文解析し、結果を
+[c:Prism::ParseResult] として返します。
+
+prism はエラー耐性のあるパーサなので、構文エラーがあっても可能な限り
+解析を継続し、部分的な構文木を [m:Prism::ParseResult#value] に格納
+します。エラーの有無は [m:Prism::ParseResult#success?] や
+[m:Prism::ParseResult#errors] で確認できます。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- 解析オプションをキーワード引数で指定します。
+       主なものは以下の通りです。
+
+- **`:filepath`**:
+  ソースコードのファイルパスを指定します(エラーメッセージなどに使われます)。
+- **`:line`**:
+  解析を開始する行番号(1 始まり)を指定します。
+- **`:encoding`**:
+  ソースコードのエンコーディングを指定します。
+- **`:scopes`**:
+  ソースコードの周囲で定義済みのローカル変数を、シンボルの配列の配列で
+  指定します。`eval` のように周囲のローカル変数を引き継いで解析したい
+  場合に使います。
+- **`:version`**:
+  解析に使う Ruby の構文バージョンを文字列(例 `"3.3.0"`)で指定します。
+  省略時は最新の構文として解析します。
+
+上記以外にも `:command_line`, `:frozen_string_literal`, `:main_script`,
+`:partial_script` などのオプションがあります。利用可能なオプションの
+完全な一覧は prism のバージョンによって多少異なるため、公式ドキュメント
+を参照してください。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("1 + 2")
+p result.class          # => Prism::ParseResult
+p result.value.class    # => Prism::ProgramNode
+p result.success?       # => true
+```
+
+```ruby title="例: 構文エラーがあっても解析を継続する"
+require "prism"
+
+result = Prism.parse('"unterminated')
+p result.success?              # => false
+p result.errors.size           # => 1
+p result.errors.first.message  # => "unterminated string meets end of file"
+p result.value.class           # => Prism::ProgramNode (エラーがあっても構文木は返る)
+```
+
+- **SEE** [c:Prism::ParseResult]
+
+### module_function def parse_file(filepath, **options) -> Prism::ParseResult
+
+`filepath` で指定したファイルを読み込んで構文解析します。
+オプションは [m:Prism?.parse] と同じです。
+
+- **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+File.write("sample.rb", "def foo(a, b) = a + b\n")
+
+result = Prism.parse_file("sample.rb")
+p result.class         # => Prism::ParseResult
+p result.value.class   # => Prism::ProgramNode
+p result.success?      # => true
+```
+
+- **SEE** [m:Prism?.parse]
+
+### module_function def lex(source, **options) -> Prism::LexResult
+
+`source` を字句解析し、`Prism::LexResult` のインスタンスを返します。
+`value` は `[トークン, 直前からの字句解析器の状態(Integer)]` という
+2 要素配列の配列です。これは [c:Ripper] の `Ripper.lex` の戻り値の
+形式に近いものになっています。オプションは [m:Prism?.parse] と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.lex("1 + 2")
+p result.class   # => Prism::LexResult
+result.value.each { |token, state| p [token.type, token.value, state] }
+# => [:INTEGER, "1", 2]
+# => [:PLUS, "+", 1]
+# => [:INTEGER, "2", 2]
+# => [:EOF, "", 2]
+```
+
+- **SEE** [m:Prism?.parse], [c:Ripper]
+
+### module_function def lex_file(filepath, **options) -> Prism::LexResult
+
+`filepath` で指定したファイルを字句解析します。
+オプションは [m:Prism?.parse] と同じです。
+
+- **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+File.write("sample.rb", "def foo(a, b) = a + b\n")
+
+result = Prism.lex_file("sample.rb")
+p result.class
+# => Prism::LexResult
+p result.value.map { |token, _state| token.type }
+# => [:KEYWORD_DEF, :IDENTIFIER, :PARENTHESIS_LEFT, :IDENTIFIER, :COMMA,
+#     :IDENTIFIER, :PARENTHESIS_RIGHT, :EQUAL, :IDENTIFIER, :PLUS,
+#     :IDENTIFIER, :NEWLINE, :EOF]
+```
+
+- **SEE** [m:Prism?.lex]
+
+### module_function def parse_lex(source, **options) -> Prism::ParseLexResult
+
+`source` に対して構文解析と字句解析の両方を行い、
+`Prism::ParseLexResult` のインスタンスを返します。`value` は
+`[構文木, トークンの配列]` という 2 要素配列です。
+
+構文木とトークン列の両方が必要な場合、[m:Prism?.parse] と [m:Prism?.lex]
+を個別に呼び出すよりも効率的です。片方だけが必要な場合はそれぞれ
+[m:Prism?.parse] または [m:Prism?.lex] を使ってください。オプションは
+[m:Prism?.parse] と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse_lex("1 + 2")
+p result.class # => Prism::ParseLexResult
+
+ast, tokens = result.value
+p ast.class    # => Prism::ProgramNode
+p tokens.size  # => 4
+```
+
+- **SEE** [m:Prism?.parse], [m:Prism?.lex]
+
+### module_function def parse_success?(source, **options) -> bool
+
+`source` を構文解析し、エラーなく解析できた場合に true を返します。
+[m:Prism?.parse] を呼び出して `.success?` を確認するのとほぼ同じ
+結果になりますが、構文木を Ruby オブジェクトとして構築しないぶん
+高速です。オプションは [m:Prism?.parse] と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+p Prism.parse_success?("1 + 1") # => true
+p Prism.parse_success?("1 +")   # => false
+```
+
+- **SEE** [m:Prism?.parse_failure?], [m:Prism::ParseResult#success?]
+
+### module_function def parse_failure?(source, **options) -> bool
+
+[m:Prism?.parse_success?] の否定です。`source` の構文解析に
+エラーがあった場合に true を返します。オプションは [m:Prism?.parse]
+と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+p Prism.parse_failure?("1 + 1") # => false
+p Prism.parse_failure?("1 +")   # => true
+```
+
+- **SEE** [m:Prism?.parse_success?], [m:Prism::ParseResult#failure?]
+
+### module_function def dump(source, **options) -> String
+
+`source` を構文解析した結果を prism 独自のバイナリ形式に
+シリアライズし、その文字列を返します。この形式は主に、CRuby の
+拡張ライブラリを経由せずに、他言語(JavaScript、Rust、Java など)の
+実装から prism の構文木を読み込むために使われます。エンコーディングは
+常に ASCII-8BIT (BINARY) になります。オプションは [m:Prism?.parse]
+と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+dumped = Prism.dump("1 + 2")
+p dumped.class     # => String
+p dumped.encoding  # => #<Encoding:BINARY (ASCII-8BIT)>
+```
+
+### module_function def dump_file(filepath, **options) -> String
+
+`filepath` で指定したファイルを構文解析し、[m:Prism?.dump] と
+同様にシリアライズした文字列を返します。オプションは [m:Prism?.parse]
+と同じです。
+
+- **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+File.write("sample.rb", "def foo(a, b) = a + b\n")
+
+p Prism.dump_file("sample.rb").class # => String
+```
+
+- **SEE** [m:Prism?.dump]
+
+### module_function def parse_comments(source, **options) -> Array
+
+`source` を構文解析し、見つかったコメントを表すオブジェクトの
+配列を返します。配列の要素は `Prism::InlineComment`(`# ...` 形式の
+コメント)または `Prism::EmbDocComment`(`=begin`/`=end` 形式の
+コメント)のインスタンスです。オプションは [m:Prism?.parse] と同じです。
+
+- **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+comments = Prism.parse_comments("# hello\n1 + 1")
+p comments.size                  # => 1
+p comments.first.class           # => Prism::InlineComment
+p comments.first.location.slice  # => "# hello"
+```
+
+- **SEE** [m:Prism::ParseResult#comments]
+
+### module_function def parse_file_comments(filepath, **options) -> Array
+
+`filepath` で指定したファイルを構文解析し、[m:Prism?.parse_comments]
+と同様にコメントを表すオブジェクトの配列を返します。
+オプションは [m:Prism?.parse] と同じです。
+
+- **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+File.write("sample2.rb", "# comment here\nputs 1\n")
+
+comments = Prism.parse_file_comments("sample2.rb")
+p comments.size         # => 1
+p comments.first.class  # => Prism::InlineComment
+```
+
+- **SEE** [m:Prism?.parse_comments]

--- a/manual/api/prism.md
+++ b/manual/api/prism.md
@@ -128,7 +128,7 @@ p result.success?      # => true
 
 `source` を字句解析し、`Prism::LexResult` のインスタンスを返します。
 `value` は `[トークン, 直前からの字句解析器の状態(Integer)]` という
-2 要素配列の配列です。これは [c:Ripper] の `Ripper.lex` の戻り値の
+2 要素配列の配列です。これは [c:Ripper] の [m:Ripper.lex] の戻り値の
 形式に近いものになっています。オプションは [m:Prism?.parse] と同じです。
 
 - **param** `source` -- 解析する Ruby プログラムの文字列を指定します。
@@ -205,7 +205,7 @@ p tokens.size  # => 4
 ### module_function def parse_success?(source, **options) -> bool
 
 `source` を構文解析し、エラーなく解析できた場合に true を返します。
-[m:Prism?.parse] を呼び出して `.success?` を確認するのとほぼ同じ
+[m:Prism?.parse] を呼び出して [`.success?`](m:Prism::ParseResult#success?) を確認するのとほぼ同じ
 結果になりますが、構文木を Ruby オブジェクトとして構築しないぶん
 高速です。オプションは [m:Prism?.parse] と同じです。
 

--- a/manual/api/prism/ParseResult.md
+++ b/manual/api/prism/ParseResult.md
@@ -1,0 +1,173 @@
+---
+library: prism
+---
+# class Prism::ParseResult < Object
+
+[m:Prism?.parse] や [m:Prism?.parse_file] などの戻り値のクラスです。
+構文解析によって得られた構文木そのものに加えて、解析中に見つかった
+コメント・マジックコメント・エラー・警告などの付随情報をまとめて
+保持します。
+
+- **SEE** [m:Prism?.parse], [m:Prism?.parse_file], [c:Prism]
+
+## Instance Methods
+
+### def value -> Prism::ProgramNode
+
+構文解析によって得られた構文木のルートノードを返します。
+[m:Prism?.parse] や [m:Prism?.parse_file] の戻り値として得られる
+`Prism::ParseResult` では、これは常に `Prism::ProgramNode`
+(`Prism::Node` のサブクラス)のインスタンスです。
+
+構文エラーがあった場合でも nil にはならず、prism が構築できた範囲の
+構文木が返ります。エラーの有無は [m:Prism::ParseResult#success?] で
+確認してください。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("1 + 2")
+p result.value.class # => Prism::ProgramNode
+
+result = Prism.parse("1 +")
+p result.value.class # => Prism::ProgramNode (エラーがあっても構文木は返る)
+```
+
+### def success? -> bool
+
+構文解析にエラーがなかった場合に true を返します。
+[m:Prism::ParseResult#errors] が空かどうかで判定されます。
+
+```ruby title="例"
+require "prism"
+
+p Prism.parse("1 + 1").success? # => true
+p Prism.parse("1 +").success?   # => false
+```
+
+- **SEE** [m:Prism::ParseResult#failure?], [m:Prism::ParseResult#errors]
+
+### def failure? -> bool
+
+[m:Prism::ParseResult#success?] の否定です。構文解析にエラーがあった
+場合に true を返します。
+
+```ruby title="例"
+require "prism"
+
+p Prism.parse("1 + 1").failure? # => false
+p Prism.parse("1 +").failure?   # => true
+```
+
+- **SEE** [m:Prism::ParseResult#success?]
+
+### def errors -> Array
+
+構文解析中に発生したエラー(`Prism::ParseError` のインスタンス)の
+配列を返します。エラーがなければ空配列です。それぞれの要素は
+`type`、`message`、`location`、`level` といったメソッドを持ちます。
+
+```ruby title="例"
+require "prism"
+
+errors = Prism.parse('"unterminated').errors
+p errors.size            # => 1
+p errors.first.class     # => Prism::ParseError
+p errors.first.message   # => "unterminated string meets end of file"
+p errors.first.level     # => :syntax
+```
+
+- **SEE** [m:Prism::ParseResult#success?], [m:Prism::ParseResult#warnings]
+
+### def warnings -> Array
+
+構文解析中に発生した警告(`Prism::ParseWarning` のインスタンス)の
+配列を返します。警告がなければ空配列です。要素が持つメソッドの
+インターフェースは [m:Prism::ParseResult#errors] と同様です。
+
+```ruby title="例"
+require "prism"
+
+warnings = Prism.parse("1 + 2").warnings
+p warnings.size           # => 1
+p warnings.first.class    # => Prism::ParseWarning
+p warnings.first.message
+# => "possibly useless use of + in void context"
+p warnings.first.level    # => :verbose
+```
+
+- **SEE** [m:Prism::ParseResult#errors]
+
+### def comments -> Array
+
+構文解析中に見つかったコメント(`Prism::InlineComment` などの
+インスタンス)の配列を返します。[m:Prism?.parse_comments] を
+呼び出した場合と同じ内容です。
+
+```ruby title="例"
+require "prism"
+
+comments = Prism.parse("# hello\n1 + 1").comments
+p comments.size                  # => 1
+p comments.first.class           # => Prism::InlineComment
+p comments.first.location.slice  # => "# hello"
+```
+
+- **SEE** [m:Prism?.parse_comments]
+
+### def magic_comments -> Array
+
+構文解析中に見つかったマジックコメント(`Prism::MagicComment` の
+インスタンス)の配列を返します。`# frozen_string_literal: true` の
+ような、Ruby の動作に影響を与える特別な形式のコメントが対象です。
+各要素は `key`(項目名)と `value`(値)を持ちます。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse(<<~RUBY)
+  # frozen_string_literal: true
+  puts "hi"
+RUBY
+p result.magic_comments.size        # => 1
+p result.magic_comments.first.key   # => "frozen_string_literal"
+p result.magic_comments.first.value # => "true"
+```
+
+### def data_loc -> Prism::Location | nil
+
+ソースコード中に `__END__` 行が存在する場合、その行からファイル末尾
+までの範囲を表す `Prism::Location` を返します。`__END__` 以降の内容は
+組み込み定数 `DATA` に読み込まれる部分に対応します。`__END__` が
+存在しない場合は nil を返します。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse(<<~RUBY)
+  puts "hi"
+  __END__
+  some data here
+RUBY
+p result.data_loc.class
+# => Prism::Location
+p result.data_loc.slice
+# => "__END__\nsome data here\n"
+
+p Prism.parse("puts 1").data_loc # => nil
+```
+
+### def source -> Prism::Source
+
+解析したソースコードそのものを表す `Prism::Source`
+(またはそのサブクラス `Prism::ASCIISource`)のインスタンスを返し
+ます。バイトオフセットから行番号・カラム番号を求めるなど、位置情報を
+扱うための補助的なメソッドを持っていますが、詳細はこのリファレンス
+では扱いません。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("1 + 2")
+p result.source.class # => Prism::ASCIISource
+```


### PR DESCRIPTION
refs #3338(第一弾)

prism ライブラリの収録を開始します。default gem なので docs/FrequentlyAskedQuestions.md の方針どおり「内容まで記述」の対象ですが、API 面が非常に大きい(ノードクラス 150 種以上)ため、第一弾として以下に絞っています:

- `manual/api/prism.md`: ライブラリページ(`since: "3.3"`)+ Prism モジュールの主要モジュール関数 11 件(parse / parse_file / lex / lex_file / parse_lex / parse_success? / parse_failure? / dump / dump_file / parse_comments / parse_file_comments)
- `manual/api/prism/ParseResult.md`: Prism::ParseResult の主要メソッド 9 件(value / success? / failure? / errors / warnings / comments / magic_comments / data_loc / source)
- ノードクラス群(`Prism::Node` のサブクラス)は対象外とし、概要から公式ドキュメントへ誘導

## 方針・検証

- 収録したのは **prism 0.19.0(Ruby 3.3)から存在する API のみ**で、メソッド単位の版ゲートは不要(gh api で 0.19.0/1.2.0/1.7.0 のソースを確認)。`Prism.parse` のオプションは版によって増えているため、主要 5 つだけを列挙し「完全な一覧はバージョンによって異なるので公式ドキュメント参照」としています(4.0 のみの `freeze:` などは記載しない)
- 全サンプルは手元の ruby 3.4.8(prism 1.5.2)で実測し、4.0(prism 1.7.0)側もソースで確認。エラー例は 1 件だけエラーになる入力(閉じていない文字列)を選んでいます
- `Prism::ParseResult` の内部的な親クラス(1.5 系から `Prism::Result`)は非公開 API のためヘッダは `< Object` とし、公開メソッド面が全版で同一であることを確認済み
- `category: Text` は同種の [lib:ripper] に合わせました
- lint + generate + check_links(3.4)でリンク切れ 0

第二弾以降(候補: Prism::Node と Location・Comment 系の基本クラス、ノードクラスの段階的収録)は issue #3338 で相談させてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
