### PR TITLE
Process: _fork と Process::Status.wait を追加

### DIFF
--- a/manual/api/_builtin/Process.md
+++ b/manual/api/_builtin/Process.md
@@ -84,6 +84,48 @@ exec "echo", "*"    # echoes an asterisk
 
 - **SEE** [man:fork(2)]
 
+#%since 3.1
+### def _fork    -> Integer
+
+fork のための内部 API です。このメソッドを直接呼び出してはいけません。
+
+[m:Kernel?.fork]、[m:Process.fork]、[m:IO.popen] に "-" を渡した場合に、
+その内部から呼び出されます。
+
+通常のプログラムのためではなく、アプリケーションを監視するライブラリのために
+用意されています。このメソッドを上書きすると、fork の前後に独自の処理を
+挟めます。
+
+[m:Process?.daemon] も fork(2) を用いて実装されることがありますが、
+そちらはこのメソッドを経由しません。fork を捕捉する目的によっては、
+[m:Process?.daemon] も併せて上書きする必要があります。
+
+- **return** -- 子プロセスでは 0 を、親プロセスでは生成した子プロセスの
+             プロセス ID を返します。
+
+```ruby
+module ForkMonitor
+  def _fork
+    pid = super
+    if pid.zero?
+      puts "子プロセスです"
+    else
+      puts "親プロセスです。子は #{pid} です"
+    end
+    pid
+  end
+end
+Process.singleton_class.prepend(ForkMonitor)
+
+pid = fork { exit }
+Process.waitpid(pid)
+# => 子プロセスです
+#    親プロセスです。子は 70024 です
+```
+
+- **SEE** [m:Process.fork], [m:Kernel?.fork], [m:Process?.daemon]
+#%end
+
 ### def spawn(cmd, *arg)    -> Integer
 
 関数 [m:Kernel?.spawn] と同じです。

--- a/manual/api/_builtin/Process__Status.md
+++ b/manual/api/_builtin/Process__Status.md
@@ -86,6 +86,48 @@ end
    done
 ```
 
+## Class Methods
+
+### def wait(pid = -1, flags = 0) -> Process::Status | nil
+
+[m:Process?.wait] と同じですが、プロセス ID ではなく
+[c:Process::Status] を返します。
+
+pid と flags の意味は [m:Process?.wait] と同じです。
+
+子プロセスがない場合は、実在しないプロセスを表す「空の」
+[c:Process::Status] を返します。この場合 [m:Process::Status#pid] は -1 になります。
+
+[m:Process?.wait] と異なり、[m:$?] は更新されません。
+
+すべてのプラットフォームで使えるわけではありません。
+
+- **param** `pid` -- 待機する子プロセスのプロセス ID を指定します。
+       指定できる値は [m:Process?.wait] と同じです。
+
+- **param** `flags` -- [m:Process::WNOHANG] などを指定します。
+             指定できる値は [m:Process?.wait] と同じです。
+
+- **return** -- flags に [m:Process::WNOHANG] を指定していて、
+             子プロセスがまだ終了していない場合は nil を返します。
+
+```ruby
+pid = fork { exit 1 }
+
+status = Process::Status.wait(pid)
+p status.class      # => Process::Status
+p status.exitstatus # => 1
+
+# Process.wait と違い $? は更新されない
+p $?                # => nil
+```
+
+```ruby title="例: 子プロセスがない場合"
+p Process::Status.wait # => #<Process::Status: pid -1 exit 0>
+```
+
+- **SEE** [m:Process?.wait], [m:Process?.wait2]
+
 ## Instance Methods
 
 ### def ==(other)    -> bool


### PR DESCRIPTION
未収録だった Process 系の 2 メソッドを追加します。

当初は `Process.clock_getres` も含めていましたが、#3354 で先に収録されたため外し、master に rebase しました。ご指摘ありがとうございます。

## `Process._fork` (3.1〜)

`#%since 3.1` で囲みました。`rb_define_singleton_method` による定義で `module_function` ではないため、Module Functions ではなく Singleton Methods に置いています (`fork` と同じ扱い)。

名前と rdoc の書き出しから内部 API に見えますが、収録対象と判断しました。理由は次のとおりです。

- **NEWS にすでに記載があります** — `manual/doc/news/3_1_0.md` に「Process._fork が追加されました。…アプリケーションモニタリングライブラリは、このメソッドを上書きして fork イベントをフックできます」とあり、NEWS から辿れるのにメソッドのページが無い状態でした
- `:nodoc:` ではなく `ri Process._fork` も本文を返します。定義行も `exit` / `abort` / `last_status` と並んだ通常の `rb_define_singleton_method` で、public な特異メソッドです
- rdoc の「直接呼び出すな」は「呼ぶな、ただし監視ライブラリは**上書きして**フックせよ」という意味で、上書き用の公開フックとして用途が明記されています

同じ先頭アンダースコアでも `Ractor._require` は非対応にしています (`ri` が "Nothing known" を返す、つまりドキュメントが無いため)。アンダースコアの有無ではなく、ドキュメントがあり public かどうかで分けています。

上書きの例も rdoc に沿って載せています。

## `Process::Status.wait`

`Process__Status.md` に `## Class Methods` を新設しました (従来は Instance Methods のみ)。

**rdoc と異なる記述にした点**があります。rdoc には子プロセスがある場合について "sets thread-local variable `$?`" とありますが、実装 (`rb_process_status_wait`) は `rb_last_status_set` を呼んでおらず、実機でも `$?` は更新されません。

```ruby
pid = fork { exit 1 }
Process::Status.wait(pid)
p $?   # => nil  (3.0 / 3.3 / 4.0 いずれも)
```

rdoc 中の実行例自体も `$?` の pid が返り値の pid と食い違っており、本文と例が矛盾しています。実機に合わせて「[m:Process?.wait] と異なり [m:$?] は更新されません」と記述しました。

rdoc 側の修正は ruby/ruby#18109 として送っています。

## 確認したこと

- 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機で 2 メソッドの有無と挙動を確認 (`_fork` は 3.1 から、`Process::Status.wait` は 3.0 にも存在)
- サンプルを対象版すべてで `-w` 付き実行し、出力と警告の有無を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- `rake check_links:3.0` 〜 `:4.0` すべて 0 broken link
- 各版の DB を生成し、`_fork` が 3.0 に出ず 3.1 から出ること、`Process::Status.wait` が 3.0 から出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


