### PR TITLE
prism: Result・LexResult・ParseLexResult を追加

### DIFF
--- a/manual/api/prism.md
+++ b/manual/api/prism.md
@@ -124,9 +124,18 @@ p result.success?      # => true
 
 - **SEE** [m:Prism?.parse]
 
+#%since 3.4
 ### module_function def lex(source, **options) -> Prism::LexResult
+#%else
+### module_function def lex(source, **options) -> Prism::ParseResult
+#%end
 
-`source` を字句解析し、`Prism::LexResult` のインスタンスを返します。
+#%since 3.4
+`source` を字句解析し、[c:Prism::LexResult] のインスタンスを返します。
+#%else
+`source` を字句解析します。Ruby 3.3 の prism には字句解析専用の
+結果クラスがないため、戻り値は [c:Prism::ParseResult] のインスタンスです。
+#%end
 `value` は `[トークン, 直前からの字句解析器の状態(Integer)]` という
 2 要素配列の配列です。これは [c:Ripper] の [m:Ripper.lex] の戻り値の
 形式に近いものになっています。オプションは [m:Prism?.parse] と同じです。
@@ -139,7 +148,9 @@ p result.success?      # => true
 require "prism"
 
 result = Prism.lex("1 + 2")
+#%since 3.4
 p result.class   # => Prism::LexResult
+#%end
 result.value.each { |token, state| p [token.type, token.value, state] }
 # => [:INTEGER, "1", 2]
 # => [:PLUS, "+", 1]
@@ -149,9 +160,14 @@ result.value.each { |token, state| p [token.type, token.value, state] }
 
 - **SEE** [m:Prism?.parse], [c:Ripper]
 
+#%since 3.4
 ### module_function def lex_file(filepath, **options) -> Prism::LexResult
+#%else
+### module_function def lex_file(filepath, **options) -> Prism::ParseResult
+#%end
 
-`filepath` で指定したファイルを字句解析します。
+`filepath` で指定したファイルを字句解析します。戻り値の形式は
+[m:Prism?.lex] と同じです。
 オプションは [m:Prism?.parse] と同じです。
 
 - **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
@@ -164,8 +180,10 @@ require "prism"
 File.write("sample.rb", "def foo(a, b) = a + b\n")
 
 result = Prism.lex_file("sample.rb")
+#%since 3.4
 p result.class
 # => Prism::LexResult
+#%end
 p result.value.map { |token, _state| token.type }
 # => [:KEYWORD_DEF, :IDENTIFIER, :PARENTHESIS_LEFT, :IDENTIFIER, :COMMA,
 #     :IDENTIFIER, :PARENTHESIS_RIGHT, :EQUAL, :IDENTIFIER, :PLUS,
@@ -174,11 +192,22 @@ p result.value.map { |token, _state| token.type }
 
 - **SEE** [m:Prism?.lex]
 
+#%since 3.4
 ### module_function def parse_lex(source, **options) -> Prism::ParseLexResult
+#%else
+### module_function def parse_lex(source, **options) -> Prism::ParseResult
+#%end
 
+#%since 3.4
 `source` に対して構文解析と字句解析の両方を行い、
-`Prism::ParseLexResult` のインスタンスを返します。`value` は
+[c:Prism::ParseLexResult] のインスタンスを返します。`value` は
 `[構文木, トークンの配列]` という 2 要素配列です。
+#%else
+`source` に対して構文解析と字句解析の両方を行います。Ruby 3.3 の
+prism には専用の結果クラスがないため、戻り値は
+[c:Prism::ParseResult] のインスタンスで、`value` が
+`[構文木, トークンの配列]` という 2 要素配列になります。
+#%end
 
 構文木とトークン列の両方が必要な場合、[m:Prism?.parse] と [m:Prism?.lex]
 を個別に呼び出すよりも効率的です。片方だけが必要な場合はそれぞれ
@@ -193,7 +222,9 @@ p result.value.map { |token, _state| token.type }
 require "prism"
 
 result = Prism.parse_lex("1 + 2")
+#%since 3.4
 p result.class # => Prism::ParseLexResult
+#%end
 
 ast, tokens = result.value
 p ast.class    # => Prism::ProgramNode

