### PR TITLE
NoMatchingPatternKeyError を追加

### DIFF
--- a/manual/api/_builtin/NoMatchingPatternKeyError.md
+++ b/manual/api/_builtin/NoMatchingPatternKeyError.md
@@ -1,0 +1,57 @@
+---
+library: _builtin
+since: "3.1"
+---
+# class NoMatchingPatternKeyError < NoMatchingPatternError
+
+パターンマッチのハッシュパターンで、対応するキーが見つからない場合に発生します。
+
+キーは存在するものの値がパターンに一致しない場合は、
+親クラスの [c:NoMatchingPatternError] が発生します。
+
+パターンマッチについては [d:spec/pattern_matching] を参照してください。
+
+```ruby
+data = {name: "ken"}
+begin
+  data => {age: Integer}
+rescue NoMatchingPatternKeyError => e
+  p e.key                # => :age
+  p e.matchee == data    # => true
+end
+```
+
+## Class Methods
+
+### def new(message = nil, matchee: nil, key: nil) -> NoMatchingPatternKeyError
+
+例外オブジェクトを生成して返します。
+
+- **param** `message` -- エラーメッセージを表す文字列です。
+
+- **param** `matchee` -- パターンマッチの対象となったオブジェクトです。
+             [m:NoMatchingPatternKeyError#matchee] で取り出せます。
+
+- **param** `key` -- 見つからなかったキーです。
+             [m:NoMatchingPatternKeyError#key] で取り出せます。
+
+```ruby
+data = {name: "ken"}
+e = NoMatchingPatternKeyError.new("key not found", matchee: data, key: :age)
+p e.matchee.equal?(data) # => true
+p e.key                  # => :age
+```
+
+## Instance Methods
+
+### def matchee -> object
+
+パターンマッチの対象となったオブジェクトを返します。
+
+生成時に matchee が設定されていない場合は [c:ArgumentError] が発生します。
+
+### def key -> object
+
+見つからなかったキーを返します。
+
+生成時に key が設定されていない場合は [c:ArgumentError] が発生します。


### PR DESCRIPTION
未収録だった `NoMatchingPatternKeyError` を追加します。子クラスなのに、親の `NoMatchingPatternError` しか収録されていない状態でした。

## 版とファイル

3.1 で追加された ([Feature #17557](https://bugs.ruby-lang.org/issues/17557)) ため front matter の `since: "3.1"` でゲートしました。3.0.7 では未定義で親が発生、3.1.6 以降で定義されていることを実機で確認しています。親の `NoMatchingPatternError.md` が `since: "2.7.0"` を持っていて版ゲートを共用できないので、単独ファイルにしました。

## 親クラスとの違いを明記しました

ここが一番の勘所でした。**ハッシュパターンでキーが「見つからない」場合が `NoMatchingPatternKeyError`、キーはあるが値が一致しない場合は親の `NoMatchingPatternError`** です。

```ruby
{name: "ken"} => {age: Integer}  # キー欠落 → NoMatchingPatternKeyError
{name: "ken"} => {name: "taro"}  # 値不一致 → NoMatchingPatternError
```

(最初 `case/in` で値の不一致を試したら親の方が出て、`KeyError` を捕捉できずに気づきました。)

## サンプルでハッシュを直接 p していません

`matchee` が返すハッシュの inspect が 3.4 で `{:name=>"ken"}` から `{name: "ken"}` に変わるため、`p` すると版分岐が必要になります。`matchee == data` / `equal?(data)` の真偽で示しました。

また one-line パターンは `{age:}` だと `age` が未使用変数の警告 (`-w`) を出すので、サブパターンつきの `{age: Integer}` にしています。

## その他

`matchee` / `key` は `new` で設定されなかった場合に `ArgumentError` を発生させる点も本文に書きました (実装の `rb_ivar_lookup` が `Qundef` のとき `rb_raise`)。

## 確認したこと

- 3.0 / 3.1 / 3.2 / 3.3 / 3.4 / 4.0 の実機で定義の有無と発生条件、サンプルを `-w` 付き実行し、出力と警告の有無を確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過
- `rake check_links:3.0` / `:3.1` / `:4.0` すべて 0 broken link
- 3.0 / 3.1 の DB を生成し、3.0 では出ず 3.1 からクラス・`new`・`key`・`matchee` が登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
