### PR TITLE
prism: Prism.parse_lex_file を追加

### DIFF
--- a/manual/api/prism.md
+++ b/manual/api/prism.md
@@ -233,6 +233,33 @@ p tokens.size  # => 4
 
 - **SEE** [m:Prism?.parse], [m:Prism?.lex]
 
+#%since 3.4
+### module_function def parse_lex_file(filepath, **options) -> Prism::ParseLexResult
+#%else
+### module_function def parse_lex_file(filepath, **options) -> Prism::ParseResult
+#%end
+
+`filepath` で指定したファイルに対して構文解析と字句解析の両方を
+行います。戻り値の形式は [m:Prism?.parse_lex] と同じです。
+オプションは [m:Prism?.parse] と同じです。
+
+- **param** `filepath` -- 解析する Ruby プログラムのファイルパスを指定します。
+
+- **param** `options` -- [m:Prism?.parse] を参照してください。
+
+```ruby title="例"
+require "prism"
+
+File.write("sample.rb", "1 + 2\n")
+
+ast, tokens = Prism.parse_lex_file("sample.rb").value
+p ast.class # => Prism::ProgramNode
+p tokens.map { |token, _state| token.type }
+# => [:INTEGER, :PLUS, :INTEGER, :NEWLINE, :EOF]
+```
+
+- **SEE** [m:Prism?.parse_lex]
+
 ### module_function def parse_success?(source, **options) -> bool
 
 `source` を構文解析し、エラーなく解析できた場合に true を返します。

--- a/manual/api/prism/ParseLexResult.md
+++ b/manual/api/prism/ParseLexResult.md
@@ -4,14 +4,14 @@ since: "3.4"
 ---
 # class Prism::ParseLexResult < Prism::Result
 
-[m:Prism?.parse_lex] などの戻り値のクラスです。
+[m:Prism?.parse_lex] や [m:Prism?.parse_lex_file] の戻り値のクラスです。
 構文解析と字句解析の両方の結果と、付随情報(コメント・エラー・
 警告など。[c:Prism::Result] を参照)を保持します。
 
 Ruby 3.3 の prism にはこのクラスはなく、[c:Prism::ParseResult] が
 使われていました(`value` の形式は同じです)。
 
-- **SEE** [m:Prism?.parse_lex], [c:Prism::Result]
+- **SEE** [m:Prism?.parse_lex], [m:Prism?.parse_lex_file], [c:Prism::Result]
 
 ## Instance Methods
 


### PR DESCRIPTION
refs #3338(#3375 のレビューで判明した未収録メソッドの補完)

- `Prism.parse_lex_file` のエントリを追加しました。戻り値クラスは lex 系と同じく版分岐(3.4 以降 = `Prism::ParseLexResult`、3.3 = `Prism::ParseResult`)です
- ParseLexResult 側の「parse_lex_file の戻り値」への参照も復元しました(前回はリンク先が未収録だったため外していた分)
- 例の出力は ruby 3.3.12 / 3.4.8 の実測値です

🤖 Generated with [Claude Code](https://claude.com/claude-code)