### PR TITLE
Hash.ruby2_keywords_hash を追加

### DIFF
--- a/manual/api/_builtin/Hash.md
+++ b/manual/api/_builtin/Hash.md
@@ -248,6 +248,45 @@ h[1]
 
 - **SEE** [m:Hash#default=],[m:Hash#default],[m:Hash#default_proc]
 
+### def ruby2_keywords_hash(hash) -> Hash
+
+hash を複製し、[m:Module#ruby2_keywords]や[m:Proc#ruby2_keywords]による
+ruby2_keywords フラグを立てたハッシュを返します。
+
+このメソッドはデバッグや調査、引数のデシリアライズのように本当に必要な場合の
+ために用意されていて、普通のプログラムで使うことは想定されていません。
+
+複製を返すため、元の hash にフラグは立ちません。
+
+ruby 2.7.1 で追加されたため、ruby 2.7.0 では定義されていません。
+
+- **param** `hash` -- ruby2_keywords フラグを立てる [c:Hash] を指定します。
+
+- **raise** `TypeError` -- hash が [c:Hash] でない場合に発生します。
+
+```ruby
+h = {k: 1}
+p Hash.ruby2_keywords_hash?(h)       # => false
+
+flagged = Hash.ruby2_keywords_hash(h)
+p Hash.ruby2_keywords_hash?(flagged) # => true
+
+# 元のハッシュにはフラグが立たない
+p Hash.ruby2_keywords_hash?(h)       # => false
+```
+
+```ruby title="例: フラグを立てたハッシュは配列で渡してもキーワード引数になる"
+def foo(k: 42)
+  k
+end
+
+p foo(*[Hash.ruby2_keywords_hash({k: 1})]) # => 1
+
+foo(*[{k: 1}])                             # ~> ArgumentError
+```
+
+- **SEE** [m:Hash.ruby2_keywords_hash?], [m:Module#ruby2_keywords], [m:Proc#ruby2_keywords]
+
 ### def ruby2_keywords_hash?(hash) -> bool
 
 [m:Module#ruby2_keywords]や[m:Proc#ruby2_keywords]による


### PR DESCRIPTION
未収録だった `Hash.ruby2_keywords_hash` を追加します。

既に収録されている `Hash.ruby2_keywords_hash?` (フラグを**調べる**方) の直前に置き、相互に SEE で結びました。「立てる方」だけが抜けていた状態です。

## 版の扱い

3.0 以降すべてに存在するため版ゲートは付けていません。`?` つきと同じコミット (ruby/ruby の `9820f9ee0a`) で追加されたメソッドなので、既存エントリにある「ruby 2.7.1 で追加されたため、ruby 2.7.0 では定義されていません」という記述にも揃えました。`v2_7_0` の hash.c に定義が無く `v2_7_1` にあることを確認しています。

## rdoc に無い点を補いました

**複製を返すため元のハッシュにはフラグが立たない**ことが rdoc に書かれていないので、実機で確認して本文に入れました。3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 すべてで同じ挙動です。

```ruby
h = {k: 1}
flagged = Hash.ruby2_keywords_hash(h)
p Hash.ruby2_keywords_hash?(flagged) # => true
p Hash.ruby2_keywords_hash?(h)       # => false
```

## サンプルでハッシュの inspect を避けています

3.4 で Hash の表示が `{:k=>1}` から `{k: 1}` に変わるため、ハッシュ自体を `p` すると版分岐が必要になります。`ruby2_keywords_hash?` の真偽値と、配列で渡してもキーワード引数として展開されるかどうかを見せる形にして、全版で同一の出力になるようにしました (既存の `?` つきエントリも同じ方針で書かれています)。

## 確認したこと

- 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機でサンプルを `-w` 付き実行し、出力と警告の有無を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- `rake check_links:3.0` / `:4.0` ともに 0 broken link (`[m:Hash.ruby2_keywords_hash?]` のような `?` を含むリンクも解決)
- 4.0 の DB で両メソッドが登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
