### PR TITLE
TracePoint.allow_reentry を追加

### DIFF
--- a/manual/api/_builtin/TracePoint.md
+++ b/manual/api/_builtin/TracePoint.md
@@ -170,6 +170,57 @@ TracePoint の内部情報を返します。
 
 このメソッドは TracePoint 自身のデバッグ用です。
 
+#%since 3.1
+### def allow_reentry { ... } -> object
+
+ブロックの中に限って、TracePoint の再入を許可します。
+
+通常、ある TracePoint のコールバックを実行している間は、他に登録された
+コールバックは呼ばれません。再入によって混乱が生じるのを避けるためです。
+このメソッドを使うと、ブロックの中でだけ他のコールバックが呼ばれるようになります。
+
+デバッガのように、自身がコールバックの中にいることで他のライブラリのフックを
+妨げてはいけない場合に使います。ただしコールバックが際限なく呼ばれることが
+あるため、使用には注意が必要です。特に、あるコールバックの中でそれ自身を
+呼び出すイベントを発生させると無限に再帰します。
+
+- **return** -- ブロックの評価結果を返します。
+
+- **raise** `RuntimeError` -- TracePoint のコールバックの外で呼び出した場合に
+             発生します。すでに再入が許可されている場合も同様です。
+
+```ruby
+def helper
+end
+
+inner = TracePoint.new(:call) do |tp|
+  next if tp.method_id != :helper
+  puts "  inner ハンドラが呼ばれた"
+end
+inner.enable
+
+outer = TracePoint.new(:end) do |tp|
+  puts "再入を許可しない場合:"
+  helper
+  puts "再入を許可した場合:"
+  TracePoint.allow_reentry { helper }
+end
+outer.enable
+
+class Foo
+end
+
+outer.disable
+inner.disable
+
+# => 再入を許可しない場合:
+#    再入を許可した場合:
+#      inner ハンドラが呼ばれた
+```
+
+- **SEE** [m:TracePoint.new]
+#%end
+
 ## Instance Methods
 
 ### def enable         -> bool


### PR DESCRIPTION
未収録だった `TracePoint.allow_reentry` を追加します。

## 版の扱い

3.1 で追加された ([Feature #15912](https://bugs.ruby-lang.org/issues/15912)) ため `#%since 3.1` で囲みました。3.0.7 では `NoMethodError`、3.1.6 以降で定義されていることを実機で確認しています。

## rdoc に無い、または補った点

**返り値がブロックの評価結果**であること。実装が `rb_ensure(rb_yield, ...)` で、コールバック内で `allow_reentry { 42 }` が 42 を返すことを実機で確認しました。

**`RuntimeError` が発生する条件**。実装では `ec->trace_arg` が NULL のときで、「コールバックの外で呼んだ場合」と「すでに再入が許可されている場合」の両方が該当します。

```ruby
TracePoint.allow_reentry { 1 }   # ~> RuntimeError: No need to allow reentrance.
```

## サンプルは `:line` を避けました

rdoc の例は `:line` イベントを使っていますが、`:line` は自分自身のコールバックで再び発火するため、rdoc の例も `__LINE__` による行フィルタで無限再帰を防いでいます (実際、最初にフィルタなしで試したら `SystemStackError` になりました)。

ここでは `:end` と `:call` を組み合わせ、行フィルタなしで再入の有無が対比できる形にしました。

```
再入を許可しない場合:
再入を許可した場合:
  inner ハンドラが呼ばれた
```

3.1 / 3.2 / 3.3 / 3.4 / 4.0 で出力が完全に一致します。

## 確認したこと

- 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機で定義の有無とサンプルを `-w` 付き実行し、出力と警告の有無を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- `rake check_links:3.0` / `:3.1` / `:4.0` すべて 0 broken link
- 3.0 / 3.1 の DB を生成し、3.0 では出ず 3.1 から出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
