### PR TITLE
OpenSSL::X509::Store#trust= の param/SEE の前に空行を入れる

### DIFF
--- a/manual/api/openssl/X509__Store.md
+++ b/manual/api/openssl/X509__Store.md
@@ -167,6 +167,7 @@ verify を一度も呼びだしていない場合は nil を返します。
 - [m:OpenSSL::X509::TRUST_SSL_SERVER]
 - [m:OpenSSL::X509::TRUST_OCSP_REQUEST]
 - [m:OpenSSL::X509::TRUST_OCSP_SIGN]
+
 - **param** `trust` -- 整数値
 - **SEE** [m:OpenSSL::X509::StoreContext#trust=]
 


### PR DESCRIPTION
bitclust#303 のマージ前後の generate 差分比較(rurema/generated-documents#184)で見つかった、#303 以前からの描画劣化の修正です。

`OpenSSL::X509::Store#trust=` の `- **param**` と `- **SEE**` が、直前の TRUST_* 定数の箇条書きに**空行なし**で続いていたため、リストの継続項目として `<li>**param** ...</li>` の形で描画され、[PARAM]/[SEE] ブロックになっていませんでした。空行 1 行を入れて通常のディスパッチに乗せます。

- 同パターン(箇条書き直後に空行なしで `- **param**`/`- **SEE**` 等が続く)を manual/ 全体で走査し、該当はこの 1 箇所だけでした
- 修正後のソースから最小ツリーで DB を構築し、`bitclust lookup --html` で `[PARAM] trust:` の dl と `[SEE_ALSO]` リンクが描画されることを確認済みです

🤖 Generated with [Claude Code](https://claude.com/claude-code)
