### PR TITLE
prism: Location・Source・Token を追加

### DIFF
--- a/manual/api/prism/Comment.md
+++ b/manual/api/prism/Comment.md
@@ -17,7 +17,7 @@ library: prism
 
 ### def location -> Prism::Location
 
-コメントのソースコード上の位置を表す `Prism::Location` を返します。
+コメントのソースコード上の位置を表す [c:Prism::Location] を返します。
 コメントの文字列そのものは `location.slice` で取得できます。
 
 ```ruby title="例"

--- a/manual/api/prism/Location.md
+++ b/manual/api/prism/Location.md
@@ -1,0 +1,209 @@
+---
+library: prism
+---
+# class Prism::Location < Object
+
+ソースコード上の範囲(開始バイトオフセットと長さ)を表すクラスです。
+構文木の各ノードのほか、[c:Prism::Comment]・[c:Prism::MagicComment]・
+[c:Prism::ParseError]・[c:Prism::ParseWarning]・[c:Prism::Token] などの
+`location` メソッドから得られます。
+
+行番号・桁位置への変換や、該当範囲の文字列の取り出しなどのメソッドを
+持ちます。桁位置を表すメソッドには「バイト単位」(`start_column` など)と
+「文字単位」(`start_character_column` など)の系列があります。
+
+```ruby title="例"
+require "prism"
+
+node = Prism.parse("x = 1 + 2").value.statements.body[0]
+loc = node.location
+p loc.slice        # => "x = 1 + 2"
+p loc.start_line   # => 1
+p loc.start_offset # => 0
+p loc.length       # => 9
+
+loc = node.value.location # 右辺の 1 + 2
+p loc.slice        # => "1 + 2"
+p loc.start_column # => 4
+```
+
+## Instance Methods
+
+### def start_offset -> Integer
+
+範囲の開始位置のバイトオフセットを返します。
+
+### def end_offset -> Integer
+
+範囲の終端位置(最後のバイトの次)のバイトオフセットを返します。
+
+### def length -> Integer
+
+範囲のバイト数を返します。`end_offset - start_offset` と同じです。
+
+### def start_line -> Integer
+
+範囲の開始位置がある行の行番号を返します。行番号は 1 から
+始まります。
+
+### def end_line -> Integer
+
+範囲の終端位置がある行の行番号を返します。
+
+### def start_column -> Integer
+
+範囲の開始位置の、行頭からのバイト単位の桁位置(0 origin)を
+返します。
+
+### def end_column -> Integer
+
+範囲の終端位置の、行頭からのバイト単位の桁位置(0 origin)を
+返します。
+
+### def start_character_column -> Integer
+
+範囲の開始位置の、行頭からの文字単位の桁位置(0 origin)を返します。
+マルチバイト文字を含む行では [m:Prism::Location#start_column] と
+異なる値になります。
+
+### def end_character_column -> Integer
+
+範囲の終端位置の、行頭からの文字単位の桁位置(0 origin)を返します。
+
+```ruby title="例"
+require "prism"
+
+loc = Prism.parse('s = "あい" + x').value.statements.body[0].location
+p loc.end_column           # => 16 (バイト単位)
+p loc.end_character_column # => 12 (文字単位)
+```
+
+### def start_character_offset -> Integer
+
+範囲の開始位置の、ソースコード先頭からの文字単位のオフセットを
+返します。
+
+### def end_character_offset -> Integer
+
+範囲の終端位置の、ソースコード先頭からの文字単位のオフセットを
+返します。
+
+### def slice -> String
+
+範囲に対応するソースコードの文字列を返します。
+
+### def start_line_slice -> String
+
+開始位置がある行の、行頭から開始位置の直前までの文字列を返します。
+
+```ruby title="例"
+require "prism"
+
+loc = Prism.parse("x = 1").value.statements.body[0].value.location
+p loc.slice            # => "1"
+p loc.start_line_slice # => "x = "
+```
+
+### def join(other) -> Prism::Location
+
+自身の開始位置から other の終端位置までを表す新しい
+`Prism::Location` を返します。間にある文字列も範囲に含まれます。
+
+- **param** `other` -- 結合する `Prism::Location`。自身より後ろに
+  ある必要があります。
+
+```ruby title="例"
+require "prism"
+
+body = Prism.parse("foo = 1\nbar = 2\n").value.statements.body
+p body[0].location.join(body[1].location).slice
+# => "foo = 1\nbar = 2"
+```
+
+### def copy(source: self.source, start_offset: self.start_offset, length: self.length) -> Prism::Location
+
+指定した属性だけを差し替えた新しい `Prism::Location` を返します。
+
+### def comments -> Array
+
+この位置に関連付けられたコメント([c:Prism::Comment] の
+サブクラスのインスタンス)の配列を返します。前に付くコメント、
+後ろに付くコメントの順に並びます。
+
+コメントの関連付けは [m:Prism::ParseResult#attach_comments!] を
+呼び出したときに行われます。呼び出す前は空配列です。
+
+### def ==(other) -> bool
+
+other が同じ範囲を表す `Prism::Location` であれば true を返します。
+
+- **param** `other` -- 比較対象のオブジェクト
+
+#%since 3.4
+### def leading_comments -> Array
+
+この位置の前に付くコメント([c:Prism::Comment] のサブクラスの
+インスタンス)の配列を返します。
+[m:Prism::ParseResult#attach_comments!] を呼び出す前は空配列です。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("# leading\na = 1 # trailing\n")
+result.attach_comments!
+loc = result.value.statements.body[0].location
+p loc.leading_comments.map { |c| c.slice }  # => ["# leading"]
+p loc.trailing_comments.map { |c| c.slice } # => ["# trailing"]
+```
+
+### def trailing_comments -> Array
+
+この位置の後ろに付くコメントの配列を返します。
+[m:Prism::ParseResult#attach_comments!] を呼び出す前は空配列です。
+
+### def chop -> Prism::Location
+
+末尾の 1 バイトを除いた新しい `Prism::Location` を返します。
+
+### def adjoin(string) -> Prism::Location
+
+範囲の直後に続くソースコードが string と一致する場合に、その分だけ
+範囲を伸ばした新しい `Prism::Location` を返します。
+
+- **param** `string` -- 取り込む文字列
+- **raise** `RuntimeError` -- 範囲の直後が string と一致しない場合に
+  発生します。
+
+### def slice_lines -> String
+
+範囲を含む行全体(開始行の行頭から終端行の行末まで)の文字列を
+返します。
+
+### def source_lines -> Array
+
+ソースコード全体を行ごとに分割した配列を返します。
+
+### def start_code_units_offset(encoding = Encoding::UTF_16LE) -> Integer
+
+範囲の開始位置の、指定エンコーディングのコード単位でのオフセットを
+返します。UTF-16 のコード単位で位置をやりとりする
+LSP(Language Server Protocol)などとの連携向けです。
+
+- **param** `encoding` -- コード単位の基準となるエンコーディング
+
+### def end_code_units_offset(encoding = Encoding::UTF_16LE) -> Integer
+
+範囲の終端位置の、指定エンコーディングのコード単位でのオフセットを
+返します。
+
+### def start_code_units_column(encoding = Encoding::UTF_16LE) -> Integer
+
+範囲の開始位置の、行頭からの指定エンコーディングのコード単位での
+桁位置を返します。
+
+### def end_code_units_column(encoding = Encoding::UTF_16LE) -> Integer
+
+範囲の終端位置の、行頭からの指定エンコーディングのコード単位での
+桁位置を返します。
+
+#%end

--- a/manual/api/prism/MagicComment.md
+++ b/manual/api/prism/MagicComment.md
@@ -38,11 +38,11 @@ p magic.value # => "true"
 
 ### def key_loc -> Prism::Location
 
-キーのソースコード上の位置を表す `Prism::Location` を返します。
+キーのソースコード上の位置を表す [c:Prism::Location] を返します。
 
 ### def value_loc -> Prism::Location
 
-値のソースコード上の位置を表す `Prism::Location` を返します。
+値のソースコード上の位置を表す [c:Prism::Location] を返します。
 
 ```ruby title="例"
 require "prism"

--- a/manual/api/prism/ParseError.md
+++ b/manual/api/prism/ParseError.md
@@ -30,7 +30,7 @@ p error.location.start_line # => 1
 
 ### def location -> Prism::Location
 
-エラーが発生したソースコード上の位置を表す `Prism::Location` を
+エラーが発生したソースコード上の位置を表す [c:Prism::Location] を
 返します。該当箇所の文字列そのものは `location.slice` で取得できます。
 
 #%since 3.4

--- a/manual/api/prism/ParseResult.md
+++ b/manual/api/prism/ParseResult.md
@@ -132,10 +132,33 @@ p result.magic_comments.first.key   # => "frozen_string_literal"
 p result.magic_comments.first.value # => "true"
 ```
 
+### def attach_comments! -> Array
+
+[m:Prism::ParseResult#comments] の各コメントを、前後の位置関係から
+構文木の各ノードの位置情報([c:Prism::Location])に関連付けます。
+#%since 3.4
+関連付けた結果は [m:Prism::Location#leading_comments]・
+[m:Prism::Location#trailing_comments]・[m:Prism::Location#comments] で
+参照できます。
+#%else
+関連付けた結果は [m:Prism::Location#comments] で参照できます。
+#%end
+
+戻り値は [m:Prism::ParseResult#comments] と同じ配列です。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.parse("# leading\na = 1\n")
+result.attach_comments!
+loc = result.value.statements.body[0].location
+p loc.comments.map { |c| c.location.slice } # => ["# leading"]
+```
+
 ### def data_loc -> Prism::Location | nil
 
 ソースコード中に `__END__` 行が存在する場合、その行からファイル末尾
-までの範囲を表す `Prism::Location` を返します。`__END__` 以降の内容は
+までの範囲を表す [c:Prism::Location] を返します。`__END__` 以降の内容は
 組み込み定数 `DATA` に読み込まれる部分に対応します。`__END__` が
 存在しない場合は nil を返します。
 
@@ -157,15 +180,19 @@ p Prism.parse("puts 1").data_loc # => nil
 
 ### def source -> Prism::Source
 
-解析したソースコードそのものを表す `Prism::Source`
-(またはそのサブクラス `Prism::ASCIISource`)のインスタンスを返し
-ます。バイトオフセットから行番号・カラム番号を求めるなど、位置情報を
-扱うための補助的なメソッドを持っていますが、詳細はこのリファレンス
-では扱いません。
+解析したソースコードそのものを表す [c:Prism::Source] のインスタンスを
+返します。バイトオフセットから行番号・桁位置を求めるなど、位置情報を
+扱うための補助的なメソッドを持ちます。
+
+#%since 3.4
+実際にはサブクラス `Prism::ASCIISource` のインスタンスであることも
+あります。
+
+#%end
 
 ```ruby title="例"
 require "prism"
 
 result = Prism.parse("1 + 2")
-p result.source.class # => Prism::ASCIISource
+p result.source.is_a?(Prism::Source) # => true
 ```

--- a/manual/api/prism/ParseResult.md
+++ b/manual/api/prism/ParseResult.md
@@ -185,8 +185,7 @@ p Prism.parse("puts 1").data_loc # => nil
 扱うための補助的なメソッドを持ちます。
 
 #%since 3.4
-実際にはサブクラス `Prism::ASCIISource` のインスタンスであることも
-あります。
+実際にはサブクラス `Prism::ASCIISource` のインスタンスの場合があります。
 
 #%end
 

--- a/manual/api/prism/ParseWarning.md
+++ b/manual/api/prism/ParseWarning.md
@@ -33,7 +33,7 @@ p warning.message # => "ambiguous `*` has been interpreted as an argument prefix
 
 ### def location -> Prism::Location
 
-警告の対象となったソースコード上の位置を表す `Prism::Location` を
+警告の対象となったソースコード上の位置を表す [c:Prism::Location] を
 返します。
 
 #%since 3.4

--- a/manual/api/prism/Source.md
+++ b/manual/api/prism/Source.md
@@ -9,7 +9,7 @@ library: prism
 
 #%since 3.4
 実際に得られるインスタンスは、ASCII のみのソース向けに最適化された
-サブクラス `Prism::ASCIISource` であることがあります。クラスの判定を
+サブクラス `Prism::ASCIISource` の場合があります。クラスの判定を
 する場合は `instance_of?` ではなく `is_a?(Prism::Source)` を使って
 ください。
 

--- a/manual/api/prism/Source.md
+++ b/manual/api/prism/Source.md
@@ -1,0 +1,132 @@
+---
+library: prism
+---
+# class Prism::Source < Object
+
+解析対象のソースコード全体と各行の開始オフセットの表を保持し、
+バイトオフセットから行番号・桁位置への変換などを提供するクラスです。
+[m:Prism::ParseResult#source] で得られます。
+
+#%since 3.4
+実際に得られるインスタンスは、ASCII のみのソース向けに最適化された
+サブクラス `Prism::ASCIISource` であることがあります。クラスの判定を
+する場合は `instance_of?` ではなく `is_a?(Prism::Source)` を使って
+ください。
+
+#%end
+
+```ruby title="例"
+require "prism"
+
+source = Prism.parse("foo = 1\nbar = 2\nbaz = foo + bar\n").source
+p source.source[0, 7] # => "foo = 1"
+p source.line(9)      # => 2 (バイトオフセット 9 は 2 行目)
+p source.column(9)    # => 1
+p source.offsets      # => [0, 8, 16, 32]
+```
+
+## Instance Methods
+
+### def source -> String
+
+ソースコード全体を文字列で返します。
+
+### def slice(byte_offset, length) -> String
+
+byte_offset から length バイト分のソースコードを返します。
+
+- **param** `byte_offset` -- 開始バイトオフセット
+- **param** `length` -- バイト数
+
+### def line(byte_offset) -> Integer
+
+byte_offset の位置がある行の行番号を返します。行番号は 1 から
+始まります。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def line_start(byte_offset) -> Integer
+
+byte_offset の位置がある行の、行頭のバイトオフセットを返します。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def column(byte_offset) -> Integer
+
+byte_offset の位置の、行頭からのバイト単位の桁位置(0 origin)を
+返します。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def character_offset(byte_offset) -> Integer
+
+byte_offset に対応する、ソースコード先頭からの文字単位の
+オフセットを返します。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def character_column(byte_offset) -> Integer
+
+byte_offset の位置の、行頭からの文字単位の桁位置(0 origin)を
+返します。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def offsets -> Array
+
+各行の開始バイトオフセットの配列を返します。末尾にはソースコード
+全体のバイト数が入ります。
+
+### def start_line -> Integer
+
+先頭行の行番号を返します。通常は 1 です。
+
+#%since 3.4
+### def encoding -> Encoding
+
+ソースコードのエンコーディングを返します。
+
+### def lines -> Array
+
+ソースコードを行ごと(改行を含む)に分割した配列を返します。
+
+### def line_end(byte_offset) -> Integer
+
+byte_offset の位置がある行の終端のバイトオフセット(次の行の
+行頭と同じ位置)を返します。
+
+- **param** `byte_offset` -- バイトオフセット
+
+### def byte_offset(line, column) -> Integer
+
+行番号と桁位置からバイトオフセットを求めます。
+
+- **param** `line` -- 行番号(1 origin)
+- **param** `column` -- 行頭からのバイト単位の桁位置(0 origin)
+
+```ruby title="例"
+require "prism"
+
+source = Prism.parse("foo = 1\nbar = 2\n").source
+p source.byte_offset(2, 1) # => 9
+p source.line(9)           # => 2
+```
+
+### def code_units_offset(byte_offset, encoding) -> Integer
+
+byte_offset に対応する、指定エンコーディングのコード単位での
+オフセットを返します。UTF-16 のコード単位で位置をやりとりする
+LSP(Language Server Protocol)などとの連携向けです。
+
+- **param** `byte_offset` -- バイトオフセット
+- **param** `encoding` -- コード単位の基準となるエンコーディング
+
+### def code_units_column(byte_offset, encoding) -> Integer
+
+byte_offset の位置の、行頭からの指定エンコーディングのコード単位
+での桁位置を返します。
+
+- **param** `byte_offset` -- バイトオフセット
+- **param** `encoding` -- コード単位の基準となるエンコーディング
+
+#%end

--- a/manual/api/prism/Token.md
+++ b/manual/api/prism/Token.md
@@ -1,0 +1,50 @@
+---
+library: prism
+---
+# class Prism::Token < Object
+
+[m:Prism?.lex] や [m:Prism?.parse_lex] の結果に含まれる、字句解析で
+得られたトークンを表すクラスです。
+
+```ruby title="例"
+require "prism"
+
+token, _state = Prism.lex("1 + 2").value.first
+p token.class    # => Prism::Token
+p token.type     # => :INTEGER
+p token.value    # => "1"
+p token.location.start_column # => 0
+```
+
+- **SEE** [m:Prism?.lex], [m:Prism?.parse_lex]
+
+## Instance Methods
+
+### def type -> Symbol
+
+トークンの種類を表すシンボル(例: `:INTEGER`、`:PLUS`、
+`:IDENTIFIER`)を返します。
+
+### def value -> String
+
+トークンに対応するソースコードの文字列を返します。
+
+### def location -> Prism::Location
+
+トークンのソースコード上の位置を表す [c:Prism::Location] を
+返します。
+
+### def ==(other) -> bool
+
+other が同じ `type` と `value` を持つ `Prism::Token` であれば true を
+返します。位置(`location`)は比較しないため、ソースコード上の別の
+場所にある同じ内容のトークンどうしも等しいと判定されます。
+
+- **param** `other` -- 比較対象のオブジェクト
+
+```ruby title="例"
+require "prism"
+
+tokens = Prism.lex("1 + 1").value
+p tokens[0][0] == tokens[2][0] # => true (別の位置の "1" どうし)
+```


### PR DESCRIPTION
refs #3338(第 3 弾: 位置情報クラス)。#3367(第 2 弾)の上に積んだブランチです。

- 3 ページを追加: `Prism::Location`(コア 14 メソッド+3.4 以降の 10 メソッド)・`Prism::Source`(コア 9+3.4 以降の 6)・`Prism::Token`
- ParseResult.md に `attach_comments!` のエントリを追加(Location の leading_comments/trailing_comments の前提になるため。3.3 から存在することを実測確認)
- 既存 prism ページの `Prism::Location`/`Prism::Source` のコードスパンをリンクに変更(Comment/MagicComment/ParseError/ParseWarning/ParseResult の計 8 箇所)

## 掲載範囲の判断

- **3.4 以降の追加メソッドは `#%since 3.4` でゲート**(Location: leading_comments / trailing_comments / chop / adjoin / slice_lines / source_lines / code_units 系 4 種、Source: encoding / lines / line_end / byte_offset / code_units 系 2 種)
- **掲載対象外**: `Location#source`(protected。instance_methods には出るが外部から呼べないことを実測確認)・`Token#source`(3.4 以降 private)・`Location#leading_comment`/`trailing_comment`(単数形。attach_comments! の内部実装用の追加 API)・`Source#replace_start_line`/`replace_offsets`/`code_units_cache`/`deep_freeze`(内部・破壊的更新系)・各クラスの deconstruct_keys / inspect / pretty_print
- `Location#comments` は 3.3 と 3.4 で内部実装が異なりますが(attr_reader か leading+trailing の連結か)、返る内容は同じため版分岐なしで記述しています
- 既知のフォローアップ(次弾=Result 系で対応予定): prism.md の `lex` の戻り値表記(3.3 では LexResult が存在せず ParseResult が返る)と、ParseResult の親クラス表記(3.4 以降は `Prism::Result`)

## 検証

- コード例の出力はすべて ruby 3.4.8 の実測値。3.3.12 でゲート対象メソッドの不在も実測
- check_blank_lines / check_indent_in_samplecode(#3367 の CI 失敗の教訓でローカル実行に追加)+ generate + check_links を 3.0 / 3.3 / 3.4 / 4.0 で実行し、リンク切れ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
