### PR TITLE
IO::Buffer: 低レベル IO の 4 メソッドを追加

### DIFF
--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -1123,3 +1123,234 @@ p buf < IO::Buffer.for("abd")    # => true
 ```ruby title="例: 大きさが同じ場合は memcmp の結果がそのまま返る"
 p(IO::Buffer.for("abc") <=> IO::Buffer.for("abz")) # => -23
 ```
+
+#%since 3.2
+### def read(io, length = nil, offset = 0) -> Integer
+#%else
+### def read(io, length) -> Integer
+#%end
+
+io から読み込んだ内容をバッファに書き込みます。
+
+読み込むのは、少なくとも length バイトです。バッファに空きがあれば、
+それより多く読み込むことがあります。
+
+読み込みは io の現在の位置から行われ、io の位置は読み込んだ分だけ進みます。
+
+- **param** `io` -- 読み込み元の [c:IO] を指定します。
+
+#%since 3.2
+- **param** `length` -- 読み込む最小のバイト数を整数で指定します。
+             省略するか nil を指定した場合は、バッファの大きさから offset を
+             引いた値、つまりバッファの残り全体になります。
+             0 を指定した場合は read(2) をちょうど 1 回呼びます。
+
+- **param** `offset` -- 読み込んだ内容を書き込む位置を、バッファの先頭からの
+             バイト数で指定します。
+#%else
+- **param** `length` -- 読み込む最小のバイト数を整数で指定します。
+#%end
+
+- **return** -- 読み込んだバイト数を返します。読み込みに失敗した場合は
+             errno を負にした整数を返します。例外は発生しません。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファの大きさを
+             超える場合に発生します。
+
+```ruby
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.new(11)
+File.open("test.txt") do |io|
+  p buf.read(io, 11) # => 11
+end
+p buf.get_string     # => "Hello World"
+```
+
+```ruby title="例: 読み込みに失敗した場合は -errno を返す"
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.new(4)
+# 書き込み専用で開いたファイルからは読み込めない
+File.open("test.txt", "w") do |io|
+  p buf.read(io, 4)      # => -9
+end
+p(-Errno::EBADF::Errno)  # => -9
+```
+
+- **SEE** [m:IO::Buffer#pread], [m:IO::Buffer#write]
+
+#%since 3.2
+### def write(io, length = nil, offset = 0) -> Integer
+#%else
+### def write(io, length) -> Integer
+#%end
+
+バッファの内容を io に書き込みます。
+
+書き込むのは、少なくとも length バイトです。バッファに続きがあれば、
+それより多く書き込むことがあります。
+
+書き込みは io の現在の位置から行われ、io の位置は書き込んだ分だけ進みます。
+
+- **param** `io` -- 書き込み先の [c:IO] を指定します。
+
+#%since 3.2
+- **param** `length` -- 書き込む最小のバイト数を整数で指定します。
+             省略するか nil を指定した場合は、バッファの大きさから offset を
+             引いた値、つまりバッファの残り全体になります。
+             0 を指定した場合は write(2) をちょうど 1 回呼びます。
+
+- **param** `offset` -- 書き込む内容の開始位置を、バッファの先頭からの
+             バイト数で指定します。
+#%else
+- **param** `length` -- 書き込む最小のバイト数を整数で指定します。
+#%end
+
+- **return** -- 書き込んだバイト数を返します。書き込みに失敗した場合は
+             errno を負にした整数を返します。例外は発生しません。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファの大きさを
+             超える場合に発生します。
+
+```ruby
+buf = IO::Buffer.for("Ruby!")
+File.open("test.txt", "w") do |io|
+  p buf.write(io, 5) # => 5
+end
+p File.read("test.txt") # => "Ruby!"
+```
+
+- **SEE** [m:IO::Buffer#pwrite], [m:IO::Buffer#read]
+
+#%since 3.2
+### def pread(io, from, length = nil, offset = 0) -> Integer
+#%else
+### def pread(io, length, from) -> Integer
+#%end
+
+io の指定した位置から読み込んだ内容をバッファに書き込みます。
+
+[m:IO::Buffer#read] と異なり、読み込む位置を io の中で直接指定します。
+io の現在の位置は変わりません。
+
+- **param** `io` -- 読み込み元の [c:IO] を指定します。
+
+#%since 3.2
+- **param** `from` -- 読み込みを開始する位置を、io の先頭からのバイト数で
+             指定します。
+
+- **param** `length` -- 読み込む最小のバイト数を整数で指定します。
+             省略するか nil を指定した場合は、バッファの大きさから offset を
+             引いた値、つまりバッファの残り全体になります。
+             0 を指定した場合は pread(2) をちょうど 1 回呼びます。
+
+- **param** `offset` -- 読み込んだ内容を書き込む位置を、バッファの先頭からの
+             バイト数で指定します。
+#%else
+- **param** `length` -- 読み込む最小のバイト数を整数で指定します。
+
+- **param** `from` -- 読み込みを開始する位置を、io の先頭からのバイト数で
+             指定します。
+#%end
+
+- **return** -- 読み込んだバイト数を返します。読み込みに失敗した場合は
+             errno を負にした整数を返します。例外は発生しません。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファの大きさを
+             超える場合に発生します。
+
+#%since 3.2
+
+```ruby
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.new(5)
+File.open("test.txt") do |io|
+  p buf.pread(io, 6, 5) # => 5
+  p io.pos              # => 0
+end
+p buf.get_string        # => "World"
+```
+
+#%else
+
+```ruby
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.new(5)
+File.open("test.txt") do |io|
+  p buf.pread(io, 5, 6) # => 5
+  p io.pos              # => 0
+end
+p buf.get_string        # => "World"
+```
+
+#%end
+
+- **SEE** [m:IO::Buffer#read], [m:IO::Buffer#pwrite], [man:pread(2)]
+
+#%since 3.2
+### def pwrite(io, from, length = nil, offset = 0) -> Integer
+#%else
+### def pwrite(io, length, from) -> Integer
+#%end
+
+バッファの内容を io の指定した位置に書き込みます。
+
+[m:IO::Buffer#write] と異なり、書き込む位置を io の中で直接指定します。
+io の現在の位置は変わりません。
+
+- **param** `io` -- 書き込み先の [c:IO] を指定します。
+
+#%since 3.2
+- **param** `from` -- 書き込みを開始する位置を、io の先頭からのバイト数で
+             指定します。
+
+- **param** `length` -- 書き込む最小のバイト数を整数で指定します。
+             省略するか nil を指定した場合は、バッファの大きさから offset を
+             引いた値、つまりバッファの残り全体になります。
+             0 を指定した場合は pwrite(2) をちょうど 1 回呼びます。
+
+- **param** `offset` -- 書き込む内容の開始位置を、バッファの先頭からの
+             バイト数で指定します。
+#%else
+- **param** `length` -- 書き込む最小のバイト数を整数で指定します。
+
+- **param** `from` -- 書き込みを開始する位置を、io の先頭からのバイト数で
+             指定します。
+#%end
+
+- **return** -- 書き込んだバイト数を返します。書き込みに失敗した場合は
+             errno を負にした整数を返します。例外は発生しません。
+
+- **raise** `ArgumentError` -- offset と length の合計がバッファの大きさを
+             超える場合に発生します。
+
+#%since 3.2
+
+```ruby
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.for("RUBY!")
+File.open("test.txt", "r+") do |io|
+  p buf.pwrite(io, 6, 5) # => 5
+end
+p File.read("test.txt")  # => "Hello RUBY!"
+```
+
+#%else
+
+```ruby
+File.write("test.txt", "Hello World")
+
+buf = IO::Buffer.for("RUBY!")
+File.open("test.txt", "r+") do |io|
+  p buf.pwrite(io, 5, 6) # => 5
+end
+p File.read("test.txt")  # => "Hello RUBY!"
+```
+
+#%end
+
+- **SEE** [m:IO::Buffer#write], [m:IO::Buffer#pread], [man:pwrite(2)]


### PR DESCRIPTION
`IO::Buffer#read` / `#write` / `#pread` / `#pwrite` を追加します。#3357 の続きで、これで **4.0 までの `IO::Buffer` の API が揃います**。

(4.1 で `#bit_count` が追加されていますが [ruby/ruby#16784](https://github.com/ruby/ruby/pull/16784)、未リリース版のため今回は対象外としました)

## 3.2 で引数体系が変わっています

3.1 では `length` が必須で、`pread` / `pwrite` は `(io, length, from)` の 3 引数でした。3.2 以降は `length` と `offset` (バッファ内の位置) が省略可能になり、`pread` / `pwrite` は `(io, from, length, offset)` の順になりました。

**同じ 3 引数で呼んでも意味が変わる**ため、シグネチャ・`param`・実行例をすべて `#%since 3.2` / `#%else` で分けています。

```ruby
# 3.1
buf.pread(io, 5, 6)   # length 5, ファイル位置 6

# 3.2 以降
buf.pread(io, 6, 5)   # ファイル位置 6, length 5
```

どちらも "World" が読めることを実機 (3.1.6 / 3.2.11 / 4.0.6) で確認しています。

## 仕様で注意した点

**「少なくとも length バイト」** — rdoc の "Read at least `length` bytes" のとおりで、バッファに余裕があれば指定より多く読み書きします。11 バイトのバッファに `read(io, 5)` を渡すと 11 を返しました。「length バイト読む」と書くと誤りになるため、本文でそう書いています。

**エラー時は例外でなく `-errno`** — 読み取り専用で開いたファイルへの `write` が `-9` (`-Errno::EBADF::Errno`) を返します。これは 3.1 から一貫していました。例外が飛ばないので返り値を見ないと失敗に気づけない点を `- **return**` に明記しました。

**`pread` / `pwrite` は io の現在位置を変えない** — 実測で `io.pos` が動かないことを確認し、例にも入れています。

## 確認したこと

- サンプルを対象版すべてで `-w` 付き実行し、出力と警告の有無を確認 (`p -Errno::...` が曖昧構文の警告を出したため `p(...)` に修正)
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` 通過
- `rake check_links:3.1` / `:3.2` / `:3.4` / `:4.0` すべて 0 broken link
- 3.1 / 3.2 / 4.0 の DB を生成し、4 メソッドのシグネチャが版で切り替わることを確認

`check_format` は実行中です。結果はコメントで追記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
