### PR TITLE
MatchData#inspect の結果を訂正

### DIFF
--- a/manual/api/_builtin/MatchData.md
+++ b/manual/api/_builtin/MatchData.md
@@ -500,7 +500,6 @@ p $~.to_a       # => ["foobar", "foo", "bar", nil]
 
 ```ruby title="例"
 /bar/ =~ "foobarbaz"
-p $~            # => #<MatchData:0x401b1be4>
 p $~.to_s       # => "bar"
 ```
 

--- a/manual/api/_builtin/Regexp.md
+++ b/manual/api/_builtin/Regexp.md
@@ -114,7 +114,7 @@ p rp # => "\\$bc\\^"
 
 ```ruby title="例"
 /(.)(.)/ =~ "ab"
-p Regexp.last_match      # => #<MatchData:0x4599e58>
+p Regexp.last_match      # => #<MatchData "ab" 1:"a" 2:"b">
 p Regexp.last_match[0]   # => "ab"
 p Regexp.last_match[1]   # => "a"
 p Regexp.last_match[2]   # => "b"
@@ -131,7 +131,6 @@ p Regexp.last_match[3]   # => nil
 
 ```ruby title="例"
 /(.)(.)/ =~ "ab"
-p Regexp.last_match      # => #<MatchData:0x4599e58>
 p Regexp.last_match(0)   # => "ab"
 p Regexp.last_match(1)   # => "a"
 p Regexp.last_match(2)   # => "b"
@@ -149,7 +148,7 @@ str = "This is Regexp"
 p Regexp.last_match # => nil
 begin
   Regexp.last_match[1] # ~> NoMethodError
-rescue 
+rescue
 #%since 3.4
   puts $! # => undefined method '[]' for nil:NilClass
 #%else
@@ -222,12 +221,12 @@ p Regexp.union(/a/e, /b/) # => /(?-mix:a)|(?-mix:b)/e
 p Regexp.union(/foo/i, /bar/x, /hoge/m) # => /(?i-mx:foo)|(?x-mi:bar)|(?m-ix:hoge)/
 
 # 文字列そのものにマッチする
-rep1 = [ "foo", "bar", "hoge"] 
+rep1 = [ "foo", "bar", "hoge"]
 p Regexp.union(*rep1) # => /foo|bar|hoge/
 p Regexp.union(rep1)  # => /foo|bar|hoge/
 
 # 下記の場合オプションがつくのは最初だけ
-rep2 = [ /foo/x, "bar", "hoge"] 
+rep2 = [ /foo/x, "bar", "hoge"]
 p Regexp.union(*rep2) # => /(?x-mi:foo)|bar|hoge/
 p Regexp.union(rep2)  # => /(?x-mi:foo)|bar|hoge/
 ```
@@ -400,14 +399,14 @@ end
 reg = Regexp.compile("foo")
 
 if ~ reg
-  puts "match" 
+  puts "match"
 else
-  puts "no match" 
+  puts "no match"
 end
 # => no match
 
 if reg
-  puts "match" 
+  puts "match"
 else
   puts "no match"
 end
@@ -501,7 +500,7 @@ re.match(str, pos)
 
 ```ruby title="例"
 results = []
-p /((.)\2)/.match("foo") {|m| results << m[0] } # => ["oo"] 
+p /((.)\2)/.match("foo") {|m| results << m[0] } # => ["oo"]
 p /((.)\2)/.match("bar") {|m| results << m[0] } # => nil
 p results # => ["oo"]
 ```
@@ -518,7 +517,7 @@ if reg.match("foobar")
 end
 # => match
 
-p reg.match("foobar") # => #<MatchData:0x29403fc>
+p reg.match("foobar") # => #<MatchData "foo">
 p reg.match("bar")    # => nil
 
 p /(foo)(bar)(baz)/.match("foobarbaz").to_a.values_at(1,2,3) # => ["foo", "bar", "baz"]


### PR DESCRIPTION
`MatchData#inspect` は，以前は  `#<MatchData:0x401b1be4>` のような結果を返していましたが，現在は中身の情報を伴った文字列を返します。
どの Ruby バージョンから変わったのか調べられませんでしたが，Ruby 2.7.8, 3.1.7, 4.0.6 で新しい形式になっていることを確認しました。
よって，バージョン分岐なしで訂正します。

なお，`MatchData#to_s` のコードサンプルの `p $~` は必要性を感じなかったので，訂正ではなく削除しました。

また，`Regexp` の `def last_match(nth)` のコードサンプルにおける `p Regexp.last_match` も削除しました。
引数ありの場合のコードサンプルなのに引数無しの呼び出しがあるのは紛らわしいからです。

今回の修正において，余計な行末スペースの削除も行いました。
レンダリング結果に影響を与えないだろうことは Markdown 上の目視確認のみ行いました。