--- a/manual/api/prism/LexResult.md
+++ b/manual/api/prism/LexResult.md
@@ -1,0 +1,32 @@
+---
+library: prism
+since: "3.4"
+---
+# class Prism::LexResult < Prism::Result
+
+[m:Prism?.lex] や [m:Prism?.lex_file] の戻り値のクラスです。
+字句解析の結果と、付随情報(コメント・エラー・警告など。
+[c:Prism::Result] を参照)を保持します。
+
+Ruby 3.3 の prism にはこのクラスはなく、[c:Prism::ParseResult] が
+使われていました(`value` の形式は同じです)。
+
+- **SEE** [m:Prism?.lex], [m:Prism?.lex_file], [c:Prism::Result]
+
+## Instance Methods
+
+### def value -> Array
+
+字句解析の結果を、`[トークン, 直前からの字句解析器の状態を表す整数]`
+という 2 要素配列の配列で返します。トークンは [c:Prism::Token] の
+インスタンスです。
+
+トークンだけの配列が欲しい場合は `value.map(&:first)` のようにします。
+
+```ruby title="例"
+require "prism"
+
+result = Prism.lex("1 + 2")
+p result.value.map { |token, _state| token.type }
+# => [:INTEGER, :PLUS, :INTEGER, :EOF]
+```

--- a/manual/api/prism/ParseLexResult.md
+++ b/manual/api/prism/ParseLexResult.md
@@ -1,0 +1,32 @@
+---
+library: prism
+since: "3.4"
+---
+# class Prism::ParseLexResult < Prism::Result
+
+[m:Prism?.parse_lex] などの戻り値のクラスです。
+構文解析と字句解析の両方の結果と、付随情報(コメント・エラー・
+警告など。[c:Prism::Result] を参照)を保持します。
+
+Ruby 3.3 の prism にはこのクラスはなく、[c:Prism::ParseResult] が
+使われていました(`value` の形式は同じです)。
+
+- **SEE** [m:Prism?.parse_lex], [c:Prism::Result]
+
+## Instance Methods
+
+### def value -> Array
+
+`[構文木, トークンの配列]` という 2 要素配列を返します。構文木は
+`Prism::ProgramNode`、トークンの配列は [c:Prism::LexResult] の
+`value` と同じ「[c:Prism::Token] と字句解析器の状態の整数のペア」の
+配列です。
+
+```ruby title="例"
+require "prism"
+
+ast, tokens = Prism.parse_lex("1 + 2").value
+p ast.class      # => Prism::ProgramNode
+p tokens.map { |token, _state| token.type }
+# => [:INTEGER, :PLUS, :INTEGER, :EOF]
+```

--- a/manual/api/prism/ParseResult.md
+++ b/manual/api/prism/ParseResult.md
@@ -1,7 +1,11 @@
 ---
 library: prism
 ---
+#%since 3.4
+# class Prism::ParseResult < Prism::Result
+#%else
 # class Prism::ParseResult < Object
+#%end
 
 [m:Prism?.parse] や [m:Prism?.parse_file] などの戻り値のクラスです。
 構文解析によって得られた構文木そのものに加えて、解析中に見つかった
