### PR TITLE
Ruby::Box と Method#box を追加

### DIFF
--- a/manual/api/_builtin/Method.md
+++ b/manual/api/_builtin/Method.md
@@ -454,6 +454,14 @@ m = Foo.new.method(:puts) # => #<Method: Foo(Kernel)#puts>
 p m.owner # => Kernel
 ```
 
+#%since 4.0
+### def box -> Ruby::Box | nil
+
+self が定義されている [c:Ruby::Box] を返します。
+
+Ruby::Box が無効なときは nil を返します。
+#%end
+
 ### def receiver    -> object
 
 このメソッドオブジェクトのレシーバを返します。

--- a/manual/api/_builtin/Method.md
+++ b/manual/api/_builtin/Method.md
@@ -459,7 +459,7 @@ p m.owner # => Kernel
 
 self が定義されている [c:Ruby::Box] を返します。
 
-Ruby::Box が無効なときは nil を返します。
+`Ruby::Box` が無効なときは `nil` を返します。
 #%end
 
 ### def receiver    -> object

--- a/manual/api/_builtin/Ruby__Box.md
+++ b/manual/api/_builtin/Ruby__Box.md
@@ -8,13 +8,13 @@ since: "4.0"
 モンキーパッチを互いに隔離するための機能です。
 Ruby 4.0 で導入されました。
 
-Ruby::Box は [c:Module] のサブクラスで、その各インスタンスは 1 つの隔離された
+`Ruby::Box` は [c:Module] のサブクラスで、その各インスタンスは 1 つの隔離された
 名前空間（ボックス）を表します。あるボックスの中で新しく定義したり変更したりした
 クラス・モジュール・定数・グローバル変数は、そのボックスの外や他のボックスからは
 見えません。
 
-Ruby::Box は実験的な機能です。既定では無効で、このとき [m:Ruby::Box.enabled?] は
-false を返し、[m:Ruby::Box.new] は [c:RuntimeError] を発生させます。
+`Ruby::Box` は実験的な機能です。既定では無効で、このとき [m:Ruby::Box.enabled?] は
+`false` を返し、[m:Ruby::Box.new] は [c:RuntimeError] を発生させます。
 利用するには、ruby プロセスの起動時に環境変数 `RUBY_BOX` に `1` を設定します。
 `1` 以外の値や未設定は無効を意味します。また、プロセスの起動後に設定しても
 有効にはなりません。
@@ -59,28 +59,28 @@ p box::Something.new.x # => 1
 他のボックスには影響しません。グローバル変数やトップレベルの定数・メソッドの変更も
 同様にボックスごとに隔離されます。
 
-## Class methods
+## Class Methods
 
 ### def new -> Ruby::Box
 
 他のボックスから独立した新しいボックスを返します。
 
-Ruby::Box が無効なとき（環境変数 `RUBY_BOX` に `1` を設定せずに起動したとき）は
+`Ruby::Box` が無効なとき（環境変数 `RUBY_BOX` に `1` を設定せずに起動したとき）は
 [c:RuntimeError] が発生します。
 
 ### def enabled? -> bool
 
-Ruby::Box が有効なら true を、無効なら false を返します。
+`Ruby::Box` が有効なら `true` を、無効なら `false` を返します。
 
-環境変数 `RUBY_BOX` に `1` を設定して ruby を起動したときに true になります。
+環境変数 `RUBY_BOX` に `1` を設定して ruby を起動したときに `true` になります。
 
 ### def current -> Ruby::Box | nil
 
 現在実行中のコードが属しているボックスを返します。
 
-Ruby::Box が無効なときは nil を返します。
+`Ruby::Box` が無効なときは `nil` を返します。
 
-## Instance methods
+## Instance Methods
 
 ### def eval(code) -> object
 
@@ -100,7 +100,7 @@ Ruby::Box が無効なときは nil を返します。
 `feature` を self（レシーバのボックス）の中に読み込みます。
 
 [m:Kernel?.require] と同様ですが、読み込まれたファイルは self の中で実行されます。
-まだ読み込まれていなければ true を、すでに読み込み済みなら false を返します。
+まだ読み込まれていなければ `true` を、すでに読み込み済みなら `false` を返します。
 
 ### def require_relative(relative_feature) -> bool
 

--- a/manual/api/_builtin/Ruby__Box.md
+++ b/manual/api/_builtin/Ruby__Box.md
@@ -1,0 +1,120 @@
+---
+library: _builtin
+since: "4.0"
+---
+# class Ruby::Box < Module
+
+クラスやモジュールをプロセス内で分離し、アプリケーションのコードやライブラリ、
+モンキーパッチを互いに隔離するための機能です。
+Ruby 4.0 で導入されました。
+
+Ruby::Box は [c:Module] のサブクラスで、その各インスタンスは 1 つの隔離された
+名前空間（ボックス）を表します。あるボックスの中で新しく定義したり変更したりした
+クラス・モジュール・定数・グローバル変数は、そのボックスの外や他のボックスからは
+見えません。
+
+Ruby::Box は実験的な機能です。既定では無効で、このとき [m:Ruby::Box.enabled?] は
+false を返し、[m:Ruby::Box.new] は [c:RuntimeError] を発生させます。
+利用するには、ruby プロセスの起動時に環境変数 `RUBY_BOX` に `1` を設定します。
+`1` 以外の値や未設定は無効を意味します。また、プロセスの起動後に設定しても
+有効にはなりません。
+
+```console
+$ RUBY_BOX=1 ruby script.rb
+```
+
+有効な状態で起動すると次の警告が出力されます。
+`-W:no-experimental` オプションで抑止できます。
+将来のバージョンで挙動が変更される可能性があります。
+
+```
+ruby: warning: Ruby::Box is experimental, and the behavior may change in the future!
+```
+
+ボックスは [m:Ruby::Box.new] で作成し、[m:Ruby::Box#require]（あるいは
+[m:Ruby::Box#require_relative] や [m:Ruby::Box#load]）でファイルをそのボックスに
+読み込みます。読み込んだファイルで定義されたクラス・モジュール・定数は、
+ボックスオブジェクト経由で参照できます。
+
+```ruby
+# foo.rb
+X = 1
+class Something
+  def x = X
+end
+```
+
+```ruby
+# main.rb
+box = Ruby::Box.new
+box.require_relative("foo")
+
+X = 2
+p X                    # => 2
+p box::X               # => 1
+p box::Something.new.x # => 1
+```
+
+ボックスの中では組み込みクラスを開いて再定義できますが、その変更はボックスの外や
+他のボックスには影響しません。グローバル変数やトップレベルの定数・メソッドの変更も
+同様にボックスごとに隔離されます。
+
+## Class methods
+
+### def new -> Ruby::Box
+
+他のボックスから独立した新しいボックスを返します。
+
+Ruby::Box が無効なとき（環境変数 `RUBY_BOX` に `1` を設定せずに起動したとき）は
+[c:RuntimeError] が発生します。
+
+### def enabled? -> bool
+
+Ruby::Box が有効なら true を、無効なら false を返します。
+
+環境変数 `RUBY_BOX` に `1` を設定して ruby を起動したときに true になります。
+
+### def current -> Ruby::Box | nil
+
+現在実行中のコードが属しているボックスを返します。
+
+Ruby::Box が無効なときは nil を返します。
+
+## Instance methods
+
+### def eval(code) -> object
+
+文字列 `code` を Ruby のコードとして self（レシーバのボックス）の中で評価し、
+その結果を返します。
+
+ファイルを [m:Ruby::Box#load] で読み込むのと同様に、`code` は self の中で実行されます。
+
+### def load(path, wrap = false) -> true
+
+`path` のファイルを self（レシーバのボックス）の中に読み込みます。
+
+[m:Kernel?.load] と同様ですが、ファイルは self の中で実行されます。
+
+### def require(feature) -> bool
+
+`feature` を self（レシーバのボックス）の中に読み込みます。
+
+[m:Kernel?.require] と同様ですが、読み込まれたファイルは self の中で実行されます。
+まだ読み込まれていなければ true を、すでに読み込み済みなら false を返します。
+
+### def require_relative(relative_feature) -> bool
+
+`relative_feature` を self（レシーバのボックス）の中に読み込みます。
+
+[m:Kernel?.require_relative] と同様ですが、読み込まれたファイルは self の中で
+実行されます。
+
+### def load_path -> [String]
+
+self（レシーバのボックス）のライブラリ読み込みパスを表す配列を返します。
+
+[m:$LOAD_PATH] のボックスごとの版に相当します。
+
+### def inspect -> String
+
+self を表す文字列を返します。


### PR DESCRIPTION
Ruby 4.0 で導入された `Ruby::Box` クラスと `Method#box` を収録します。#3383 の `Ruby` モジュールに続くものです。

