### PR TITLE
Class#attached_object を追加

### DIFF
--- a/manual/api/_builtin/Class.md
+++ b/manual/api/_builtin/Class.md
@@ -156,6 +156,36 @@ p BasicObject.superclass #=> nil
 #%since 3.1
 - **SEE** [m:Class#subclasses]
 #%end
+
+#%since 3.2
+### def attached_object    -> object
+
+自身が特異クラスであるとき、その特異クラスが属しているオブジェクトを返します。
+
+- **raise** `TypeError` -- 自身が特異クラスでない場合に発生します。
+
+```ruby
+class Foo; end
+
+p Foo.singleton_class.attached_object      # => Foo
+
+obj = Foo.new
+p obj.singleton_class.attached_object.equal?(obj) # => true
+
+# 特異クラスの特異クラスも特異クラスなので、その属するオブジェクトを返す
+p Foo.singleton_class.singleton_class.attached_object # => #<Class:Foo>
+```
+
+```ruby title="例: 特異クラスでない場合"
+class Foo; end
+
+Foo.attached_object       # ~> TypeError
+NilClass.attached_object  # ~> TypeError
+```
+
+- **SEE** [m:Object#singleton_class]
+#%end
+
 ### def _load(str)    -> Class
 
 [m:Object#_dump] を参照して下さい。


### PR DESCRIPTION
未収録だった `Class#attached_object` を追加します。`Class#superclass` の直後、`_load` の前に置きました。

## 版の扱い

3.2 で追加された ([Feature #12084](https://bugs.ruby-lang.org/issues/12084)) ため `#%since 3.2` で囲みました。3.1.6 では `NoMethodError`、3.2.11 以降で定義されていることを実機で確認しています。

## 例で TypeError のメッセージを書いていません

メッセージ中のクォートが 3.4 で ``` `Foo' ``` から `'Foo'` に変わるため、書くと `#%since 3.4` での分岐が必要になります。

```
3.2.11  TypeError: `Foo' is not a singleton class
4.0.6   TypeError: 'Foo' is not a singleton class
```

分岐を増やさずに済むよう、例は `# ~> TypeError` までにして、発生条件は本文と `- **raise**` で説明しました。

## 例の構成を少し変えました

rdoc の例には `NilClass.attached_object` と `TrueClass.attached_object` が並んでいますが、どちらも「特異クラスではない」ことによる同じ TypeError です。`NilClass` の方だけ残し、代わりに**特異クラスの特異クラス**を渡す例を足しました。

```ruby
p Foo.singleton_class.singleton_class.attached_object # => #<Class:Foo>
```

こちらは実機で確認済みで、「特異クラスもまたオブジェクトである」ことが伝わる例だと思います。

## 確認したこと

- 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機で定義の有無とサンプルを `-w` 付き実行し、出力と警告の有無を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- `rake check_links:3.1` / `:3.2` / `:4.0` すべて 0 broken link
- 3.1 / 3.2 の DB を生成し、3.1 では出ず 3.2 から出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
