### PR TITLE
Ruby モジュールを追加し、RUBY_PATCHLEVEL を 4.0 の挙動に更新

### DIFF
--- a/manual/api/_builtin/Ruby.md
+++ b/manual/api/_builtin/Ruby.md
@@ -1,0 +1,74 @@
+---
+library: _builtin
+since: "4.0"
+---
+# module Ruby
+
+Ruby の実装間で可搬な情報を集めたモジュールです。
+Ruby 4.0 で導入されました。
+
+このモジュールで定義されている定数は、トップレベルで `RUBY_` を接頭辞に付けた
+定数（`RUBY_VERSION` など）と同じ値で参照できます。
+たとえば `Ruby::VERSION` と `RUBY_VERSION` は同じ文字列を返します。
+
+## Constants
+
+### const VERSION -> String
+
+Ruby のバージョンを表す文字列。
+
+Ruby のバージョンは、major.minor.teeny という形式です。
+トップレベル定数 `RUBY_VERSION` と同じ値です。
+
+### const RELEASE_DATE -> String
+
+Ruby のリリース日を表す文字列。
+
+トップレベル定数 `RUBY_RELEASE_DATE` と同じ値です。
+
+### const PLATFORM -> String
+
+プラットフォームを表す文字列。
+
+トップレベル定数 `RUBY_PLATFORM` と同じ値です。
+
+### const PATCHLEVEL -> Integer
+
+Ruby のパッチレベルを表す [c:Integer] オブジェクトです。
+
+パッチレベルは teeny リリースのそれぞれについて 0 から始まり、
+その teeny リリースに対してバグ修正パッチが適用される度に増えていきます。
+開発版の Ruby では -1 になります。
+
+トップレベル定数 `RUBY_PATCHLEVEL` と同じ値です。
+
+### const REVISION -> String
+
+Ruby の GIT コミットハッシュを表す [c:String] オブジェクトです。
+
+トップレベル定数 `RUBY_REVISION` と同じ値です。
+
+### const COPYRIGHT -> String
+
+Ruby のコピーライトを表す文字列。
+
+トップレベル定数 `RUBY_COPYRIGHT` と同じ値です。
+
+### const ENGINE -> String
+
+Ruby 処理系実装の種類を表す文字列。
+
+トップレベル定数 `RUBY_ENGINE` と同じ値です。
+
+### const ENGINE_VERSION -> String
+
+Ruby 処理系実装のバージョンを表す文字列。
+
+トップレベル定数 `RUBY_ENGINE_VERSION` と同じ値です。
+
+### const DESCRIPTION -> String
+
+Ruby の詳細を表す文字列。
+
+`ruby -v` で表示される内容が格納されています。
+トップレベル定数 `RUBY_DESCRIPTION` と同じ値です。

--- a/manual/api/_builtin/Ruby.md
+++ b/manual/api/_builtin/Ruby.md
@@ -9,7 +9,10 @@ Ruby 4.0 で導入されました。
 
 このモジュールで定義されている定数は、トップレベルで `RUBY_` を接頭辞に付けた
 定数（`RUBY_VERSION` など）と同じ値で参照できます。
-たとえば `Ruby::VERSION` と `RUBY_VERSION` は同じ文字列を返します。
+たとえば `Ruby::VERSION` と [m:Object::RUBY_VERSION] は同じ文字列を返します。
+
+また、このモジュールの下には、クラスやモジュールをプロセス内で隔離する
+実験的機能のためのクラス `Ruby::Box` も定義されています。
 
 ## Constants
 
@@ -18,57 +21,55 @@ Ruby 4.0 で導入されました。
 Ruby のバージョンを表す文字列。
 
 Ruby のバージョンは、major.minor.teeny という形式です。
-トップレベル定数 `RUBY_VERSION` と同じ値です。
+トップレベル定数 [m:Object::RUBY_VERSION] と同じ値です。
 
 ### const RELEASE_DATE -> String
 
 Ruby のリリース日を表す文字列。
 
-トップレベル定数 `RUBY_RELEASE_DATE` と同じ値です。
+トップレベル定数 [m:Object::RUBY_RELEASE_DATE] と同じ値です。
 
 ### const PLATFORM -> String
 
 プラットフォームを表す文字列。
 
-トップレベル定数 `RUBY_PLATFORM` と同じ値です。
+トップレベル定数 [m:Object::RUBY_PLATFORM] と同じ値です。
 
-### const PATCHLEVEL -> Integer
+### const PATCHLEVEL -> 0
 
 Ruby のパッチレベルを表す [c:Integer] オブジェクトです。
 
-パッチレベルは teeny リリースのそれぞれについて 0 から始まり、
-その teeny リリースに対してバグ修正パッチが適用される度に増えていきます。
-開発版の Ruby では -1 になります。
-
-トップレベル定数 `RUBY_PATCHLEVEL` と同じ値です。
+Ruby 4.0 以降はパッチレベルの増分をやめたため、リリース版では常に 0 になります
+（master などの開発版では -1 になります）。
+トップレベル定数 [m:Object::RUBY_PATCHLEVEL] と同じ値です。
 
 ### const REVISION -> String
 
 Ruby の GIT コミットハッシュを表す [c:String] オブジェクトです。
 