## 内容 — Ruby::Box（`Ruby__Box.md` 新規）

プロセス内でクラス・モジュール・モンキーパッチを分離する実験的機能です。`RUBY_BOX=1` で有効化します。

- 特異メソッド: `new` / `enabled?` / `current`
- インスタンスメソッド: `eval` / `load` / `require` / `require_relative` / `load_path` / `inspect`

## 内容 — Method#box（`Method.md` に追記）

メソッドが定義されている `[c:Ruby::Box]` を返します（Ruby::Box が無効なときは nil）。

## 根拠・確認

- 登場版: 実機で 3.3.12 / 3.4.10 に `Ruby::Box` ・ `Method#box` は無く、4.0.6 で追加されることを確認。`Ruby__Box.md` は `since: "4.0"`、`Method#box` は `#%since 4.0`（`Array#rfind` と同じ方式）で 4.0 に限定しています。
- API: `RUBY_BOX=1` の実機で、公開メソッドと各シグネチャ・返り値を確認しました（`load` は `rb_scan_args "11"` で `load(path, wrap = false)`、`require` / `require_relative` は bool、`eval` は評価結果を返す）。無効時は `new` が `RuntimeError`、`current` / `Method#box` は nil です。
- rdoc: 本体の `doc/language/box.md` ・ `box.c` ・ `proc.c` に準拠しています。
- bitclust: 3.4 / 4.0 の実 DB 生成で、4.0 のみ登録・3.4 では非表示を確認。`check_blank_lines` / `check_indent_in_samplecode` / `check_links:3.4` / `check_links:4.0`（いずれも 0 broken）/ `check_format` すべてパス。

## 補足（今回入れていないもの）

- `master` / `root` / `main`（と `master?` / `root?` / `main?`）は `RUBY_BOX=1` のときだけ定義され、call-seq rdoc も無い試験・確認用のメソッドのため、初版では収録していません。ご指摘があれば追加します。
- 内部実装クラスの `Ruby::Box::Entry` / `Ruby::Box::Loader` は非対応です（本体の doc でも "Make Entry invisible" と TODO 化されている内部データです）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
