### PR TITLE
Thread::Backtrace を追加

### DIFF
--- a/manual/api/_builtin/Thread__Backtrace.md
+++ b/manual/api/_builtin/Thread__Backtrace.md
@@ -1,0 +1,83 @@
+---
+library: _builtin
+---
+# class Thread::Backtrace < Object
+
+バックトレースの内部表現を表すクラスです。
+
+このクラスのオブジェクトを直接扱うことはありません。
+実行中のプログラムのバックトレースに関する設定を、クラスメソッドで取得できます。
+
+バックトレースの個々のフレームは [c:Thread::Backtrace::Location] で表されます。
+
+#%since 3.1
+## Class Methods
+
+### def limit -> Integer
+
+コマンドラインオプション `--backtrace-limit` で指定された、
+バックトレースを表示する行数の上限を返します。
+
+指定がない場合は -1 を返します。この場合、表示される行数は制限されません。
+
+0 以上の値が指定されている場合、処理されなかった例外が表示されるときや
+[m:Exception#full_message] が返す文字列で、バックトレースがその行数までに
+省略されます。省略された分は「... 2 levels...」のように表示されます。
+
+省略されるのは表示だけで、[m:Exception#backtrace] が返す配列は省略されません。
+
+```ruby title="例: backtrace_limit.rb"
+def level3
+  raise "error"
+end
+
+def level2
+  level3
+end
+
+def level1
+  level2
+end
+
+p Thread::Backtrace.limit
+level1
+```
+
+#%since 3.4
+
+```
+$ ruby backtrace_limit.rb
+-1
+backtrace_limit.rb:2:in 'Object#level3': error (RuntimeError)
+	from backtrace_limit.rb:6:in 'Object#level2'
+	from backtrace_limit.rb:10:in 'Object#level1'
+	from backtrace_limit.rb:14:in '<main>'
+
+$ ruby --backtrace-limit=1 backtrace_limit.rb
+1
+backtrace_limit.rb:2:in 'Object#level3': error (RuntimeError)
+	from backtrace_limit.rb:6:in 'Object#level2'
+	 ... 2 levels...
+```
+
+#%else
+
+```
+$ ruby backtrace_limit.rb
+-1
+backtrace_limit.rb:2:in `level3': error (RuntimeError)
+	from backtrace_limit.rb:6:in `level2'
+	from backtrace_limit.rb:10:in `level1'
+	from backtrace_limit.rb:14:in `<main>'
+
+$ ruby --backtrace-limit=1 backtrace_limit.rb
+1
+backtrace_limit.rb:2:in `level3': error (RuntimeError)
+	from backtrace_limit.rb:6:in `level2'
+	 ... 2 levels...
+```
+
+#%end
+
+- **SEE** [m:Exception#full_message], [m:Exception#backtrace]
+#%end


### PR DESCRIPTION
`Thread::Backtrace` のクラスページと `Thread::Backtrace.limit` を追加します。

子である `Thread::Backtrace::Location` は収録済みなのに、親の `Thread::Backtrace` のページが無い状態でした。

## 版の扱い

**クラス自体** — 2.1 から存在し、るりまのビルド対象 (3.0 以降) すべてにあるため front matter の `since:` は付けていません。

**`.limit`** — 3.1 で追加された ([Feature #17479](https://bugs.ruby-lang.org/issues/17479)) ため `#%since 3.1` で囲みました。3.0 のページではクラスの説明だけが残り、`## Class Methods` ごと消えます。

**実行例** — バックトレースの表示形式が 3.4 で変わった (``` `level3' ``` から `'Object#level3'`) ため、`#%since 3.4` / `#%else` で出し分けています。

## 内容について

クラスの説明は本体の rdoc ("An internal representation of the backtrace. The user will never interact with objects of this class directly, but class methods can be used to get backtrace settings of the current session.") に沿っています。

`.limit` は rdoc が `net/http` で存在しないホストに接続する例を使っていますが、ネットワークに依存せずコピペで再現できるよう、3 段の呼び出しで例外を出す例に差し替えました。`--backtrace-limit` の指定が要るのでシェルの実行例も併記しています。

rdoc に記載が無い点として、**省略されるのは表示だけで [m:Exception#backtrace] が返す配列は省略されない**ことを明記しました。`--backtrace-limit=1` を指定しても `e.backtrace.size` は変わりません。

## 確認したこと

- 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機で `.limit` の有無とデフォルト値 (-1)、`--backtrace-limit` 指定時の挙動を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- 3.0 / 3.1 / 3.3 / 3.4 の DB を生成し、クラスの登録・`.limit` の有無・実行例の形式の出し分けを確認
- `rake check_links:3.0` 〜 `:4.0` すべて 0 broken link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
