### PR TITLE
Set::CoreSet を追加し、Set にサブクラスの節を設ける

### DIFF
--- a/manual/api/_builtin/Set.md
+++ b/manual/api/_builtin/Set.md
@@ -45,6 +45,31 @@ p set1                  # => #<Set: {"bar", "baz", "heh"}>
 #%end
 ```
 
+#%since 4.0
+### Set のサブクラスを作る {#subclass}
+
+Ruby 4.0 で Set は C で再実装され、一部のメソッドの振る舞いが変わりました。
+Set を継承してサブクラスを作る場合、互換性を必要とするかどうかで
+継承元を選べます。
+
+古い実装との互換性が必要な場合は、Set を直接継承します。
+この場合は互換レイヤが自動的に組み込まれ、振る舞いが古い実装に近くなります。
+
+```ruby
+class MySet < Set; end
+p MySet[[1, 2, 3]]      # => #<MySet: {[1, 2, 3]}>
+```
+
+互換性が不要な場合は、[c:Set::CoreSet] を継承します。
+互換レイヤを挟まないぶん効率的です。
+
+```ruby
+class MyCoreSet < Set::CoreSet; end
+p MyCoreSet[[1, 2, 3]]  # => MyCoreSet[[1, 2, 3]]
+```
+
+#%end
+
 ## Class Methods
 ### def new(enum = nil) -> Set
 ### def new(enum = nil) {|o| ... } -> Set

--- a/manual/api/_builtin/Set__CoreSet.md
+++ b/manual/api/_builtin/Set__CoreSet.md
@@ -1,0 +1,21 @@
+---
+library: _builtin
+since: "4.0"
+---
+# class Set::CoreSet < Set
+
+[c:Set] のサブクラスを、互換レイヤを挟まずに作るための継承元です。
+
+Ruby 4.0 で Set は C で再実装され、一部のメソッドの振る舞いが変わりました。
+Set を直接継承すると、古い実装との互換性のための互換レイヤが自動的に
+組み込まれます。互換性が不要な場合は、代わりに Set::CoreSet を継承すると、
+互換レイヤを挟まないぶん効率的です。
+
+独自のメソッドや定数は持たず、機能はすべて [c:Set] から継承します。
+
+```ruby
+class MyCoreSet < Set::CoreSet; end
+p MyCoreSet[[1, 2, 3]]  # => MyCoreSet[[1, 2, 3]]
+```
+
+- **SEE** [ref:c:Set#subclass]


### PR DESCRIPTION
未収録だった `Set::CoreSet` を追加します。

## 版

`Set::CoreSet` は 4.0 で追加された (Set の C 再実装に伴うもの) ため `since: "4.0"` でゲートしました。3.4.10 では未定義、4.0.6 で定義されていることを実機で確認しています。

## 収録の形

当初は Set.md への統合を考えていましたが、Set.md は `include:` を持ちエンティティを 1 つしか置けないため、**CoreSet は独立ファイル `Set__CoreSet.md`** にしました (`IO__TimeoutError.md` と同じ、説明のみで固有メソッドを持たないクラスページ)。CoreSet は固有メソッドを持たず、機能はすべて Set から継承します。

あわせて **Set.md のクラス説明に「Set のサブクラスを作る」の節**を `{#subclass}` アンカー付きで設け、両者を `[c:Set::CoreSet]` と `[ref:c:Set#subclass]` で相互にリンクしました。生成 HTML で `<h2 id='subclass'>` になり、双方向のリンクが解決することを確認しています。

## CoreSet は公開、SubclassCompatible は非公開

`Set::CoreSet` は `Set.constants` に現れる公開クラスで、`:nodoc:` でも `private_constant` でもありません (`ri Set` の本文も新規コードでの継承を推奨)。

一方 **`Set::SubclassCompatible` は `private_constant` で非公開**のため、収録せず「互換レイヤ」として説明文で触れるに留めました。サンプルで直接参照すると `private constant referenced` になるので、ancestors 経由でも触れていません。

## 実機で確認した振る舞いの違い

```ruby
class MySet < Set; end
p MySet[[1, 2, 3]]      # => #<MySet: {[1, 2, 3]}>  (互換レイヤあり)

class MyCoreSet < Set::CoreSet; end
p MyCoreSet[[1, 2, 3]]  # => MyCoreSet[[1, 2, 3]]    (互換レイヤなし)
```

## 確認したこと

- 3.4 / 4.0 の実機で定義の有無とサンプルを `-w` 付き実行し、警告なしを確認
- `rake check_blank_lines` / `check_indent_in_samplecode` / `check_filename_case_conflicts` / `check_format` 通過 (MD031 を 1 件出したので修正済み)
- `rake check_links:3.2` / `:3.4` / `:4.0` すべて 0 broken link
- 3.4 / 4.0 の DB で 3.4 では出ず 4.0 から CoreSet が登録されることを確認
- 静的 HTML で `{#subclass}` アンカーの属性化と双方向リンクを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
