### PR TITLE
Thread::Mutex へ移動したメソッドのリンク化と since バッジ補正

### DIFF
--- a/manual/api/thread/Mutex.md
+++ b/manual/api/thread/Mutex.md
@@ -39,6 +39,7 @@ m.synchronize {
 ## Instance Methods
 
 ### def lock -> self
+{: since="1.9.1"}
 
 mutex オブジェクトをロックします。一度に一つのス
 レッドだけが mutex をロックできます。既にロックされている mutex
@@ -66,6 +67,7 @@ p m.locked? # => true
 ```
 
 ### def synchronize { ... } -> object
+{: since="1.9.1"}
 
 mutex をロックし、ブロックを実行します。実行後に必ず mutex のロックを解放します。
 
@@ -88,6 +90,7 @@ p result # => "result"
 ```
 
 ### def try_lock -> bool
+{: since="1.9.1"}
 
 mutex をロックしようとして、ロックが成功した場合、真を返します。
 ロックできなかった場合にはブロックせず偽を返します。
@@ -99,6 +102,7 @@ p m.try_lock # => false
 ```
 
 ### def unlock     -> self
+{: since="1.9.1"}
 
 mutex のロックを解放します。mutex のロック待ちになっていたスレッドの実行は再開されます。
 
@@ -131,6 +135,7 @@ end.join
                    した場合に発生します。
 
 ### def sleep(timeout = nil)    -> Integer
+{: since="1.9.1"}
 
 与えられた秒数の間ロックを解除してスリープして、実行後にまたロックします。
 
@@ -161,6 +166,7 @@ p th.status # => false
 ```
 
 ### def owned? -> bool
+{: since="2.0.0"}
 
 self がカレントスレッドによってロックされている場合に true を返します。
 そうでない場合に false を返します。

--- a/manual/doc/news/2_0_0.md
+++ b/manual/doc/news/2_0_0.md
@@ -86,11 +86,11 @@
       ```
 
   - [c:Mutex]
-    - 追加(実験的): `Mutex#owned?` mutex が現在のスレッドに所持されているかどうかを返します
+    - 追加(実験的): [`Mutex#owned?`](m:Thread::Mutex#owned?) mutex が現在のスレッドに所持されているかどうかを返します
     - 非互換: 
-      - `Mutex#lock`, `Mutex#unlock`, `Mutex#try_lock`, `Mutex#synchronize`, `Mutex#sleep`
+      - [`Mutex#lock`](m:Thread::Mutex#lock), [`Mutex#unlock`](m:Thread::Mutex#unlock), [`Mutex#try_lock`](m:Thread::Mutex#try_lock), [`Mutex#synchronize`](m:Thread::Mutex#synchronize), [`Mutex#sleep`](m:Thread::Mutex#sleep)
         はトラップハンドラの中では使えなくなりました。そのようなときは ThreadError が発生します
-      - `Mutex#sleep` may spurious wakeup. Check after wakeup.
+      - [`Mutex#sleep`](m:Thread::Mutex#sleep) may spurious wakeup. Check after wakeup.
 
   - [c:NilClass]
     - 追加: [m:NilClass#to_h] 空のハッシュを返します
@@ -216,7 +216,7 @@
   - [m:Thread#join], [m:Thread#value]
     - 上を参照
 
-  - `Mutex#lock`, `Mutex#unlock`, `Mutex#try_lock`, `Mutex#synchronize`, `Mutex#sleep`
+  - [`Mutex#lock`](m:Thread::Mutex#lock), [`Mutex#unlock`](m:Thread::Mutex#unlock), [`Mutex#try_lock`](m:Thread::Mutex#try_lock), [`Mutex#synchronize`](m:Thread::Mutex#synchronize), [`Mutex#sleep`](m:Thread::Mutex#sleep)
     - 上を参照
 
 ### 標準添付ライブラリの更新 (優れたもののみ)

--- a/manual/doc/news/2_1_0.md
+++ b/manual/doc/news/2_1_0.md
@@ -87,7 +87,7 @@
     - 拡張: [m:Module#include] と [m:Module#prepend] はパブリックメソッドになりました
 
   - [c:Mutex]
-    - `Mutex#owned?` はもはや実験的な機能ではありません。
+    - [`Mutex#owned?`](m:Thread::Mutex#owned?) はもはや実験的な機能ではありません。
 
   - [c:Numeric]
     - 拡張: [m:Numeric#step] limit が省略可能になり無限数列を作れるようになりました。


### PR DESCRIPTION
fix #3353

## リンク化(13 箇所)

news/2_0_0・news/2_1_0 の移動前名のコードスパンを、見た目を維持したままのラベル付きリンクにしました(例: `` [`Mutex#owned?`](m:Thread::Mutex#owned?) ``)。機械抽出で確認したところ、対象になるのは Mutex のみでした(これらの news に ConditionVariable/Queue/SizedQueue のメソッドへのコードスパン言及はありません)。置き換え先 6 メソッドはすべて thread/Mutex.md に実在することを確認済みです。

## since バッジ補正(6 メソッド)

thread/Mutex.md に `{: since=}` を付与し、Thread::Mutex という名前の登場(2.3.0)由来の誤バッジを補正しました:

- lock / unlock / try_lock / synchronize / sleep → `1.9.1`
- owned? → `2.0.0`

導入版は tools/method-versions/matrix.tsv(実 Ruby 各版でのメソッド実在の実測データ、#3274)で確認しています。

1 点、issue 本文からの変更があります: **owned? は issue 記載の 2.1.0 ではなく 2.0.0 を採用**しました。news/2_0_0 自身に「追加(実験的): Mutex#owned?」と明記されており、実測データも 2.0.0 から存在を示しています(2.1.0 は「実験的フラグが外れた」版)。バッジは存在開始を示すものとして 2.0.0 が正しいと判断しましたが、「安定化した版を示す」方針であれば 2.1.0 に直します。

## 検証

- generate + check_links(3.4)でリンク切れ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
