### PR TITLE
prism: ParseResult の付随情報クラス 6 種を追加

### DIFF
--- a/manual/api/prism/Comment.md
+++ b/manual/api/prism/Comment.md
@@ -1,0 +1,75 @@
+---
+library: prism
+---
+# class Prism::Comment < Object
+
+[m:Prism::ParseResult#comments] や [m:Prism?.parse_comments] で得られる、
+ソースコード中のコメントを表す抽象基底クラスです。
+
+実際に生成されるのはサブクラスの [c:Prism::InlineComment](`#` から
+始まる通常のコメント)または [c:Prism::EmbDocComment](`=begin` 〜
+`=end` の埋め込みドキュメント)のどちらかで、このクラス自体の
+インスタンスが返されることはありません。
+
+- **SEE** [m:Prism::ParseResult#comments], [m:Prism?.parse_comments]
+
+## Instance Methods
+
+### def location -> Prism::Location
+
+コメントのソースコード上の位置を表す `Prism::Location` を返します。
+コメントの文字列そのものは `location.slice` で取得できます。
+
+```ruby title="例"
+require "prism"
+
+comment = Prism.parse("# hello\n1 + 1").comments.first
+p comment.location.start_line # => 1
+p comment.location.slice      # => "# hello"
+```
+
+#%since 3.4
+### def slice -> String
+
+コメントの文字列そのものを返します。`location.slice` の短縮形です。
+
+```ruby title="例"
+require "prism"
+
+comment = Prism.parse("# hello\n1 + 1").comments.first
+p comment.slice # => "# hello"
+```
+
+#%end
+# class Prism::InlineComment < Prism::Comment
+
+`#` から始まる通常のコメントを表すクラスです。
+
+## Instance Methods
+
+### def trailing? -> bool
+
+コードの後ろに続く行末コメントであれば true を、行頭(または空白だけ)
+から始まる独立した行のコメントであれば false を返します。
+
+```ruby title="例"
+require "prism"
+
+comments = Prism.parse(<<~RUBY).comments
+  # 独立した行のコメント
+  1 + 1 # 行末コメント
+RUBY
+p comments[0].trailing? # => false
+p comments[1].trailing? # => true
+```
+
+# class Prism::EmbDocComment < Prism::Comment
+
+`=begin` 〜 `=end` で囲まれた埋め込みドキュメントを表すクラスです。
+
+## Instance Methods
+
+### def trailing? -> bool
+
+常に false を返します。行末コメントになり得るのは
+[c:Prism::InlineComment] だけです。

--- a/manual/api/prism/MagicComment.md
+++ b/manual/api/prism/MagicComment.md
@@ -1,0 +1,53 @@
+---
+library: prism
+---
+# class Prism::MagicComment < Object
+
+[m:Prism::ParseResult#magic_comments] で得られる、マジックコメント
+(`# frozen_string_literal: true` のような、Ruby の動作に影響を与える
+特別な形式のコメント)を表すクラスです。
+
+キーも値も**文字列**として取得されます。`"true"` を真偽値に変換する
+ような意味の解釈は行われないことに注意してください。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse(<<~RUBY)
+  # frozen_string_literal: true
+  puts "hi"
+RUBY
+magic = result.magic_comments.first
+p magic.key   # => "frozen_string_literal"
+p magic.value # => "true"
+```
+
+- **SEE** [m:Prism::ParseResult#magic_comments]
+
+## Instance Methods
+
+### def key -> String
+
+マジックコメントのキー(`:` の左側)を文字列で返します。
+`key_loc.slice` と同じ内容です。
+
+### def value -> String
+
+マジックコメントの値(`:` の右側)を文字列で返します。
+`value_loc.slice` と同じ内容です。
+
+### def key_loc -> Prism::Location
+
+キーのソースコード上の位置を表す `Prism::Location` を返します。
+
+### def value_loc -> Prism::Location
+
+値のソースコード上の位置を表す `Prism::Location` を返します。
+
+```ruby title="例"
+require "prism"
+
+magic = Prism.parse("# coding: utf-8\np 1\n").magic_comments.first
+p magic.key_loc.slice   # => "coding"
+p magic.value_loc.slice # => "utf-8"
+```

--- a/manual/api/prism/ParseError.md
+++ b/manual/api/prism/ParseError.md
@@ -1,0 +1,50 @@
+---
+library: prism
+---
+# class Prism::ParseError < Object
+
+[m:Prism::ParseResult#errors] で得られる、構文解析中に発生した
+エラーを表すクラスです。
+
+例外クラスではないことに注意してください。prism はエラー耐性のある
+パーサであり、構文エラーがあっても例外を発生させず、見つかった
+エラーをこのクラスのインスタンスとして
+[m:Prism::ParseResult#errors] に蓄積します。
+
+```ruby title="例"
+require "prism"
+
+error = Prism.parse("1 +\n").errors.first
+p error.class    # => Prism::ParseError
+p error.message  # => "unexpected end-of-input; expected an expression after the operator"
+p error.location.start_line # => 1
+```
+
+- **SEE** [m:Prism::ParseResult#errors], [c:Prism::ParseWarning]
+
+## Instance Methods
+
+### def message -> String
+
+エラーメッセージを返します。
+
+### def location -> Prism::Location
+
+エラーが発生したソースコード上の位置を表す `Prism::Location` を
+返します。該当箇所の文字列そのものは `location.slice` で取得できます。
+
+#%since 3.4
+### def type -> Symbol
+
+エラーの種類を表すシンボル(例: `:expect_expression_after_operator`)を
+返します。
+
+これはエラーメッセージの変換レイヤーとの連携のために使われる内部用の
+シンボルであり、正式な公開 API ではありません。将来のバージョンで
+予告なく変わる可能性があります。
+
+### def level -> Symbol
+
+エラーの深刻度による分類を表すシンボル(例: `:syntax`)を返します。
+
+#%end

--- a/manual/api/prism/ParseResult.md
+++ b/manual/api/prism/ParseResult.md
@@ -63,9 +63,8 @@ p Prism.parse("1 +").failure?   # => true
 
 ### def errors -> Array
 
-構文解析中に発生したエラー(`Prism::ParseError` のインスタンス)の
-配列を返します。エラーがなければ空配列です。それぞれの要素は
-`type`、`message`、`location`、`level` といったメソッドを持ちます。
+構文解析中に発生したエラー([c:Prism::ParseError] のインスタンス)の
+配列を返します。エラーがなければ空配列です。
 
 ```ruby title="例"
 require "prism"
@@ -81,9 +80,8 @@ p errors.first.level     # => :syntax
 
 ### def warnings -> Array
 
-構文解析中に発生した警告(`Prism::ParseWarning` のインスタンス)の
-配列を返します。警告がなければ空配列です。要素が持つメソッドの
-インターフェースは [m:Prism::ParseResult#errors] と同様です。
+構文解析中に発生した警告([c:Prism::ParseWarning] のインスタンス)の
+配列を返します。警告がなければ空配列です。
 
 ```ruby title="例"
 require "prism"
@@ -100,7 +98,7 @@ p warnings.first.level    # => :verbose
 
 ### def comments -> Array
 
-構文解析中に見つかったコメント(`Prism::InlineComment` などの
+構文解析中に見つかったコメント([c:Prism::Comment] のサブクラスの
 インスタンス)の配列を返します。[m:Prism?.parse_comments] を
 呼び出した場合と同じ内容です。
 
@@ -117,7 +115,7 @@ p comments.first.location.slice  # => "# hello"
 
 ### def magic_comments -> Array
 
-構文解析中に見つかったマジックコメント(`Prism::MagicComment` の
+構文解析中に見つかったマジックコメント([c:Prism::MagicComment] の
 インスタンス)の配列を返します。`# frozen_string_literal: true` の
 ような、Ruby の動作に影響を与える特別な形式のコメントが対象です。
 各要素は `key`(項目名)と `value`(値)を持ちます。

--- a/manual/api/prism/ParseWarning.md
+++ b/manual/api/prism/ParseWarning.md
@@ -14,6 +14,7 @@ library: prism
 ハッシュキーの警告などは検出されません。
 
 #%end
+
 ```ruby title="例"
 require "prism"
 

--- a/manual/api/prism/ParseWarning.md
+++ b/manual/api/prism/ParseWarning.md
@@ -1,0 +1,52 @@
+---
+library: prism
+---
+# class Prism::ParseWarning < Object
+
+[m:Prism::ParseResult#warnings] で得られる、構文解析中に発生した
+警告を表すクラスです。インターフェースは [c:Prism::ParseError] と
+同様です。
+
+#%since 3.4
+なお、警告として検出される種類は Ruby 3.4 以降(prism 1.x)で
+大きく増えています。Ruby 3.3 の prism では「曖昧な演算子の解釈」の
+ような一部の警告だけが対象で、未使用のローカル変数や重複した
+ハッシュキーの警告などは検出されません。
+
+#%end
+```ruby title="例"
+require "prism"
+
+warning = Prism.parse("foo *[1]\n").warnings.first
+p warning.class   # => Prism::ParseWarning
+p warning.message # => "ambiguous `*` has been interpreted as an argument prefix"
+```
+
+- **SEE** [m:Prism::ParseResult#warnings], [c:Prism::ParseError]
+
+## Instance Methods
+
+### def message -> String
+
+警告メッセージを返します。
+
+### def location -> Prism::Location
+
+警告の対象となったソースコード上の位置を表す `Prism::Location` を
+返します。
+
+#%since 3.4
+### def type -> Symbol
+
+警告の種類を表すシンボル(例: `:ambiguous_prefix_star`)を返します。
+
+これは警告メッセージの変換レイヤーとの連携のために使われる内部用の
+シンボルであり、正式な公開 API ではありません。将来のバージョンで
+予告なく変わる可能性があります。
+
+### def level -> Symbol
+
+警告の深刻度による分類を表すシンボル(`:default` または `:verbose`)を
+返します。
+
+#%end


### PR DESCRIPTION
refs #3338(第 2 弾: ParseResult の付随情報クラス)

- 4 ファイル 6 クラスを追加: [Prism::Comment / InlineComment / EmbDocComment](1 ファイルに束ね)・MagicComment・ParseError・ParseWarning
- ParseResult.md の該当メソッド(errors / warnings / comments / magic_comments)の説明を新ページへのリンクに変更(4 箇所)
- バージョン境界は実測に基づき **3.4 の一点のみ**(Ruby 3.3 = prism 0.19.0、3.4/4.0 = prism 1.9.0 で同一。3 バージョンの実測で確認): `Comment#slice`・`ParseError#type`/`#level`・`ParseWarning#type`/`#level` を `#%since 3.4` でゲート
- `ParseError#type` / `ParseWarning#type` には「メッセージ変換レイヤー連携のための内部用シンボルであり、正式な公開 API ではない」旨の注記を付けました(prism ソースコード中のコメントの明言に基づく)
- ParseWarning には「3.3 と 3.4 以降で警告として検出される種類自体が大きく違う」旨の注記(未使用ローカル変数・重複ハッシュキーなどは 3.4 以降で追加)
- `Prism::Location` / `Source` / `Token` と Result 系 3 クラス(3.4 以降の新設)は次弾にします(API 面積が大きいことと、ParseResult の親クラス表記(3.4 以降は `Prism::Result`)の扱いに構成判断が要るため)

## 検証

- コード例の出力はすべて ruby 3.4.8 の実測値。3.3.12 でゲート対象 4 点(slice / type ×2 / level)の不在と警告カタログの差も実測で確認
- generate + check_links を 3.0(prism 不在 = 新規ファイルが版ごとスキップされること)/ 3.3 / 3.4 / 4.0 で実行し、リンク切れ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