-トップレベル定数 `RUBY_REVISION` と同じ値です。
+トップレベル定数 [m:Object::RUBY_REVISION] と同じ値です。
 
 ### const COPYRIGHT -> String
 
 Ruby のコピーライトを表す文字列。
 
-トップレベル定数 `RUBY_COPYRIGHT` と同じ値です。
+トップレベル定数 [m:Object::RUBY_COPYRIGHT] と同じ値です。
 
 ### const ENGINE -> String
 
 Ruby 処理系実装の種類を表す文字列。
 
-トップレベル定数 `RUBY_ENGINE` と同じ値です。
+トップレベル定数 [m:Object::RUBY_ENGINE] と同じ値です。
 
 ### const ENGINE_VERSION -> String
 
 Ruby 処理系実装のバージョンを表す文字列。
 
-トップレベル定数 `RUBY_ENGINE_VERSION` と同じ値です。
+トップレベル定数 [m:Object::RUBY_ENGINE_VERSION] と同じ値です。
 
 ### const DESCRIPTION -> String
 
 Ruby の詳細を表す文字列。
 
 `ruby -v` で表示される内容が格納されています。
-トップレベル定数 `RUBY_DESCRIPTION` と同じ値です。
+トップレベル定数 [m:Object::RUBY_DESCRIPTION] と同じ値です。

--- a/manual/api/_builtin/constants.md
+++ b/manual/api/_builtin/constants.md
@@ -214,6 +214,17 @@ Ruby のリリース日を表す文字列。
 
 プラットフォームを表す文字列。
 
+#%since 4.0
+### const RUBY_PATCHLEVEL -> 0
+
+Ruby のパッチレベルを表す [c:Integer] オブジェクトです。
+
+Ruby 4.0 以降はパッチレベルの増分をやめたため、リリース版では常に 0 になります
+（master などの開発版では -1 になります）。
+
+パッチレベルという概念および RUBY_PATCHLEVEL 定数は、 Ruby 1.8.5-p1 以降、 1.8.6 以降で導入されました。
+1.8.5やそれ以前のバージョンでは定義されていません。
+#%else
 ### const RUBY_PATCHLEVEL -> Integer
 
 Ruby のパッチレベルを表す [c:Integer] オブジェクトです。
@@ -224,6 +235,7 @@ teeny リリースのそれぞれについてパッチレベルは 0 から始�
 
 パッチレベルという概念および RUBY_PATCHLEVEL 定数は、 Ruby 1.8.5-p1 以降、 1.8.6 以降で導入されました。
 1.8.5やそれ以前のバージョンでは定義されていません。
+#%end
 
 ### const RUBY_REVISION -> String
 


### PR DESCRIPTION
Ruby 4.0 で導入された `Ruby` モジュールを収録します。あわせて、レビュー指摘を受けて `RUBY_PATCHLEVEL` の 4.0 での挙動変更も反映しました。

## 内容 — Ruby モジュール（新規）

実装間で可搬な情報を集めたモジュールで、以下の 9 定数を持ちます。いずれもトップレベルの `RUBY_*` 定数と同じ値です（例: `Ruby::VERSION == RUBY_VERSION`）。

- VERSION / RELEASE_DATE / PLATFORM / PATCHLEVEL / REVISION / COPYRIGHT / ENGINE / ENGINE_VERSION / DESCRIPTION

各定数の説明から、対応するトップレベル定数を `[m:Object::RUBY_*]` でリンクしています。概要にはクラス `Ruby::Box`（4.0 新規・実験的）の存在を一言添えました（本体ページは別 PR 予定）。

## 内容 — RUBY_PATCHLEVEL の 4.0 挙動（bug #21770）

Ruby 4.0 以降はパッチレベルの増分をやめ、リリース版では常に 0（master などの開発版では -1）になります。これに合わせて:

- 新規 `Ruby::PATCHLEVEL` を `-> 0` とし、上記を明記。
- 既存の `[m:Object::RUBY_PATCHLEVEL]`（constants.md、全バージョン対象）を `#%since 4.0` で版分岐し、4.0 は `-> 0`＋新説明、3.4 以前は従来どおり `-> Integer`。

## 根拠・確認

- 登場版: 実機で 3.3.12 / 3.4.10 に `Ruby` モジュールは無く、4.0.6 で追加されることを確認（`defined?(Ruby)`）。`since: "4.0"` を指定。
- 定数値: 9 定数すべてが対応する `RUBY_*` グローバルと `==` であることを 4.0.6 実機で確認。
- PATCHLEVEL: 実機で 4.0.6 = 0、4.1-dev(master) = -1 を確認。bug #21770 の方針（リリース 0 / dev -1）と一致。
- rdoc: 本体 `version.c` の各定数 rdoc、既存 `constants.md` の記述に合わせています。
- bitclust: 3.4 / 4.0 の実 DB 生成で、`Ruby` モジュール（4.0 のみ登録・3.4 では非表示）と `RUBY_PATCHLEVEL` の版差（4.0 = `-> 0` / 3.4 = `-> Integer`）を確認。`check_blank_lines` / `check_indent_in_samplecode` / `check_links:3.4` / `check_links:4.0`（いずれも 0 broken）/ `check_format` すべてパス。

## 補足

- `Ruby::Box`（同じく 4.0 新規・実験的）は別 PR で対応予定です。
- 4.1-dev では `Ruby::SourceRange` 定数が増えていますが、4.0 には無いため対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
