### PR TITLE
OpenSSL::SSL::SSLSocket#sysread の漢字訂正

### DIFF
--- a/manual/api/openssl/OpenSSL__SSL__SSLSocket.md
+++ b/manual/api/openssl/OpenSSL__SSL__SSLSocket.md
@@ -220,7 +220,7 @@ bufに文字列を指定するとその文字列のメモリ領域にデータ�
 
 - **param** `length` -- 読み込むバイト数を指定します
 - **param** `buf` -- データを書き込むバッファ
-- **raise** `EOFError` -- 入力が終端に逹した場合に発生します
+- **raise** `EOFError` -- 入力が終端に達した場合に発生します
 - **raise** `OpenSSL::SSL::SSLError` -- 読み込みに失敗した場合に発生します
 
 ### def syswrite(string) -> Integer


### PR DESCRIPTION
「逹した」の「逹」は「達」の俗字なので，ふつうの字体「達」にします。