@@ -78,6 +82,14 @@ p errors.first.level     # => :syntax
 
 - **SEE** [m:Prism::ParseResult#success?], [m:Prism::ParseResult#warnings]
 
+#%since 3.4
+### def errors_format -> String
+
+ソースコードに [m:Prism::ParseResult#errors] の位置(`^~` の下線)と
+エラーメッセージの注釈を付けた、人間が読みやすい形式の文字列を
+返します。構文エラーの内容をまとめて表示したいときに使えます。
+
+#%end
 ### def warnings -> Array
 
 構文解析中に発生した警告([c:Prism::ParseWarning] のインスタンス)の

--- a/manual/api/prism/Result.md
+++ b/manual/api/prism/Result.md
@@ -1,0 +1,85 @@
+---
+library: prism
+since: "3.4"
+---
+# class Prism::Result < Object
+
+[m:Prism?.parse]・[m:Prism?.lex]・[m:Prism?.parse_lex] などの解析系
+メソッドの戻り値([c:Prism::ParseResult]・[c:Prism::LexResult]・
+[c:Prism::ParseLexResult])の共通基底クラスです。解析結果本体
+(`value`)以外の付随情報(コメント・マジックコメント・エラー・
+警告・ソースコード)を保持します。
+
+Ruby 3.3 の prism にはこのクラスはなく、[c:Prism::ParseResult] が
+これらのメソッドを直接持っていました。
+
+- **SEE** [c:Prism::ParseResult], [c:Prism::LexResult], [c:Prism::ParseLexResult]
+
+## Instance Methods
+
+### def comments -> Array
+
+解析中に見つかったコメント([c:Prism::Comment] のサブクラスの
+インスタンス)の配列を返します。
+
+- **SEE** [m:Prism::ParseResult#comments]
+
+### def magic_comments -> Array
+
+解析中に見つかったマジックコメント([c:Prism::MagicComment] の
+インスタンス)の配列を返します。
+
+- **SEE** [m:Prism::ParseResult#magic_comments]
+
+### def data_loc -> Prism::Location | nil
+
+ソースコード中に `__END__` 行が存在する場合、その行からファイル末尾
+までの範囲を表す [c:Prism::Location] を返します。存在しない場合は
+nil を返します。
+
+- **SEE** [m:Prism::ParseResult#data_loc]
+
+### def errors -> Array
+
+解析中に発生したエラー([c:Prism::ParseError] のインスタンス)の
+配列を返します。
+
+- **SEE** [m:Prism::ParseResult#errors]
+
+### def warnings -> Array
+
+解析中に発生した警告([c:Prism::ParseWarning] のインスタンス)の
+配列を返します。
+
+- **SEE** [m:Prism::ParseResult#warnings]
+
+### def source -> Prism::Source
+
+解析したソースコードそのものを表す [c:Prism::Source] のインスタンスを
+返します。
+
+- **SEE** [m:Prism::ParseResult#source]
+
+### def encoding -> Encoding
+
+解析したソースコードのエンコーディングを返します。
+`source.encoding` と同じです。
+
+### def success? -> bool
+
+解析にエラーがなかった場合に true を返します。
+
+- **SEE** [m:Prism::ParseResult#success?]
+
+### def failure? -> bool
+
+[m:Prism::Result#success?] の否定です。
+
+### def code_units_cache(encoding) -> Proc
+
+バイトオフセットを指定エンコーディングのコード単位のオフセットへ
+変換する処理をキャッシュ付きで行う Proc を返します。
+[c:Prism::Location] の `code_units` 系メソッドを多数の位置に対して
+繰り返し使う場合の高速化用です。
+
+- **param** `encoding` -- コード単位の基準となるエンコーディング


### PR DESCRIPTION
refs #3338(第 4 弾・最終: Result 系クラスと版差の正確化)。#3371(第 3 弾)の上に積んだブランチです。これで #3338 で挙がっていた prism の補助クラス群は一通り揃います(ノードクラス群は別課題)。

- 3 ページを追加(いずれも front matter `since: "3.4"`。Ruby 3.3 の prism 0.19 には存在しないクラスのため): `Prism::Result`(共通基底。encoding / code_units_cache は本ページのみに記載)・`Prism::LexResult`・`Prism::ParseLexResult`
- **ParseResult の親クラスを版分岐**: 3.4 以降 = `Prism::Result`、3.3 = `Object`。H1 の `#%since`/`#%else` ゲートで表現し、ネイティブ経路(`update --markdowntree`)で 3.3/3.4 の実 DB を構築して「3.3 = Object・Result なし/3.4 = Prism::Result」になることを実証してから採用しました
- **prism.md の lex / lex_file / parse_lex の戻り値クラスを版分岐**(3.3 では専用クラスがなく `Prism::ParseResult` が返る。シグネチャ(MARKUP_SPEC §3.7)・本文・例の class 行をそれぞれゲート)
- `ParseResult#errors_format`(3.4 以降。エラー位置の注釈付き文字列)を追加

## 記載範囲の判断

- Result の共通メソッド(errors / warnings / comments など)は Result.md では簡潔な説明+ParseResult 側への SEE とし、詳しい説明と例は従来どおり ParseResult.md に置いています(3.3 では ParseResult が直接持つ構成のため、両立させる形)
- `Prism.parse_lex_file` は実装に存在しますが prism.md 未収録のため、今回はリンクせず対象外としました(収録は今後の課題)
- `ParseResult#mark_newlines!` は内部用途のため対象外

## 検証

- コード例の出力はすべて ruby 3.4.8 の実測値
- lint(check_blank_lines / check_indent_in_samplecode)+ generate + check_links を 3.0 / 3.3 / 3.4 / 4.0 で実行し、リンク切れ 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
