### PR TITLE
特異メソッドのエントリを def Klass.name 形式に統一する

### DIFF
--- a/manual/api/_builtin/Array.md
+++ b/manual/api/_builtin/Array.md
@@ -18,7 +18,7 @@ include:
 
 ## Class Methods
 
-### def try_convert(obj) -> Array | nil
+### def Array.try_convert(obj) -> Array | nil
 
 to_ary メソッドを用いて obj を配列に変換しようとします。
 
@@ -36,7 +36,7 @@ elsif tmp = String.try_convert(arg)
 end
 ```
 
-### def [](*item)    -> Array
+### def Array.[](*item)    -> Array
 
 引数 item を要素として持つ配列を生成して返します。
 
@@ -54,7 +54,7 @@ end
 p SubArray[1, 2, 3] # => [1, 2, 3]
 ```
 
-### def new(size = 0, val = nil)    -> Array
+### def Array.new(size = 0, val = nil)    -> Array
 
 長さ size の配列を生成し、各要素を val で初期化して返します。
 
@@ -73,7 +73,7 @@ ary[0].capitalize!
 p ary                     #=> ["Foo", "Foo", "Foo"]  (各要素は同一のオブジェクトである)
 ```
 
-### def new(ary)    -> Array
+### def Array.new(ary)    -> Array
 
 指定された配列 ary を複製して返します。
 [m:Array#dup] 同様 要素を複製しない浅い複製です。
@@ -90,7 +90,7 @@ p a                        #=> ["A", "B", "C"]
 p b                        #=> ["A", "B", "C"]   (b は a と要素を共有する)
 ```
 
-### def new(size) {|index| ... }    -> Array
+### def Array.new(size) {|index| ... }    -> Array
 
 長さ size の配列を生成し、各要素のインデックスを引数としてブロックを実行し、
 各要素の値をブロックの評価結果に設定します。

--- a/manual/api/_builtin/Class.md
+++ b/manual/api/_builtin/Class.md
@@ -28,8 +28,8 @@ library: _builtin
 
 ## Class Methods
 
-### def new(superclass = Object)                -> Class
-### def new(superclass = Object) {|klass| ... } -> Class
+### def Class.new(superclass = Object)                -> Class
+### def Class.new(superclass = Object) {|klass| ... } -> Class
 
 新しく名前の付いていない superclass のサブクラスを生成します。
 

--- a/manual/api/_builtin/Complex.md
+++ b/manual/api/_builtin/Complex.md
@@ -430,8 +430,8 @@ p Complex(-8, 6).to_c  # => (-8+6i)
 
 ## Class Methods
 
-### def rect(r, i = 0)        -> Complex
-### def rectangular(r, i = 0) -> Complex
+### def Complex.rect(r, i = 0)        -> Complex
+### def Complex.rectangular(r, i = 0) -> Complex
 
 実部が r、虚部が i である [c:Complex] クラスのオブジェクトを生成します。
 
@@ -447,7 +447,7 @@ p Complex.rectangular(1, 2) # => (1+2i)
 
 - **SEE** [m:Kernel?.Complex]
 
-### def polar(r, theta = 0) -> Complex
+### def Complex.polar(r, theta = 0) -> Complex
 
 絶対値が r、偏角が theta である [c:Complex] クラスのオブジェクトを生成します。
 

--- a/manual/api/_builtin/Data.md
+++ b/manual/api/_builtin/Data.md
@@ -38,8 +38,8 @@ fred.age = 6 # ~> NoMethodError
 
 ## Class Methods
 
-### def define(*args)       -> Class
-### def define(*args) {|subclass| block } -> Class
+### def Data.define(*args)       -> Class
+### def Data.define(*args) {|subclass| block } -> Class
 
 [c:Data] クラスに新しいサブクラスを作って、それを返します。
 
@@ -126,10 +126,10 @@ p Point.new(x: 1)        # => #<data Point x=1, y=0>
 p Point.new(x: 1, y: 2)  # => #<data Point x=1, y=2>
 ```
 
-### def new(*args) -> Data
-### def new(**kwargs) -> Data
-### def [](*args) -> Data
-### def [](**kwargs) -> Data
+### def Data.new(*args) -> Data
+### def Data.new(**kwargs) -> Data
+### def Data.[](*args) -> Data
+### def Data.[](**kwargs) -> Data
 
 (このメソッドは Data のサブクラスにのみ定義されています)
 値オブジェクトを生成して返します。
@@ -205,7 +205,7 @@ p Point.new(x: 1, y: 2)                # => #<data Point x=1, y=2>
 p Point.new(x: 1, y: 2, multiplier: 10)  # => #<data Point x=10, y=20>
 ```
 
-### def members -> [Symbol]
+### def Data.members -> [Symbol]
 
 値オブジェクトのメンバの名前([c:Symbol])の配列を返します。
 

--- a/manual/api/_builtin/Dir.md
+++ b/manual/api/_builtin/Dir.md
@@ -9,9 +9,9 @@ include:
 
 ## Class Methods
 
-### def [](*pattern, base: nil, sort: true)                            -> [String]
-### def glob(pattern, flags = 0, base: nil, sort: true)                -> [String]
-### def glob(pattern, flags = 0, base: nil, sort: true) {|file| ...}   -> nil
+### def Dir.[](*pattern, base: nil, sort: true)                            -> [String]
+### def Dir.glob(pattern, flags = 0, base: nil, sort: true)                -> [String]
+### def Dir.glob(pattern, flags = 0, base: nil, sort: true) {|file| ...}   -> nil
 
 ワイルドカードの展開を行い、
 パターンにマッチするファイル名を文字列の配列として返します。
@@ -105,10 +105,10 @@ p Dir.glob("*", File::FNM_DOTMATCH)  #=> [".", "..", "bar", "foo"]
                                       #    "song/karaoke.rb"]
   ```
 
-### def chdir           -> 0
-### def chdir(path)     -> 0
-### def chdir {|path| ... }          -> object
-### def chdir(path) {|path| ... }    -> object
+### def Dir.chdir           -> 0
+### def Dir.chdir(path)     -> 0
+### def Dir.chdir {|path| ... }          -> object
+### def Dir.chdir(path) {|path| ... }    -> object
 
 カレントディレクトリを path に変更します。
 
@@ -140,8 +140,8 @@ p Dir.chdir("~/.ssh")        # => Errno::ENOENT
 #%end
 
 #%since 3.3
-### def fchdir(fd)    -> 0
-### def fchdir(fd) { ... }    -> object
+### def Dir.fchdir(fd)    -> 0
+### def Dir.fchdir(fd) { ... }    -> object
 
 カレントディレクトリを、整数のファイルディスクリプタ fd が指す
 ディレクトリに変更します。
@@ -172,7 +172,7 @@ p Dir.pwd            # => "/usr"
 - **SEE** [m:Dir.chdir], [m:Dir#fileno], [m:Dir.for_fd]
 #%end
 
-### def chroot(path)    -> 0
+### def Dir.chroot(path)    -> 0
 
 ルートディレクトリを path に変更します。
 
@@ -192,9 +192,9 @@ p Dir.glob("/*")  #=> ["/file1", "/file2]
 
 - **SEE** <http://opengroup.org/onlinepubs/007908799/xsh/chroot.html>
 
-### def delete(path)    -> 0
-### def rmdir(path)     -> 0
-### def unlink(path)    -> 0
+### def Dir.delete(path)    -> 0
+### def Dir.rmdir(path)     -> 0
+### def Dir.unlink(path)    -> 0
 
 ディレクトリを削除します。ディレクトリは空でなければいけませ
 ん。ディレクトリの削除に成功すれば 0 を返します。
@@ -207,8 +207,8 @@ p Dir.glob("/*")  #=> ["/file1", "/file2]
 Dir.delete("/tmp/hoge-jbrYBh.tmp")
 ```
 
-### def entries(path)                                        -> [String]
-### def entries(path, encoding: Encoding.find("filesystem")) -> [String]
+### def Dir.entries(path)                                        -> [String]
+### def Dir.entries(path, encoding: Encoding.find("filesystem")) -> [String]
 
 ディレクトリ path に含まれるファイルエントリ名の
 配列を返します。
@@ -228,8 +228,8 @@ p Dir.entries('.') #=> [".", "..", "bar", "foo"]
 - **SEE** [m:Dir.foreach]
 - **SEE** [m:Dir.children]
 
-### def children(path)                -> [String]
-### def children(path, encoding: enc) -> [String]
+### def Dir.children(path)                -> [String]
+### def Dir.children(path, encoding: enc) -> [String]
 
 ディレクトリ path に含まれるファイルエントリ名のうち、
 "." と ".." をのぞいた配列を返します。
@@ -250,10 +250,10 @@ p Dir.children('.') #=> ["bar", "foo"]
 - **SEE** [m:Dir.each_child]
 - **SEE** [m:Dir.entries]
 
-### def foreach(path) {|file| ...}                                        -> nil
-### def foreach(path, encoding: Encoding.find("filesystem")) {|file| ...} -> nil
-### def foreach(path)                                                     -> Enumerator
-### def foreach(path, encoding: Encoding.find("filesystem"))              -> Enumerator
+### def Dir.foreach(path) {|file| ...}                                        -> nil
+### def Dir.foreach(path, encoding: Encoding.find("filesystem")) {|file| ...} -> nil
+### def Dir.foreach(path)                                                     -> Enumerator
+### def Dir.foreach(path, encoding: Encoding.find("filesystem"))              -> Enumerator
 
 ディレクトリ path の各エントリを表す文字列を引数として、ブロックを評価します。
 
@@ -281,10 +281,10 @@ Dir.foreach('.'){|f|
 - **SEE** [m:Dir.entries]
 - **SEE** [m:Dir.each_child]
 
-### def each_child(path) {|file| ...}                -> nil
-### def each_child(path, encoding: enc) {|file| ...} -> nil
-### def each_child(path)                             -> Enumerator
-### def each_child(path, encoding: enc)              -> Enumerator
+### def Dir.each_child(path) {|file| ...}                -> nil
+### def Dir.each_child(path, encoding: enc) {|file| ...} -> nil
+### def Dir.each_child(path)                             -> Enumerator
+### def Dir.each_child(path, encoding: enc)              -> Enumerator
 
 ディレクトリ path の "." と ".." をのぞく各エントリを表す文字列を引数として、
 ブロックを評価します。
@@ -312,8 +312,8 @@ Dir.each_child('.'){|f|
 - **SEE** [m:Dir.children]
 - **SEE** [m:Dir#each_child]
 
-### def getwd    -> String
-### def pwd      -> String
+### def Dir.getwd    -> String
+### def Dir.pwd      -> String
 
 カレントディレクトリのフルパスを文字列で返します。
 
@@ -324,7 +324,7 @@ p Dir.chdir("/tmp") #=> 0
 p Dir.getwd         #=> "/tmp"
 ```
 
-### def mkdir(path, mode = 0777)    -> 0
+### def Dir.mkdir(path, mode = 0777)    -> 0
 
 path で指定された新しいディレクトリを作ります。パーミッションは
 mode で指定された値に umask をかけた値 (mode & ~umask) になります。
@@ -345,12 +345,12 @@ p "%#o" % (07777 & File.stat('t').mode)  #=> "0664"
 
 - **SEE** [m:FileUtils?.makedirs]
 
-### def new(path)                                                      -> Dir
-### def new(path, encoding: Encoding.find("filesystem"))               -> Dir
-### def open(path)                                                     -> Dir
-### def open(path, encoding: Encoding.find("filesystem"))              -> Dir
-### def open(path) {|dir| ...}                                         -> object
-### def open(path, encoding: Encoding.find("filesystem")) {|dir| ...}  -> object
+### def Dir.new(path)                                                      -> Dir
+### def Dir.new(path, encoding: Encoding.find("filesystem"))               -> Dir
+### def Dir.open(path)                                                     -> Dir
+### def Dir.open(path, encoding: Encoding.find("filesystem"))              -> Dir
+### def Dir.open(path) {|dir| ...}                                         -> object
+### def Dir.open(path, encoding: Encoding.find("filesystem")) {|dir| ...}  -> object
 
 path に対するディレクトリストリームをオープンして返します。
 
@@ -400,7 +400,7 @@ end
 ```
 
 #%since 3.3
-### def for_fd(fd)    -> Dir
+### def Dir.for_fd(fd)    -> Dir
 
 整数のディレクトリファイルディスクリプタ fd が指すディレクトリを表す、
 新しい [c:Dir] オブジェクトを返します。
@@ -431,7 +431,7 @@ end
 - **SEE** [m:Dir#fileno], [m:Dir#path], [m:Dir.fchdir]
 #%end
 
-### def exist?(file_name)    -> bool
+### def Dir.exist?(file_name)    -> bool
 
 file_name で与えられたディレクトリが存在する場合に真を返します。
 そうでない場合は、偽を返します。
@@ -446,13 +446,13 @@ p File.directory?(".") # => true
 - **SEE** [m:File.directory?]
 
 #%until 3.2
-### def exists?(file_name)    -> bool
+### def Dir.exists?(file_name)    -> bool
 {: since="1.9.1"}
 
 このメソッドは Ruby 2.1 から deprecated です。[m:Dir.exist?] を使用してください。
 #%end
-### def home          -> String | nil
-### def home(user)    -> String | nil
+### def Dir.home          -> String | nil
+### def Dir.home(user)    -> String | nil
 
 現在のユーザまたは指定されたユーザのホームディレクトリを返します。
 
@@ -467,7 +467,7 @@ p Dir.home("root")  # => "/root"
 
 - **SEE** [m:File.expand_path]
 
-### def empty?(path_name)    -> bool
+### def Dir.empty?(path_name)    -> bool
 
 path_name で与えられたディレクトリが空の場合に真を返します。
 ディレクトリでない場合や空でない場合に偽を返します。

--- a/manual/api/_builtin/ENV.md
+++ b/manual/api/_builtin/ENV.md
@@ -22,7 +22,7 @@ p ENV['OS'] # => Windows_NT
 p ENV['os'] # => Windows_NT
 ```
 
-### def [](key) -> String
+### def ENV.[](key) -> String
 
 key に対応する環境変数の値を返します。該当する環境変数が存在
 しない時には nil を返します。
@@ -36,8 +36,8 @@ p ENV['PATH']         # => "/usr/local/bin:/usr/bin:/bin:/usr/X11/bin"
 p ENV['NON_EXIST_KEY']  # => nil
 ```
 
-### def []=(key, value)
-### def store(key, value) -> String
+### def ENV.[]=(key, value)
+### def ENV.store(key, value) -> String
 
 key に対応する環境変数の値を value にします。
 value が nil の時、key に対応する環境変数を取り除きます。
@@ -58,7 +58,7 @@ p ENV.store('NEW_KEY', nil) # => nil
 p ENV.has_key?('NEW_KEY') # => false
 ```
 
-### def clear  -> self
+### def ENV.clear  -> self
 
 環境変数をすべてクリアします。self を返します。
 
@@ -67,8 +67,8 @@ ENV.clear
 p ENV # => {}
 ```
 
-### def delete(key) -> String | nil
-### def delete(key) {|key| ... } -> String | nil
+### def ENV.delete(key) -> String | nil
+### def ENV.delete(key) {|key| ... } -> String | nil
 
 key に対応する環境変数を取り除きます。取り除かれた環境変数の
 値を返しますが、key に対応する環境変数が存在しない時には
@@ -87,8 +87,8 @@ p ENV.delete('TEST')  # => "foo"
 ENV.delete('TEST') { |key| puts "#{key} is not found in ENV" } # TEST is not found in ENV
 ```
 
-### def reject                     -> Enumerator
-### def reject {|key, value| ... } -> Hash
+### def ENV.reject                     -> Enumerator
+### def ENV.reject {|key, value| ... } -> Hash
 
 環境変数のうち、ブロックを評価した値が真であるものをとり除きます。
 [m:Enumerable#reject] と異なり Hash を返します。また、とり除いた結果
@@ -101,10 +101,10 @@ p result['TEST'] # => nil
 p ENV['TEST'] # => "foo"
 ```
 
-### def delete_if {|key, value| ... } -> ENV
-### def reject! {|key, value| ... }   -> ENV | nil
-### def delete_if  -> Enumerator
-### def reject!    -> Enumerator
+### def ENV.delete_if {|key, value| ... } -> ENV
+### def ENV.reject! {|key, value| ... }   -> ENV | nil
+### def ENV.delete_if  -> Enumerator
+### def ENV.reject!    -> Enumerator
 
 key と value を引数としてブロックを評価した値が真であ
 る時、環境変数を削除します。
@@ -117,10 +117,10 @@ p ENV.delete_if { |key, value| key == 'FOO' && value == 'bar' } # => ENV
 p ENV.reject! { |key, value| key == 'FOO' && value == 'bar' } # => nil
 ```
 
-### def each                          -> Enumerator
-### def each_pair                     -> Enumerator
-### def each {|key, value| ... }      -> self
-### def each_pair {|key, value| ... } -> self
+### def ENV.each                          -> Enumerator
+### def ENV.each_pair                     -> Enumerator
+### def ENV.each {|key, value| ... }      -> self
+### def ENV.each_pair {|key, value| ... } -> self
 
 key と value を引数としてブロックを評価します。
 
@@ -132,8 +132,8 @@ end
 # => ENV
 ```
 
-### def each_key              -> Enumerator
-### def each_key {|key| ... } -> self
+### def ENV.each_key              -> Enumerator
+### def ENV.each_key {|key| ... } -> self
 
 key を引数としてブロックを評価します。
 
@@ -145,18 +145,18 @@ end
 # "key FOO detected"
 ```
 
-### def each_value                -> Enumerator
-### def each_value {|value| ... } -> self
+### def ENV.each_value                -> Enumerator
+### def ENV.each_value {|value| ... } -> self
 
 value を引数としてブロックを評価します。
 
-### def empty? -> bool
+### def ENV.empty? -> bool
 
 環境変数がひとつも定義されていない時真を返します。
 
-### def fetch(key) -> String
-### def fetch(key, default) -> String
-### def fetch(key) {|key| ... } -> String
+### def ENV.fetch(key) -> String
+### def ENV.fetch(key, default) -> String
+### def ENV.fetch(key) {|key| ... } -> String
 
 key に関連づけられた値を返します。該当するキーが登録されてい
 ない時には、引数 default が与えられていればその値を、ブロッ
@@ -169,10 +169,10 @@ key に関連づけられた値を返します。該当するキーが登録さ�
 - **param** `default` --   keyに対応する環境変数の値がないときにこの値を返します。 
 - **raise**  `KeyError` --   引数defaultもブロックも与えられてない時、キーの探索に失敗すると発生します。
 
-### def has_key?(key) -> bool
-### def include?(key) -> bool
-### def key?(key)     -> bool
-### def member?(key)  -> bool
+### def ENV.has_key?(key) -> bool
+### def ENV.include?(key) -> bool
+### def ENV.key?(key)     -> bool
+### def ENV.member?(key)  -> bool
 
 key で指定される環境変数が存在する時、真を返します。
 
@@ -180,8 +180,8 @@ key で指定される環境変数が存在する時、真を返します。
            文字列以外のオブジェクトを指定した場合は to_str メソッ
            ドによる暗黙の型変換を試みます。
 
-### def has_value?(val) -> bool
-### def value?(val)     -> bool
+### def ENV.has_value?(val) -> bool
+### def ENV.value?(val)     -> bool
 
 val を値として持つ環境変数が存在する時、真を返します。
 
@@ -189,7 +189,7 @@ val を値として持つ環境変数が存在する時、真を返します。
            列以外のオブジェクトを指定した場合は to_str メソッドによる暗
            黙の型変換を試みます。
 
-### def key(val)   -> String | nil
+### def ENV.key(val)   -> String | nil
 
 val に対応するキーを返します。対応する要素が存在しない時には
 nil を返します。
@@ -198,56 +198,56 @@ nil を返します。
            列以外のオブジェクトを指定した場合は to_str メソッドによる暗
            黙の型変換を試みます。
 
-### def inspect -> String
+### def ENV.inspect -> String
 
 ENV オブジェクトを文字列化します。 [m:Hash#inspect] と同じように動作します。
 
-### def invert -> Hash
+### def ENV.invert -> Hash
 
 環境変数の値をキー、名前を値とした [c:Hash] を生成して返します。
 
-### def keys -> [String]
+### def ENV.keys -> [String]
 
 全環境変数の名前の配列を返します。
 
-### def length -> Integer
-### def size   -> Integer
+### def ENV.length -> Integer
+### def ENV.size   -> Integer
 
 環境変数の数を返します。
 
-### def rehash -> nil
+### def ENV.rehash -> nil
 
 何もしません。nilを返します。
 
-### def replace(hash) -> ENV
+### def ENV.replace(hash) -> ENV
 
 環境変数を hash と同じ内容に変更します。 self を返します。
 
 - **param** `hash` --  キーと値の対応関係を指定します。 to_hash でハッシュに変換されます。
 
-### def select                      -> Enumerator
-### def select {|key, value| ... }  -> Hash
-### def filter                      -> Enumerator
-### def filter {|key, value| ... }  -> Hash
+### def ENV.select                      -> Enumerator
+### def ENV.select {|key, value| ... }  -> Hash
+### def ENV.filter                      -> Enumerator
+### def ENV.filter {|key, value| ... }  -> Hash
 
 環境変数名と値についてブロックを評価し、真を返したものを集めたハッシュ
 を返します。
 
-### def shift -> [String, String] | nil
+### def ENV.shift -> [String, String] | nil
 
 環境変数を一つ取り除いて、それを名前と値の組の配列で返します。
 環境変数が一つも設定されていなければ nil を返します。
 
-### def to_a -> [[String, String]]
+### def ENV.to_a -> [[String, String]]
 
 環境変数から [変数名, 値] となる 2 要素の配列の配列を生成します。
 
-### def to_hash -> Hash
+### def ENV.to_hash -> Hash
 
 環境変数の名前をキーとし、対応する値をもつハッシュを返します。
 
-### def to_h -> Hash
-### def to_h {|name, value| block } -> Hash
+### def ENV.to_h -> Hash
+### def ENV.to_h {|name, value| block } -> Hash
 
 環境変数の名前をキーとし、対応する値をもつハッシュを返します。
 
@@ -258,15 +258,15 @@ ENV オブジェクトを文字列化します。 [m:Hash#inspect] と同じよ�
 ENV.to_h {|name, value| [name, value.size] }
 ```
 
-### def to_s -> String
+### def ENV.to_s -> String
 
 環境変数を文字列化します。 Hash#to_s と同じように動作します。
 
 #%since 3.2
-### def merge!(*others) -> ENV
-### def merge!(*others) {|key, self_val, other_val| ... } -> ENV
-### def update(*others) -> ENV
-### def update(*others) {|key, self_val, other_val| ... } -> ENV
+### def ENV.merge!(*others) -> ENV
+### def ENV.merge!(*others) {|key, self_val, other_val| ... } -> ENV
+### def ENV.update(*others) -> ENV
+### def ENV.update(*others) {|key, self_val, other_val| ... } -> ENV
 
 ハッシュ others の内容を環境変数にマージします。重複するキー
 に対応する値は others の内容で上書きされます。
@@ -278,10 +278,10 @@ self と others に同じキーがあった場合はブロック付きか否か�
 
 - **param** `others` -- マージ用のハッシュです。
 #%else
-### def update(other) -> ENV
-### def update(other) {|key, self_val, other_val| ... } -> ENV
-### def merge!(other) -> ENV
-### def merge!(other) {|key, self_val, other_val| ... } -> ENV
+### def ENV.update(other) -> ENV
+### def ENV.update(other) {|key, self_val, other_val| ... } -> ENV
+### def ENV.merge!(other) -> ENV
+### def ENV.merge!(other) {|key, self_val, other_val| ... } -> ENV
 
 ハッシュ other の内容を環境変数にマージします。重複するキー
 に対応する値は other の内容で上書きされます。
@@ -293,11 +293,11 @@ self と other に同じキーがあった場合はブロック付きか否か�
 
 - **param** `other` --  上書きするハッシュを指定します。
 #%end
-### def values -> [String]
+### def ENV.values -> [String]
 
 環境変数の全値の配列を返します。
 
-### def values_at(*key) -> [String]
+### def ENV.values_at(*key) -> [String]
 
 引数で指定されたキー(環境変数名)に対応する値の配列を返します。存在
 しないキーに対しては nil が対応します。
@@ -310,7 +310,7 @@ p ENV.values_at(*%w(FOO BAR BAZ))   # => ["foo", "bar", nil]
 - **param** `key` -- 環境変数名を指定します。文字列で指定します。
            文字列以外のオブジェクトを指定した場合は to_str メソッドによる暗黙の型変換を試みます。
            
-### def assoc(key) -> Array | nil
+### def ENV.assoc(key) -> Array | nil
 
 自身が与えられたキーに対応する要素を持つとき、見つかった要素のキーと値のペアを
 配列として返します。
@@ -319,7 +319,7 @@ p ENV.values_at(*%w(FOO BAR BAZ))   # => ["foo", "bar", nil]
 
 - **SEE** [m:Hash#assoc]
 
-### def rassoc(value) -> Array | nil
+### def ENV.rassoc(value) -> Array | nil
 
 自身が与えられた値に対応する要素を持つとき、見つかった要素のキーと値のペアを
 配列として返します。
@@ -328,12 +328,12 @@ p ENV.values_at(*%w(FOO BAR BAZ))   # => ["foo", "bar", nil]
 
 - **SEE** [m:Hash#rassoc]
 
-### def keep_if {|key, value| ... } -> ENV
-### def select! {|key, value| ... } -> ENV | nil
-### def filter! {|key, value| ... } -> ENV | nil
-### def keep_if -> Enumerator
-### def select! -> Enumerator
-### def filter! -> Enumerator
+### def ENV.keep_if {|key, value| ... } -> ENV
+### def ENV.select! {|key, value| ... } -> ENV | nil
+### def ENV.filter! {|key, value| ... } -> ENV | nil
+### def ENV.keep_if -> Enumerator
+### def ENV.select! -> Enumerator
+### def ENV.filter! -> Enumerator
 
 キーと値を引数としてブロックを評価した結果が真であ
 るような要素を環境変数に残します。
@@ -346,7 +346,7 @@ select! と filter! はオブジェクトが変更された場合に self を、
 
 - **SEE** [m:ENV.delete_if],[m:ENV.reject!], [m:Hash#keep_if], [m:Hash#select!],
 
-### def slice(*keys) -> Hash
+### def ENV.slice(*keys) -> Hash
 
 引数で指定されたキーとその値だけを含む Hash を返します。
 
@@ -362,14 +362,14 @@ p ENV.slice("foo", "baz") # => {"foo"=>"bar", "baz"=>"qux"}
 
 - **SEE** [m:Hash#slice], [m:ENV.except]
 
-### def freeze -> ()
+### def ENV.freeze -> ()
 {: since="2.7.0"}
 
 ENV.freeze は環境変数の変更を禁止できないため、[c:TypeError]を発生させます。
 
 Ruby 2.7 で追加された挙動です。それより前のバージョンでは例外を発生させませんでした。
 
-### def except(*keys) -> Hash
+### def ENV.except(*keys) -> Hash
 
 引数で指定された以外のキーとその値だけを含む Hash を返します。
 
@@ -381,10 +381,10 @@ p ENV.except("TERM","HOME") #=> {"LANG"=>"en_US.UTF-8"}
 - **SEE** [m:Hash#except], [m:ENV.slice]
 
 #%since 3.2
-### def clone(freeze: true) -> ()
+### def ENV.clone(freeze: true) -> ()
 {: since=""}
 #%else
-### def clone(freeze: true) -> object
+### def ENV.clone(freeze: true) -> object
 {: since=""}
 #%end
 
@@ -406,7 +406,7 @@ ENV.replace(saved_env)
 #%since 3.1
 - **SEE** [m:ENV.dup]
 
-### def dup -> ()
+### def ENV.dup -> ()
 
 [c:TypeError]を発生させます。
 

--- a/manual/api/_builtin/Encoding.md
+++ b/manual/api/_builtin/Encoding.md
@@ -12,7 +12,7 @@ since: "1.9.1"
 
 ## Class Methods
 
-### def aliases    -> Hash
+### def Encoding.aliases    -> Hash
 
 エンコーディングの別名に対して元の名前を対応づけるハッシュを返します。
 
@@ -22,7 +22,7 @@ p Encoding.aliases
 #   "SJIS"=>"Windows-31J", "eucJP"=>"EUC-JP", "CP932"=>"Windows-31J"}
 ```
 
-### def compatible?(obj1, obj2) -> Encoding | nil
+### def Encoding.compatible?(obj1, obj2) -> Encoding | nil
 
 2つのオブジェクトのエンコーディングに関する互換性をチェックします。
 互換性がある場合はそのエンコーディングを、
@@ -55,7 +55,7 @@ p Encoding.compatible?(Encoding::UTF_8, Encoding::US_ASCII)
 - **param** `obj1` -- チェック対象のオブジェクト
 - **param** `obj2` -- チェック対象のオブジェクト
 
-### def find(name) -> Encoding
+### def Encoding.find(name) -> Encoding
 
 指定された name という名前を持つ Encoding オブジェクトを返します。
 
@@ -69,7 +69,7 @@ p Encoding.compatible?(Encoding::UTF_8, Encoding::US_ASCII)
 p Encoding.find("utf-8")       #=> #<Encoding:UTF-8>
 ```
 
-### def list -> [Encoding]
+### def Encoding.list -> [Encoding]
 
 現在ロードされているエンコーディングのリストを返します。
 
@@ -88,7 +88,7 @@ p Encoding.list
 #     #<Encoding:US-ASCII>, #<Encoding:ISO-2022-JP (dummy)>]
 ```
 
-### def name_list    -> [String]
+### def Encoding.name_list    -> [String]
 
 利用可能なエンコーディングの名前を文字列の配列で返します。
 
@@ -100,7 +100,7 @@ p Encoding.name_list
 #    "BINARY", "CP932", "eucJP", ...]
 ```
 
-### def default_external -> Encoding
+### def Encoding.default_external -> Encoding
 
 既定の外部エンコーディングを返します。
 
@@ -115,7 +115,7 @@ default_external は必ず設定されます。[m:Encoding.locale_charmap] が n
 
 - **SEE** [d:spec/rubycmd] [man:locale(1)], [m:Encoding.locale_charmap] [m:Encoding.default_internal]
 
-### def default_external=(encoding)
+### def Encoding.default_external=(encoding)
 
 既定の外部エンコーディングを設定します。
 
@@ -125,7 +125,7 @@ default_external を変更する前に作成した文字列と、default_externa
 
 - **SEE** [d:spec/rubycmd] [m:Encoding.default_external]
 
-### def default_internal -> Encoding | nil
+### def Encoding.default_internal -> Encoding | nil
 
 既定の内部エンコーディングを返します。デフォルトでは nil です。
 
@@ -139,7 +139,7 @@ default_internal は、ソースファイルの [m:IO#internal_encoding] また�
 
 - **SEE** [d:spec/rubycmd] [m:Encoding.default_external]
 
-### def default_internal=(encoding)
+### def Encoding.default_internal=(encoding)
 
 既定の内部エンコーディングを設定します。
 
@@ -149,7 +149,7 @@ default_internal を変更する前に作成した文字列と、default_interna
 
 - **SEE** [d:spec/rubycmd] [m:Encoding.default_internal]
 
-### def locale_charmap -> String | nil
+### def Encoding.locale_charmap -> String | nil
 
 ロケールエンコーディングを決定するために用いる、locale charmap 名を返します。nl_langinfo 等がない環境では nil を、miniruby では ASCII_8BIT を返します。
 

--- a/manual/api/_builtin/Encoding__Converter.md
+++ b/manual/api/_builtin/Encoding__Converter.md
@@ -11,9 +11,9 @@ Encoding::Converter を用いて変換を行う場合は、[m:Encoding::Converte
 などがあります。
 
 ## Class Methods
-### def new(source_encoding, destination_encoding) -> Encoding::Converter
-### def new(source_encoding, destination_encoding, options) -> Encoding::Converter
-### def new(convpath) -> Encoding::Converter
+### def Encoding::Converter.new(source_encoding, destination_encoding) -> Encoding::Converter
+### def Encoding::Converter.new(source_encoding, destination_encoding, options) -> Encoding::Converter
+### def Encoding::Converter.new(convpath) -> Encoding::Converter
 
 Encoding::Converter オブジェクトを作成します。
 
@@ -56,8 +56,8 @@ p ec.convpath #=> ["universal_newline",
               #    [#<Encoding:UTF-8>, #<Encoding:UTF-16BE>]]
 ```
 
-### def asciicompat_encoding(string) -> Encoding | nil
-### def asciicompat_encoding(encoding) -> Encoding | nil
+### def Encoding::Converter.asciicompat_encoding(string) -> Encoding | nil
+### def Encoding::Converter.asciicompat_encoding(encoding) -> Encoding | nil
 
 同じ文字集合を持つ ASCII 互換エンコーディングを返します。
 
@@ -74,7 +74,7 @@ p Encoding::Converter.asciicompat_encoding("UTF-16BE") #=> #<Encoding:UTF-8>
 p Encoding::Converter.asciicompat_encoding("UTF-8") #=> nil
 ```
 
-### def search_convpath(source_encoding, destination_encoding, options) -> Array
+### def Encoding::Converter.search_convpath(source_encoding, destination_encoding, options) -> Array
 
 引数で指定した文字エンコーディングの変換の経路を配列にして返します。
 

--- a/manual/api/_builtin/Enumerator.md
+++ b/manual/api/_builtin/Enumerator.md
@@ -43,7 +43,7 @@ p a.next
 
 ## Class Methods
 
-### def new(size=nil){|y| ... }         -> Enumerator
+### def Enumerator.new(size=nil){|y| ... }         -> Enumerator
 
 Enumerator オブジェクトを生成して返します。与えられたブロックは [c:Enumerator::Yielder] オブジェクトを
 引数として実行されます。
@@ -85,9 +85,9 @@ p fib.take(10) #=> [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 ```
 
 #%since 4.0
-### def produce(initial = nil, size: nil) { |prev| ... } -> Enumerator
+### def Enumerator.produce(initial = nil, size: nil) { |prev| ... } -> Enumerator
 #%else
-### def produce(initial = nil) { |prev| ... } -> Enumerator
+### def Enumerator.produce(initial = nil) { |prev| ... } -> Enumerator
 #%end
 
 与えられたブロックを呼び出し続ける、停止しない Enumerator を返します。
@@ -160,8 +160,8 @@ p unknown.size  # => nil
 #%end
 
 #%since 3.2
-### def product(*enums) -> Enumerator::Product
-### def product(*enums) { |elts| ... } -> nil
+### def Enumerator.product(*enums) -> Enumerator::Product
+### def Enumerator.product(*enums) { |elts| ... } -> nil
 
 与えた [c:Enumerable] なオブジェクトの直積(デカルト積)を列挙する Enumerator を作って返します。
 

--- a/manual/api/_builtin/Enumerator__Chain.md
+++ b/manual/api/_builtin/Enumerator__Chain.md
@@ -10,7 +10,7 @@ Enumerator::Chain のオブジェクトは、[m:Enumerable#chain] や [m:Enumera
 
 ## Class Methods
 
-### def new(*enums) -> Enumerator::Chain
+### def Enumerator::Chain.new(*enums) -> Enumerator::Chain
 
 複数の Enumerable から、1つの新しい Enumerator を作って返します。
 

--- a/manual/api/_builtin/Enumerator__Lazy.md
+++ b/manual/api/_builtin/Enumerator__Lazy.md
@@ -49,7 +49,7 @@ open("log.txt"){|f|
 
 ## Class Methods
 
-### def new(obj, size=nil) {|yielder, *values| ... } -> Enumerator::Lazy
+### def Enumerator::Lazy.new(obj, size=nil) {|yielder, *values| ... } -> Enumerator::Lazy
 
 Lazy Enumerator を作成します。[m:Enumerator::Lazy#force] メソッドなどに
 よって列挙が実行されたとき、objのeachメソッドが実行され、値が一つずつ

--- a/manual/api/_builtin/Enumerator__Product.md
+++ b/manual/api/_builtin/Enumerator__Product.md
@@ -24,7 +24,7 @@ end
 
 ## Class Methods
 
-### def new(*enums) -> Enumerator::Product
+### def Enumerator::Product.new(*enums) -> Enumerator::Product
 
 与えた [c:Enumerable] なオブジェクトの直積を列挙する Enumerator を作って返します。
 

--- a/manual/api/_builtin/Exception.md
+++ b/manual/api/_builtin/Exception.md
@@ -7,8 +7,8 @@ library: _builtin
 
 ## Class Methods
 
-### def new(error_message = nil)       -> Exception
-### def exception(error_message = nil) -> Exception
+### def Exception.new(error_message = nil)       -> Exception
+### def Exception.exception(error_message = nil) -> Exception
 
 例外オブジェクトを生成して返します。
 
@@ -27,7 +27,7 @@ p e         # => #<Exception: some message>
 p e.message # => "some message"
 ```
 
-### def to_tty? -> bool
+### def Exception.to_tty? -> bool
 
 $stderr が変更されておらず、$stderr.tty? が真の場合は true を返します。
 

--- a/manual/api/_builtin/Fiber.current.md
+++ b/manual/api/_builtin/Fiber.current.md
@@ -1,4 +1,4 @@
-### def current -> Fiber
+### def Fiber.current -> Fiber
 
 このメソッドが評価されたコンテキストにおける [c:Fiber] のインスタンスを返します。
 

--- a/manual/api/_builtin/Fiber.md
+++ b/manual/api/_builtin/Fiber.md
@@ -149,9 +149,9 @@ Ruby 3.0 から、ファイバーはブロッキングとノンブロッキン�
 #%end
 
 #%since 3.2
-### def new(blocking: false, storage: true) {|obj| ... } -> Fiber
+### def Fiber.new(blocking: false, storage: true) {|obj| ... } -> Fiber
 #%else
-### def new(blocking: false) {|obj| ... } -> Fiber
+### def Fiber.new(blocking: false) {|obj| ... } -> Fiber
 #%else
 #%end
 
@@ -197,7 +197,7 @@ p Fiber.new(storage: {key: 2}) { Fiber[:key] }.resume # => 2
 
 #%end
 
-### def yield(*arg = nil)   -> object
+### def Fiber.yield(*arg = nil)   -> object
 
 現在のファイバーの親にコンテキストを切り替えます。
 
@@ -220,7 +220,7 @@ p a  #=> :foo
 ```
 
 #%since 3.2
-### def [](key) -> object | nil
+### def Fiber.[](key) -> object | nil
 
 現在のファイバーの fiber storage から key に対応する値を返します。
 対応する値がない場合は nil を返します。
@@ -243,7 +243,7 @@ p Fiber[:unknown] # => nil
 
 - **SEE** [m:Fiber.\[\]=], [m:Fiber#storage]
 
-### def []=(key, value)
+### def Fiber.[]=(key, value)
 
 現在のファイバーの fiber storage の key に対応する値を value に設定します。
 key に対応する値がまだない場合は追加します。
@@ -274,7 +274,7 @@ p Fiber[:key]   # => 1
 
 - **SEE** [m:Fiber.\[\]], [m:Fiber#storage]
 
-### def blocking {|fiber| ... } -> object
+### def Fiber.blocking {|fiber| ... } -> object
 
 ブロックを実行している間だけ、現在のファイバーをブロッキングにします。
 
@@ -297,7 +297,7 @@ f.resume
 - **SEE** [m:Fiber.blocking?], [ref:c:Fiber#nonblocking]
 #%end
 
-### def blocking? -> false | 1
+### def Fiber.blocking? -> false | 1
 
 現在の実行コンテキストがブロッキングである場合に 1 を返します。
 ノンブロッキングである場合は false を返します。
@@ -314,7 +314,7 @@ p Fiber.new(blocking: true) { Fiber.blocking? }.resume # => 1
 - **SEE** [m:Fiber#blocking?], [ref:c:Fiber#nonblocking]
 
 #%since 3.1
-### def current_scheduler -> object | nil
+### def Fiber.current_scheduler -> object | nil
 
 現在のスレッドに設定されているスケジューラを返します。
 ただし現在のファイバーがブロッキングである場合は nil を返します。
@@ -325,7 +325,7 @@ p Fiber.new(blocking: true) { Fiber.blocking? }.resume # => 1
 - **SEE** [m:Fiber.scheduler], [m:Fiber.set_scheduler]
 #%end
 
-### def schedule(*args) {|*args| ... } -> Fiber
+### def Fiber.schedule(*args) {|*args| ... } -> Fiber
 
 現在のスレッドに設定されているスケジューラを使って、
 ブロックをノンブロッキングなファイバーで実行します。
@@ -343,7 +343,7 @@ Fiber.schedule { }  # ~> RuntimeError: No scheduler is available!
 
 - **SEE** [m:Fiber.set_scheduler], [ref:c:Fiber#nonblocking]
 
-### def scheduler -> object | nil
+### def Fiber.scheduler -> object | nil
 
 現在のスレッドに設定されているスケジューラを返します。
 設定されていない場合は nil を返します。
@@ -357,7 +357,7 @@ p Fiber.scheduler # => nil
 - **SEE** [m:Fiber.current_scheduler]
 #%end
 
-### def set_scheduler(scheduler) -> object
+### def Fiber.set_scheduler(scheduler) -> object
 
 現在のスレッドにスケジューラを設定します。
 

--- a/manual/api/_builtin/File.md
+++ b/manual/api/_builtin/File.md
@@ -13,7 +13,7 @@ include:
 
 ## Class Methods
 
-### def atime(filename)    -> Time
+### def File.atime(filename)    -> Time
 
 最終アクセス時刻を返します。
 
@@ -25,7 +25,7 @@ include:
 p File.atime(__FILE__) # => 2017-11-28 22:38:44 +0900
 ```
 
-### def ctime(filename)    -> Time
+### def File.ctime(filename)    -> Time
 
 状態が最後に変更された時刻を返します。
 状態の変更とは chmod などによるものです。
@@ -41,7 +41,7 @@ File.chmod(0755, "testfile")
 p File.ctime("testfile") # => 2017-11-30 22:42:12 +0900
 ```
 
-### def mtime(filename)    -> Time
+### def File.mtime(filename)    -> Time
 
 最終更新時刻を返します。
 
@@ -53,7 +53,7 @@ p File.ctime("testfile") # => 2017-11-30 22:42:12 +0900
 p File.mtime(__FILE__) # => 2017-12-03 03:16:22 +0900
 ```
 
-### def birthtime(filename) -> Time
+### def File.birthtime(filename) -> Time
 
 作成された時刻を返します。
 
@@ -67,7 +67,7 @@ p File.mtime(__FILE__) # => 2017-12-03 03:16:22 +0900
 p File.birthtime("testfile") #=> Wed Apr 09 08:53:13 CDT 2003
 ```
 
-### def basename(filename, suffix = "")     -> String
+### def File.basename(filename, suffix = "")     -> String
 
 filename の一番後ろのスラッシュに続く要素を返します。もし、
 引数 suffix が与えられて、かつそれが filename の末尾に
@@ -96,7 +96,7 @@ p File.basename("foo/bar/")      # => "bar"
 
 - **SEE** [m:File.dirname], [m:File.extname]
 
-### def chmod(mode, *filename)    -> Integer
+### def File.chmod(mode, *filename)    -> Integer
 
 ファイルのモードを mode に変更します。モードを変更したファイ
 ルの数を返します。
@@ -107,7 +107,7 @@ p File.basename("foo/bar/")      # => "bar"
 
 - **raise** `Errno::EXXX` -- モードの変更に失敗した場合に発生します。
 
-### def lchmod(mode, *filename)    -> Integer
+### def File.lchmod(mode, *filename)    -> Integer
 
 [m:File.chmod] と同様ですが、シンボリックリンクに関してリンクそのものの
 モードを変更します。
@@ -129,7 +129,7 @@ p File.stat("testlink").mode.to_s(8)    # => "100644"
 p File.lstat("testlink").mode.to_s(8)   # => "120744"
 ```
 
-### def chown(owner, group, *filename)    -> Integer
+### def File.chown(owner, group, *filename)    -> Integer
 
 ファイルのオーナーとグループを変更します。スーパーユーザだけがファ
 イルのオーナーとグループを変更できます。変更を行ったファイルの数を
@@ -151,7 +151,7 @@ p File.stat("test.txt").uid # => 502
 
 - **SEE** [m:File#chown]
 
-### def lchown(owner, group, *filename)    -> Integer
+### def File.lchown(owner, group, *filename)    -> Integer
 
 [m:File#chown] と同様ですが、
 シンボリックリンクに関してリンクそのもののオーナー、
@@ -175,8 +175,8 @@ p File.stat("testlink").uid     # => 501
 p File.lstat("testlink").uid    # => 0
 ```
 
-### def delete(*filename)    -> Integer
-### def unlink(*filename)    -> Integer
+### def File.delete(*filename)    -> Integer
+### def File.unlink(*filename)    -> Integer
 
 ファイルを削除します。削除したファイルの数を返します。
 削除に失敗した場合は例外 [c:Errno::EXXX] が発生します。
@@ -201,9 +201,9 @@ end
 ```
 
 #%since 3.1
-### def dirname(filename, level=1)    -> String
+### def File.dirname(filename, level=1)    -> String
 #%else
-### def dirname(filename)    -> String
+### def File.dirname(filename)    -> String
 #%end
 
 filename の一番後ろのスラッシュより前を文
@@ -243,7 +243,7 @@ p File.dirname("/home/gumby/work/ruby.rb", 4) # => "/"
 
 - **SEE** [m:File.basename], [m:File.extname]
 
-### def expand_path(path, default_dir = '.')    -> String
+### def File.expand_path(path, default_dir = '.')    -> String
 
 path を絶対パスに展開した文字列を返します。
 path が相対パスであれば default_dir を基準にします。
@@ -264,7 +264,7 @@ p File.expand_path("~foo")       #=> "/home/foo"
 
 - **param** `default_dir` -- path が相対パスであれば default_dir を基準に展開されます。
 
-### def absolute_path(file_name, dir_string=nil) -> String
+### def File.absolute_path(file_name, dir_string=nil) -> String
 
 file_name を絶対パスに変換した文字列を返します。
 
@@ -285,7 +285,7 @@ p File.absolute_path("~foo")       #=> "/home/matz/work/bar/~foo"
 
 - **SEE** [m:File.expand_path]
 
-### def absolute_path?(file_name) -> bool
+### def File.absolute_path?(file_name) -> bool
 
 file_name が絶対パスなら true を、そうでなければ false を返します。
 
@@ -307,7 +307,7 @@ p File.absolute_path?("C:\\foo\\bar") # => false
 p File.absolute_path?("/foo/bar\\baz")  # => true
 ```
 
-### def extname(filename)    -> String
+### def File.extname(filename)    -> String
 
 ファイル名 filename の拡張子部分(最後の "." に続く文字列)を
 返します。ディレクトリ名に含まれる "." や、ファイル名先頭の "."
@@ -332,8 +332,8 @@ p File.extname("foo.")            # => "."
 
 - **SEE** [m:File.basename], [m:File.dirname]
 
-### def fnmatch(pattern, path, flags = 0)     -> bool
-### def fnmatch?(pattern, path, flags = 0)    -> bool
+### def File.fnmatch(pattern, path, flags = 0)     -> bool
+### def File.fnmatch?(pattern, path, flags = 0)    -> bool
 
 ファイル名のパターンのマッチ [man:fnmatch(3)] を行います。
 path が pattern にマッチすれば真を返します。そうでない場合には false を返します。
@@ -417,7 +417,7 @@ path が pattern にマッチすれば真を返します。そうでない場合
   p File.fnmatch('{foo,bar{foo,bar}}', 'barfoo', File::FNM_EXTGLOB) # => true
   ```
 
-### def ftype(filename)    -> String
+### def File.ftype(filename)    -> String
 
 ファイルのタイプを表す文字列を返します。
 
@@ -443,7 +443,7 @@ p File.ftype("/dev/tty")          # => "characterSpecial"
 p File.ftype("/tmp/.X11-unix/X0") # => "socket"
 ```
 
-### def join(*item)    -> String
+### def File.join(*item)    -> String
 
 [m:File::SEPARATOR]を間に入れて文字列を連結します。
 
@@ -470,7 +470,7 @@ p File.join([])                           # => ""
 p File.join                               # => ""
 ```
 
-### def link(old, new)    -> 0
+### def File.link(old, new)    -> 0
 
 old を指す new という名前のハードリンクを
 生成します。old はすでに存在している必要があります。
@@ -490,9 +490,9 @@ p File.link("testfile", "testlink") # => 0
 p IO.read("testlink")               # => "test"
 ```
 
-### def new(path, mode = "r", perm = 0666, **opts)                -> File 
-### def open(path, mode = "r", perm = 0666, **opts)               -> File 
-### def open(path, mode = "r", perm = 0666, **opts) {|file| ... } -> object
+### def File.new(path, mode = "r", perm = 0666, **opts)                -> File 
+### def File.open(path, mode = "r", perm = 0666, **opts)               -> File 
+### def File.open(path, mode = "r", perm = 0666, **opts) {|file| ... } -> object
 
 path で指定されるファイルをオープンし、[c:File] オブジェクトを生成して
 返します。
@@ -530,7 +530,7 @@ File.open("testfile", "w", 0755) { |f| f.print "test" }
 p File.read("testfile")  # => "test"
 ```
 
-### def path(filename)    -> String
+### def File.path(filename)    -> String
 
 指定されたファイル名を文字列で返します。filename が文字列でない場合は、to_path メソッドを呼びます。
 
@@ -553,7 +553,7 @@ p File.path(Pathname("/tmp"))   # => "/tmp"
 p File.path(MyPath.new("."))    # => "/Users/user/projects/txt"
 ```
 
-### def readlink(path)    -> String
+### def File.readlink(path)    -> String
 
 シンボリックリンクのリンク先のパスを文字列で返します。
 
@@ -567,7 +567,7 @@ p File.symlink("testfile", "testlink") # => 0
 p File.readlink("testlink")            # => "testfile"
 ```
 
-### def realpath(pathname, basedir = nil) -> String
+### def File.realpath(pathname, basedir = nil) -> String
 
 与えられた pathname に対応する絶対パスを返します。
 
@@ -587,7 +587,7 @@ p File.realpath("testlink")     # => "/home/matz/testfile"
 p File.realpath("..", "/tmp")   # => "/"
 ```
 
-### def realdirpath(pathname, basedir = nil) -> String
+### def File.realdirpath(pathname, basedir = nil) -> String
 
 与えられた pathname に対応する絶対パスを返します。
 
@@ -599,7 +599,7 @@ pathname の最後のコンポーネントは存在していなくても例外�
 
 - **raise** `Errno::ENOENT` -- ファイルが存在しない場合に発生します。
 
-### def rename(from, to)    -> 0
+### def File.rename(from, to)    -> 0
 
 ファイルの名前を変更します。ディレクトリが異なる場合には移動も行い
 ます。[man:rename(2)] を参照してください。移動先のファ
@@ -624,7 +624,7 @@ rescue
 end
 ```
 
-### def split(pathname)    -> [String]
+### def File.split(pathname)    -> [String]
 
 pathname を dirname とbasename に分割して、2 要
 素の配列を返します。
@@ -637,7 +637,7 @@ pathname を dirname とbasename に分割して、2 要
 
 - **param** `pathname` -- パス名を表す文字列を指定します。 
 
-### def stat(filename)    -> File::Stat
+### def File.stat(filename)    -> File::Stat
 
 filename の情報を含む [c:File::Stat] オブジェクトを生成し
 て返します。
@@ -653,7 +653,7 @@ p File.stat("testfile").mtime # => 2017-12-10 01:13:56 +0900
 
 - **SEE** [m:IO#stat], [m:File#lstat]
 
-### def lstat(filename)   -> File::Stat
+### def File.lstat(filename)   -> File::Stat
 
 [m:File.stat]と同様ですが、シンボリックリンクに関してリンクそのものの
 情報を File::Stat として返します。[man:lstat(2)] を実装していないシステムでは、File.stat と同じです。
@@ -670,7 +670,7 @@ p File.stat("link.rb")  == File.stat("t.rb") # => true
 
 - **SEE** [m:IO#stat], [m:File#lstat]
 
-### def symlink(old, new)    -> 0
+### def File.symlink(old, new)    -> 0
 
 old への new という名前のシンボリックリンクを生成します。
 
@@ -687,7 +687,7 @@ old への new という名前のシンボリックリンクを生成します�
 p File.symlink("testfile", "testlink") # => 0
 ```
 
-### def truncate(path, length)    -> 0
+### def File.truncate(path, length)    -> 0
 
 path で指定されたファイルのサイズを最大 length バイト
 にします。
@@ -707,13 +707,13 @@ p File.truncate("testfile", 5) # => 0
 p File.size("testfile")        # => 5
 ```
 
-### def umask           -> Integer
+### def File.umask           -> Integer
 
 現在の umask の値を返します。
 
 - **SEE** [man:umask(2)]
 
-### def umask(umask)    -> Integer
+### def File.umask(umask)    -> Integer
 
 umask を変更します。変更前の umask の値を返します。
 
@@ -726,7 +726,7 @@ p File.umask       # => 6
 
 - **SEE** [man:umask(2)]
 
-### def utime(atime, mtime, *filename)    -> Integer
+### def File.utime(atime, mtime, *filename)    -> Integer
 
 ファイルの最終アクセス時刻と更新時刻を変更します。
 シンボリックリンクに対しては [m:File.lutime]　と違って、
@@ -758,7 +758,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 - **SEE** [m:File.lutime]
 
-### def lutime(atime, mtime, *filename)    -> Integer
+### def File.lutime(atime, mtime, *filename)    -> Integer
 
 ファイルの最終アクセス時刻と更新時刻を変更します。
 シンボリックリンクに対しては [m:File.utime]　と違って、
@@ -776,7 +776,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 - **SEE** [m:File.utime]
 
-### def blockdev?(path)    -> bool
+### def File.blockdev?(path)    -> bool
 
 [m:FileTest?.blockdev?] と同じです。
 
@@ -786,7 +786,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 - **SEE** [m:FileTest?.blockdev?]
 
-### def chardev?(path)    -> bool
+### def File.chardev?(path)    -> bool
 
 [m:FileTest?.chardev?] と同じです。
 
@@ -794,7 +794,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def directory?(path)    -> bool
+### def File.directory?(path)    -> bool
 
 [m:FileTest?.directory?] と同じです。
 
@@ -802,7 +802,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def executable?(path)    -> bool
+### def File.executable?(path)    -> bool
 
 [m:FileTest?.executable?] と同じです。
 
@@ -810,7 +810,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def executable_real?(path)    -> bool
+### def File.executable_real?(path)    -> bool
 
 [m:FileTest?.executable_real?] と同じです。
 
@@ -818,7 +818,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def exist?(path)    -> bool
+### def File.exist?(path)    -> bool
 
 [m:FileTest?.exist?] と同じです。
 
@@ -827,13 +827,13 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 #%#noexample
 
 #%until 3.2
-### def exists?(path)    -> bool
+### def File.exists?(path)    -> bool
 
 このメソッドは Ruby 2.1 から deprecated です。[m:File.exist?] を使用してください。
 
 #%#noexample
 #%end
-### def file?(path)    -> bool
+### def File.file?(path)    -> bool
 
 [m:FileTest?.file?] と同じです。
 
@@ -841,7 +841,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def grpowned?(path)    -> bool
+### def File.grpowned?(path)    -> bool
 
 [m:FileTest?.grpowned?] と同じです。
 
@@ -849,7 +849,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def owned?(path)    -> bool
+### def File.owned?(path)    -> bool
 
 [m:FileTest?.owned?] と同じです。
 
@@ -857,7 +857,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def identical?(filename1, filename2)    -> bool
+### def File.identical?(filename1, filename2)    -> bool
 
 [m:FileTest?.identical?] と同じです。
 
@@ -867,7 +867,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def pipe?(path)    -> bool
+### def File.pipe?(path)    -> bool
 
 [m:FileTest?.pipe?] と同じです。
 
@@ -875,7 +875,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def readable?(path)    -> bool
+### def File.readable?(path)    -> bool
 
 [m:FileTest?.readable?] と同じです。
 
@@ -883,7 +883,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def readable_real?(path)    -> bool
+### def File.readable_real?(path)    -> bool
 
 [m:FileTest?.readable_real?] と同じです。
 
@@ -891,7 +891,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def setgid?(path)    -> bool
+### def File.setgid?(path)    -> bool
 
 [m:FileTest?.setgid?] と同じです。
 
@@ -899,7 +899,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def setuid?(path)    -> bool
+### def File.setuid?(path)    -> bool
 
 [m:FileTest?.setuid?] と同じです。
 
@@ -907,13 +907,13 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def size(path)    -> Integer
+### def File.size(path)    -> Integer
 
 [m:FileTest?.size] と同じです。
 
 - **param** `path` -- パスを表す文字列か IO オブジェクトを指定します。
 
-### def size?(path)    -> Integer | nil
+### def File.size?(path)    -> Integer | nil
 
 [m:FileTest?.size?] と同じです。
 
@@ -921,7 +921,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def socket?(path)    -> bool
+### def File.socket?(path)    -> bool
 
 [m:FileTest?.socket?] と同じです。
 
@@ -929,7 +929,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def sticky?(path)    -> bool
+### def File.sticky?(path)    -> bool
 
 [m:FileTest?.sticky?] と同じです。
 
@@ -937,7 +937,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def symlink?(path)    -> bool
+### def File.symlink?(path)    -> bool
 
 [m:FileTest?.symlink?] と同じです。
 
@@ -945,7 +945,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def writable?(path)    -> bool
+### def File.writable?(path)    -> bool
 
 [m:FileTest?.writable?] と同じです。
 
@@ -953,7 +953,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def writable_real?(path)    -> bool
+### def File.writable_real?(path)    -> bool
 
 [m:FileTest?.writable_real?] と同じです。
 
@@ -961,8 +961,8 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def zero?(path)    -> bool
-### def empty?(path)   -> bool
+### def File.zero?(path)    -> bool
+### def File.empty?(path)   -> bool
 
 [m:FileTest?.zero?] と同じです。
 
@@ -970,7 +970,7 @@ p File.mtime("testfile")              # => 1970-01-01 09:00:02 +0900
 
 #%#noexample
 
-### def world_readable?(path)    -> Integer | nil
+### def File.world_readable?(path)    -> Integer | nil
 
 path が全てのユーザから読めるならばそのファイルのパーミッションを表す
 整数を返します。そうでない場合は nil を返します。
@@ -984,7 +984,7 @@ m = File.world_readable?("/etc/passwd")
 p "%o" % m                             # => "644"
 ```
 
-### def world_writable?(path)    -> bool
+### def File.world_writable?(path)    -> bool
 
 path が全てのユーザから書き込めるならば、そのファイルのパーミッションを表す
 整数を返します。そうでない場合は nil を返します。
@@ -998,7 +998,7 @@ m = File.world_writable?("/tmp")
 p "%o" % m                             #=> "777"
 ```
 
-### def mkfifo(file_name, mode = 0666) -> 0
+### def File.mkfifo(file_name, mode = 0666) -> 0
 
 引数 file_name で指定した名前の FIFO スペシャルファイルを作成します。
 

--- a/manual/api/_builtin/File__Stat.md
+++ b/manual/api/_builtin/File__Stat.md
@@ -40,7 +40,7 @@ ctime       最終状態変更時刻(状態の変更とは chmod などによる
 
 ## Class Methods
 
-### def new(path)    -> File::Stat
+### def File::Stat.new(path)    -> File::Stat
 
 path に関する File::Stat オブジェクトを生成して返します。
 [m:File.stat] と同じです。

--- a/manual/api/_builtin/FrozenError.md
+++ b/manual/api/_builtin/FrozenError.md
@@ -12,8 +12,8 @@ since: "2.5.0"
 
 ## Class Methods
 
-### def new(error_message = "") -> FrozenError
-### def new(error_message = "", receiver:) -> FrozenError
+### def FrozenError.new(error_message = "") -> FrozenError
+### def FrozenError.new(error_message = "", receiver:) -> FrozenError
 
 例外オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/GC.md
+++ b/manual/api/_builtin/GC.md
@@ -586,7 +586,7 @@ p GC::OPTS # => ["USE_RGENGC", "RGENGC_ESTIMATE_OLDMALLOC", "GC_ENABLE_LAZY_SWEE
 # この場合、GCデバッグ機能やプロファイル機能は無効化されている
 ```
 
-### def INTERNAL_CONSTANTS -> {Symbol => Integer}
+### const INTERNAL_CONSTANTS -> {Symbol => Integer}
 
 GC用内部定数の値を保持するハッシュテーブルです。
 

--- a/manual/api/_builtin/GC.md
+++ b/manual/api/_builtin/GC.md
@@ -176,7 +176,7 @@ oldmalloc_increase_bytes と呼ばれる。この2つの性質は以下のよう
 
 ## Singleton Methods
 
-### def auto_compact -> bool
+### def GC.auto_compact -> bool
 
 auto compaction が有効化どうかを返します。
 
@@ -185,7 +185,7 @@ auto compaction が有効化どうかを返します。
 
 - **SEE** [m:GC.auto_compact=]
 
-### def auto_compact=(bool)
+### def GC.auto_compact=(bool)
 
 [m:GC.compact] をフルGCで行うかどうかを制御します。
 
@@ -202,8 +202,8 @@ true を設定するとフルGCのタイミングででヒープをコンパク�
 - **SEE** [m:GC.compact] [m:GC.auto_compact]
 
 #%since 3.4
-### def config -> {Symbol => object}
-### def config(hash) -> {Symbol => object}
+### def GC.config -> {Symbol => object}
+### def GC.config(hash) -> {Symbol => object}
 
 GC の設定を取得、変更します。
 
@@ -240,7 +240,7 @@ p GC.config # => {rgengc_allow_full_mark: false, implementation: "default"}
 
 #%end
 
-### def disable -> bool
+### def GC.disable -> bool
 
 ガーベージコレクトを禁止します。
 
@@ -254,7 +254,7 @@ p GC.disable # => true
 
 - **SEE** [m:GC.enable]
 
-### def enable -> bool
+### def GC.enable -> bool
 
 ガーベージコレクトを許可します。
 
@@ -269,7 +269,7 @@ p GC.enable  # => true
 p GC.enable  # => false
 ```
 
-### def start(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
+### def GC.start(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil
 
 ガーベージコレクトを開始します。
 
@@ -297,7 +297,7 @@ p GC.start  # => nil
 p GC.count  # => 4
 ```
 
-### def stress -> bool
+### def GC.stress -> bool
 
 GCがストレスモードかどうかを返します。
 
@@ -305,7 +305,7 @@ GCがストレスモードかどうかを返します。
 
 - **SEE** [m:GC.stress=]
 
-### def stress=(value)
+### def GC.stress=(value)
 
 GCのストレスモードを引数 value に設定します。
 引数 value が真に設定されている間は、GC を行えるすべての機会に GC を行います。
@@ -330,7 +330,7 @@ GCのストレスモードを引数 value に設定します。
 
 - **SEE** [m:GC.stress]
 
-### def count -> Integer
+### def GC.count -> Integer
 
 プロセス開始からガーベージコレクトを実行した回数を [c:Integer] で返し
 ます。
@@ -339,8 +339,8 @@ GCのストレスモードを引数 value に設定します。
 p GC.count # => 3
 ```
 
-### def stat(result_hash = {}) -> {Symbol => Integer}
-### def stat(key) -> Numeric
+### def GC.stat(result_hash = {}) -> {Symbol => Integer}
+### def GC.stat(key) -> Numeric
 
 GC 内部の統計情報を [c:Hash] で返します。
 
@@ -392,11 +392,11 @@ p GC.stat
 本メソッドは C Ruby 以外では動作しません。
 
 #%since 3.2
-### def stat_heap                     -> {Integer => Hash}
-### def stat_heap(heap_id)            -> {Symbol => Integer}
-### def stat_heap(heap_id, key)       -> Integer
-### def stat_heap(heap_id, result_hash) -> {Symbol => Integer}
-### def stat_heap(nil, result_hash)   -> {Integer => Hash}
+### def GC.stat_heap                     -> {Integer => Hash}
+### def GC.stat_heap(heap_id)            -> {Symbol => Integer}
+### def GC.stat_heap(heap_id, key)       -> Integer
+### def GC.stat_heap(heap_id, result_hash) -> {Symbol => Integer}
+### def GC.stat_heap(nil, result_hash)   -> {Integer => Hash}
 
 サイズプールごとの GC の統計情報を [c:Hash] で返します。
 
@@ -427,8 +427,8 @@ p GC.stat_heap(0, :slot_size) # => 40
 - **SEE** [m:GC.stat]
 #%end
 
-### def latest_gc_info(result_hash = {}) -> Hash
-### def latest_gc_info(key)              -> object
+### def GC.latest_gc_info(result_hash = {}) -> Hash
+### def GC.latest_gc_info(key)              -> object
 
 最新のGCの情報を返します。
 
@@ -451,7 +451,7 @@ p GC.latest_gc_info(:gc_by)  # => :newobj
 ```
 
 #%since 3.1
-### def total_time -> Integer
+### def GC.total_time -> Integer
 
 プロセス開始から GC にかかった時間の合計をナノ秒で返します。
 
@@ -474,8 +474,8 @@ p GC.total_time         # => 937500  計測が無効なので増えない
 
 - **SEE** [m:GC.measure_total_time]
 
-### def measure_total_time -> bool
-### def measure_total_time=(flag)
+### def GC.measure_total_time -> bool
+### def GC.measure_total_time=(flag)
 
 GC にかかった時間を計測するかどうかを取得、設定します。
 既定では計測が有効です。
@@ -500,7 +500,7 @@ p GC.measure_total_time # => false
 - **SEE** [m:GC.total_time]
 #%end
 
-### def compact -> Hash
+### def GC.compact -> Hash
 
 ヒープをコンパクションします。
 
@@ -508,7 +508,7 @@ p GC.measure_total_time # => false
 
 - **SEE** [m:GC.verify_compaction_references]
 
-### def verify_compaction_references(toward: nil, double_heap: nil) -> Hash
+### def GC.verify_compaction_references(toward: nil, double_heap: nil) -> Hash
 
 コンパクションの参照の一貫性を検証します。
 

--- a/manual/api/_builtin/GC__Profiler.md
+++ b/manual/api/_builtin/GC__Profiler.md
@@ -12,7 +12,7 @@ GC の起動回数や起動したタイミング、処理時間などの GC に�
 
 ## Singleton Methods 
 
-### def enabled? -> bool
+### def GC::Profiler.enabled? -> bool
 
 GC のプロファイラを起動中であれば true、停止中であれば false を返します。
 
@@ -26,7 +26,7 @@ p GC::Profiler.enabled? #=> false
 
 - **SEE** [m:GC::Profiler.enable], [m:GC::Profiler.disable]
 
-### def enable -> nil
+### def GC::Profiler.enable -> nil
 
 GC のプロファイラを起動します。
 
@@ -40,7 +40,7 @@ p GC::Profiler.enabled? #=> true
 
 - **SEE** [m:GC::Profiler.disable], [m:GC::Profiler.enabled?]
 
-### def disable -> nil
+### def GC::Profiler.disable -> nil
 
 GC のプロファイラを停止します。
 
@@ -54,7 +54,7 @@ p GC::Profiler.enabled? #=> false
 
 - **SEE** [m:GC::Profiler.enable], [m:GC::Profiler.enabled?]
 
-### def clear -> nil
+### def GC::Profiler.clear -> nil
 
 蓄積している GC のプロファイル情報をすべて削除します。
 
@@ -68,7 +68,7 @@ GC.start
 p GC::Profiler.report #=> 1 回分の GC のプロファイル情報出力する。
 ```
 
-### def result -> String
+### def GC::Profiler.result -> String
 
 GC のプロファイル情報をフォーマットし、文字列として返します。
 
@@ -103,7 +103,7 @@ Index    Invoke Time(sec)       Use Size(byte)     Total Size(byte)         Tota
 
 - **SEE** [m:GC::Profiler.report]
 
-### def report(out = $stdout) -> nil
+### def GC::Profiler.report(out = $stdout) -> nil
 
 [m:GC::Profiler.result] の結果を out に出力します。
 
@@ -121,7 +121,7 @@ GC::Profiler.report
 
 - **SEE** [m:GC::Profiler.result]
 
-### def total_time -> Float
+### def GC::Profiler.total_time -> Float
 
 GC のプロファイル情報から GC の総計時間を計算し、msec 単位で返します。
 
@@ -131,7 +131,7 @@ GC.start
 p GC::Profiler.total_time # => 0.0011530000000000012
 ```
 
-### def raw_data -> [Hash, ...] | nil
+### def GC::Profiler.raw_data -> [Hash, ...] | nil
 
 GC のプロファイル情報を GC の発生ごとに [c:Hash] の配列
 (:GC_INVOKE_TIME が早いもの順)で返します。[c:GC::Profiler] が有効になっ

--- a/manual/api/_builtin/Hash.md
+++ b/manual/api/_builtin/Hash.md
@@ -41,7 +41,7 @@ include:
 
 ## Class Methods
 
-### def try_convert(obj) -> Hash | nil
+### def Hash.try_convert(obj) -> Hash | nil
 
 to_hash メソッドを用いて obj をハッシュに変換しようとします。
 
@@ -53,7 +53,7 @@ p Hash.try_convert({1=>2}) # => {1=>2}
 p Hash.try_convert("1=>2") # => nil
 ```
 
-### def [](other) -> Hash
+### def Hash.[](other) -> Hash
 
 新しいハッシュを生成します。
 引数otherと同一のキーと値を持つ新たなハッシュを生成して返します。
@@ -86,7 +86,7 @@ p h #=> {1=>"valueplus", :add=>"some"}
 p g #=> {1=>"valueplus"}
 ```
 
-### def [](*key_and_value)  -> Hash
+### def Hash.[](*key_and_value)  -> Hash
 
 新しいハッシュを生成します。
 引数は必ず偶数個指定しなければなりません。奇数番目がキー、偶数番目が値になります。
@@ -134,10 +134,10 @@ hash = Hash[alist] # => {1=>["a"], 2=>["b"], 3=>["c"], [4, 5]=>["a", "b"]}
 ```
 
 #%until 3.4
-### def new(ifnone = nil) -> Hash
+### def Hash.new(ifnone = nil) -> Hash
 #%end
 #%since 3.4
-### def new(ifnone = nil, capacity: 0) -> Hash
+### def Hash.new(ifnone = nil, capacity: 0) -> Hash
 #%end
 
 空の新しいハッシュを生成します。ifnone はキーに対
@@ -191,10 +191,10 @@ h[1] << 1     # ~> FrozenError: can't modify frozen Array: []
 ```
 
 #%until 3.4
-### def new {|hash, key| ... } -> Hash
+### def Hash.new {|hash, key| ... } -> Hash
 #%end
 #%since 3.4
-### def new(capacity: 0) {|hash, key| ... } -> Hash
+### def Hash.new(capacity: 0) {|hash, key| ... } -> Hash
 #%end
 空の新しいハッシュを生成します。ブロックの評価結果がデフォルト値になりま
 す。設定したデフォルト値は[m:Hash#default_proc]で参照できます。
@@ -248,7 +248,7 @@ h[1]
 
 - **SEE** [m:Hash#default=],[m:Hash#default],[m:Hash#default_proc]
 
-### def ruby2_keywords_hash(hash) -> Hash
+### def Hash.ruby2_keywords_hash(hash) -> Hash
 {: since="2.7.1"}
 
 hash を複製し、[m:Module#ruby2_keywords]や[m:Proc#ruby2_keywords]による
@@ -288,7 +288,7 @@ foo(*[{k: 1}])                             # ~> ArgumentError
 
 - **SEE** [m:Hash.ruby2_keywords_hash?], [m:Module#ruby2_keywords], [m:Proc#ruby2_keywords]
 
-### def ruby2_keywords_hash?(hash) -> bool
+### def Hash.ruby2_keywords_hash?(hash) -> bool
 {: since="2.7.1"}
 
 [m:Module#ruby2_keywords]や[m:Proc#ruby2_keywords]による

--- a/manual/api/_builtin/IO.md
+++ b/manual/api/_builtin/IO.md
@@ -209,8 +209,8 @@ IO#sysread                    EOFError
 
 ## Class Methods
 
-### def copy_stream(src, dst, copy_length = nil)             -> Integer
-### def copy_stream(src, dst, copy_length, src_offset) -> Integer
+### def IO.copy_stream(src, dst, copy_length = nil)             -> Integer
+### def IO.copy_stream(src, dst, copy_length, src_offset) -> Integer
 
 指定された src から dst へコピーします。
 コピーしたバイト数を返します。
@@ -254,7 +254,7 @@ p IO.copy_stream(src, dst)   # => 11
 p dst.string                 # => "hello world"
 ```
 
-### def try_convert(obj) -> IO | nil
+### def IO.try_convert(obj) -> IO | nil
 
 obj を to_io メソッドによって [c:IO] オブジェクトに変換します。
 変換できなかった場合は nil を返します。
@@ -264,10 +264,10 @@ p IO.try_convert(STDOUT)   # => STDOUT
 p IO.try_convert("STDOUT") # => nil
 ```
 
-### def new(fd, mode = "r", **opts)                -> IO
-### def for_fd(fd, mode = "r", **opts)             -> IO
-### def open(fd, mode = "r", **opts)               -> IO
-### def open(fd, mode = "r", **opts) {|io| ... }   -> object
+### def IO.new(fd, mode = "r", **opts)                -> IO
+### def IO.for_fd(fd, mode = "r", **opts)             -> IO
+### def IO.open(fd, mode = "r", **opts)               -> IO
+### def IO.open(fd, mode = "r", **opts) {|io| ... }   -> object
 
 オープン済みのファイルディスクリプタ fd に対する新しい
 IO オブジェクトを生成して返します。
@@ -332,8 +332,8 @@ io.close
 p IO.open(IO.sysopen("testfile")) { |io| p io.class } # => IO
 ```
 
-### def foreach(path, rs = $/, chomp: false, **opts) {|line| ... }    -> nil
-### def foreach(path, rs = $/, chomp: false, **opts)                  -> Enumerator
+### def IO.foreach(path, rs = $/, chomp: false, **opts) {|line| ... }    -> nil
+### def IO.foreach(path, rs = $/, chomp: false, **opts)                  -> Enumerator
 
 path で指定されたファイルの各行を引数としてブロックを繰り返し実行します。
 path のオープンに成功すれば nil を返します。
@@ -405,14 +405,14 @@ IO.foreach("testfile", encoding: "UTF-8") { |x| p x.encoding }
 
 - **SEE** [m:$/]
 
-### def pipe                    -> [IO]
-### def pipe(ext_enc)           -> [IO]
-### def pipe(enc_str, **opts)           -> [IO]
-### def pipe(ext_enc, int_enc, **opts)  -> [IO]
-### def pipe{|read_io, write_io| ... } -> object
-### def pipe(ext_enc){|read_io, write_io| ... } -> object
-### def pipe(enc_str, **opts){|read_io, write_io| ... }           -> object
-### def pipe(ext_enc, int_enc, **opts){|read_io, write_io| ... }  -> object
+### def IO.pipe                    -> [IO]
+### def IO.pipe(ext_enc)           -> [IO]
+### def IO.pipe(enc_str, **opts)           -> [IO]
+### def IO.pipe(ext_enc, int_enc, **opts)  -> [IO]
+### def IO.pipe{|read_io, write_io| ... } -> object
+### def IO.pipe(ext_enc){|read_io, write_io| ... } -> object
+### def IO.pipe(enc_str, **opts){|read_io, write_io| ... }           -> object
+### def IO.pipe(ext_enc, int_enc, **opts){|read_io, write_io| ... }  -> object
 
 [man:pipe(2)] を実行して、相互につながった2つの
 [c:IO] オブジェクトを要素とする配列を返します。
@@ -447,16 +447,16 @@ end
 p r.gets           # => "foo\n"
 ```
 
-### def popen(env = {}, command, mode = "r", opt={}) -> IO
-### def popen(env = {}, command, mode = "r", opt={}){|f| ... } -> object
-### def popen([env = {}, cmdname, *args, execopt={}], mode = "r", opt={}) -> IO
-### def popen([env = {}, cmdname, *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
-### def popen([env = {}, [cmdname, arg0], *args, execopt={}], mode = "r", opt={}) -> IO
-### def popen([env = {}, [cmdname, arg0], *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
-### def popen(env = {}, [cmdname, *args, execopt={}], mode = "r", opt={}) -> IO
-### def popen(env = {}, [cmdname, *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
-### def popen(env = {}, [[cmdname, arg0], *args, execopt={}], mode = "r", opt={}) -> IO
-### def popen(env = {}, [[cmdname, arg0], *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
+### def IO.popen(env = {}, command, mode = "r", opt={}) -> IO
+### def IO.popen(env = {}, command, mode = "r", opt={}){|f| ... } -> object
+### def IO.popen([env = {}, cmdname, *args, execopt={}], mode = "r", opt={}) -> IO
+### def IO.popen([env = {}, cmdname, *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
+### def IO.popen([env = {}, [cmdname, arg0], *args, execopt={}], mode = "r", opt={}) -> IO
+### def IO.popen([env = {}, [cmdname, arg0], *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
+### def IO.popen(env = {}, [cmdname, *args, execopt={}], mode = "r", opt={}) -> IO
+### def IO.popen(env = {}, [cmdname, *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
+### def IO.popen(env = {}, [[cmdname, arg0], *args, execopt={}], mode = "r", opt={}) -> IO
+### def IO.popen(env = {}, [[cmdname, arg0], *args, execopt={}], mode = "r", opt={}){|f| ... } -> object
 
 サブプロセスを実行し、そのプロセスの標準入出力
 との間にパイプラインを確立します。生成したパイプを [c:IO] オブジェクトとして返します。
@@ -534,10 +534,10 @@ IO.popen(["ls", "/"], :err=>[:child, :out]) {|ls_io|
 
 - **raise** `Errno::EXXX` -- パイプ、あるいは子プロセスの生成に失敗した場合に発生します。
 
-### def popen("-", mode = "r", opt={})                -> IO
-### def popen("-", mode = "r", opt={}) {|io| ... }    -> object
-### def popen(env, "-", mode = "r", opt={})            -> IO
-### def popen(env, "-", mode = "r", opt={}){|io| ... } -> object
+### def IO.popen("-", mode = "r", opt={})                -> IO
+### def IO.popen("-", mode = "r", opt={}) {|io| ... }    -> object
+### def IO.popen(env, "-", mode = "r", opt={})            -> IO
+### def IO.popen(env, "-", mode = "r", opt={}){|io| ... } -> object
 
 第一引数に文字列 "-" が指定された時、[man:fork(2)] を
 行い子プロセスの標準入出力との間にパイプラインを確立します。
@@ -585,9 +585,9 @@ opt ではエンコーディングの設定やプロセス起動のためのオ�
 
 - **raise** `Errno::EXXX` -- パイプ、あるいは子プロセスの生成に失敗した場合に発生します。
 
-### def read(path, **opt)     -> String | nil
-### def read(path, length = nil, **opt)     -> String | nil
-### def read(path, length = nil, offset = 0, **opt)     -> String | nil
+### def IO.read(path, **opt)     -> String | nil
+### def IO.read(path, length = nil, **opt)     -> String | nil
+### def IO.read(path, length = nil, offset = 0, **opt)     -> String | nil
 
 path で指定されたファイルを offset 位置から
 length バイト分読み込んで返します。
@@ -671,7 +671,7 @@ p IO.read(one_byte_file, nil, 10) #=> ""
 p IO.read(one_byte_file, 1, 10) #=> nil
 ```
 
-### def binread(path, length = nil, offset = 0)     -> String | nil
+### def IO.binread(path, length = nil, offset = 0)     -> String | nil
 
 path で指定したファイルを open し、offset の所まで seek し、
 length バイト読み込みます。
@@ -702,9 +702,9 @@ p IO.binread("testfile", 20, 10) # => "ne one\nThis is line "
 
 - **SEE** [m:IO.read]
 
-### def readlines(path, rs = $/, chomp: false, opts={})    -> [String]
-### def readlines(path, limit, chomp: false, opts={})      -> [String]
-### def readlines(path, rs, limit, chomp: false, opts={})  -> [String]
+### def IO.readlines(path, rs = $/, chomp: false, opts={})    -> [String]
+### def IO.readlines(path, limit, chomp: false, opts={})      -> [String]
+### def IO.readlines(path, rs, limit, chomp: false, opts={})  -> [String]
 
 path で指定されたファイルを全て読み込んで、その各行を要素としてもつ配列を返します。
 
@@ -752,7 +752,7 @@ p IO.readlines("testfile", chomp: true)      # => ["line1,\rline2,", "line3,"]
 p IO.readlines("testfile", "\r", chomp: true)  # => ["line1,", "line2,", "\nline3,\n"]
 ```
 
-### def select(reads, writes = [], excepts = [], timeout = nil)    -> [[IO]] | nil
+### def IO.select(reads, writes = [], excepts = [], timeout = nil)    -> [[IO]] | nil
 
 [man:select(2)] を実行します。
 
@@ -795,7 +795,7 @@ mesg = "ping "
 
 - **SEE** [m:Kernel?.select]
 
-### def sysopen(path, mode = "r", perm = 0666)     -> Integer
+### def IO.sysopen(path, mode = "r", perm = 0666)     -> Integer
 
 path で指定されるファイルをオープンし、ファイル記述子を返しま
 す。
@@ -818,8 +818,8 @@ p IO.sysopen("testfile", "w+") # => 3
 
 - **SEE** [m:Kernel?.open]
 
-### def write(path, string, **opts) -> Integer
-### def write(path, string, offset=nil, **opts) -> Integer
+### def IO.write(path, string, **opts) -> Integer
+### def IO.write(path, string, offset=nil, **opts) -> Integer
 
 path で指定されるファイルを開き、string を書き込み、
 閉じます。
@@ -867,7 +867,7 @@ p IO.read("testfile")
 
 - **SEE** [m:IO.binwrite]
 
-### def binwrite(path, string, offset=nil) -> Integer
+### def IO.binwrite(path, string, offset=nil) -> Integer
 
 path で指定されるファイルを開き、string を書き込み、
 閉じます。

--- a/manual/api/_builtin/IO__Buffer.md
+++ b/manual/api/_builtin/IO__Buffer.md
@@ -115,8 +115,8 @@ p IO::Buffer::HOST_ENDIAN == IO::Buffer::LITTLE_ENDIAN # => true
 
 ## Class Methods
 
-### def for(string) -> IO::Buffer
-### def for(string) {|buffer| ... } -> object
+### def IO::Buffer.for(string) -> IO::Buffer
+### def IO::Buffer.for(string) {|buffer| ... } -> object
 
 文字列 string のメモリ領域を参照する、コピーを伴わないバッファを作成します。
 
@@ -157,7 +157,7 @@ p str # => "Ruby"
 
 - **SEE** [m:IO::Buffer.new], [m:IO::Buffer.map]
 
-### def map(file, size = nil, offset = 0, flags = 0) -> IO::Buffer
+### def IO::Buffer.map(file, size = nil, offset = 0, flags = 0) -> IO::Buffer
 
 ファイルをメモリにマップしたバッファを作成して返します。
 
@@ -199,7 +199,7 @@ p File.read("test.txt") # => "HELLO world"
 
 - **SEE** [m:IO::Buffer.new], [m:IO::Buffer.for]
 
-### def new(size = IO::Buffer::DEFAULT_SIZE, flags = 0) -> IO::Buffer
+### def IO::Buffer.new(size = IO::Buffer::DEFAULT_SIZE, flags = 0) -> IO::Buffer
 
 size バイトの、0 で埋められた新しいバッファを作成して返します。
 
@@ -224,7 +224,7 @@ p buf.get_string # => "\x00\x00\x00\x00"
 - **SEE** [m:IO::Buffer.for], [m:IO::Buffer.map]
 
 #%since 3.3
-### def string(length) {|buffer| ... } -> String
+### def IO::Buffer.string(length) {|buffer| ... } -> String
 
 length バイトの文字列を新しく作り、それを元にしたコピーを伴わないバッファを
 ブロックに渡します。ブロックの実行後、その文字列を返します。
@@ -248,8 +248,8 @@ p str.encoding.name   # => "ASCII-8BIT"
 #%end
 
 #%since 3.2
-### def size_of(buffer_type) -> Integer
-### def size_of(buffer_types) -> Integer
+### def IO::Buffer.size_of(buffer_type) -> Integer
+### def IO::Buffer.size_of(buffer_types) -> Integer
 
 数値の型が占めるバイト数を返します。
 

--- a/manual/api/_builtin/Integer.md
+++ b/manual/api/_builtin/Integer.md
@@ -23,7 +23,7 @@ Ruby 2.4.0 からはどちらも `Integer` クラスのエイリアスとなっ�
 ## Class Methods
 
 #%since 3.1
-### def try_convert(obj) -> Integer | nil
+### def Integer.try_convert(obj) -> Integer | nil
 
 `obj` を `Integer` に変換しようと試みます。変換には [m:Object#to_int]
 メソッドが使われます。
@@ -43,7 +43,7 @@ p Integer.try_convert([]) # => nil
 
 #%end
 
-### def sqrt(n) -> Integer
+### def Integer.sqrt(n) -> Integer
 
 非負整数 `n` の整数の平方根を返します。すなわち `n` の平方根以下の
 最大の非負整数を返します。

--- a/manual/api/_builtin/KeyError.md
+++ b/manual/api/_builtin/KeyError.md
@@ -10,10 +10,10 @@ Ruby 1.8 以前では同様の場面で [c:IndexError] が発生していまし�
 
 ## Class Methods
 
-### def new(error_message = "")                   -> KeyError
-### def new(error_message = "", receiver:)        -> KeyError
-### def new(error_message = "", key:)             -> KeyError
-### def new(error_message = "", receiver:, key:)  -> KeyError
+### def KeyError.new(error_message = "")                   -> KeyError
+### def KeyError.new(error_message = "", receiver:)        -> KeyError
+### def KeyError.new(error_message = "", key:)             -> KeyError
+### def KeyError.new(error_message = "", receiver:, key:)  -> KeyError
 {: since="1.9.1"}
 
 例外オブジェクトを生成して返します。

--- a/manual/api/_builtin/Module.md
+++ b/manual/api/_builtin/Module.md
@@ -7,7 +7,7 @@ library: _builtin
 
 ## Class Methods
 
-### def constants -> [Symbol]
+### def Module.constants -> [Symbol]
 
 このメソッドを呼び出した時点で参照可能な定数名の配列を返します。
 
@@ -21,7 +21,7 @@ p Module.constants   # => [:RUBY_PLATFORM, :STDIN, ..., :C, ...]
 
 - **SEE** [m:Module#constants], [m:Kernel?.local_variables], [m:Kernel?.global_variables], [m:Object#instance_variables], [m:Module#class_variables]
 
-### def nesting -> [Class, Module]
+### def Module.nesting -> [Class, Module]
 
 このメソッドを呼び出した時点でのクラス/モジュールのネスト情
 報を配列に入れて返します。
@@ -36,8 +36,8 @@ module Company
 end
 ```
 
-### def new -> Module
-### def new {|mod| ... } -> Module
+### def Module.new -> Module
+### def Module.new {|mod| ... } -> Module
 
 名前の付いていないモジュールを新しく生成して返します。
 
@@ -71,7 +71,7 @@ Helpers = m
 p m.name          # => "Utils"   # 一度確定した名前は変わらない
 ```
 
-### def used_modules -> [Module]
+### def Module.used_modules -> [Module]
 
 現在のスコープで using されているすべてのモジュールを配列で返します。
 配列内のモジュールの順番は未定義です。
@@ -94,7 +94,7 @@ p Module.used_modules
 ```
 
 #%since 3.2
-### def used_refinements -> [Refinement]
+### def Module.used_refinements -> [Refinement]
 
 現在のスコープで using されているすべての [c:Refinement] を配列で返します。
 配列内の順番は未定義です。

--- a/manual/api/_builtin/NameError.md
+++ b/manual/api/_builtin/NameError.md
@@ -20,8 +20,8 @@ bar
 
 ## Class Methods
 
-### def new(error_message = "", name = nil) -> NameError
-### def new(error_message = "", name = nil, receiver:) -> NameError
+### def NameError.new(error_message = "", name = nil) -> NameError
+### def NameError.new(error_message = "", name = nil, receiver:) -> NameError
 
 例外オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/NoMatchingPatternKeyError.md
+++ b/manual/api/_builtin/NoMatchingPatternKeyError.md
@@ -23,7 +23,7 @@ end
 
 ## Class Methods
 
-### def new(message = nil, matchee: nil, key: nil) -> NoMatchingPatternKeyError
+### def NoMatchingPatternKeyError.new(message = nil, matchee: nil, key: nil) -> NoMatchingPatternKeyError
 
 例外オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/NoMethodError.md
+++ b/manual/api/_builtin/NoMethodError.md
@@ -50,8 +50,8 @@ bar
 
 ## Class Methods
 
-### def new(error_message = "", name = nil, args = nil, priv = false) -> NoMethodError
-### def new(error_message = "", name = nil, args = nil, priv = false, receiver:) -> NoMethodError
+### def NoMethodError.new(error_message = "", name = nil, args = nil, priv = false) -> NoMethodError
+### def NoMethodError.new(error_message = "", name = nil, args = nil, priv = false, receiver:) -> NoMethodError
 
 例外オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/Object.md
+++ b/manual/api/_builtin/Object.md
@@ -11,7 +11,7 @@ include:
 このクラスのメソッドは上書きしたり未定義にしない限り、すべてのオブジェクトで使用できます。
 
 ## Class Methods
-### def new -> Object
+### def Object.new -> Object
 
 Objectクラスのインスタンスを生成して返します。
 

--- a/manual/api/_builtin/Proc.md
+++ b/manual/api/_builtin/Proc.md
@@ -29,7 +29,7 @@ p foo       # => 2
 
 ## Class Methods
 
-### def new { ... } -> Proc
+### def Proc.new { ... } -> Proc
 
 ブロックをコンテキストとともにオブジェクト化して返します。
 

--- a/manual/api/_builtin/Process.md
+++ b/manual/api/_builtin/Process.md
@@ -14,14 +14,14 @@ Process がプロセスを表現するクラスではなく、プロセスに対
 
 ## Singleton Methods
 
-### def abort            -> ()
-### def abort(message)   -> ()
+### def Process.abort            -> ()
+### def Process.abort(message)   -> ()
 
 関数 [m:Kernel?.abort] と同じです。
 
 - **param** `message` -- 終了時のメッセージを文字列で指定します。
 
-### def exec(command, *args) -> ()
+### def Process.exec(command, *args) -> ()
 
 カレントプロセスを与えられた外部コマンドで置き換えます。
 
@@ -59,7 +59,7 @@ exec "echo", "*"    # echoes an asterisk
 # never get here
 ```
 
-### def exit(status = true)    -> ()
+### def Process.exit(status = true)    -> ()
 
 プロセスを終了します。関数 [m:Kernel?.exit] と同じです。
 
@@ -67,7 +67,7 @@ exec "echo", "*"    # echoes an asterisk
 
 - **SEE** [man:exit(3)]
 
-### def exit!(status = false)    -> ()
+### def Process.exit!(status = false)    -> ()
 
 関数 [m:Kernel?.exit!] と同じです。
 
@@ -75,8 +75,8 @@ exec "echo", "*"    # echoes an asterisk
 
 - **SEE** [man:_exit(2)]
 
-### def fork            -> Integer | nil
-### def fork { ... }    -> Integer | nil
+### def Process.fork            -> Integer | nil
+### def Process.fork { ... }    -> Integer | nil
 
 子プロセスを生成します。関数 [m:Kernel?.fork] と同じです。
 
@@ -85,7 +85,7 @@ exec "echo", "*"    # echoes an asterisk
 - **SEE** [man:fork(2)]
 
 #%since 3.1
-### def _fork    -> Integer
+### def Process._fork    -> Integer
 
 fork のための内部 API です。このメソッドを直接呼び出してはいけません。
 
@@ -126,7 +126,7 @@ Process.waitpid(pid)
 - **SEE** [m:Process.fork], [m:Kernel?.fork], [m:Process?.daemon]
 #%end
 
-### def spawn(cmd, *arg)    -> Integer
+### def Process.spawn(cmd, *arg)    -> Integer
 
 関数 [m:Kernel?.spawn] と同じです。
 
@@ -136,7 +136,7 @@ Process.waitpid(pid)
 
 - **raise** `NotImplementedError` -- メソッドが現在のプラットフォームで実装されていない場合に発生します。
 
-### def last_status -> Process::Status | nil
+### def Process.last_status -> Process::Status | nil
 
 カレントスレッドで最後に終了した子プロセスのステータスを返します。
 

--- a/manual/api/_builtin/Process__Status.md
+++ b/manual/api/_builtin/Process__Status.md
@@ -88,7 +88,7 @@ end
 
 ## Class Methods
 
-### def wait(pid = -1, flags = 0) -> Process::Status | nil
+### def Process::Status.wait(pid = -1, flags = 0) -> Process::Status | nil
 
 [m:Process?.wait] と同じですが、プロセス ID ではなく
 [c:Process::Status] を返します。

--- a/manual/api/_builtin/Ractor.md
+++ b/manual/api/_builtin/Ractor.md
@@ -8,7 +8,7 @@ since: "3.0"
 
 ## Class Methods
 
-### def new(*args, name: nil) {|*args| ... } -> Ractor
+### def Ractor.new(*args, name: nil) {|*args| ... } -> Ractor
 
 Ractor を生成して、ブロックの評価を開始します。
 生成した Ractor を返します。
@@ -19,7 +19,7 @@ Ractor を生成して、ブロックの評価を開始します。
 - **param** `name` -- Ractor の名前を指定します。
 
 #%since 3.4
-### def [](sym) -> object | nil
+### def Ractor.[](sym) -> object | nil
 
 このメソッドを呼び出した Ractor の Ractor-local storage の sym に対応するデータを取り出します。
 sym に対応するデータがなければ nil を返します。
@@ -27,31 +27,31 @@ sym に対応するデータがなければ nil を返します。
 - **param**  `sym` -- Ractor-local storage のキーを指定します。
 - **return** --     Ractor-local storage に格納されている値を返します。
 
-### def []=(sym, val)
+### def Ractor.[]=(sym, val)
 
 - **param** `sym` -- Ractor-local storage のキーを指定します。
 - **param** `val` -- 格納するデータを指定します。
 #%end
 
-### def count -> Integer
+### def Ractor.count -> Integer
 
 実行中の Ractor の数を返します。
 
-### def current -> Ractor
+### def Ractor.current -> Ractor
 
 このメソッドを呼び出された Ractor を返します。
 
-### def main -> Ractor
+### def Ractor.main -> Ractor
 
 main Ractor（プログラムの実行が開始された Ractor）を返します。
 
 #%since 3.4
-### def main? -> bool
+### def Ractor.main? -> bool
 
 このメソッドを呼び出した Ractor が main Ractor であるとき、true を返します。
 #%end
 
-### def make_shareable(obj, copy: false) -> object
+### def Ractor.make_shareable(obj, copy: false) -> object
 
 obj が shareable になるよう変換します。
 
@@ -60,8 +60,8 @@ obj が shareable でない場合、obj と obj が参照する shareable でな
 - **param** `obj` -- Shareable にしたいオブジェクトを指定します。
 - **param** `copy` -- true の場合、obj を変更する代わりに obj のコピーを作成し shareable にします。
 
-### def receive -> object
-### def recv -> object
+### def Ractor.receive -> object
+### def Ractor.recv -> object
 
 #%since 4.0
 このメソッドを呼び出した Ractor の default port からメッセージを受信します。
@@ -75,19 +75,19 @@ obj が shareable でない場合、obj と obj が参照する shareable でな
 #%end
 
 #%until 4.0
-### def receive_if {|msg| ... } -> object
+### def Ractor.receive_if {|msg| ... } -> object
 
 このメソッドを呼び出した Ractor が受信したメッセージのうち、
 ブロックの評価結果が真になる最初のメッセージを受信して返します。
 #%end
 
 #%since 4.0
-### def select(*ports) -> [object, object]
+### def Ractor.select(*ports) -> [object, object]
 
 引数で指定した Ractor または [c:Ractor::Port] のいずれかが受信可能になるまで待ち、
 受信可能になったものと受信した値の配列を返します。
 #%else
-### def select(*ractors, yield_value: nil, move: false) -> [object, object]
+### def Ractor.select(*ractors, yield_value: nil, move: false) -> [object, object]
 
 引数で指定した Ractor のいずれかが [m:Ractor.yield] などで送信可能になるまで待ち、
 その Ractor と受信したオブジェクトの配列 [Ractor, obj] を返します。
@@ -96,14 +96,14 @@ yield_value を指定すると、他の Ractor が [m:Ractor#take] を呼んだ�
 [:yield, nil] が返ります。move が真のとき yield_value は移動されます。
 #%end
 
-### def shareable?(obj) -> bool
+### def Ractor.shareable?(obj) -> bool
 
 obj が shareable である場合、true を返します。
 
 - **param** `obj` -- Shareable であるか判定したいオブジェクトを指定します。
 
 #%since 4.0
-### def shareable_proc { ... } -> Proc
+### def Ractor.shareable_proc { ... } -> Proc
 
 与えられたブロックから shareable な [c:Proc] を作成して返します。
 
@@ -124,7 +124,7 @@ p Ractor.new(pr) {|p| p.call }.value # => 42
 
 - **SEE** [m:Ractor.shareable_lambda], [m:Ractor.make_shareable]
 
-### def shareable_lambda { ... } -> Proc
+### def Ractor.shareable_lambda { ... } -> Proc
 
 [m:Ractor.shareable_proc] と同じですが、lambda である [c:Proc] を返します。
 
@@ -138,7 +138,7 @@ p l.lambda?            # => true
 #%end
 
 #%since 3.4
-### def store_if_absent(key) { ... } -> object
+### def Ractor.store_if_absent(key) { ... } -> object
 
 このメソッドを呼び出した Ractor の Ractor-local storage の key データがない場合、
 ブロックを評価した結果を格納します。
@@ -148,7 +148,7 @@ p l.lambda?            # => true
 #%end
 
 #%until 4.0
-### def yield(obj, move: false) -> object
+### def Ractor.yield(obj, move: false) -> object
 
 現在の Ractor の outgoing port に obj を送信します。
 別の Ractor が [m:Ractor#take] でこのメッセージを受信するまでブロックします。

--- a/manual/api/_builtin/Random.md
+++ b/manual/api/_builtin/Random.md
@@ -12,7 +12,7 @@ MT19937に基づく擬似乱数生成器を提供するクラスです。
 オリジナル版 <http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/mt.html>
 
 ## Class Methods
-### def new(seed = Random.new_seed) -> Random
+### def Random.new(seed = Random.new_seed) -> Random
 
 メルセンヌ・ツイスタに基づく擬似乱数発生装置オブジェクトを作ります。
 引数が省略された場合は、[m:Random.new_seed]の値を使用します。
@@ -29,7 +29,7 @@ p [ prng.rand, prng.rand ] #=> [0.1915194503788923, 0.6221087710398319]
 p [ prng.rand(10), prng.rand(1000) ]  #=> [4, 664]
 ```
 
-### def new_seed -> Integer
+### def Random.new_seed -> Integer
 
 適切な乱数の種を返します。
 
@@ -37,7 +37,7 @@ p [ prng.rand(10), prng.rand(1000) ]  #=> [4, 664]
 p Random.new_seed # => 184271600931914695177248627591520900872
 ```
 
-### def urandom(size) -> String
+### def Random.urandom(size) -> String
 
 プラットフォームの提供する機能を使って、文字列を返します。
 
@@ -55,9 +55,9 @@ p Random.new_seed # => 184271600931914695177248627591520900872
 p Random.urandom(8)  #=> "\x78\x41\xBA\xAF\x7D\xEA\xD8\xEA"
 ```
 
-### def rand -> Float
-### def rand(max) -> Integer | Float
-### def rand(range) -> Integer | Float
+### def Random.rand -> Float
+### def Random.rand(max) -> Integer | Float
+### def Random.rand(range) -> Integer | Float
 
 擬似乱数を発生させます。
 
@@ -84,8 +84,8 @@ p rand(10.0)       #=> 6                   (rand(10) と同じ)
 - **SEE** [m:Random.srand], [m:Random#rand], [m:Random::DEFAULT]
 #%end
 
-### def srand -> Integer
-### def srand(number) -> Integer
+### def Random.srand -> Integer
+### def Random.srand(number) -> Integer
 
 デフォルトの擬似乱数生成器の種を設定し、古い種を返します。
 [m:Kernel?.srand] と同じです。
@@ -99,7 +99,7 @@ p rand(10.0)       #=> 6                   (rand(10) と同じ)
 #%else
 - **SEE** [m:Kernel?.rand], [m:Random::DEFAULT]
 #%end
-### def bytes(size) -> String
+### def Random.bytes(size) -> String
 
 ランダムなバイナリー文字列を返します。結果の文字列のサイズを指定できます。
 
@@ -295,13 +295,13 @@ p r1 == r3 # => true
 
 ## Private Singleton Methods
 
-### def state -> Integer
+### def Random.state -> Integer
 
 C言語レベルで定義されている構造体MTの静的変数default_randの状態を参照します。詳しくはrandom.c を参照してください。
 
 #%#noexample 詳しくはrandom.c を参照
 
-### def left -> Integer
+### def Random.left -> Integer
 
 C言語レベルで定義されている構造体MTの静的変数default_randの変数leftを参照します。詳しくはrandom.c を参照してください。
 

--- a/manual/api/_builtin/Range.md
+++ b/manual/api/_builtin/Range.md
@@ -117,7 +117,7 @@ p Range.new(1, 10).frozen?
 
 ## Class Methods
 
-### def new(first, last, exclude_end = false) -> Range
+### def Range.new(first, last, exclude_end = false) -> Range
 
 first から last までの範囲オブジェクトを生成して返しま
 す。

--- a/manual/api/_builtin/Rational.md
+++ b/manual/api/_builtin/Rational.md
@@ -496,7 +496,7 @@ p Rational(0.5).to_s # => "1/2"
 
 ## Private Singleton Methods
 
-### def convert(*arg) -> Rational
+### def Rational.convert(*arg) -> Rational
 
 引数を有理数([c:Rational])に変換した結果を返します。
 

--- a/manual/api/_builtin/Regexp.md
+++ b/manual/api/_builtin/Regexp.md
@@ -36,8 +36,8 @@ p Regexp.new('abc').frozen?
 ## Class Methods
 
 #%since 3.3
-### def compile(string, option = nil) -> Regexp
-### def new(string, option = nil) -> Regexp
+### def Regexp.compile(string, option = nil) -> Regexp
+### def Regexp.new(string, option = nil) -> Regexp
 
 文字列 string をコンパイルして正規表現オブジェクトを生成して返します。
 
@@ -52,8 +52,8 @@ p Regexp.new('abc').frozen?
               、真(nil, false 以外)であれば
               [m:Regexp::IGNORECASE] の指定と同じになります。
 #%else
-### def compile(string, option = nil, code = nil) -> Regexp
-### def new(string, option = nil, code = nil) -> Regexp
+### def Regexp.compile(string, option = nil, code = nil) -> Regexp
+### def Regexp.new(string, option = nil, code = nil) -> Regexp
 
 文字列 string をコンパイルして正規表現オブジェクトを生成して返します。
 
@@ -93,8 +93,8 @@ t2 = Regexp.compile("ふる.*?と", Regexp::MULTILINE)
 p t2.match(str)[0]  # => "ふるいけや\nかわずと"
 ```
 
-### def escape(string) -> String
-### def quote(string) -> String
+### def Regexp.escape(string) -> String
+### def Regexp.quote(string) -> String
 
 string の中で正規表現において特別な意味を持つ文字の直前にエ
 スケープ文字(バックスラッシュ)を挿入した文字列を返します。
@@ -106,7 +106,7 @@ rp = Regexp.escape("$bc^")
 p rp # => "\\$bc\\^"
 ```
 
-### def last_match -> MatchData
+### def Regexp.last_match -> MatchData
 
 カレントスコープで最後に行った正規表現マッチの [c:MatchData] オ
 ブジェクトを返します。このメソッドの呼び出しは [m:$~]
@@ -121,7 +121,7 @@ p Regexp.last_match[2]   # => "b"
 p Regexp.last_match[3]   # => nil
 ```
 
-### def last_match(nth) -> String | nil
+### def Regexp.last_match(nth) -> String | nil
 
 整数 nth が 0 の場合、マッチした文字列を返します
 ([m:$&])。それ以外では、nth 番目の括弧にマッチ
@@ -161,7 +161,7 @@ p Regexp.last_match(1) # => nil
 - **param** `nth` -- 整数を指定します。
 	整数 nth が 0 の場合、マッチした文字列を返します。それ以外では、nth 番目の括弧にマッチした部分文字列を返します。
 
-### def union(*pattern) -> Regexp
+### def Regexp.union(*pattern) -> Regexp
 
 引数として与えた pattern を選択 | で連結し、Regexp として返します。
 結果の Regexp は与えた pattern のどれかにマッチする場合にマッチするものになります。
@@ -231,7 +231,7 @@ p Regexp.union(*rep2) # => /(?x-mi:foo)|bar|hoge/
 p Regexp.union(rep2)  # => /(?x-mi:foo)|bar|hoge/
 ```
 
-### def try_convert(obj) -> Regexp | nil
+### def Regexp.try_convert(obj) -> Regexp | nil
 
 obj を to_regexp メソッドで Regexp オブジェクトに変換しようと
 試みます。
@@ -244,7 +244,7 @@ p Regexp.try_convert("re")    # => nil
 ```
 
 #%since 3.2
-### def timeout -> Float | nil
+### def Regexp.timeout -> Float | nil
 
 正規表現のマッチにかける時間の上限を秒数で返します。
 
@@ -259,7 +259,7 @@ p Regexp.timeout # => nil
 
 - **SEE** [m:Regexp.timeout=], [m:Regexp#timeout]
 
-### def timeout=(seconds)
+### def Regexp.timeout=(seconds)
 
 正規表現のマッチにかける時間の上限を秒数で設定します。
 
@@ -282,8 +282,8 @@ p Regexp.timeout # => 0.5
 
 - **SEE** [m:Regexp.timeout], [m:Regexp#timeout], [c:Regexp::TimeoutError]
 
-### def linear_time?(re) -> bool
-### def linear_time?(string, options = 0) -> bool
+### def Regexp.linear_time?(re) -> bool
+### def Regexp.linear_time?(string, options = 0) -> bool
 
 正規表現 re が入力文字列の長さに対して線形時間でマッチできる場合に true を、
 そうでない場合に false を返します。

--- a/manual/api/_builtin/RubyVM.md
+++ b/manual/api/_builtin/RubyVM.md
@@ -79,7 +79,7 @@ p RubyVM.stat(:next_shape_id)
 #%# --- USAGE_ANALYSIS_REGS
 #%# --- USAGE_ANALYSIS_INSN_BIGRAM
 
-### def DEFAULT_PARAMS -> {Symbol => Integer}
+### const DEFAULT_PARAMS -> {Symbol => Integer}
 
 [c:RubyVM] のデフォルトのパラメータを返します。
 

--- a/manual/api/_builtin/RubyVM.md
+++ b/manual/api/_builtin/RubyVM.md
@@ -35,9 +35,9 @@ Ruby の 内部情報へのアクセス手段を提供するクラスです。
 #%#
 #%# VM_COLLECT_USAGE_DETAILS を有効にしてコンパイルした時のみ有効
 
-### def stat -> Hash
-### def stat(hsh) -> Hash
-### def stat(sym) -> Integer
+### def RubyVM.stat -> Hash
+### def RubyVM.stat(hsh) -> Hash
+### def RubyVM.stat(sym) -> Integer
 
 VM 内部のキャッシュなどに関する統計情報を返します。
 

--- a/manual/api/_builtin/RubyVM__AbstractSyntaxTree.md
+++ b/manual/api/_builtin/RubyVM__AbstractSyntaxTree.md
@@ -23,9 +23,9 @@ parser gem (<https://github.com/whitequark/parser>)や
 
 ## Singleton Methods
 
-### def of(proc) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.of(proc) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
-### def of(proc, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.of(proc, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
 #%end
 
 引数 proc に渡したProcやメソッドオブジェクトの抽象構文木を返します。
@@ -72,9 +72,9 @@ pp RubyVM::AbstractSyntaxTree.of(method(:hello))
 #       (FCALL@6:2-6:21 :puts (LIST@6:7-6:21 (STR@6:7-6:21 "hello, world") nil)))
 ```
 
-### def parse(string) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.parse(string) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
-### def parse(string, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.parse(string, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
 #%end
 
 文字列を抽象構文木にパースし、その木の根ノードを返します。
@@ -104,9 +104,9 @@ pp RubyVM::AbstractSyntaxTree.parse("x = 1; p(x; y=2", error_tolerant: true)
 #%end
 ```
 
-### def parse_file(pathname) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.parse_file(pathname) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
-### def parse_file(pathname, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+### def RubyVM::AbstractSyntaxTree.parse_file(pathname, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
 #%end
 
 pathname のファイルを読み込み、その内容を抽象構文木にパースし、その木の根ノードを返します。

--- a/manual/api/_builtin/RubyVM__InstructionSequence.md
+++ b/manual/api/_builtin/RubyVM__InstructionSequence.md
@@ -22,8 +22,8 @@ VM の命令シーケンスの一覧はRuby のソースコード中の insns.de
 
 ## Singleton Methods
 
-### def compile(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
-### def new(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
+### def RubyVM::InstructionSequence.compile(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
+### def RubyVM::InstructionSequence.new(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
 
 引数 source で指定した Ruby のソースコードを元にコンパイル済みの
 [c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
@@ -48,7 +48,7 @@ p RubyVM::InstructionSequence.compile("a = 1 + 2")
 
 - **SEE** [m:RubyVM::InstructionSequence.compile_file]
 
-### def compile_file(file, options = nil) -> RubyVM::InstructionSequence
+### def RubyVM::InstructionSequence.compile_file(file, options = nil) -> RubyVM::InstructionSequence
 
 引数 file で指定した Ruby のソースコードを元にコンパイル済みの
 [c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
@@ -74,7 +74,7 @@ p RubyVM::InstructionSequence.compile_file("/tmp/hello.rb")
 
 - **SEE** [m:RubyVM::InstructionSequence.compile]
 
-### def compile_option -> Hash
+### def RubyVM::InstructionSequence.compile_option -> Hash
 
 命令シーケンスのコンパイル時のデフォルトの最適化オプションを Hash で返
 します。
@@ -140,7 +140,7 @@ pp RubyVM::InstructionSequence.compile_option
 
 - **SEE** [m:RubyVM::InstructionSequence.compile_option=]
 
-### def compile_option=(options)
+### def RubyVM::InstructionSequence.compile_option=(options)
 
 命令シーケンスのコンパイル時のデフォルトの最適化オプションを引数
 options で指定します。
@@ -172,8 +172,8 @@ options で指定します。
      [m:RubyVM::InstructionSequence.compile],
      [m:RubyVM::InstructionSequence.compile_file]
 
-### def disasm(body)      -> String
-### def disassemble(body) -> String
+### def RubyVM::InstructionSequence.disasm(body)      -> String
+### def RubyVM::InstructionSequence.disassemble(body) -> String
 
 引数 body で指定したオブジェクトから作成した
 [c:RubyVM::InstructionSequence] オブジェクトを人間が読める形式の文字
@@ -230,7 +230,7 @@ puts RubyVM::InstructionSequence.disasm(method(:hello))
 
 - **SEE** [m:RubyVM::InstructionSequence#disasm]
 
-### def of(body) -> RubyVM::InstructionSequence
+### def RubyVM::InstructionSequence.of(body) -> RubyVM::InstructionSequence
 
 引数 body で指定した [c:Proc]、[c:Method] オブジェクトを元に
 [c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
@@ -273,7 +273,7 @@ $a_global_proc = proc { str = 'a' + 'b' }
 > # => #<RubyVM::InstructionSequence:0x007fb73d7caf78>
 ```
 
-### def load_from_binary(binary) -> RubyVM::InstructionSequence
+### def RubyVM::InstructionSequence.load_from_binary(binary) -> RubyVM::InstructionSequence
 
 [m:RubyVM::InstructionSequence#to_binary]により作られたバイナリフォーマットの文字列からiseqのオブジェクトをロードします。
 
@@ -289,7 +289,7 @@ p RubyVM::InstructionSequence.load_from_binary(binary).eval # => 3
 
 - **SEE** [m:RubyVM::InstructionSequence#to_binary]
 
-### def load_from_binary_extra_data(binary) -> String
+### def RubyVM::InstructionSequence.load_from_binary_extra_data(binary) -> String
 
 バイナリフォーマットの文字列から埋め込まれたextra_dataを取り出します。
 

--- a/manual/api/_builtin/RubyVM__MJIT.md
+++ b/manual/api/_builtin/RubyVM__MJIT.md
@@ -21,13 +21,13 @@ MJIT は Ruby 3.3 で削除され、このモジュールも同時に削除さ�
 
 ## Singleton Methods
 
-### def enabled? -> bool
+### def RubyVM::MJIT.enabled? -> bool
 
 JIT が有効かどうかを返します。
 
 - **SEE** [m:RubyVM::MJIT.pause], [m:RubyVM::MJIT.resume]
 
-### def pause(wait: true) -> bool
+### def RubyVM::MJIT.pause(wait: true) -> bool
 
 MJIT を一時停止します。
 
@@ -37,7 +37,7 @@ MJIT を一時停止します。
 
 - **SEE** [m:RubyVM::MJIT.enabled?], [m:RubyVM::MJIT.resume]
 
-### def resume -> bool
+### def RubyVM::MJIT.resume -> bool
 
 [m:RubyVM::MJIT.pause] で一時停止した JIT を再開します。
 

--- a/manual/api/_builtin/RubyVM__YJIT.md
+++ b/manual/api/_builtin/RubyVM__YJIT.md
@@ -40,7 +40,7 @@ Ruby 3.2 で「実験的」の位置づけが外れ、Ruby 3.3 では実行時�
 
 ## Singleton Methods
 
-### def enabled? -> bool
+### def RubyVM::YJIT.enabled? -> bool
 
 YJIT が有効かどうかを返します。
 
@@ -55,7 +55,7 @@ JIT の有効・無効はコマンドラインオプションや環境変数な�
 - **SEE** [m:RubyVM::YJIT.enable]
 #%end
 
-### def stats_enabled? -> bool
+### def RubyVM::YJIT.stats_enabled? -> bool
 
 `--yjit-stats` が指定されているなど、統計情報の収集が有効かどうかを返します。
 
@@ -66,14 +66,14 @@ JIT の有効・無効はコマンドラインオプションや環境変数な�
 #%end
 
 #%since 3.4
-### def log_enabled? -> bool
+### def RubyVM::YJIT.log_enabled? -> bool
 
 `--yjit-log` が指定されているなど、コンパイルログの収集が有効かどうかを返します。
 
 - **SEE** [m:RubyVM::YJIT.log], [m:RubyVM::YJIT.enable]
 #%end
 
-### def reset_stats! -> nil
+### def RubyVM::YJIT.reset_stats! -> nil
 
 `--yjit-stats` で収集した統計情報を破棄します。
 
@@ -81,13 +81,13 @@ JIT の有効・無効はコマンドラインオプションや環境変数な�
 
 #%since 3.3
 #%version 4.0...
-### def enable(stats: false, log: false, mem_size: nil, call_threshold: nil) -> bool
+### def RubyVM::YJIT.enable(stats: false, log: false, mem_size: nil, call_threshold: nil) -> bool
 #%end
 #%version 3.4...4.0
-### def enable(stats: false, log: false) -> bool
+### def RubyVM::YJIT.enable(stats: false, log: false) -> bool
 #%end
 #%version ...3.4
-### def enable(stats: false) -> bool
+### def RubyVM::YJIT.enable(stats: false) -> bool
 #%end
 
 実行時に YJIT を有効化します。
@@ -122,7 +122,7 @@ JIT の有効・無効はビルドオプションや実行環境に依存する�
 #%end
 
 #%since 3.2
-### def dump_exit_locations(filename) -> Integer
+### def RubyVM::YJIT.dump_exit_locations(filename) -> Integer
 
 `--yjit-trace-exits` を指定して収集した、サイドイグジット(exit)が発生した位置の情報を
 Marshal 形式で `filename` にダンプします。ダンプしたファイルは Stackprof で読み込んで解析できます。
@@ -135,13 +135,13 @@ Marshal 形式で `filename` にダンプします。ダンプしたファイル
 #%end
 
 #%version 3.4...
-### def runtime_stats(key = nil) -> Hash | object | nil
+### def RubyVM::YJIT.runtime_stats(key = nil) -> Hash | object | nil
 #%end
 #%version 3.3...3.4
-### def runtime_stats(context: false) -> Hash | nil
+### def RubyVM::YJIT.runtime_stats(context: false) -> Hash | nil
 #%end
 #%version ...3.3
-### def runtime_stats -> Hash | nil
+### def RubyVM::YJIT.runtime_stats -> Hash | nil
 #%end
 
 `--yjit-stats` コマンドラインオプションを指定して収集した統計情報を返します。
@@ -167,7 +167,7 @@ Marshal 形式で `filename` にダンプします。ダンプしたファイル
 - **SEE** [m:RubyVM::YJIT.stats_enabled?], [m:RubyVM::YJIT.reset_stats!]
 
 #%since 3.3
-### def stats_string -> String
+### def RubyVM::YJIT.stats_string -> String
 
 [m:RubyVM::YJIT.runtime_stats] の内容を人が読める形式に整形した文字列を返します。
 `--yjit-stats` が有効なとき以外は空文字列を返します。
@@ -178,7 +178,7 @@ Marshal 形式で `filename` にダンプします。ダンプしたファイル
 #%end
 
 #%since 3.4
-### def log -> [[Time, String]] | nil
+### def RubyVM::YJIT.log -> [[Time, String]] | nil
 
 `--yjit-log` で収集したコンパイルログを返します。配列の各要素は、
 コンパイルした日時とコンパイル対象を表す文字列との組です。
@@ -190,7 +190,7 @@ Marshal 形式で `filename` にダンプします。ダンプしたファイル
 #%end
 
 #%since 3.2
-### def code_gc -> nil
+### def RubyVM::YJIT.code_gc -> nil
 
 コンパイル済みのコードを破棄してメモリを解放します。以降、必要に応じて再度コンパイルが行われます。
 #%end

--- a/manual/api/_builtin/Ruby__Box.md
+++ b/manual/api/_builtin/Ruby__Box.md
@@ -61,20 +61,20 @@ p box::Something.new.x # => 1
 
 ## Class Methods
 
-### def new -> Ruby::Box
+### def Ruby::Box.new -> Ruby::Box
 
 他のボックスから独立した新しいボックスを返します。
 
 `Ruby::Box` が無効なとき（環境変数 `RUBY_BOX` に `1` を設定せずに起動したとき）は
 [c:RuntimeError] が発生します。
 
-### def enabled? -> bool
+### def Ruby::Box.enabled? -> bool
 
 `Ruby::Box` が有効なら `true` を、無効なら `false` を返します。
 
 環境変数 `RUBY_BOX` に `1` を設定して ruby を起動したときに `true` になります。
 
-### def current -> Ruby::Box | nil
+### def Ruby::Box.current -> Ruby::Box | nil
 
 現在実行中のコードが属しているボックスを返します。
 

--- a/manual/api/_builtin/Set.md
+++ b/manual/api/_builtin/Set.md
@@ -71,8 +71,8 @@ p MyCoreSet[[1, 2, 3]]  # => MyCoreSet[[1, 2, 3]]
 #%end
 
 ## Class Methods
-### def new(enum = nil) -> Set
-### def new(enum = nil) {|o| ... } -> Set
+### def Set.new(enum = nil) -> Set
+### def Set.new(enum = nil) {|o| ... } -> Set
 
 引数 enum で与えられた要素を元に、新しい集合を作ります。
 
@@ -102,7 +102,7 @@ p Set.new([1, 2]) {|o| o * 2}  # => #<Set: {2, 4}>
 #%end
 ```
 
-### def [](*ary) -> Set
+### def Set.[](*ary) -> Set
 
 与えられたオブジェクトを要素とする新しい集合を作ります。
 

--- a/manual/api/_builtin/SignalException.md
+++ b/manual/api/_builtin/SignalException.md
@@ -25,9 +25,9 @@ library: _builtin
 
 ## Singleton Methods
 
-### def new(sig_number)           -> SignalException
-### def new(sig_name)             -> SignalException
-### def new(sig_number, sig_name) -> SignalException
+### def SignalException.new(sig_number)           -> SignalException
+### def SignalException.new(sig_name)             -> SignalException
+### def SignalException.new(sig_number, sig_name) -> SignalException
 
 引数で指定したシグナルに関する SignalException オブジェクトを生成して返
 します。

--- a/manual/api/_builtin/String.md
+++ b/manual/api/_builtin/String.md
@@ -180,7 +180,7 @@ p a + b                            #=> "abcabc"
 
 ## Class Methods
 
-### def try_convert(obj) -> String | nil
+### def String.try_convert(obj) -> String | nil
 
 obj を String に変換しようと試みます。変換には [m:Object#to_str] メソッ
 ドが使われます。変換後の文字列を返すか、何らかの理由により変換できなかっ
@@ -194,8 +194,8 @@ p String.try_convert("str")   # => "str"
 p String.try_convert(/re/)    # => nil
 ```
 
-### def new(string = "")                -> String
-### def new(string = "", encoding: string.encoding, capacity: Integer) -> String
+### def String.new(string = "")                -> String
+### def String.new(string = "", encoding: string.encoding, capacity: Integer) -> String
 
 string と同じ内容の新しい文字列を作成して返します。
 引数を省略した場合は空文字列を生成して返します。

--- a/manual/api/_builtin/Struct.md
+++ b/manual/api/_builtin/Struct.md
@@ -14,11 +14,11 @@ include:
 ## Class Methods
 
 #%since 3.1
-### def new(*args, keyword_init: nil)                     -> Class
-### def new(*args, keyword_init: nil) {|subclass| block } -> Class
+### def Struct.new(*args, keyword_init: nil)                     -> Class
+### def Struct.new(*args, keyword_init: nil) {|subclass| block } -> Class
 #%else
-### def new(*args, keyword_init: false)                     -> Class
-### def new(*args, keyword_init: false) {|subclass| block } -> Class
+### def Struct.new(*args, keyword_init: false)                     -> Class
+### def Struct.new(*args, keyword_init: false) {|subclass| block } -> Class
 #%end
 
 [c:Struct] クラスに新しいサブクラスを作って、それを返します。
@@ -163,8 +163,8 @@ Structをカスタマイズする場合はこの方法が推奨されます。�
 
 - **SEE** [m:Class.new]
 
-### def new(*args) -> Struct
-### def [](*args) -> Struct
+### def Struct.new(*args) -> Struct
+### def Struct.[](*args) -> Struct
 
 (このメソッドは Struct の下位クラスにのみ定義されています)
 構造体オブジェクトを生成して返します。
@@ -181,7 +181,7 @@ foo = Foo.new(1)
 p foo.values      # => [1, nil]
 ```
 
-### def members -> [Symbol]
+### def Struct.members -> [Symbol]
 
 (このメソッドは Struct の下位クラスにのみ定義されています)
 構造体のメンバの名前([c:Symbol])の配列を返します。
@@ -192,7 +192,7 @@ p Foo.members      # => [:foo, :bar]
 ```
 
 #%since 3.1
-### def keyword_init? -> bool | nil
+### def Struct.keyword_init? -> bool | nil
 
 (このメソッドは Struct の下位クラスにのみ定義されています)
 構造体が作成されたときに keyword_init: true を指定されていたら true を返します。

--- a/manual/api/_builtin/Symbol.md
+++ b/manual/api/_builtin/Symbol.md
@@ -96,7 +96,7 @@ Ruby によって GC されます。すなわち、ある使わなくなった
 
 ## Class Methods
 
-### def all_symbols -> [Symbol]
+### def Symbol.all_symbols -> [Symbol]
 
 定義済みの全てのシンボルオブジェクトの配列を返します。
 

--- a/manual/api/_builtin/SystemCallError.md
+++ b/manual/api/_builtin/SystemCallError.md
@@ -13,7 +13,7 @@ Ruby の実装に用いられているシステムコールまたは一部の C 
 
 ## Class Methods
 
-### def new(error_message) -> SystemCallError
+### def SystemCallError.new(error_message) -> SystemCallError
 
 SystemCallError オブジェクトを生成して返します。
 
@@ -24,8 +24,8 @@ p SystemCallError.new("message")
     # => #<SystemCallError: unknown error - message>
 ```
 
-### def new(error_message, errno, location = nil) -> SystemCallError
-### def new(errno) -> SystemCallError
+### def SystemCallError.new(error_message, errno, location = nil) -> SystemCallError
+### def SystemCallError.new(errno) -> SystemCallError
 
 整数 errno に対応する [c:Errno::EXXX] オブジェクトを生成して返します。
 
@@ -57,7 +57,7 @@ p SystemCallError.new("message", 2, "location")
     # => #<Errno::ENOENT: No such file or directory @ location - message>
 ```
 
-### def ===(other) -> bool
+### def SystemCallError.===(other) -> bool
 
 other が SystemCallError のサブクラスのインスタンスで、
 かつ、other.errno の値が self::Errno と同じ場合に真を返します。そうでない場合は偽を返します。
@@ -294,8 +294,8 @@ Microsoft Windows システムにおいては <http://msdn2.microsoft.com/ja-jp/
 
 ## Class Methods
 
-### def new() -> Errno::EXXX
-### def new(error_message) -> Errno::EXXX
+### def Errno::EXXX.new() -> Errno::EXXX
+### def Errno::EXXX.new(error_message) -> Errno::EXXX
 
 Errno::EXXX オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/SystemExit.md
+++ b/manual/api/_builtin/SystemExit.md
@@ -8,7 +8,7 @@ Ruby インタプリタを終了させるときに発生します。
 
 ## Class Methods
 
-### def new(status = 0, error_message = "") -> SystemExit
+### def SystemExit.new(status = 0, error_message = "") -> SystemExit
 
 SystemExit オブジェクトを生成して返します。
 

--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -9,8 +9,8 @@ Thread を使うことで並行プログラミングが可能になります。
 #%include(thread.inc)
 
 ## Class Methods
-### def abort_on_exception             -> bool
-### def abort_on_exception=(newstate)
+### def Thread.abort_on_exception             -> bool
+### def Thread.abort_on_exception=(newstate)
 
 真の時は、いずれかのスレッドが例外によって終了した時に、その例外をメインスレッドで
 再度発生させます。メインスレッドがその例外を捕捉しない限り、結果としてインタプリタ
@@ -29,8 +29,8 @@ Thread.abort_on_exception = true
 p Thread.abort_on_exception # => true
 ```
 
-### def report_on_exception             -> bool
-### def report_on_exception=(newstate)
+### def Thread.report_on_exception             -> bool
+### def Thread.report_on_exception=(newstate)
 
 真の時は、いずれかのスレッドが例外によって終了した時に、その内容を $stderr に報告します。
 
@@ -70,7 +70,7 @@ Traceback (most recent call last):
 
 - **param** `newstate` -- スレッド実行中に例外発生した場合、その内容を報告するかどうかを true か false で指定します。
 
-### def ignore_deadlock -> bool
+### def Thread.ignore_deadlock -> bool
 
 デッドロック検知を無視する機能のon/offを返します。
 
@@ -80,7 +80,7 @@ Traceback (most recent call last):
 
 - **SEE** [m:Thread.ignore_deadlock=]
 
-### def ignore_deadlock=(bool)
+### def Thread.ignore_deadlock=(bool)
 
 デッドロック検知を無視する機能をon/offします。デフォルト値はfalseです。
 
@@ -98,7 +98,7 @@ puts queue.pop
 
 - **SEE** [m:Thread.ignore_deadlock]
 
-### def current    -> Thread
+### def Thread.current    -> Thread
 
 現在実行中のスレッド(カレントスレッド)を返します。
 
@@ -106,13 +106,13 @@ puts queue.pop
 p Thread.current #=> #<Thread:0x4022e6fc run>
 ```
 
-### def exit    -> ()
+### def Thread.exit    -> ()
 
 カレントスレッドに対して [m:Thread#exit] を呼びます。
 
 #%#noexample Thread#exitを参照
 
-### def kill(thread)    -> Thread
+### def Thread.kill(thread)    -> Thread
 
 指定したスレッド thread に対して [m:Thread#exit] を呼びます。終了したスレッドを返します。
 
@@ -125,7 +125,7 @@ end
 p Thread.kill(th)     #=> #<Thread:0x40221bc8 dead>
 ```
 
-### def list    -> [Thread]
+### def Thread.list    -> [Thread]
 
 全ての生きているスレッドを含む配列を生成して返します。aborting 状態であるスレッド
 も要素に含まれます。
@@ -139,7 +139,7 @@ sleep 0.1
 p Thread.list   #=> [#<Thread:0x40377a54 sleep>, #<Thread:0x4022e6fc run>]
 ```
 
-### def main    -> Thread
+### def Thread.main    -> Thread
 
 メインスレッドを返します。
 
@@ -147,8 +147,8 @@ p Thread.list   #=> [#<Thread:0x40377a54 sleep>, #<Thread:0x4022e6fc run>]
 p Thread.main #=> #<Thread:0x4022e6fc run>
 ```
 
-### def start(*arg) {|*arg| ... }       -> Thread
-### def fork(*arg) {|*arg| ... }        -> Thread
+### def Thread.start(*arg) {|*arg| ... }       -> Thread
+### def Thread.fork(*arg) {|*arg| ... }        -> Thread
 
 スレッドを生成して、ブロックの評価を開始します。
 生成したスレッドを返します。
@@ -180,7 +180,7 @@ for i in 1..5
 end
 ```
 
-### def new(*arg) {|*arg| ... }         -> Thread
+### def Thread.new(*arg) {|*arg| ... }         -> Thread
 
 スレッドを生成して、ブロックの評価を開始します。
 生成したスレッドを返します。
@@ -209,7 +209,7 @@ for i in 1..5
 end
 ```
 
-### def pass    -> nil
+### def Thread.pass    -> nil
 
 他のスレッドに実行権を譲ります。実行中のスレッドの状態を変えずに、
 他の実行可能状態のスレッドに切り替わるよう、スレッドスケジューラにヒントを与
@@ -241,7 +241,7 @@ end
 
 上記の出力は一例です。実行環境によって出力順序は異なり、保証されません。
 
-### def stop     -> nil
+### def Thread.stop     -> nil
 
 他のスレッドから [m:Thread#run] メソッドで再起動されるまで、カレ
 ントスレッドの実行を停止します。
@@ -259,10 +259,10 @@ a.join
 
 #%since 3.2
 #%since 3.4
-### def each_caller_location(start = 1, length = nil) {|location| ... } -> nil
-### def each_caller_location(range) {|location| ... } -> nil
+### def Thread.each_caller_location(start = 1, length = nil) {|location| ... } -> nil
+### def Thread.each_caller_location(range) {|location| ... } -> nil
 #%else
-### def each_caller_location {|location| ... } -> nil
+### def Thread.each_caller_location {|location| ... } -> nil
 #%end
 
 現在の実行スタックの各フレームを、[c:Thread::Backtrace::Location] オブジェクトと
@@ -298,7 +298,7 @@ foo
 - **SEE** [m:Kernel?.caller_locations]
 #%end
 
-### def DEBUG -> Integer
+### def Thread.DEBUG -> Integer
 
 スレッドのデバッグレベルを返します。
 
@@ -314,7 +314,7 @@ p Thread.DEBUG # => 0
 
 - **SEE** [m:Thread.DEBUG=]
 
-### def DEBUG=(val)
+### def Thread.DEBUG=(val)
 
 スレッドのデバッグレベルを val に設定します。
 
@@ -332,7 +332,7 @@ p Thread.DEBUG # => 1
 - **SEE** [m:Thread.DEBUG]
 
 #%# 参考: [[ruby-dev:45341]]
-### def pending_interrupt?(error = nil) -> bool
+### def Thread.pending_interrupt?(error = nil) -> bool
 
 非同期割り込みのキューが空かどうかを返します。
 
@@ -396,7 +396,7 @@ flag = false # スレッド停止
 
 - **SEE** [m:Thread#pending_interrupt?], [m:Thread.handle_interrupt]
 
-### def handle_interrupt(hash) { ... } -> object
+### def Thread.handle_interrupt(hash) { ... } -> object
 
 スレッドの割り込みのタイミングを引数で指定した内容に変更してブロックを
 実行します。

--- a/manual/api/_builtin/ThreadGroup.md
+++ b/manual/api/_builtin/ThreadGroup.md
@@ -39,7 +39,7 @@ Thread.new{ ... } はエラーになりません。生成されたスレッド�
 
 ## Class Methods
 
-### def new    -> ThreadGroup
+### def ThreadGroup.new    -> ThreadGroup
 
 新たな ThreadGroup を生成して返します。
 

--- a/manual/api/_builtin/Thread__Backtrace.md
+++ b/manual/api/_builtin/Thread__Backtrace.md
@@ -13,7 +13,7 @@ library: _builtin
 #%since 3.1
 ## Class Methods
 
-### def limit -> Integer
+### def Thread::Backtrace.limit -> Integer
 
 コマンドラインオプション `--backtrace-limit` で指定された、
 バックトレースを表示する行数の上限を返します。

--- a/manual/api/_builtin/Time.md
+++ b/manual/api/_builtin/Time.md
@@ -45,8 +45,8 @@ yday は 1 から数えます。
 
 ## Class Methods
 
-### def at(time)         -> Time
-### def at(time, in:)    -> Time
+### def Time.at(time)         -> Time
+### def Time.at(time, in:)    -> Time
 
 time で指定した時刻の Time オブジェクトを返します。
 
@@ -71,8 +71,8 @@ p Time.at(1582721899, in: "UTC")          # => 2020-02-26 12:58:19 UTC
 p Time.at(1582721899, in: "C")            # => 2020-02-26 13:58:19 +0300
 ```
 
-### def at(time, usec)         -> Time
-### def at(time, usec, in:)    -> Time
+### def Time.at(time, usec)         -> Time
+### def Time.at(time, usec, in:)    -> Time
 
 time + (usec/1000000) の時刻を表す Time オブジェクトを返します。
 浮動小数点の精度では不十分な場合に使用します。
@@ -92,8 +92,8 @@ time + (usec/1000000) の時刻を表す Time オブジェクトを返します�
 p Time.at(946684800, 123456.789).nsec  # => 123456789
 ```
 
-### def at(seconds, xseconds, unit)      -> Time
-### def at(seconds, xseconds, unit, in:) -> Time
+### def Time.at(seconds, xseconds, unit)      -> Time
+### def Time.at(seconds, xseconds, unit, in:) -> Time
 
 unit に応じて seconds + xseconds ミリ秒などの時刻を表す Time オブジェクトを返します。
 
@@ -111,8 +111,8 @@ p Time.at(946684800, 123456.789, :microsecond).nsec  # => 123456789
 p Time.at(946684800, 123456789, :nsec).nsec        # => 123456789
 ```
 
-### def gm(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)             -> Time
-### def utc(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)            -> Time
+### def Time.gm(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)             -> Time
+### def Time.utc(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)            -> Time
 
 引数で指定した協定世界時の Time オブジェクトを返します。
 
@@ -139,8 +139,8 @@ p Time.at(946684800, 123456789, :nsec).nsec        # => 123456789
 p Time.gm(2000, 1, 1)  # => 2000-01-01 00:00:00 UTC
 ```
 
-### def gm(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)     -> Time
-### def utc(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)    -> Time
+### def Time.gm(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)     -> Time
+### def Time.utc(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)    -> Time
 
 引数で指定した協定世界時の Time オブジェクトを返します。
 
@@ -172,8 +172,8 @@ p Time.gm(2000, 1, 1)  # => 2000-01-01 00:00:00 UTC
 
 - **raise** `ArgumentError` -- 与えられた引数の範囲が valid でない場合に発生します。
 
-### def local(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)      -> Time
-### def mktime(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)     -> Time
+### def Time.local(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)      -> Time
+### def Time.mktime(year, mon = 1, day = 1, hour = 0, min = 0, sec = 0, usec = 0)     -> Time
 
 引数で指定した地方時の Time オブジェクトを返します。
 
@@ -200,8 +200,8 @@ p Time.gm(2000, 1, 1)  # => 2000-01-01 00:00:00 UTC
 p Time.local(2000, 1, 1) # => 2000-01-01 00:00:00 +0900
 ```
 
-### def local(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)     -> Time
-### def mktime(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)    -> Time
+### def Time.local(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)     -> Time
+### def Time.mktime(sec, min, hour, mday, mon, year, wday, yday, isdst, zone)    -> Time
 
 引数で指定した地方時の Time オブジェクトを返します。
 
@@ -233,8 +233,8 @@ p Time.local(2000, 1, 1) # => 2000-01-01 00:00:00 +0900
 
 - **raise** `ArgumentError` -- 与えられた引数の範囲が valid でない場合に発生します。
 
-### def new    -> Time
-### def now    -> Time
+### def Time.new    -> Time
+### def Time.now    -> Time
 
 現在時刻の Time オブジェクトを生成して返します。
 タイムゾーンは地方時となります。
@@ -243,9 +243,9 @@ p Time.local(2000, 1, 1) # => 2000-01-01 00:00:00 +0900
 p Time.now # => 2009-06-24 12:39:54 +0900
 ```
 
-### def new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, zone = nil)    -> Time
+### def Time.new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, zone = nil)    -> Time
 #%since 3.1
-### def new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, in: nil)       -> Time
+### def Time.new(year, mon = nil, day = nil, hour = nil, min = nil, sec = nil, in: nil)       -> Time
 #%end
 
 引数で指定した地方時の Time オブジェクトを返します。
@@ -289,7 +289,7 @@ p Time.new(2008, 6, 21, 13, 30, 0, "+09:00") # => 2008-06-21 13:30:00 +0900
 ```
 
 #%since 3.2
-### def new(iso8601, in: nil)       -> Time
+### def Time.new(iso8601, in: nil)       -> Time
 
 引数で指定した地方時の Time オブジェクトを返します。
 

--- a/manual/api/_builtin/TracePoint.md
+++ b/manual/api/_builtin/TracePoint.md
@@ -35,7 +35,7 @@ p trace.enable
 
 ## Singleton Methods
 
-### def new(*events) {|obj| ... } -> TracePoint
+### def TracePoint.new(*events) {|obj| ... } -> TracePoint
 
 新しい [c:TracePoint] オブジェクトを作成して返します。トレースを有効
 にするには [m:TracePoint#enable] を実行してください。
@@ -143,7 +143,7 @@ $tp.lineno # => access from outside (RuntimeError)
 
 - **raise** `ArgumentError` -- ブロックを指定しなかった場合に発生します。
 
-### def trace(*events) {|obj| ... } -> TracePoint
+### def TracePoint.trace(*events) {|obj| ... } -> TracePoint
 
 新しい [c:TracePoint] オブジェクトを作成して自動的にトレースを開始し
 ます。[m:TracePoint.new] のコンビニエンスメソッドです。
@@ -161,7 +161,7 @@ p trace.enabled? # => true
 
 - **raise** `ThreadError` -- ブロックを指定しなかった場合に発生します。
 
-### def stat -> object
+### def TracePoint.stat -> object
 
 TracePoint の内部情報を返します。
 
@@ -171,7 +171,7 @@ TracePoint の内部情報を返します。
 このメソッドは TracePoint 自身のデバッグ用です。
 
 #%since 3.1
-### def allow_reentry { ... } -> object
+### def TracePoint.allow_reentry { ... } -> object
 
 ブロックの中に限って、TracePoint の再入を許可します。
 

--- a/manual/api/_builtin/Warning.md
+++ b/manual/api/_builtin/Warning.md
@@ -12,7 +12,7 @@ since: "2.4.0"
 
 ## Class Methods
 
-### def [](category) -> bool
+### def Warning.[](category) -> bool
 
 category の種類の警告を表示するかどうかのフラグを返します。
 
@@ -40,7 +40,7 @@ category の種類の警告を表示するかどうかのフラグを返しま�
   「別クラスの同名メソッドがブロックを使う」場合を含めて、常に警告します。
 #%end
 
-### def []=(category, flag)
+### def Warning.[]=(category, flag)
 
 category の警告を表示するかどうかのフラグを設定します。
 サポートされている category については [m:Warning.\[\]] を参照してください。
@@ -50,7 +50,7 @@ category の警告を表示するかどうかのフラグを設定します。
 
 - **SEE** [m:Warning.\[\]]
 
-### def warn(message, category: nil) -> nil
+### def Warning.warn(message, category: nil) -> nil
 
 引数 message を標準エラー出力 [m:$stderr] に出力します。
 
@@ -77,7 +77,7 @@ warn("hoge", category: :deprecated)
 - **SEE** [m:Kernel?.warn], [m:Warning#warn]
 
 #%since 3.4
-### def categories -> Array
+### def Warning.categories -> Array
 
 警告カテゴリの一覧を返します。
 

--- a/manual/api/_builtin/functions_pp.md
+++ b/manual/api/_builtin/functions_pp.md
@@ -1,4 +1,4 @@
-### def pp(*obj)    -> object
+### module_function def pp(*obj)    -> object
 
 指定されたオブジェクト obj を標準出力に見やすい形式(プリティプリント)で出力します。
 obj それぞれを引数として [m:PP.pp] を呼ぶことと同等です。

--- a/manual/api/benchmark.md
+++ b/manual/api/benchmark.md
@@ -260,7 +260,7 @@ benchmark ライブラリのバージョンを表します。
 
 ## Class Methods
 
-### def new(utime = 0.0, stime = 0.0, cutime = 0.0, cstime = 0.0, real = 0.0, label = nil) -> Benchmark::Tms
+### def Benchmark::Tms.new(utime = 0.0, stime = 0.0, cutime = 0.0, cstime = 0.0, real = 0.0, label = nil) -> Benchmark::Tms
 
 新しい [c:Benchmark::Tms] オブジェクトを生成して返します。
 
@@ -453,7 +453,7 @@ System CPU time
 
 ## Class Methods
 
-### def new(width) -> Benchmark::Job
+### def Benchmark::Job.new(width) -> Benchmark::Job
 
 [c:Benchmark::Job] のインスタンスを初期化して返します。
 
@@ -489,7 +489,7 @@ System CPU time
 
 ## Class Methods
 
-### def new(width = 0, fmtstr = nil) -> Benchmark::Report
+### def Benchmark::Report.new(width = 0, fmtstr = nil) -> Benchmark::Report
 
 [c:Benchmark::Report] のインスタンスを初期化して返します。
 

--- a/manual/api/bigdecimal/BigDecimal.md
+++ b/manual/api/bigdecimal/BigDecimal.md
@@ -198,8 +198,8 @@ NaN を表す [c:BigDecimal] オブジェクトを返します。
 
 ## Class Methods
 
-### def mode(s)    -> Integer | nil
-### def mode(s, v) -> Integer | nil
+### def BigDecimal.mode(s)    -> Integer | nil
+### def BigDecimal.mode(s, v) -> Integer | nil
 
 [c:BigDecimal] の計算処理の制御方法を設定、確認します。
 
@@ -281,7 +281,7 @@ f = BigDecimal::mode(BigDecimal::ROUND_MODE,flag)
 
 戻り値は指定後の flag の値です。第2引数に nil を指定すると、現状の設定値が返ります。 mode メソッドでは丸め操作の位置をユーザが指定することはできません。丸め操作と位置を自分で制御したい場合は BigDecimal::limit や truncate/round/ceil/floor、 add/sub/mult/div といったインスタンスメソッドを使用して下さい。
 
-### def limit(n = nil) -> Integer
+### def BigDecimal.limit(n = nil) -> Integer
 
 生成されるBigDecimalオブジェクトの最大桁数をn桁に制限します。
 n を指定しない、または n が nil の場合は、現状の最大桁数が返ります。
@@ -305,7 +305,7 @@ mf = BigDecimal::limit(n)
 
 - **raise** `ArgumentError` -- n に負の数を指定した場合に発生します。
 
-### def double_fig -> Integer
+### def BigDecimal.double_fig -> Integer
 
 Ruby の [c:Float] クラスが保持できる有効数字の数を返します。
 
@@ -325,7 +325,7 @@ while (v + 1.0 > 1.0) {
 }
 ```
 
-### def _load(str) -> BigDecimal
+### def BigDecimal._load(str) -> BigDecimal
 
 引数で指定された文字列を元に [c:BigDecimal] オブジェクトを復元します。
 [m:Marshal?.load] から呼び出されます。

--- a/manual/api/cgi/cookie.md
+++ b/manual/api/cgi/cookie.md
@@ -49,7 +49,7 @@ cookie1.httponly  = true
 
 ## Class Methods
 
-### def new(name = "", *value) -> CGI::Cookie
+### def CGI::Cookie.new(name = "", *value) -> CGI::Cookie
 
 クッキーオブジェクトを作成します。
 
@@ -109,7 +109,7 @@ cookie1.secure    = true
 cookie1.httponly  = true
 ```
 
-### def parse(raw_cookie) -> Hash
+### def CGI::Cookie.parse(raw_cookie) -> Hash
 
 クッキー文字列をパースします。
 

--- a/manual/api/cgi/core/CGI.md
+++ b/manual/api/cgi/core/CGI.md
@@ -8,7 +8,7 @@ include:
 CGI スクリプトを書くために必要な機能を提供するクラスです。
 
 ## Class Methods
-### def parse(query) -> Hash
+### def CGI.parse(query) -> Hash
 
 与えられたクエリ文字列をパースします。
 
@@ -22,12 +22,12 @@ params = CGI.parse("query_string")
   #  "name2" => ["value1", "value2", ...], ... }
 ```
 
-### def accept_charset -> String
+### def CGI.accept_charset -> String
 
 受けとることができるキャラクタセットを文字列で返します。
 デフォルトは UTF-8 です。
 
-### def accept_charset=(charset)
+### def CGI.accept_charset=(charset)
 
 受けとることができるキャラクタセットを設定します。
 

--- a/manual/api/cgi/session.md
+++ b/manual/api/cgi/session.md
@@ -209,7 +209,7 @@ SessionDemo.new
 
 ## Class Methods
 
-### def new(request, option = {}) -> CGI::Session
+### def CGI::Session.new(request, option = {}) -> CGI::Session
 
 セッションオブジェクトを新しく作成し返します。
 
@@ -282,7 +282,7 @@ SessionDemo.new
   CGI::Session.new(cgi, {"new_session" => true})
   ```
 
-### def callback(dbman)
+### def CGI::Session.callback(dbman)
 #%# nodoc
 
 ## Instance Methods
@@ -346,7 +346,7 @@ FileStore の場合はセッションファイルを削除します。
 
 ## Class Methods
 
-### def new(session, option = {}) -> CGI::Session::FileStore
+### def CGI::Session::FileStore.new(session, option = {}) -> CGI::Session::FileStore
 
 自身を初期化します。
 
@@ -401,7 +401,7 @@ FileStore の場合はセッションファイルを削除します。
 
 ## Class Methods
 
-### def new(session, option = nil) -> CGI::Session::MemoryStore
+### def CGI::Session::MemoryStore.new(session, option = nil) -> CGI::Session::MemoryStore
 
 自身を初期化します。
 
@@ -444,7 +444,7 @@ FileStore の場合はセッションファイルを削除します。
 
 ## Class Methods
 
-### def new(session, option = nil) -> CGI::Session::NullStore
+### def CGI::Session::NullStore.new(session, option = nil) -> CGI::Session::NullStore
 
 自身を初期化します。
 

--- a/manual/api/cgi/session/pstore.md
+++ b/manual/api/cgi/session/pstore.md
@@ -9,7 +9,7 @@ require:
 
 ## Class Methods
 
-### def new(session, option = {}) -> CGI::Session::FileStore
+### def CGI::Session::PStore.new(session, option = {}) -> CGI::Session::FileStore
 
 自身を初期化します。
 

--- a/manual/api/cgi/util.md
+++ b/manual/api/cgi/util.md
@@ -6,7 +6,7 @@ CGI で利用するユーティリティメソッドを定義したライブラ�
 # reopen CGI
 
 ## Class Methods
-### def escape(string) -> String
+### def CGI.escape(string) -> String
 
 与えられた文字列を URL エンコードした文字列を新しく作成し返します。
 
@@ -23,7 +23,7 @@ p url
 #=> "http://www.example.com/register?url=http%3A%2F%2Fwww.example.com%2Findex.rss"
 ```
 
-### def unescape(string) -> String
+### def CGI.unescape(string) -> String
 
 与えられた文字列を URL デコードした文字列を新しく作成し返します。
 
@@ -39,7 +39,7 @@ p CGI.unescape("http%3A%2F%2Fwww.example.com%2Findex.rss")
 ```
 
 #%since 3.2
-### def escapeURIComponent(string) -> String
+### def CGI.escapeURIComponent(string) -> String
 
 与えられた文字列を [RFC:3986] に従って URL エンコードした文字列を新しく作成し返します。
 
@@ -60,7 +60,7 @@ p CGI.escapeURIComponent("a b") #=> "a%20b"
 
 - **SEE** [m:CGI.escape], [m:CGI.unescapeURIComponent]
 
-### def unescapeURIComponent(string) -> String
+### def CGI.unescapeURIComponent(string) -> String
 
 与えられた文字列を [m:CGI.escapeURIComponent] でエンコードされたものとして URL デコードした文字列を新しく作成し返します。
 
@@ -75,8 +75,8 @@ p CGI.unescapeURIComponent("%27Stop%21%27%20said%20Fred") #=> "'Stop!' said Fred
 - **SEE** [m:CGI.unescape], [m:CGI.escapeURIComponent]
 #%end
 
-### def escapeHTML(string) -> String
-### def escape_html(string) -> String
+### def CGI.escapeHTML(string) -> String
+### def CGI.escape_html(string) -> String
 
 与えられた文字列中の '、&、"、<、> を実体参照に置換した文字列を新しく作成し返します。
 
@@ -93,8 +93,8 @@ p CGI.escapeHTML('<script type="text/javascript">alert("警告")</script>')
 #=> "&lt;script type=&quot;text/javascript&quot;&gt;alert(&quot;警告&quot;)&lt;/script&gt;"
 ```
 
-### def unescapeHTML(string) -> String
-### def unescape_html(string) -> String
+### def CGI.unescapeHTML(string) -> String
+### def CGI.unescape_html(string) -> String
 
 与えられた文字列中の実体参照のうち、&amp; &gt; &lt; &quot;
 と数値指定がされているもの (&#0ffff など) を元の文字列に置換します。
@@ -107,8 +107,8 @@ require "cgi"
 p CGI.unescapeHTML("3 &gt; 1")   #=> "3 > 1"
 ```
 
-### def escapeElement(string, *elements) -> String
-### def escape_element(string, *elements) -> String
+### def CGI.escapeElement(string, *elements) -> String
+### def CGI.escape_element(string, *elements) -> String
 
 第二引数以降に指定したエレメントのタグだけを実体参照に置換します。
 
@@ -126,8 +126,8 @@ p CGI.escapeElement('<BR><A HREF="url"></A>', ["A", "IMG"])
      # => "<BR>&lt;A HREF="url"&gt;&lt;/A&gt"
 ```
 
-### def unescapeElement(string, *elements) -> String
-### def unescape_element(string, *elements) -> String
+### def CGI.unescapeElement(string, *elements) -> String
+### def CGI.unescape_element(string, *elements) -> String
 
 特定の要素だけをHTMLエスケープから戻す。
 
@@ -146,7 +146,7 @@ print CGI.unescapeElement('&lt;BR&gt;&lt;A HREF="url"&gt;&lt;/A&gt;', %w(A IMG))
 ```
 
 #%until 4.0
-### def rfc1123_date(time) -> String
+### def CGI.rfc1123_date(time) -> String
 
 与えられた時刻を [RFC:1123] フォーマットに準拠した文字列に変換します。
 
@@ -159,7 +159,7 @@ p CGI.rfc1123_date(Time.now)
   # => Sat, 1 Jan 2000 00:00:00 GMT
 ```
 
-### def pretty(string, shift = "  ") -> String
+### def CGI.pretty(string, shift = "  ") -> String
 
 HTML を人間に見やすく整形した文字列を返します。
 

--- a/manual/api/coverage.md
+++ b/manual/api/coverage.md
@@ -169,7 +169,7 @@ pp Coverage.result
 
 ## Class Methods
 
-### def start(option = {})  -> nil
+### def Coverage.start(option = {})  -> nil
 
 カバレッジの測定を開始します。既に実行されていた場合には何も起こりません。
 ただし、カバレッジ計測中に測定対象を変更しようとした場合は、RuntimeError となります。
@@ -209,7 +209,7 @@ bool(0)
 pp Coverage.result  #=> {"bool.rb"=>{:methods=>{[Object, :bool, 1, 0, 7, 3]=>1}}}
 ```
 
-### def result(stop: true, clear: true)  -> Hash
+### def Coverage.result(stop: true, clear: true)  -> Hash
 
 対象ファイル名をキー、測定結果を値したハッシュを返します。
 測定結果の詳細は、[lib:coverage] ライブラリ を参照してください。
@@ -260,7 +260,7 @@ p Coverage.result(clear: true, stop: false)  #=> {"bool.rb"=>{:oneshot_lines=>[5
 
 - **SEE** [m:Coverage.peek_result]
 
-### def peek_result -> Hash
+### def Coverage.peek_result -> Hash
 
 測定を止めることなく、測定中のその時の結果をハッシュで返します。
 測定結果の詳細は、[lib:coverage] ライブラリ を参照してください。
@@ -299,7 +299,7 @@ p Coverage.peek_result  #=> {"bool.rb"=>[1, 2, 1, nil, 1, nil, nil]}
 
 - **SEE** [m:Coverage.result]
 
-### def running? -> bool
+### def Coverage.running? -> bool
 
 カバレッジ測定中かどうかを返します。カバレッジの測定中とは、Coverage.start の
 呼び出し後から Coverage.result の呼び出し前です。
@@ -315,7 +315,7 @@ p Coverage.result      #=> {}
 p Coverage.running?    #=> false
 ```
 
-### def line_stub(file)  -> Array
+### def Coverage.line_stub(file)  -> Array
 
 行カバレッジの配列のスタブを返します。
 

--- a/manual/api/csv/CSV.md
+++ b/manual/api/csv/CSV.md
@@ -223,7 +223,7 @@ row of output though, when using CSV::generate_line() or Array#to_csv().
 
 ## Singleton Methods
 
-### def new(data, options = Hash.new) -> CSV
+### def CSV.new(data, options = Hash.new) -> CSV
 
 このメソッドは CSV ファイルを読み込んだり、書き出したりするために
 [c:String] か [c:IO] のインスタンスをラップします。
@@ -348,9 +348,9 @@ p csv.first # => #<CSV::Row "id":"1" "first name":"taro" "last name":"tanaka" "a
 
 - **SEE** [m:CSV::DEFAULT_OPTIONS], [m:CSV.open]
 
-### def filter(options = Hash.new){|row| ... }
-### def filter(input, options = Hash.new){|row| ... }
-### def filter(input, output, options = Hash.new){|row| ... }
+### def CSV.filter(options = Hash.new){|row| ... }
+### def CSV.filter(input, options = Hash.new){|row| ... }
+### def CSV.filter(input, output, options = Hash.new){|row| ... }
 #%# -> discard
 
 このメソッドは CSV データに対して Unix のツール群のようなフィルタを構築
@@ -421,8 +421,8 @@ end
 
 - **SEE** [m:CSV.new]
 
-### def foreach(path, options = Hash.new) -> Enumerator
-### def foreach(path, options = Hash.new){|row| ... } -> nil
+### def CSV.foreach(path, options = Hash.new) -> Enumerator
+### def CSV.foreach(path, options = Hash.new){|row| ... } -> nil
 
 このメソッドは CSV ファイルを読むための主要なインターフェイスです。
 各行が与えられたブロックに渡されます。
@@ -448,7 +448,7 @@ CSV.foreach("a.csv", encoding: "UTF-32BE:UTF-8"){|row| p row }
 
 - **SEE** [m:CSV.new], [m:File.open]
 
-### def generate(str = "", options = Hash.new){|csv| ... } -> String
+### def CSV.generate(str = "", options = Hash.new){|csv| ... } -> String
 
 このメソッドは与えられた文字列をラップして [c:CSV] のオブジェクトとしてブロックに渡します。
 ブロック内で [c:CSV] オブジェクトに行を追加できます。
@@ -490,7 +490,7 @@ print csv
 
 - **SEE** [m:CSV.new]
 
-### def generate_line(row, options = Hash.new) -> String
+### def CSV.generate_line(row, options = Hash.new) -> String
 
 このメソッドは一つの [c:Array] オブジェクトを CSV 文字列に変換するためのショートカットです。
 複数行のCSVを扱う際は[m:CSV#<<]を使うとより高速です。
@@ -513,8 +513,8 @@ p CSV.generate_line(taro, col_sep: '|') # => "1|taro|tanaka|20\n"
 
 - **SEE** [m:CSV.new]
 
-### def instance(data = $stdout, **options) -> CSV
-### def instance(data = $stdout, **options){|csv| ... } -> object
+### def CSV.instance(data = $stdout, **options) -> CSV
+### def CSV.instance(data = $stdout, **options){|csv| ... } -> object
 
 このメソッドは [m:CSV.new] のように [c:CSV] のインスタンスを返します。
 しかし、返される値は [m:Object#object_id] と与えられたオプションを
@@ -554,10 +554,10 @@ print csv.read
 
 - **SEE** [m:CSV.new]
 
-### def open(filename, mode = "rb", options = Hash.new){|csv| ... } -> nil
-### def open(filename, mode = "rb", options = Hash.new) -> CSV
-### def open(filename, options = Hash.new){|csv| ... } -> nil
-### def open(filename, options = Hash.new) -> CSV
+### def CSV.open(filename, mode = "rb", options = Hash.new){|csv| ... } -> nil
+### def CSV.open(filename, mode = "rb", options = Hash.new) -> CSV
+### def CSV.open(filename, options = Hash.new){|csv| ... } -> nil
+### def CSV.open(filename, options = Hash.new) -> CSV
 
 このメソッドは [c:IO] オブジェクトをオープンして [c:CSV] でラップします。
 これは CSV ファイルを書くための主要なインターフェイスとして使うことを意図しています。
@@ -674,8 +674,8 @@ print File.read("test.csv")
 
 - **SEE** [m:CSV.new], [m:IO.open]
 
-### def parse(str, options = Hash.new){|row| ... } -> nil
-### def parse(str, options = Hash.new) -> Array
+### def CSV.parse(str, options = Hash.new){|row| ... } -> nil
+### def CSV.parse(str, options = Hash.new) -> Array
 
 このメソッドは文字列を簡単にパースできます。
 ブロックを与えた場合は、ブロックにそれぞれの行を渡します。
@@ -719,7 +719,7 @@ end
 # => ["jiro", "suzuki"]
 ```
 
-### def parse_line(line, options = Hash.new) -> Array
+### def CSV.parse_line(line, options = Hash.new) -> Array
 
 このメソッドは一行の CSV 文字列を配列に変換するためのショートカットです。
 
@@ -742,8 +742,8 @@ p CSV.parse_line("1,\"ta,ro\",\"tana\nka\", 20")
 # => ["1", "ta,ro", "tana\nka", " 20"]
 ```
 
-### def read(path, options = Hash.new) -> [Array] | CSV::Table
-### def readlines(path, options = Hash.new) -> [Array] | CSV::Table
+### def CSV.read(path, options = Hash.new) -> [Array] | CSV::Table
+### def CSV.readlines(path, options = Hash.new) -> [Array] | CSV::Table
 
 CSV ファイルを配列の配列にするために使います。
 headers オプションに偽でない値を指定した場合は [c:CSV::Table] オブジェクトを返します。
@@ -798,7 +798,7 @@ p table[0]    # => #<CSV::Row "id":"1" "first name":"taro" "last name":"tanaka" 
 
 - **SEE** [m:CSV.new], [m:CSV.table]
 
-### def table(path, options = Hash.new) -> CSV::Table | [Array]
+### def CSV.table(path, options = Hash.new) -> CSV::Table | [Array]
 
 以下と同等のことを行うメソッドです。
 

--- a/manual/api/csv/CSV__Row.md
+++ b/manual/api/csv/CSV__Row.md
@@ -22,7 +22,7 @@ extend:
 
 ## Singleton Methods
 
-### def new(headers, fields, header_row = false) -> CSV::Row
+### def CSV::Row.new(headers, fields, header_row = false) -> CSV::Row
 
 自身を初期化します。
 

--- a/manual/api/csv/CSV__Table.md
+++ b/manual/api/csv/CSV__Table.md
@@ -34,7 +34,7 @@ extend:
 
 ## Singleton Methods
 
-### def new(array_of_rows) -> CSV::Table
+### def CSV::Table.new(array_of_rows) -> CSV::Table
 
 自身を初期化します。
 

--- a/manual/api/date/Date.md
+++ b/manual/api/date/Date.md
@@ -103,8 +103,8 @@ yesterday = Date.today - 1
 
 ## Class Methods
 
-### def civil(year = -4712, mon = 1, mday = 1, start = Date::ITALY) -> Date
-### def new(year = -4712, mon = 1, mday = 1, start = Date::ITALY) -> Date
+### def Date.civil(year = -4712, mon = 1, mday = 1, start = Date::ITALY) -> Date
+### def Date.new(year = -4712, mon = 1, mday = 1, start = Date::ITALY) -> Date
 
 暦日付に相当する日付オブジェクトを生成します。
 
@@ -130,7 +130,7 @@ require 'date'
 p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 ```
 
-### def commercial(cwyear = -4712, cweek = 1, cwday = 1, start = Date::ITALY) -> Date
+### def Date.commercial(cwyear = -4712, cweek = 1, cwday = 1, start = Date::ITALY) -> Date
 
 暦週日付に相当する日付オブジェクトを生成します。
 
@@ -148,15 +148,15 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 - **raise** `Date::Error` -- 正しくない日付になる組み合わせである場合に発生します。
 
-### def gregorian_leap? (year) -> bool
-### def leap? (year) -> bool
+### def Date.gregorian_leap? (year) -> bool
+### def Date.leap? (year) -> bool
 
 グレゴリオ暦の閏年なら真を返します。
 
 - **param** `year` -- 年
 
 #%# exp
-### def _httpdate(str) -> Hash
+### def Date._httpdate(str) -> Hash
 
 このメソッドは [m:Date.httpdate] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -165,7 +165,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def httpdate(str = 'Mon, 01 Jan -4712 00:00:00 GMT', start = Date::ITALY) -> Date
+### def Date.httpdate(str = 'Mon, 01 Jan -4712 00:00:00 GMT', start = Date::ITALY) -> Date
 
 [RFC:2616] で定められた書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -176,7 +176,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def _iso8601(str) -> Hash
+### def Date._iso8601(str) -> Hash
 
 このメソッドは [m:Date.iso8601] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -185,7 +185,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def iso8601(str = '-4712-01-01', start = Date::ITALY) -> Date
+### def Date.iso8601(str = '-4712-01-01', start = Date::ITALY) -> Date
 
 いくつかの代表的な ISO 8601 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -198,7 +198,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def _jisx0301(str) -> Hash
+### def Date._jisx0301(str) -> Hash
 
 このメソッドは [m:Date.jisx0301] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -207,7 +207,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def jisx0301(str = '-4712-01-01', start = Date::ITALY) -> Date
+### def Date.jisx0301(str = '-4712-01-01', start = Date::ITALY) -> Date
 
 いくつかの代表的な JIS X 0301 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -217,7 +217,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def jd(jd = 0, start = Date::ITALY) -> Date
+### def Date.jd(jd = 0, start = Date::ITALY) -> Date
 
 ユリウス日に相当する日付オブジェクトを生成します。
 
@@ -229,7 +229,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `jd` -- ユリウス日
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def julian_leap? (year) -> bool
+### def Date.julian_leap? (year) -> bool
 
 ユリウス暦の閏年なら真を返します。
 
@@ -238,7 +238,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `year` -- 年
 
-### def ordinal(year = -4712, yday = 1, start = Date::ITALY) -> Date
+### def Date.ordinal(year = -4712, yday = 1, start = Date::ITALY) -> Date
 
 年間通算日 (年日付) に相当する日付オブジェクトを生成します。
 
@@ -253,7 +253,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 - **raise** `Date::Error` -- 正しくない日付になる組み合わせである場合に発生します。
 
-### def _parse(str, complete = true) -> Hash
+### def Date._parse(str, complete = true) -> Hash
 
 このメソッドは [m:Date.parse] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -263,7 +263,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `str` -- 日付をあらわす文字列
 - **param** `complete` -- 年を補完するか
 
-### def parse(str = '-4712-01-01', complete = true, start = Date::ITALY) -> Date
+### def Date.parse(str = '-4712-01-01', complete = true, start = Date::ITALY) -> Date
 
 与えられた日付表現を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -280,8 +280,8 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **raise** `Date::Error` -- 正しくない日付になる組み合わせである場合に発生します。
 
 #%# exp
-### def _rfc2822(str) -> Hash
-### def _rfc822(str) -> Hash
+### def Date._rfc2822(str) -> Hash
+### def Date._rfc822(str) -> Hash
 
 このメソッドは [m:Date.rfc2822] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -290,8 +290,8 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def rfc2822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> Date
-### def rfc822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> Date
+### def Date.rfc2822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> Date
+### def Date.rfc822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> Date
 
 [RFC:2822] で定められた書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -302,7 +302,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def _rfc3339(str) -> Hash
+### def Date._rfc3339(str) -> Hash
 
 このメソッドは [m:Date.rfc3339] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -311,7 +311,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def rfc3339(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> Date
+### def Date.rfc3339(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> Date
 
 [RFC:3339] 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -321,7 +321,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def _strptime(str, format = '%F') -> Hash
+### def Date._strptime(str, format = '%F') -> Hash
 
 このメソッドは [m:Date.strptime] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -378,7 +378,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
   - %%: %自身
   - %+: [man:date(1)]の形式 (%a %b %e %H:%M:%S %Z %Y)
 
-### def strptime(str = '-4712-01-01', format = '%F', start = Date::ITALY) -> Date
+### def Date.strptime(str = '-4712-01-01', format = '%F', start = Date::ITALY) -> Date
 
 与えられた雛型で日付表現を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -391,7 +391,7 @@ p Date.new(2017, 9, 20)  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 - **raise** `Date::Error` -- 正しくない日付になる組み合わせである場合に発生します。
 
-### def today(start = Date::ITALY) -> Date
+### def Date.today(start = Date::ITALY) -> Date
 
 現在の日付に相当する日付オブジェクトを生成します。
 
@@ -402,8 +402,8 @@ require 'date'
 p Date.today  # => #<Date: 2017-09-20 ...>
 ```
 
-### def valid_civil? (year, mon, mday, start = Date::GREGORIAN) -> bool
-### def valid_date? (year, mon, mday, start = Date::GREGORIAN) -> bool
+### def Date.valid_civil? (year, mon, mday, start = Date::GREGORIAN) -> bool
+### def Date.valid_date? (year, mon, mday, start = Date::GREGORIAN) -> bool
 
 正しい暦日付であれば真、そうでないなら偽を返します。
 
@@ -414,7 +414,7 @@ p Date.today  # => #<Date: 2017-09-20 ...>
 - **param** `mday` -- 日
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def valid_commercial? (cwyear, cweek, cwday, start = Date::GREGORIAN) -> bool
+### def Date.valid_commercial? (cwyear, cweek, cwday, start = Date::GREGORIAN) -> bool
 
 正しい暦週日付であれば真、そうでないなら偽を返します。
 
@@ -425,7 +425,7 @@ p Date.today  # => #<Date: 2017-09-20 ...>
 - **param** `cwday` -- 週の日 (曜日)
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def valid_jd? (jd, start = Date::GREGORIAN) -> bool
+### def Date.valid_jd? (jd, start = Date::GREGORIAN) -> bool
 
 真を返します。
 
@@ -436,7 +436,7 @@ p Date.today  # => #<Date: 2017-09-20 ...>
 - **param** `jd` -- ユリウス日
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def valid_ordinal? (year, yday, start = Date::GREGORIAN) -> bool
+### def Date.valid_ordinal? (year, yday, start = Date::GREGORIAN) -> bool
 
 正しい年間通算日 (年日付) であれば真、そうでないなら偽を返します。
 
@@ -447,7 +447,7 @@ p Date.today  # => #<Date: 2017-09-20 ...>
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def _xmlschema(str) -> Hash
+### def Date._xmlschema(str) -> Hash
 
 このメソッドは [m:Date.xmlschema] と似ていますが、日付オブジェクトを生成せずに、
 見いだした要素をハッシュで返します。
@@ -456,7 +456,7 @@ p Date.today  # => #<Date: 2017-09-20 ...>
 
 - **param** `str` -- 日付をあらわす文字列
 
-### def xmlschema(str = '-4712-01-01', start = Date::ITALY) -> Date
+### def Date.xmlschema(str = '-4712-01-01', start = Date::ITALY) -> Date
 
 XML Schema による書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。

--- a/manual/api/date/DateTime.md
+++ b/manual/api/date/DateTime.md
@@ -26,8 +26,8 @@ yesterday = DateTime.now - 1
 
 ## Class Methods
 
-### def civil(year = -4712, mon = 1, mday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
-### def new(year = -4712, mon = 1, mday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
+### def DateTime.civil(year = -4712, mon = 1, mday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
+### def DateTime.new(year = -4712, mon = 1, mday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
 
 暦日付に相当する日時オブジェクトを生成します。
 
@@ -44,7 +44,7 @@ yesterday = DateTime.now - 1
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 - **raise** `ArgumentError` -- 正しくない日時
 
-### def commercial(cwyear = -4712, cweek = 1, cwday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
+### def DateTime.commercial(cwyear = -4712, cweek = 1, cwday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
 
 暦週日付に相当する日時オブジェクトを生成します。
 
@@ -61,7 +61,7 @@ yesterday = DateTime.now - 1
 - **raise** `ArgumentError` -- 正しくない日時
 
 #%# exp
-### def httpdate(str = 'Mon, 01 Jan -4712 00:00:00 GMT', start = Date::ITALY) -> DateTime
+### def DateTime.httpdate(str = 'Mon, 01 Jan -4712 00:00:00 GMT', start = Date::ITALY) -> DateTime
 
 [RFC:2616] で定められた書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -72,7 +72,7 @@ yesterday = DateTime.now - 1
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def iso8601(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
+### def DateTime.iso8601(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
 
 いくつかの代表的な ISO 8601 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -84,7 +84,7 @@ yesterday = DateTime.now - 1
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def jd(jd = 0, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
+### def DateTime.jd(jd = 0, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
 
 ユリウス日に相当する日時オブジェクトを生成します。
 
@@ -99,7 +99,7 @@ yesterday = DateTime.now - 1
 - **raise** `ArgumentError` -- 正しくない日時
 
 #%# exp
-### def jisx0301(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
+### def DateTime.jisx0301(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
 
 いくつかの代表的な JIS X 0301 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -109,13 +109,13 @@ yesterday = DateTime.now - 1
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def now(start = Date::ITALY) -> DateTime
+### def DateTime.now(start = Date::ITALY) -> DateTime
 
 現在の時刻に相当する日時オブジェクトを生成します。
 
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def ordinal(year = -4712, yday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
+### def DateTime.ordinal(year = -4712, yday = 1, hour = 0, min = 0, sec = 0, offset = 0, start = Date::ITALY) -> DateTime
 
 年日付に相当する日時オブジェクトを生成します。
 
@@ -131,8 +131,8 @@ yesterday = DateTime.now - 1
 - **raise** `ArgumentError` -- 正しくない日時
 
 #%# exp
-### def rfc2822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> DateTime
-### def rfc822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> DateTime
+### def DateTime.rfc2822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> DateTime
+### def DateTime.rfc822(str = 'Mon, 1 Jan -4712 00:00:00 +0000', start = Date::ITALY) -> DateTime
 
 [RFC:2822] で定められた書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -143,7 +143,7 @@ yesterday = DateTime.now - 1
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def rfc3339(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
+### def DateTime.rfc3339(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
 
 [RFC:3339] 書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -153,7 +153,7 @@ yesterday = DateTime.now - 1
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def today(start = Date::ITALY) -> Date
+### def DateTime.today(start = Date::ITALY) -> Date
 
 このクラスでは利用できません。
 
@@ -162,7 +162,7 @@ yesterday = DateTime.now - 1
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
 #%# exp
-### def xmlschema(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
+### def DateTime.xmlschema(str = '-4712-01-01T00:00:00+00:00', start = Date::ITALY) -> DateTime
 
 XML Schema による書式の日付を解析し、
 その情報に基づいて日付オブジェクトを生成します。
@@ -172,7 +172,7 @@ XML Schema による書式の日付を解析し、
 - **param** `str` -- 日付をあらわす文字列
 - **param** `start` -- グレゴリオ暦をつかい始めた日をあらわすユリウス日
 
-### def parse(str = '-4712-01-01T00:00:00+00:00', complete = true, start = Date::ITALY) -> DateTime
+### def DateTime.parse(str = '-4712-01-01T00:00:00+00:00', complete = true, start = Date::ITALY) -> DateTime
 
 与えられた日時表現を解析し、
 その情報に基づいて DateTime オブジェクトを生成します。
@@ -194,7 +194,7 @@ p DateTime.parse('2001-02-03T12:13:14Z').to_s
 
 - **SEE** [m:Date._parse], [m:Date.parse]
 
-### def _strptime(str, format = '%FT%T%z') -> Hash
+### def DateTime._strptime(str, format = '%FT%T%z') -> Hash
 
 与えられた雛型で日時表現を解析し、その情報に基づいてハッシュを生成します。
 
@@ -211,7 +211,7 @@ p DateTime._strptime('2001-02-03T12:13:14Z')
 
 - **SEE** [m:Date._strptime], [m:DateTime.strptime]
 
-### def strptime(str = '-4712-01-01T00:00:00+00:00', format = '%FT%T%z', start = Date::ITALY) -> DateTime
+### def DateTime.strptime(str = '-4712-01-01T00:00:00+00:00', format = '%FT%T%z', start = Date::ITALY) -> DateTime
 
 与えられた雛型で日時表現を解析し、
 その情報に基づいて DateTime オブジェクトを生成します。

--- a/manual/api/dbm/DBM.md
+++ b/manual/api/dbm/DBM.md
@@ -12,12 +12,12 @@ NDBM ファイルをアクセスするクラス。
 
 ## Class Methods
 
-### def new(dbname, mode = 0666, flags = nil) -> DBM
+### def DBM.new(dbname, mode = 0666, flags = nil) -> DBM
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 
-### def open(dbname, mode = 0666, flags = nil) -> DBM
-### def open(dbname, mode = 0666, flags = nil) {|db| ... } -> ()
+### def DBM.open(dbname, mode = 0666, flags = nil) -> DBM
+### def DBM.open(dbname, mode = 0666, flags = nil) {|db| ... } -> ()
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 

--- a/manual/api/debug.md
+++ b/manual/api/debug.md
@@ -203,7 +203,7 @@ M-x rubydb
 
 ## class Methods
 
-### def trace_func(*vars) -> object | nil
+### def Tracer.trace_func(*vars) -> object | nil
 
 [lib:debug] ライブラリの内部で使用します。
 

--- a/manual/api/delegate/SimpleDelegator.md
+++ b/manual/api/delegate/SimpleDelegator.md
@@ -20,7 +20,7 @@ p foo2.test # => 25
 
 ## Class Methods
 
-### def new(obj) -> object
+### def SimpleDelegator.new(obj) -> object
 
 メソッドを委譲するオブジェクトの設定と、
 メソッド委譲を行うためのクラスメソッドの定義を行います。

--- a/manual/api/digest/Digest__Base.md
+++ b/manual/api/digest/Digest__Base.md
@@ -20,22 +20,22 @@ p Digest::MD5.file('ruby-1.8.5.tar.gz').to_s #=> '3fbb02294a8ca33d4684055adba5ed
 
 ## Class Methods
 
-### def new            -> Digest::Base
+### def Digest::Base.new            -> Digest::Base
 
 新しいダイジェストオブジェクトを生成します。
 
-### def digest(str) -> String
+### def Digest::Base.digest(str) -> String
 
 与えられた文字列に対するハッシュ値を文字列で返します。
 new(str).digest と等価です。
 
-### def hexdigest(str) -> String
+### def Digest::Base.hexdigest(str) -> String
 
 与えられた文字列に対するハッシュ値を、ASCIIコードを使って
 16進数の列を示す文字列にエンコードして返します。
 new(str).hexdigest と等価です。
 
-### def base64digest(str) -> String
+### def Digest::Base.base64digest(str) -> String
 
 与えられた文字列に対するハッシュ値を、Base64 エンコードした文字列にして返します。
 new(str).base64digest と等価です。
@@ -49,7 +49,7 @@ p Digest::MD5.base64digest('ruby') # => "WOU9EyTu9iZf25ewjtmq3w=="
 
 - **SEE** [m:Digest::Base#base64digest]
 
-### def file(path) -> object
+### def Digest::Base.file(path) -> object
 
 新しいダイジェストオブジェクトを生成し、
 ファイル名 file で指定したファイルの内容を読み込み、

--- a/manual/api/digest/sha2.md
+++ b/manual/api/digest/sha2.md
@@ -31,7 +31,7 @@ Standards and Technology) の SHA-512 Secure Hash Algorithmを
 
 # class Digest::SHA2 < Digest::Class
 ## Class Methods
-### def new(bitlen = 256) -> Digest::SHA2
+### def Digest::SHA2.new(bitlen = 256) -> Digest::SHA2
 
 与えられた bitlen に対応する SHA2 ハッシュを生成するためのオブジェクト
 を内部で設定して自身を初期化します。

--- a/manual/api/drb/DRbObject.md
+++ b/manual/api/drb/DRbObject.md
@@ -35,7 +35,7 @@ hook して、それを転送します。
 #%# this is nil. uri is the URI of the remote object that this will
 #%# be a stub for.
 
-### def new_with_uri(uri) -> DRb::DRbObject
+### def DRb::DRbObject.new_with_uri(uri) -> DRb::DRbObject
 
 URI から新しい DRbObject を生成します。
 

--- a/manual/api/drb/DRbServer.md
+++ b/manual/api/drb/DRbServer.md
@@ -19,7 +19,7 @@ dRuby サーバは
 
 ## Class Methods
 
-### def default_acl(acl) -> ()
+### def DRb::DRbServer.default_acl(acl) -> ()
 
 サーバ起動時の :acl オプションのデフォルト値を指定します。
 
@@ -27,7 +27,7 @@ dRuby サーバは
 
 - **SEE** [m:DRb::DRbServer.new], [m:DRb?.start_service], [c:ACL]
 
-### def default_argc_limit(argc) -> ()
+### def DRb::DRbServer.default_argc_limit(argc) -> ()
 
 サーバ起動時の :argc_limit オプションのデフォルト値を指定します。
 
@@ -35,7 +35,7 @@ dRuby サーバは
 
 - **SEE** [m:DRb::DRbServer.new], [m:DRb?.start_service]
 
-### def default_id_conv(idconv) -> ()
+### def DRb::DRbServer.default_id_conv(idconv) -> ()
 
 サーバ起動時の :id_conv オプションのデフォルト値を指定します。
 
@@ -43,7 +43,7 @@ dRuby サーバは
 
 - **SEE** [m:DRb::DRbServer.new], [m:DRb?.start_service]
 
-### def default_load_limit(sz) -> ()
+### def DRb::DRbServer.default_load_limit(sz) -> ()
 
 サーバ起動時の :load_limit オプションのデフォルト値を指定します。
 
@@ -51,7 +51,7 @@ dRuby サーバは
 
 - **SEE** [m:DRb::DRbServer.new], [m:DRb?.start_service]
 
-### def new(uri=nil, front=nil, config_or_acl=nil) -> DRb::DRbServer
+### def DRb::DRbServer.new(uri=nil, front=nil, config_or_acl=nil) -> DRb::DRbServer
 
 dRuby サーバを起動し、DRbServerのインスタンスを返します。
 
@@ -62,14 +62,14 @@ dRuby サーバを起動し、DRbServerのインスタンスを返します。
 
 - **SEE** [m:DRb?.start_service]
 
-### def verbose -> bool
+### def DRb::DRbServer.verbose -> bool
 
 サーバ起動時の :verbose オプションのデフォルト値を返します。
 
 - **SEE** [m:DRb::DRbServer.new], [m:DRb?.start_service], 
      [m:DRb::DRbServer.verbose=]
 
-### def verbose=(on)
+### def DRb::DRbServer.verbose=(on)
 
 サーバ起動時の :verbose オプションのデフォルト値を指定します。
 

--- a/manual/api/drb/DRbUNIXSocket.md
+++ b/manual/api/drb/DRbUNIXSocket.md
@@ -16,7 +16,7 @@ DRbTCPSocket のサブクラスとして実装されています。
 
 ## Class Methods
 
-### def open(uri, config) -> DRb::DRbUNIXSocket
+### def DRb::DRbUNIXSocket.open(uri, config) -> DRb::DRbUNIXSocket
 
 uri で指定した UNIX ドメインソケットに接続します。
 
@@ -26,7 +26,7 @@ uri で指定した UNIX ドメインソケットに接続します。
 
 - **raise** `DRb::DRbBadScheme` -- uri が "drbunix:" で始まらない場合に発生します。
 
-### def open_server(uri, config) -> DRb::DRbUNIXSocket
+### def DRb::DRbUNIXSocket.open_server(uri, config) -> DRb::DRbUNIXSocket
 
 uri で指定したパスに UNIX ドメインソケットを作成し、接続を待ち受けます。
 
@@ -38,7 +38,7 @@ uri で指定したパスに UNIX ドメインソケットを作成し、接続�
              `:UNIXFileMode`、`:UNIXFileOwner`、`:UNIXFileGroup` を指定できます。
              詳細は [lib:drb/unix] を参照してください。
 
-### def uri_option(uri, config) -> [String, String | nil]
+### def DRb::DRbUNIXSocket.uri_option(uri, config) -> [String, String | nil]
 
 uri をパースして [uri, option] という配列を返します。
 

--- a/manual/api/drb/acl.md
+++ b/manual/api/drb/acl.md
@@ -50,7 +50,7 @@ p acl.allow_addr?(addr) # => true
 
 ## Class Methods
 
-### def new(list=nil, order = DENY_ALLOW) -> ACL
+### def ACL.new(list=nil, order = DENY_ALLOW) -> ACL
 
 新たな ACL オブジェクトを返します。
 

--- a/manual/api/drb/extserv.md
+++ b/manual/api/drb/extserv.md
@@ -17,7 +17,7 @@ include:
 
 ## Class Methods
 
-### def new(there, name, server=nil) -> DRb::ExtServ
+### def DRb::ExtServ.new(there, name, server=nil) -> DRb::ExtServ
 
 DRb::ExtServ オブジェクトを生成し、サービスを 
 [c:DRb::ExtServManager] オブジェクトに登録します。

--- a/manual/api/drb/extservm.md
+++ b/manual/api/drb/extservm.md
@@ -110,7 +110,7 @@ s.service(ARGV[0]).stop_service
 [c:DRb::ExtServ] で作られたサービスを管理するクラスです。
 
 ## Class Methods
-### def command -> { String => String|[String] }
+### def DRb::ExtServManager.command -> { String => String|[String] }
 
 サービスを起動するためのコマンドを指定するための [c:Hash] を
 返します。
@@ -125,7 +125,7 @@ Hash のキーがサービス名で、値がそのサービスを起動するた
 プロセスを起動する際に shell 経由で起動されます。
 文字列の配列で指定すると shell を経由せずに起動されます。
 
-### def command=(cmd)
+### def DRb::ExtServManager.command=(cmd)
 
 サービスを起動するためのコマンドを指定するための [c:Hash] を
 設定します。
@@ -133,7 +133,7 @@ Hash のキーがサービス名で、値がそのサービスを起動するた
 - **param** `cmd` -- コマンドを設定した Hash
 - **SEE** [m:DRb::ExtServManager.command]
 
-### def new -> DRb::ExtServManager
+### def DRb::ExtServManager.new -> DRb::ExtServManager
 
 DRb::ExtServManager オブジェクトを生成して返します。
 

--- a/manual/api/drb/gw.md
+++ b/manual/api/drb/gw.md
@@ -103,7 +103,7 @@ drb 通信中継のためのゲートウェイです。
 
 ## Class Methods
 
-### def new -> DRb::GW
+### def DRb::GW.new -> DRb::GW
 
 新たな GW オブジェクトを生成します。
 

--- a/manual/api/drb/timeridconv.md
+++ b/manual/api/drb/timeridconv.md
@@ -27,7 +27,7 @@ to_id でオブジェクトを識別子に変換してから
 基本的にはオブジェクトをリモートに送る直前に変換されます。
 
 ## Class Methods
-### def new(timeout=600) -> DRb::TimerIdConv
+### def DRb::TimerIdConv.new(timeout=600) -> DRb::TimerIdConv
 
 TimerIdConv のインスタンスを生成して返します。
 

--- a/manual/api/e2mmap/Exception2MessageMapper.md
+++ b/manual/api/e2mmap/Exception2MessageMapper.md
@@ -9,7 +9,7 @@ until: "2.7.0"
 例外クラスに特定のエラーメッセージ用フォーマットを関連づけるためのモジュールです。
 
 ## Singleton Methods
-### def def_e2message(klass, exception_class, message_format) -> Class
+### def Exception2MessageMapper.def_e2message(klass, exception_class, message_format) -> Class
 
 すでに存在する例外クラス exception_class に、
 エラーメッセージ用フォーマット message_format を関連づけます。
@@ -23,7 +23,7 @@ until: "2.7.0"
 
 - **return** -- exception_class を返します。
 
-### def def_exception(klass, exception_name, message_format, superklass = StandardError) -> Class
+### def Exception2MessageMapper.def_exception(klass, exception_name, message_format, superklass = StandardError) -> Class
 
 exception_name という名前の例外クラスを定義します。
 
@@ -39,21 +39,21 @@ exception_name という名前の例外クラスを定義します。
 
 - **return** -- 定義した例外クラスを返します。
 
-### def e2mm_message(klass, exp) -> String | nil
-### def message(klass, exp) -> String | nil
+### def Exception2MessageMapper.e2mm_message(klass, exp) -> String | nil
+### def Exception2MessageMapper.message(klass, exp) -> String | nil
 #%todo
 
 - **param** `klass` --
 
 - **param** `exp` --
 
-### def extend_object(cl) -> ()
+### def Exception2MessageMapper.extend_object(cl) -> ()
 #%todo
 
 - **param** `cl` --
 
-### def Raise(klass = E2MM, exception_class = nil, *rest) -> ()
-### def Fail(klass = E2MM, exception_class = nil, *rest)  -> ()
+### def Exception2MessageMapper.Raise(klass = E2MM, exception_class = nil, *rest) -> ()
+### def Exception2MessageMapper.Fail(klass = E2MM, exception_class = nil, *rest)  -> ()
 
 登録されている情報を使用して、例外を発生させます。
 

--- a/manual/api/erb.md
+++ b/manual/api/erb.md
@@ -148,9 +148,9 @@ puts template.result # => __ENCODING__ is Big5
 ## Class Methods
 
 #%since 3.2
-### def new(str, trim_mode: nil, eoutvar: '_erbout') -> ERB
+### def ERB.new(str, trim_mode: nil, eoutvar: '_erbout') -> ERB
 #%else
-### def new(str, safe_level=NOT_GIVEN, trim_mode=NOT_GIVEN, eoutvar=NOT_GIVEN, trim_mode: nil, eoutvar: '_erbout') -> ERB
+### def ERB.new(str, safe_level=NOT_GIVEN, trim_mode=NOT_GIVEN, eoutvar=NOT_GIVEN, trim_mode: nil, eoutvar: '_erbout') -> ERB
 #%end
 eRubyスクリプト から ERB オブジェクトを生成して返します。
 
@@ -213,7 +213,7 @@ puts listings.product + "\n" + listings.price
 # A well messages pattie, breaded and fried.
 ```
 
-### def version -> String
+### def ERB.version -> String
 
 erb.rbのリビジョン情報を返します。
 

--- a/manual/api/etc/Etc__Group.md
+++ b/manual/api/etc/Etc__Group.md
@@ -13,8 +13,8 @@ alias:
 
 ## Class Methods
 
-### def each {|entry| ... } -> Etc::Group
-### def each                -> Enumerator
+### def Etc::Group.each {|entry| ... } -> Etc::Group
+### def Etc::Group.each                -> Enumerator
 
 /etc/group に含まれるエントリを一つずつブロックに渡して評価します。
 ブロックを省略した場合は [c:Enumerator] を返します。

--- a/manual/api/etc/Etc__Passwd.md
+++ b/manual/api/etc/Etc__Passwd.md
@@ -30,8 +30,8 @@ alias:
 
 ## Class Methods
 
-### def each {|entry| ... } -> Etc::Passwd
-### def each                -> Enumerator
+### def Etc::Passwd.each {|entry| ... } -> Etc::Passwd
+### def Etc::Passwd.each                -> Enumerator
 
 /etc/passwd に含まれるエントリを一つずつブロックに渡して評価します。
 ブロックを省略した場合は [c:Enumerator] を返します。

--- a/manual/api/fiddle/1.9/fiddle.lib.md
+++ b/manual/api/fiddle/1.9/fiddle.lib.md
@@ -15,7 +15,7 @@ DL を経由して利用してください。
 fiddle ライブラリの名前空間をなすモジュール
 
 ## Singleton Methods
-### def win32_last_error -> Integer
+### def Fiddle.win32_last_error -> Integer
 
 最後に [m:Fiddle::Function#call] で C の関数を呼び出した
 結果設定された errno を返します。
@@ -24,7 +24,7 @@ fiddle ライブラリの名前空間をなすモジュール
 
 この値はスレッドローカルです。
 
-### def win32_last_error=(errno)
+### def Fiddle.win32_last_error=(errno)
 
 [m:Fiddle.win32_last_error] で返される値を設定します。
 
@@ -34,14 +34,14 @@ errno は fiddle が設定するのでユーザはこのメソッドを使わな
 
 - **param** `errno` -- 設定する errno
 
-### def last_error -> Integer
+### def Fiddle.last_error -> Integer
 
 最後に [m:Fiddle::Function#call] で C の関数を呼び出した
 結果設定された errno を返します。
 
 この値はスレッドローカルです。
 
-### def last_error=(errno)
+### def Fiddle.last_error=(errno)
 
 [m:Fiddle.last_error] で返される値を設定します。
 
@@ -120,7 +120,7 @@ Windows 環境下では true、それ以外では false です。
 C の関数を表すクラスです。
 
 ## Class Methods
-### def new(ptr, args, ret_type, abi=Fiddle::Function::DEFAULT) -> Fiddle::Function
+### def Fiddle::Function.new(ptr, args, ret_type, abi=Fiddle::Function::DEFAULT) -> Fiddle::Function
 
 ptr (関数ポインタを表す整数)から Fiddle::Function オブジェクトを
 生成します。
@@ -273,7 +273,7 @@ compare = Class.new(Fiddle::Closure){
 [c:Fiddle::Closure::BlockCaller] を使うほうが簡単です。
 
 ## Class Methods
-### def new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
+### def Fiddle::Closure.new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
 
 そのクラスの call メソッドを呼びだすような
 Fiddle::Closure オブジェクトを返します。
@@ -326,7 +326,7 @@ p s # =>  "()07Uabcqx"
 ```
 
 ## Class Methods
-### def new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
+### def Fiddle::Closure::BlockCaller.new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
 
 Ruby のブロックを呼び出す Fiddle::Closure オブジェクトを返します。
 

--- a/manual/api/fiddle/2.0/Fiddle.md
+++ b/manual/api/fiddle/2.0/Fiddle.md
@@ -10,7 +10,7 @@ UNIX の [man:dlopen(3)] や Windows の LoadLibrary()
 などのダイナミックリンカへの低レベルなインターフェースを提供するモジュールです。
 
 ## Singleton Methods
-### def win32_last_error -> Integer
+### def Fiddle.win32_last_error -> Integer
 
 最後に [m:Fiddle::Function#call] で C の関数を呼び出した
 結果設定された errno を返します。
@@ -19,7 +19,7 @@ UNIX の [man:dlopen(3)] や Windows の LoadLibrary()
 
 この値はスレッドローカルです。
 
-### def win32_last_error=(errno)
+### def Fiddle.win32_last_error=(errno)
 
 [m:Fiddle.win32_last_error] で返される値を設定します。
 
@@ -29,14 +29,14 @@ errno は fiddle が設定するのでユーザはこのメソッドを使わな
 
 - **param** `errno` -- 設定する errno
 
-### def last_error -> Integer
+### def Fiddle.last_error -> Integer
 
 最後に [m:Fiddle::Function#call] で C の関数を呼び出した
 結果設定された errno を返します。
 
 この値はスレッドローカルです。
 
-### def last_error=(errno)
+### def Fiddle.last_error=(errno)
 
 [m:Fiddle.last_error] で返される値を設定します。
 

--- a/manual/api/fiddle/2.0/Fiddle__CStruct.md
+++ b/manual/api/fiddle/2.0/Fiddle__CStruct.md
@@ -28,7 +28,7 @@ S = struct(["long foo", "void* bar"])
 このドキュメントは説明の便宜のためだと考えてください。
 
 ## Class Methods
-### def new(addr) -> Fiddle::CStruct
+### def Fiddle::CStruct.new(addr) -> Fiddle::CStruct
 
 addr のアドレスが指すメモリを構造体のアドレスとみなし、
 構造体を作ります。
@@ -43,7 +43,7 @@ return (struct foo*)addr;
 
 - **param** `addr` -- アドレス
 
-### def malloc -> Fiddle::CStruct
+### def Fiddle::CStruct.malloc -> Fiddle::CStruct
 
 構造体のためのメモリを確保し、Fiddle::CStruct の(子孫クラスの)
 オブジェクトで返します。
@@ -56,7 +56,7 @@ return (struct foo*)malloc(sizeof(struct foo));
 
 というコードと対応していると言えます。
 
-### def size -> Integer
+### def Fiddle::CStruct.size -> Integer
 
 構造体のサイズをバイト数で返します。
 

--- a/manual/api/fiddle/2.0/Fiddle__Function.md
+++ b/manual/api/fiddle/2.0/Fiddle__Function.md
@@ -7,7 +7,7 @@ since: "2.0.0"
 C の関数を表すクラスです。
 
 ## Class Methods
-### def new(ptr, args, ret_type, abi=Fiddle::Function::DEFAULT, name: nil) -> Fiddle::Function
+### def Fiddle::Function.new(ptr, args, ret_type, abi=Fiddle::Function::DEFAULT, name: nil) -> Fiddle::Function
 
 ptr (関数ポインタ)から Fiddle::Function オブジェクトを
 生成します。
@@ -164,7 +164,7 @@ compare = Class.new(Fiddle::Closure){
 [c:Fiddle::Closure::BlockCaller] を使うほうが簡単です。
 
 ## Class Methods
-### def new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
+### def Fiddle::Closure.new(ret, args, abi=Fiddle::Function::DEFAULT) -> Fiddle::Closure
 
 そのクラスの call メソッドを呼びだすような
 Fiddle::Closure オブジェクトを返します。
@@ -217,7 +217,7 @@ p s # =>  "()07Uabcqx"
 ```
 
 ## Class Methods
-### def new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
+### def Fiddle::Closure::BlockCaller.new(ret, args, abi=Fiddle::Function::DEFAULT){ ... } -> Fiddle::Closure::BlockCaller
 
 Ruby のブロックを呼び出す Fiddle::Closure オブジェクトを返します。
 

--- a/manual/api/fiddle/2.0/Fiddle__Handle.md
+++ b/manual/api/fiddle/2.0/Fiddle__Handle.md
@@ -10,8 +10,8 @@ since: "2.0.0"
 
 ## Class Methods
 
-### def new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) -> Fiddle::Handle
-### def new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) {|handle| ... }    -> Fiddle::Handle
+### def Fiddle::Handle.new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) -> Fiddle::Handle
+### def Fiddle::Handle.new(lib, flags=Fiddle::Handle::RTLD_LAZY|Fiddle::Handle::RTLD_GLOBAL) {|handle| ... }    -> Fiddle::Handle
 
 ライブラリ lib をオープンし、Handle オブジェクトとして返します。
 
@@ -37,8 +37,8 @@ func = Fiddle::Function.new(i, [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
 p func.call("uxyz") # => 4
 ```
 
-### def sym(func) -> Integer
-### def [](func) -> Integer
+### def Fiddle::Handle.sym(func) -> Integer
+### def Fiddle::Handle.[](func) -> Integer
 
 ライブラリのデフォルトの検索順序に従い、現在のライブラリ以降の
 シンボルを探します。

--- a/manual/api/fiddle/2.0/Fiddle__Pointer.md
+++ b/manual/api/fiddle/2.0/Fiddle__Pointer.md
@@ -11,7 +11,7 @@ DL::CPtrとほぼ同じインターフェースを持ちます。
 
 ## Singleton Methods
 
-### def new(addr, size = 0, free = nil)   -> Fiddle::Pointer
+### def Fiddle::Pointer.new(addr, size = 0, free = nil)   -> Fiddle::Pointer
 
 与えられた addr が指すメモリ領域を表す Pointer オブジェクトを生成して返します。
 
@@ -25,7 +25,7 @@ size であると仮定されます。GC は free 関数を使用してメモリ
 - **param** `free` -- GC 時に呼ばれる free 関数を [c:Fiddle::Function] オブジェクトか
        整数で指定します。
 
-### def malloc(size, free = nil)   -> Fiddle::Pointer
+### def Fiddle::Pointer.malloc(size, free = nil)   -> Fiddle::Pointer
 
 与えられた長さ size のメモリ領域を確保し、それを表す Pointer オブジェクトを生成して返します。
 
@@ -34,8 +34,8 @@ size であると仮定されます。GC は free 関数を使用してメモリ
 - **param** `free` -- GC 時に呼ばれる Pointer オブジェクトの free 関数を 
        [c:Fiddle::Function] オブジェクトか整数で指定します。
 
-### def [](val)       -> Fiddle::Pointer
-### def to_ptr(val)   -> Fiddle::Pointer
+### def Fiddle::Pointer.[](val)       -> Fiddle::Pointer
+### def Fiddle::Pointer.to_ptr(val)   -> Fiddle::Pointer
 
 与えられた val と関連した Pointer オブジェクトを生成して返します。
 

--- a/manual/api/fileutils/FileUtils.md
+++ b/manual/api/fileutils/FileUtils.md
@@ -851,7 +851,7 @@ FileUtils.uptodate?('hello.o', ['hello.c', 'hello.h']) or system('make')
 ```
 
 ## Singleton Methods
-### def collect_method(opt) -> Array
+### def FileUtils.collect_method(opt) -> Array
 
 与えられたオプションを持つメソッド名の配列を返します。
 
@@ -862,7 +862,7 @@ require 'fileutils'
 p FileUtils.collect_method(:preserve) # => ["cp", "cp_r", "copy", "install"]
 ```
 
-### def commands -> Array
+### def FileUtils.commands -> Array
 
 何らかのオプションを持つメソッド名の配列を返します。
 
@@ -871,7 +871,7 @@ require 'fileutils'
 p FileUtils.commands  # => ["chmod", "cp", "cp_r", "install", ...]
 ```
 
-### def have_option?(mid, opt) -> bool
+### def FileUtils.have_option?(mid, opt) -> bool
 
 mid というメソッドが opt というオプションを持つ場合、真を返します。
 そうでない場合は、偽を返します。
@@ -880,7 +880,7 @@ mid というメソッドが opt というオプションを持つ場合、真�
 
 - **param** `opt` -- オプション名を指定します。
 
-### def options -> Array
+### def FileUtils.options -> Array
 
 オプション名の配列を返します。
 
@@ -890,7 +890,7 @@ p FileUtils.options
 # => ["noop", "verbose", "force", "mode", "parents", "owner", "group", "preserve", "dereference_root", "remove_destination", "secure", "mtime", "nocreate"]
 ```
 
-### def options_of(mid) -> Array
+### def FileUtils.options_of(mid) -> Array
 
 与えられたメソッド名で使用可能なオプション名の配列を返します。
 

--- a/manual/api/forwardable.md
+++ b/manual/api/forwardable.md
@@ -42,14 +42,14 @@ f.content_at(1)
 
 ## Singleton Methods
 
-### def debug -> bool
+### def Forwardable.debug -> bool
 
 委譲部分をバックトレースに含めるかどうかの状態を返します。
 
 バックトレースを含める設定となっている時、真を返します。
 デフォルトは含めない設定となっています。
 
-### def debug= -> bool
+### def Forwardable.debug= -> bool
 
 委譲部分をバックトレースに含めるかどうかの状態を設定します。
 

--- a/manual/api/gdbm/GDBM.md
+++ b/manual/api/gdbm/GDBM.md
@@ -13,7 +13,7 @@ GDBM ファイルをアクセスするクラス。
 
 ## Class Methods
 
-### def new(dbname, mode = 0666, flags = 0) -> GDBM
+### def GDBM.new(dbname, mode = 0666, flags = 0) -> GDBM
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 
@@ -29,8 +29,8 @@ dbname で指定したデータベースをモードを mode に設定してオ�
              これらをどれも指定しなかった場合には、
              [m:GDBM::WRCREAT], [m:GDBM::WRITER], [m:GDBM::READER] の順で試します。
 
-### def open(dbname, mode = 0666, flags = 0) -> GDBM
-### def open(dbname, mode = 0666, flags = 0) {|db| ... } -> object
+### def GDBM.open(dbname, mode = 0666, flags = 0) -> GDBM
+### def GDBM.open(dbname, mode = 0666, flags = 0) {|db| ... } -> object
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 

--- a/manual/api/getoptlong.md
+++ b/manual/api/getoptlong.md
@@ -153,7 +153,7 @@ parser.quiet = true
 GNU getopt_long() を Ruby で模したクラスです。
 
 ## Class Methods
-### def new(*arguments)
+### def GetoptLong.new(*arguments)
 
 GetoptLong のオブジェクトを生成します。引数が与えられ
 たときは、それを [m:GetoptLong#set_options] メソッドに渡します。

--- a/manual/api/io/console.md
+++ b/manual/api/io/console.md
@@ -136,7 +136,7 @@ cooked モードを有効にします。端末のモードを後で元に戻す�
 
 ## Singleton Methods
 
-### def console -> File | nil
+### def IO.console -> File | nil
 
 端末を [c:File] オブジェクトで返します。
 

--- a/manual/api/io/console/size.md
+++ b/manual/api/io/console/size.md
@@ -7,11 +7,11 @@ type: library
 
 ## Singleton Methods
 
-### def default_console_size -> [Integer, Integer]
+### def IO.default_console_size -> [Integer, Integer]
 
 デフォルトの端末のサイズを [rows, columns] で返します。
 
-### def console_size -> [Integer, Integer]
+### def IO.console_size -> [Integer, Integer]
 
 端末のサイズを [rows, columns] で返します。
 

--- a/manual/api/ipaddr.md
+++ b/manual/api/ipaddr.md
@@ -24,7 +24,7 @@ p ipaddr3   # => #<IPAddr: IPv4:192.168.2.0/255.255.255.0>
 
 ## Class Methods
 
-### def new(addr = '::', family = Socket::AF_UNSPEC) -> IPAddr
+### def IPAddr.new(addr = '::', family = Socket::AF_UNSPEC) -> IPAddr
 
 新しい IPAddr オブジェクトを生成します。
 
@@ -40,7 +40,7 @@ p ipaddr3   # => #<IPAddr: IPv4:192.168.2.0/255.255.255.0>
 
 - **raise** `ArgumentError` -- family にサポートされていない address family を指定した場合に発生します。
 
-### def new_ntoh(addr) -> IPAddr
+### def IPAddr.new_ntoh(addr) -> IPAddr
 
 ネットワークバイトオーダーのバイト列から IPAddr オブジェクトを生成します。
 
@@ -51,7 +51,7 @@ require 'ipaddr'
 p IPAddr.new_ntoh("\300\250\001\001")   # => <IPAddr: IPv4:192.168.1.1/255.255.255.255>
 ```
 
-### def ntop(addr) -> String
+### def IPAddr.ntop(addr) -> String
 
 ネットワークバイトオーダーのバイト列で表現された IP アドレスを人間の読める形式に変換します。
 

--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -707,7 +707,7 @@ IRB のバージョンを文字列で返します。
 ~/.irbrc などの設定ファイル内で IRB.conf[:VERSION] を設定していた場合は
 任意のバージョンを返すように設定できます。
 
-### const CurrentContext -> IRB::Context
+### def IRB.CurrentContext -> IRB::Context
 
 現在の irb に関する [c:IRB::Context] を返します。
 

--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -696,11 +696,11 @@ irb のメインモジュールです。
 
 ## Class Methods
 
-### def conf -> Hash
+### def IRB.conf -> Hash
 
 irb の設定をハッシュで返します。
 
-### def version -> String
+### def IRB.version -> String
 
 IRB のバージョンを文字列で返します。
 
@@ -711,19 +711,19 @@ IRB のバージョンを文字列で返します。
 
 現在の irb に関する [c:IRB::Context] を返します。
 
-### def start(ap_path = nil) -> ()
+### def IRB.start(ap_path = nil) -> ()
 
 [c:IRB] を初期化して、トップレベルの irb を開始します。
 
 - **param** `ap_path` -- irb コマンドのパスを指定します。
 
-### def irb_at_exit -> ()
+### def IRB.irb_at_exit -> ()
 
 at_exit で登録された処理を実行します。
 
 ユーザが直接使用するものではありません。
 
-### def irb_exit(irb, ret) -> object
+### def IRB.irb_exit(irb, ret) -> object
 
 irb を終了します。ret で指定したオブジェクトを返します。
 
@@ -733,7 +733,7 @@ irb を終了します。ret で指定したオブジェクトを返します。
 
 ユーザが直接使用するものではありません。
 
-### def irb_abort(irb, exception = Abort)
+### def IRB.irb_abort(irb, exception = Abort)
 
 実行中の処理を中断します。必ず例外が発生するため、何も返しません。
 

--- a/manual/api/irb/cmd/nop.md
+++ b/manual/api/irb/cmd/nop.md
@@ -14,7 +14,7 @@ irb 中でコマンドを拡張するクラスのベースになるクラスで�
 
 ## Class Methods
 
-### def execute(conf, *opts) -> ()
+### def IRB::ExtendCommand::Nop.execute(conf, *opts) -> ()
 
 コマンドを実行します。ユーザが直接使用するものではありません。
 
@@ -22,7 +22,7 @@ irb 中でコマンドを拡張するクラスのベースになるクラスで�
 
 - **param** `opts` -- irb 中でコマンドに渡す引数を指定します。
 
-### def new(conf) -> IRB::ExtendCommand::Nop
+### def IRB::ExtendCommand::Nop.new(conf) -> IRB::ExtendCommand::Nop
 
 自身を初期化します。ユーザが直接使用するものではありません。
 

--- a/manual/api/irb/context.md
+++ b/manual/api/irb/context.md
@@ -100,7 +100,7 @@ irb 中で conf コマンドの戻り値や .irbrc で IRB.conf を操作する�
 
 ## Class Methods
 
-### def new(irb, workspace = nil, input_method = nil, output_method = nil) -> IRB::Context
+### def IRB::Context.new(irb, workspace = nil, input_method = nil, output_method = nil) -> IRB::Context
 
 自身を初期化します。
 

--- a/manual/api/irb/ext/save-history/IRB__HistorySavingAbility.md
+++ b/manual/api/irb/ext/save-history/IRB__HistorySavingAbility.md
@@ -10,7 +10,7 @@ include:
 
 ## Class Methods
 
-### def extended(obj) -> object
+### def IRB::HistorySavingAbility.extended(obj) -> object
 
 obj に irb のヒストリの読み込み、保存の機能を提供します。
 

--- a/manual/api/irb/extend-command.md
+++ b/manual/api/irb/extend-command.md
@@ -21,7 +21,7 @@ irb のコマンドを拡張するためのモジュールです。
 
 ## Singleton Methods
 
-### def def_extend_command(cmd_name, cmd_class, load_file = nil, *aliases) -> object
+### def IRB::ExtendCommandBundle.def_extend_command(cmd_name, cmd_class, load_file = nil, *aliases) -> object
 
 irb に cmd_name で指定したメソッドが実行できるように拡張します。
 
@@ -44,14 +44,14 @@ irb に cmd_name で指定したメソッドが実行できるように拡張し
                [m:IRB::ExtendCommandBundle::OVERRIDE_ALL] のいずれか
                を指定します。
 
-### def extend_object(obj) -> IRB::ExtendCommandBundle
+### def IRB::ExtendCommandBundle.extend_object(obj) -> IRB::ExtendCommandBundle
 
 [c:IRB::ExtendCommandBundle] で定義済みの拡張に指定されたエイリアスを
 obj に定義します。
 
 - **param** `obj` -- [c:IRB::ExtendCommandBundle] を extend したオブジェクト
 
-### def install_extend_commands -> object
+### def IRB::ExtendCommandBundle.install_extend_commands -> object
 
 定義済みの拡張を読み込みます。
 
@@ -76,7 +76,7 @@ irb で以下のメソッドが利用できるようになります。(それぞ
 
 - **SEE** [m:IRB::ExtendCommandBundle.install_extend_commands]
 
-### def irb_original_method_name(method_name) -> String
+### def IRB::ExtendCommandBundle.irb_original_method_name(method_name) -> String
 
 method_name で指定したメソッドの irb 中でのエイリアスを返します。ライブ
 ラリ内部で使用します。
@@ -149,7 +149,7 @@ irb でコマンドのエイリアスを定義する際に、既にこれから�
 
 ## Singleton Methods
 
-### def install_extend_commands -> object
+### def IRB::ContextExtender.install_extend_commands -> object
 
 定義済みの拡張を読み込みます。
 
@@ -166,7 +166,7 @@ irb でコマンドのエイリアスを定義する際に、既にこれから�
 
 - **SEE** [m:IRB::ContextExtender.def_extend_command]
 
-### def def_extend_command(cmd_name, load_file, *aliases) -> object
+### def IRB::ContextExtender.def_extend_command(cmd_name, load_file, *aliases) -> object
 
 [c:IRB::Context] に cmd_name で指定したメソッドが実行できるように拡張
 します。

--- a/manual/api/irb/frame.md
+++ b/manual/api/irb/frame.md
@@ -17,21 +17,21 @@ set_trace_func を用いて Ruby の実行をトレースしています。
 
 ## Class Methods
 
-### def top(n = 0) -> Binding
+### def IRB::Frame.top(n = 0) -> Binding
 
 上から n 番目のコンテキストを取り出します。
 
 - **param** `n` -- 取り出すコンテキストを [c:Integer] で指定します。n は 0 が最
          上位になります。
 
-### def bottom(n = 0) -> Binding
+### def IRB::Frame.bottom(n = 0) -> Binding
 
 下から n 番目のコンテキストを取り出します。
 
 - **param** `n` -- 取り出すコンテキストを [c:Integer] で指定します。n は 0 が最
          下位になります。
 
-### def sender -> object
+### def IRB::Frame.sender -> object
 
 センダになっているオブジェクトを取り出します。
 センダとは、そのメソッドを呼び出した側の self のことです。

--- a/manual/api/irb/help.md
+++ b/manual/api/irb/help.md
@@ -7,6 +7,6 @@ irb コマンドのヘルプを表示するためのライブラリです。
 
 ## Singleton Methods
 
-### def print_usage -> ()
+### def IRB.print_usage -> ()
 
 irb コマンドのヘルプを表示します。

--- a/manual/api/irb/input-method/IRB.md
+++ b/manual/api/irb/input-method/IRB.md
@@ -5,7 +5,7 @@ library: irb/input-method
 
 ## Constants
 
-### def STDIN_FILE_NAME -> "(line)"
+### const STDIN_FILE_NAME -> "(line)"
 
 標準入力を使用する際のファイル名を文字列で返します。
 

--- a/manual/api/irb/input-method/IRB__FileInputMethod.md
+++ b/manual/api/irb/input-method/IRB__FileInputMethod.md
@@ -7,7 +7,7 @@ library: irb/input-method
 
 ## Class Methods
 
-### def new(path) -> IRB::FileInputMethod
+### def IRB::FileInputMethod.new(path) -> IRB::FileInputMethod
 
 自身を初期化します。
 

--- a/manual/api/irb/input-method/IRB__InputMethod.md
+++ b/manual/api/irb/input-method/IRB__InputMethod.md
@@ -7,7 +7,7 @@ library: irb/input-method
 
 ## Class Methods
 
-### def new(file = STDIN_FILE_NAME) -> IRB::InputMethod
+### def IRB::InputMethod.new(file = STDIN_FILE_NAME) -> IRB::InputMethod
 
 自身を初期化します。
 

--- a/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
+++ b/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
@@ -10,7 +10,7 @@ readline を用いた標準入力からの入力を表すクラスです。ラ�
 
 ## Class Methods
 
-### def new -> IRB::ReadlineInputMethod
+### def IRB::ReadlineInputMethod.new -> IRB::ReadlineInputMethod
 
 自身を初期化します。
 

--- a/manual/api/irb/input-method/IRB__StdioInputMethod.md
+++ b/manual/api/irb/input-method/IRB__StdioInputMethod.md
@@ -7,7 +7,7 @@ library: irb/input-method
 
 ## Class Methods
 
-### def new -> IRB::StdioInputMethod
+### def IRB::StdioInputMethod.new -> IRB::StdioInputMethod
 
 自身を初期化します。
 

--- a/manual/api/irb/inspector.md
+++ b/manual/api/irb/inspector.md
@@ -8,7 +8,7 @@ irb コマンドで実行結果の出力方式(inspect_mode)を定義するた�
 
 ## Singleton Methods
 
-### def Inspector(inspect, init = nil) -> IRB::Inspector
+### def IRB.Inspector(inspect, init = nil) -> IRB::Inspector
 
 [c:IRB::Inspector] オブジェクトを生成します。
 
@@ -34,7 +34,7 @@ irb コマンドで実行結果の出力方式(inspect_mode)を定義するた�
 
 ## Singleton Methods
 
-### def def_inspector(key, arg = nil) { |v| ... } -> object
+### def IRB::Inspector.def_inspector(key, arg = nil) { |v| ... } -> object
 
 新しい実行結果の出力方式を定義します。
 
@@ -58,7 +58,7 @@ irb(main):001:0> :abc # => abcabc
 
 - **SEE** [ref:lib:irb#inspect_mode]
 
-### def keys_with_inspector(inspector) -> Array
+### def IRB::Inspector.keys_with_inspector(inspector) -> Array
 
 引数で指定した [c:IRB::Inspector] に対応する key の配列を返します。
 

--- a/manual/api/irb/magic-file.md
+++ b/manual/api/irb/magic-file.md
@@ -10,12 +10,12 @@ irb が扱う入力やファイル中のマジックコメントを正しく扱�
 
 irb が扱う入力やファイル中のマジックコメントを正しく扱うためのクラスです。
 
-### def ENCODING_SPEC_RE -> %r"coding\s*[=:]\s*([[:alnum:]\-_]+)"
+### def IRB::MagicFile.ENCODING_SPEC_RE -> %r"coding\s*[=:]\s*([[:alnum:]\-_]+)"
 
 マジックコメントにマッチする正規表現を返します。
 
-### def open(path) -> File
-### def open(path) { |io| ... } -> object
+### def IRB::MagicFile.open(path) -> File
+### def IRB::MagicFile.open(path) { |io| ... } -> object
 
 引数 path で指定したファイルを開いて、ファイル中のマジックコメントをエ
 ンコーディングに設定します。

--- a/manual/api/irb/xmp.md
+++ b/manual/api/irb/xmp.md
@@ -105,7 +105,7 @@ Ruby のソースコードとその実行結果を、行ごとに交互に表示
 
 ## Class Methods
 
-### def new(bind = nil) -> XMP
+### def XMP.new(bind = nil) -> XMP
 
 自身を初期化します。
 

--- a/manual/api/json/JSON.md
+++ b/manual/api/json/JSON.md
@@ -7,7 +7,7 @@ JSON (JavaScript Object Notation) を扱うためのモジュールです。
 
 ## Singleton Methods
 
-### def [](object, options) -> object
+### def JSON.[](object, options) -> object
 
 文字列のように扱えるデータを受け取った場合は Ruby のオブジェクトに変換して返します。
 そうでない場合は JSON に変換して返します。
@@ -32,7 +32,7 @@ p JSON[hash]                         # => "{\"a\":1,\"b\":2,\"c\":3}"
 
 - **SEE** [m:JSON?.parse], [m:JSON?.generate]
 
-### def create_id -> String
+### def JSON.create_id -> String
 
 json_create メソッドで使用するクラスを決定するために使用する値を返します。
 
@@ -70,7 +70,7 @@ p JSON.parse(json, create_additions: true)
 # => #<User:0x0000557709b269e0 @id=1, @name="tanaka">
 ```
 
-### def create_id=(identifier)
+### def JSON.create_id=(identifier)
 
 json_create メソッドで使用するクラスを決定するために使用する値をセットします。
 
@@ -90,7 +90,7 @@ puts (1..5).to_json              # => {"my_json_class":"Range","a":[1,5,false]}
 #%# nodoc
 #%# --- deep_const_get
 
-### def generator -> JSON::Ext::Generator
+### def JSON.generator -> JSON::Ext::Generator
 
 JSON ライブラリがジェネレータとして使用するモジュールを返します。
 
@@ -99,7 +99,7 @@ JSON ライブラリがジェネレータとして使用するモジュールを
 #%# nodoc
 #%# --- generator=(generator)
 
-### def parser -> JSON::Ext::Parser
+### def JSON.parser -> JSON::Ext::Parser
 
 JSON ライブラリがパーサとして使用するクラスを返します。
 
@@ -112,7 +112,7 @@ p JSON.parser # => JSON::Ext::Parser
 #%# nodoc
 #%# --- parser=(parser)
 
-### def state -> JSON::Ext::Generator::State
+### def JSON.state -> JSON::Ext::Generator::State
 
 JSON ライブラリがジェネレータの状態を表すクラスとして使用するクラスを返します。
 

--- a/manual/api/json/JSON__Coder.md
+++ b/manual/api/json/JSON__Coder.md
@@ -35,7 +35,7 @@ p MyApp::API_JSON_CODER.dump(t) # => "\"2025-01-21T08:41:44.286Z\""
 
 ## Singleton Methods
 
-### def new(options = nil) {|object| ... } -> JSON::Coder
+### def JSON::Coder.new(options = nil) {|object| ... } -> JSON::Coder
 
 自身を初期化します。
 

--- a/manual/api/json/JSON__Generator__GeneratorMethods__String__Extend.md
+++ b/manual/api/json/JSON__Generator__GeneratorMethods__String__Extend.md
@@ -8,7 +8,7 @@ alias:
 [c:String] に JSON で使用する特異メソッドを追加するためのモジュールです。
 
 ## Class Methods
-### def json_create(hash) -> String
+### def JSON::Generator::GeneratorMethods::String::Extend.json_create(hash) -> String
 
 JSON のオブジェクトから Ruby の文字列を生成して返します。
 

--- a/manual/api/json/JSON__Parser.md
+++ b/manual/api/json/JSON__Parser.md
@@ -7,7 +7,7 @@ alias:
 
 ## Singleton Methods
 
-### def new(source, options => {}) -> JSON::Parser
+### def JSON::Parser.new(source, options => {}) -> JSON::Parser
 
 パーサを初期化します。
 

--- a/manual/api/json/JSON__State.md
+++ b/manual/api/json/JSON__State.md
@@ -14,7 +14,7 @@ JSON 形式の文字列を生成するための設定を保持しておくため
 
 ## Singleton Methods
 
-### def new(options = {}) -> JSON::State
+### def JSON::State.new(options = {}) -> JSON::State
 
 自身を初期化します。
 
@@ -65,7 +65,7 @@ JSON 形式の文字列を生成するための設定を保持しておくため
   copy.indent # => "\t"
   ```
 
-### def from_state(options) -> JSON::State
+### def JSON::State.from_state(options) -> JSON::State
 
 与えられた options によって生成した [c:JSON::State] のインスタンスを返します。
 

--- a/manual/api/json/add/bigdecimal.md
+++ b/manual/api/json/add/bigdecimal.md
@@ -8,7 +8,7 @@ require:
 # reopen BigDecimal
 ## Singleton Methods
 
-### def json_create(hash) -> BigDecimal
+### def BigDecimal.json_create(hash) -> BigDecimal
 
 JSON のオブジェクトから [c:BigDecimal] のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/complex.md
+++ b/manual/api/json/add/complex.md
@@ -6,7 +6,7 @@ type: library
 # reopen Complex
 ## Singleton Methods
 
-### def json_create(hash) -> Complex
+### def Complex.json_create(hash) -> Complex
 
 JSON のオブジェクトから [c:Complex] のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/date.md
+++ b/manual/api/json/add/date.md
@@ -8,7 +8,7 @@ require:
 # reopen Date
 ## Singleton Methods
 
-### def json_create(hash) -> Date
+### def Date.json_create(hash) -> Date
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/date_time.md
+++ b/manual/api/json/add/date_time.md
@@ -8,7 +8,7 @@ require:
 # reopen DateTime
 ## Singleton Methods
 
-### def json_create(hash) -> DateTime
+### def DateTime.json_create(hash) -> DateTime
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/exception.md
+++ b/manual/api/json/add/exception.md
@@ -6,7 +6,7 @@ type: library
 # reopen Exception
 ## Singleton Methods
 
-### def json_create(hash) -> Exception
+### def Exception.json_create(hash) -> Exception
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/ostruct.md
+++ b/manual/api/json/add/ostruct.md
@@ -8,7 +8,7 @@ require:
 # reopen OpenStruct
 ## Singleton Methods
 
-### def json_create(hash) -> OpenStruct
+### def OpenStruct.json_create(hash) -> OpenStruct
 
 JSON のオブジェクトから [c:OpenStruct] のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/range.md
+++ b/manual/api/json/add/range.md
@@ -6,7 +6,7 @@ type: library
 # reopen Range
 ## Singleton Methods
 
-### def json_create(hash) -> Range
+### def Range.json_create(hash) -> Range
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/rational.md
+++ b/manual/api/json/add/rational.md
@@ -6,7 +6,7 @@ type: library
 # reopen Rational
 ## Singleton Methods
 
-### def json_create(hash) -> Rational
+### def Rational.json_create(hash) -> Rational
 
 JSON のオブジェクトから [c:Rational] のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/regexp.md
+++ b/manual/api/json/add/regexp.md
@@ -6,7 +6,7 @@ type: library
 # reopen Regexp
 ## Singleton Methods
 
-### def json_create(hash) -> Regexp
+### def Regexp.json_create(hash) -> Regexp
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/struct.md
+++ b/manual/api/json/add/struct.md
@@ -6,7 +6,7 @@ type: library
 # reopen Struct
 ## Singleton Methods
 
-### def json_create(hash) -> Struct
+### def Struct.json_create(hash) -> Struct
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/symbol.md
+++ b/manual/api/json/add/symbol.md
@@ -6,7 +6,7 @@ type: library
 # reopen Symbol
 ## Singleton Methods
 
-### def json_create(hash) -> Symbol
+### def Symbol.json_create(hash) -> Symbol
 
 JSON のオブジェクトから [c:Symbol] のオブジェクトを生成して返します。
 

--- a/manual/api/json/add/time.md
+++ b/manual/api/json/add/time.md
@@ -6,7 +6,7 @@ type: library
 # reopen Time
 ## Singleton Methods
 
-### def json_create(hash) -> Time
+### def Time.json_create(hash) -> Time
 
 JSON のオブジェクトから Ruby のオブジェクトを生成して返します。
 

--- a/manual/api/logger/Logger.md
+++ b/manual/api/logger/Logger.md
@@ -9,7 +9,7 @@ include:
 
 ## Class Methods
 
-### def new(logdev, shift_age = 0, shift_size = 1048576, level: Logger::Severity::DEBUG, progname: nil, formatter: Formatter.new, datetime_format: nil, binmode: false, shift_period_suffix: '%Y%m%d', reraise_write_errors: [], skip_header: false) -> Logger
+### def Logger.new(logdev, shift_age = 0, shift_size = 1048576, level: Logger::Severity::DEBUG, progname: nil, formatter: Formatter.new, datetime_format: nil, binmode: false, shift_period_suffix: '%Y%m%d', reraise_write_errors: [], skip_header: false) -> Logger
 
 Logger オブジェクトを生成します。
 

--- a/manual/api/logger/Logger__Application.md
+++ b/manual/api/logger/Logger__Application.md
@@ -41,7 +41,7 @@ status = FooApp.new(....).start
 
 ## Class Methods
 
-### def new(appname = nil) -> Logger::Application
+### def Logger::Application.new(appname = nil) -> Logger::Application
 
 このクラスを初期化します。
 

--- a/manual/api/logger/Logger__LogDevice.md
+++ b/manual/api/logger/Logger__LogDevice.md
@@ -7,7 +7,7 @@ library: logger
 
 ## Class Methods
 
-### def new(log = nil, opt = {}) -> Logger::LogDevice
+### def Logger::LogDevice.new(log = nil, opt = {}) -> Logger::LogDevice
 
 ログの出力先を初期化します。
 

--- a/manual/api/matrix/Matrix.md
+++ b/manual/api/matrix/Matrix.md
@@ -43,7 +43,7 @@ i=jの要素a(i,j)を対角要素(diagonal element)、
 #%#  require 'matrix'
 
 ## Class Methods
-### def [](*rows) -> Matrix
+### def Matrix.[](*rows) -> Matrix
 
 rows[i] を第 i 行とする行列を生成します。
 
@@ -57,7 +57,7 @@ p m  # => Matrix[[11, 12], [21, 22]]
      #    [21, 22]
 ```
 
-### def rows(rows, copy = true) -> Matrix
+### def Matrix.rows(rows, copy = true) -> Matrix
 
 引数 rows を行ベクトルの列とする行列を生成します。
 
@@ -78,7 +78,7 @@ p m # => Matrix[[1, 2, 3], [10, 1000, 20]]
 - **param** `rows` -- 配列の配列
 - **param** `copy` -- 配列を複製するかどうかを真偽値で指定
 
-### def columns(columns) -> Matrix
+### def Matrix.columns(columns) -> Matrix
 
 引数 columns を列ベクトルの集合とする行列を生成します。
 
@@ -110,7 +110,7 @@ p m # => Matrix[[1, 4, -1], [2, 5, -2], [3, 6, -3]]
     #                          [3, 6, -3]
 ```
 
-### def diagonal(*values) -> Matrix
+### def Matrix.diagonal(*values) -> Matrix
 
 対角要素がvaluesで、非対角要素が全て0であるような
 正方行列を生成します。
@@ -131,7 +131,7 @@ m = Matrix.diagonal(a)
 p m # => Matrix[[[1, 2, 3]]]
 ```
 
-### def scalar(n, value) -> Matrix
+### def Matrix.scalar(n, value) -> Matrix
 
 対角要素が全てvalue(数)で、非対角要素が全て0であるようなn次の正方行列を生成します。
 
@@ -145,9 +145,9 @@ m = Matrix.scalar(3, 2.5)
 p m # => Matrix[[2.5, 0, 0], [0, 2.5, 0], [0, 0, 2.5]]
 ```
 
-### def identity(n) -> Matrix
-### def unit(n) -> Matrix
-### def I(n) -> Matrix
+### def Matrix.identity(n) -> Matrix
+### def Matrix.unit(n) -> Matrix
+### def Matrix.I(n) -> Matrix
 
 n次の単位行列を生成します。
 
@@ -155,7 +155,7 @@ n次の単位行列を生成します。
 
 単位行列とは、対角要素が全て1で非対角要素が全て0であるような行列のことです。
 
-### def zero(n) -> Matrix
+### def Matrix.zero(n) -> Matrix
 
 n × n の零行列（要素が全て 0 の行列）を生成して返します。
 
@@ -166,7 +166,7 @@ p Matrix.zero(2) #=> Matrix[[0, 0], [0, 0]]
 
 - **param** `n` -- 生成する正方零行列の次数
 
-### def zero(row, column) -> Matrix
+### def Matrix.zero(row, column) -> Matrix
 
 row × column の零行列（要素が全て 0 の行列）を生成して返します。
 
@@ -178,7 +178,7 @@ p Matrix.zero(2, 3) #=> Matrix[[0, 0, 0], [0, 0, 0]]
 - **param** `row` -- 生成する行列の行数
 - **param** `column` -- 生成する行列の列数
 
-### def empty(row_count=0, column_count=0) -> Matrix
+### def Matrix.empty(row_count=0, column_count=0) -> Matrix
 
 要素を持たない行列を返します。
 
@@ -202,20 +202,20 @@ p m * n
 - **param** `column_count` -- 行列の列数
 - **raise** `ArgumentError` -- `row_count`, `column_count` が両方とも0でない場合に発生します
 
-### def row_vector(row) -> Matrix
+### def Matrix.row_vector(row) -> Matrix
 
 要素がrowの(1,n)型の行列(行ベクトル)を生成します。
 
 - **param** `row` -- (1,n)型の行列として生成する[c:Vector] [c:Array] オブジェクト
 
-### def column_vector(column) -> Matrix
+### def Matrix.column_vector(column) -> Matrix
 
 要素がcolumnの(n,1)型の行列(列ベクトル)を生成します。
 
 - **param** `column` -- (n,1)型の行列として生成する[c:Vector] [c:Array] オブジェクト
 
-### def build(row_count, column_count = row_count) {|row, col| ... } -> Matrix
-### def build(row_count, column_count = row_count) -> Enumerable
+### def Matrix.build(row_count, column_count = row_count) {|row, col| ... } -> Matrix
+### def Matrix.build(row_count, column_count = row_count) -> Enumerable
 
 `row_count`×`column_count` の行列をブロックの返り値から生成します。
 
@@ -234,7 +234,7 @@ m = Matrix.build(3) { rand }
 - **param** `row_count` -- 行列の行数
 - **param** `column_count` -- 行列の列数
 
-### def hstack(*matrices) -> Matrix
+### def Matrix.hstack(*matrices) -> Matrix
 
 行列 matrices を横に並べた行列を生成します。
 
@@ -249,7 +249,7 @@ p Matrix.hstack(x, y) # => Matrix[[1, 2, 5, 6], [3, 4, 7, 8]]
 - **raise** `ExceptionForMatrix::ErrDimensionMismatch` -- 行数の異なる行列がある場合に発生します
 - **SEE** [m:Matrix.vstack], [m:Matrix#hstack]
 
-### def vstack(*matrices) -> Matrix
+### def Matrix.vstack(*matrices) -> Matrix
 
 行列 matrices を縦に並べた行列を生成します。
 
@@ -264,8 +264,8 @@ p Matrix.vstack(x, y) # => Matrix[[1, 2], [3, 4], [5, 6], [7, 8]]
 - **raise** `ExceptionForMatrix::ErrDimensionMismatch` -- 列数の異なる行列がある場合に発生します
 - **SEE** [m:Matrix.hstack], [m:Matrix#vstack]
 
-### def combine(*matrices) {|*elements| ... } -> Matrix
-### def combine(*matrices) -> Enumerator
+### def Matrix.combine(*matrices) {|*elements| ... } -> Matrix
+### def Matrix.combine(*matrices) -> Enumerator
 
 要素ごとにブロックを呼び出した結果を組み合わせた Matrix を返します。
 

--- a/manual/api/matrix/Vector.md
+++ b/manual/api/matrix/Vector.md
@@ -38,7 +38,7 @@ include:
 
 ## Class Methods
 
-### def [](*a) -> Vector
+### def Vector.[](*a) -> Vector
 
 可変個引数を要素とするベクトルを生成します。
 
@@ -52,7 +52,7 @@ require 'matrix'
 p Vector[1, 3, 4.0] # => Vector[1, 3, 4.0]
 ```
 
-### def elements(a, copy = true) -> Vector
+### def Vector.elements(a, copy = true) -> Vector
 
 配列 `a` を要素とするベクトルを生成します。
 ただし、オプション引数 `copy` が偽 (`false`) ならば、複製を行いません。
@@ -73,13 +73,13 @@ p v1        # => Vector[1, 2, 3]
 p v2        # => Vector[-1, 2, 3]
 ```
 
-### def independent?(*vectors) -> bool
+### def Vector.independent?(*vectors) -> bool
 
 ベクトルの列 `vectors` が線形独立であれば `true` を返し、そうでなければ `false` を返します。
 
 - **param** `vectors` -- 線形独立性を判定するベクトル列
 
-### def basis(size:, index:) -> Vector
+### def Vector.basis(size:, index:) -> Vector
 
 `size` 次元ベクトル空間の `index` 番目の標準基底を返します。
 

--- a/manual/api/minitest/MiniTest__Unit.md
+++ b/manual/api/minitest/MiniTest__Unit.md
@@ -126,11 +126,11 @@ until: "2.2.0"
 
 ## Singleton Methods
 
-### def autorun -> true
+### def MiniTest::Unit.autorun -> true
 
 プロセスの終了時にテストを実行するように登録します。
 
-### def output=(stream)
+### def MiniTest::Unit.output=(stream)
 
 出力先をセットします。
 

--- a/manual/api/minitest/MiniTest__Unit__TestCase.md
+++ b/manual/api/minitest/MiniTest__Unit__TestCase.md
@@ -47,21 +47,21 @@ until: "2.2.0"
 
 ## Singleton Methods
 
-### def new(name)
+### def MiniTest::Unit::TestCase.new(name)
 
 自身を初期化します。
 
 - **param** `name` -- 自身の名前を指定します。
 
-### def inherited(klass)
+### def MiniTest::Unit::TestCase.inherited(klass)
 
 テストクラス名をテストスイート登録します。
 
-### def reset
+### def MiniTest::Unit::TestCase.reset
 
 テストスイートをクリアします。
 
-### def test_methods -> Array
+### def MiniTest::Unit::TestCase.test_methods -> Array
 
 テストメソッドのリストを返します。
 
@@ -69,13 +69,13 @@ until: "2.2.0"
 返されるメソッドリストの順番はランダムです。
 そうでない場合は、文字コード順にソートされます。
 
-### def test_order -> Symbol
+### def MiniTest::Unit::TestCase.test_order -> Symbol
 
 テストの実行順序を返します。
 
 デフォルトはランダムです。
 
-### def test_suites -> Array
+### def MiniTest::Unit::TestCase.test_suites -> Array
 
 テストクラス名のリストを返します。
 

--- a/manual/api/monitor/Monitor.md
+++ b/manual/api/monitor/Monitor.md
@@ -61,7 +61,7 @@ mx.synchronize {
 
 ## Class Methods
 
-### def new -> Monitor
+### def Monitor.new -> Monitor
 
 新しい Monitor オブジェクトを生成します。
 

--- a/manual/api/mutex_m.md
+++ b/manual/api/mutex_m.md
@@ -54,17 +54,17 @@ obj.unlock
 
 ## Singleton Methods
 
-### def append_features(klass) -> Class | nil
+### def Mutex_m.append_features(klass) -> Class | nil
 
 ユーザが直接、使うことはありません。
 
 - **SEE** [m:Module#append_features]
 
-### def define_aliases(klass) -> Class
+### def Mutex_m.define_aliases(klass) -> Class
 
 ユーザが直接、使うことはありません。
 
-### def extend_object(module) -> Module
+### def Mutex_m.extend_object(module) -> Module
 
 ユーザが直接、使うことはありません。
 

--- a/manual/api/net/Net__HTTPRequest.md
+++ b/manual/api/net/Net__HTTPRequest.md
@@ -36,7 +36,7 @@ print res.body
 ```
 
 ## Class Methods
-### def new(path, initheader = nil) -> Net::HTTPRequest
+### def Net::HTTPRequest.new(path, initheader = nil) -> Net::HTTPRequest
 
 HTTP リクエストオブジェクトを生成します。
 

--- a/manual/api/net/Net__HTTPResponse.md
+++ b/manual/api/net/Net__HTTPResponse.md
@@ -10,7 +10,7 @@ Net::HTTP クラスは実際には HTTPResponse のサブクラスを返しま�
 
 ## Class Methods
 
-### def body_permitted? -> bool
+### def Net::HTTPResponse.body_permitted? -> bool
 
 エンティティボディを含むことが許されているレスポンスクラス
 ならば真を、そうでなければ偽を返します。

--- a/manual/api/net/ftp.md
+++ b/manual/api/net/ftp.md
@@ -78,8 +78,8 @@ FTP を実装したクラスです。
 
 ## Class Methods
 
-### def new(host = nil, options = {}) -> Net::FTP
-### def new(host = nil, user = nil, passwd = nil, acct = nil) -> Net::FTP
+### def Net::FTP.new(host = nil, options = {}) -> Net::FTP
+### def Net::FTP.new(host = nil, user = nil, passwd = nil, acct = nil) -> Net::FTP
 
 新しい Net::FTP のインスタンスを生成します。
 
@@ -141,8 +141,8 @@ host が指定された場合、生成されたインスタンスに対して
 
 - **SEE** [m:Net::FTP.open]
 
-### def open(host, user = nil, passwd = nil, acct = nil) -> Net::FTP
-### def open(host, user = nil, passwd = nil, acct = nil){|ftp| ... } -> object
+### def Net::FTP.open(host, user = nil, passwd = nil, acct = nil) -> Net::FTP
+### def Net::FTP.open(host, user = nil, passwd = nil, acct = nil){|ftp| ... } -> object
 
 新しい Net::FTP インスタンスを生成します。
 
@@ -168,11 +168,11 @@ user が指定された場合は [m:Net::FTP#login]
 - **raise** `Net::FTPProtoError` -- 応答コードが RFC 的に正しくない場合に発生します。
 - **raise** `Net::FTPReplyError` -- 応答コードが上の場合以外で正しくない場合(1xy, 3xyが来るべきでないときに来た場合など)に発生します。
 
-### def default_passive -> bool
+### def Net::FTP.default_passive -> bool
 
 FTPの接続のグローバルなデフォルトモードが passive mode である場合に true を返します。
 
-### def default_passive=(on)
+### def Net::FTP.default_passive=(on)
 
 passive mode をFTPの接続のグローバルなデフォルトモードにするかどうかを設定します。
 

--- a/manual/api/net/http/Net__HTTP.md
+++ b/manual/api/net/http/Net__HTTP.md
@@ -22,7 +22,7 @@ Net::HTTP は、リクエストに Accept-Encoding ヘッダも Range ヘッダ�
 
 ## Class Methods
 
-### def new(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil, no_proxy=nil) -> Net::HTTP
+### def Net::HTTP.new(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil, no_proxy=nil) -> Net::HTTP
 
 新しい [c:Net::HTTP] オブジェクトを生成します。
 
@@ -47,8 +47,8 @@ no_proxy の文字列に address のホスト名やIPアドレスが含まれて
 - **param** `proxy_pass` -- プロクシの認証のパスワードを指定します。
 - **param** `no_proxy` -- プロクシを経由せずに接続するホストの名前/IPアドレスを文字列で指定します。
 
-### def start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
-### def start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) {|http| .... } -> object
+### def Net::HTTP.start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) -> Net::HTTP
+### def Net::HTTP.start(address, port = 80, proxy_addr = :ENV, proxy_port = nil, proxy_user=nil, proxy_pass=nil) {|http| .... } -> object
 
 新しい [c:Net::HTTP] オブジェクトを生成し、
 TCP コネクション、 HTTP セッションを開始します。
@@ -80,8 +80,8 @@ Net::HTTP.new(address, port, proxy_addr, proxy_port, proxy_user, proxy_pass).sta
 - **raise** `Net::OpenTimeout` -- 接続がタイムアウトしたときに発生します
 - **SEE** [m:Net::HTTP.new], [m:Net::HTTP#start]
 
-### def get(uri) -> String
-### def get(host, path, port = 80) -> String
+### def Net::HTTP.get(uri) -> String
+### def Net::HTTP.get(host, path, port = 80) -> String
 
 指定した対象に GET リクエストを送り、そのボディを
 文字列として返します。
@@ -95,8 +95,8 @@ Net::HTTP.new(address, port, proxy_addr, proxy_port, proxy_user, proxy_pass).sta
 - **param** `port` -- 接続するポートを整数で指定します。
 - **SEE** [m:Net::HTTP#get]
 
-### def get_print(uri) -> ()
-### def get_print(host, path, port = 80) -> ()
+### def Net::HTTP.get_print(uri) -> ()
+### def Net::HTTP.get_print(host, path, port = 80) -> ()
 
 指定した対象から HTTP でエンティティボディを取得し、
 [m:$stdout] に出力します。
@@ -125,8 +125,8 @@ require 'net/http'
 Net::HTTP.get_print 'www.example.com', '/index.html'
 ```
 
-### def get_response(uri) -> Net::HTTPResponse
-### def get_response(host, path = nil, port = nil) -> Net::HTTPResponse
+### def Net::HTTP.get_response(uri) -> Net::HTTPResponse
+### def Net::HTTP.get_response(host, path = nil, port = nil) -> Net::HTTPResponse
 
 指定した対象に GET リクエストを送り、そのレスポンスを
 [c:Net::HTTPResponse] として返します。
@@ -140,7 +140,7 @@ Net::HTTP.get_print 'www.example.com', '/index.html'
 - **param** `port` -- 接続するポートを整数で指定します。
 - **SEE** [m:Net::HTTP#get]
 
-### def post_form(uri, params) -> Net::HTTPResponse
+### def Net::HTTP.post_form(uri, params) -> Net::HTTPResponse
 
 [c:URI] で指定した対象に フォームのデータを HTTP で 
 POST します。
@@ -151,7 +151,7 @@ POST します。
 - **param** `uri` -- POST する対象を [c:URI] で指定します。
 - **param** `params` -- POST するデータです。
 
-### def proxy_address -> String|nil
+### def Net::HTTP.proxy_address -> String|nil
 
 自身が ([m:Net::HTTP.Proxy] によって作成された) 
 プロクシ用のクラスならばプロクシのアドレスを返します。
@@ -160,7 +160,7 @@ POST します。
 
 - **SEE** [m:Net::HTTP.Proxy]
 
-### def proxy_port -> Integer|nil
+### def Net::HTTP.proxy_port -> Integer|nil
 
 自身が ([m:Net::HTTP.Proxy] によって作成された) 
 プロクシ用のクラスならばプロクシのポート番号を返します。
@@ -169,7 +169,7 @@ POST します。
 
 - **SEE** [m:Net::HTTP.Proxy]
 
-### def proxy_pass -> String|nil
+### def Net::HTTP.proxy_pass -> String|nil
 
 自身が ([m:Net::HTTP.Proxy] によって作成された) 
 プロクシ用のクラスならばプロクシ認証のパスワードを返します。
@@ -178,7 +178,7 @@ POST します。
 
 - **SEE** [m:Net::HTTP.Proxy]
 
-### def proxy_user -> String|nil
+### def Net::HTTP.proxy_user -> String|nil
 
 自身が ([m:Net::HTTP.Proxy] によって作成された)
 プロクシ用のクラスで、かつプロクシの認証を利用する場合は
@@ -192,7 +192,7 @@ POST します。
 #%#
 #%# このメソッドは obsolete です。
 
-### def Proxy(address, port = 80) -> Class
+### def Net::HTTP.Proxy(address, port = 80) -> Class
 
 Proxy 経由で http サーバに接続するためのクラスを作成し返します。
 
@@ -222,36 +222,36 @@ proxy_class.start('www.example.org') {|h|
 - **param** `address` -- プロクシのホスト名を文字列で与えます。
 - **param** `port` -- プロクシのポート番号を与えます。
 
-### def proxy_class? -> bool
+### def Net::HTTP.proxy_class? -> bool
 
 自身が ([m:Net::HTTP.Proxy] によって作成された) プロクシ用のクラスならば真を返し、そうでなければ偽を返します。
 
 - **SEE** [m:Net::HTTP.Proxy]
 
-### def http_default_port -> Integer
-### def default_port -> Integer
+### def Net::HTTP.http_default_port -> Integer
+### def Net::HTTP.default_port -> Integer
 
 HTTP のデフォルトポート (80) を返します。
 
-### def https_default_port -> Integer
+### def Net::HTTP.https_default_port -> Integer
 
 HTTPS のデフォルトポート (443) を返します。
 
-### def version_1_1? -> false
-### def is_version_1_1? -> false
+### def Net::HTTP.version_1_1? -> false
+### def Net::HTTP.is_version_1_1? -> false
 
 何もしません。互換性のために残されており、常に false を返します。
 
 - **SEE** [m:Net::HTTP.version_1_2], [m:Net::HTTP.version_1_2?]
 
-### def version_1_2 -> true
+### def Net::HTTP.version_1_2 -> true
 
 何もしません。互換性のために残されており、常に true を返します。
 
 - **SEE** [m:Net::HTTP.version_1_1?], [m:Net::HTTP.version_1_2?]
 
-### def version_1_2? -> true
-### def is_version_1_2? -> true
+### def Net::HTTP.version_1_2? -> true
+### def Net::HTTP.is_version_1_2? -> true
 
 何もしません。互換性のために残されており、常に true を返します。
 

--- a/manual/api/net/imap.md
+++ b/manual/api/net/imap.md
@@ -212,8 +212,8 @@ IMAP 接続を表現するクラスです。
 
 ## Class Methods
 
-### def new(host, port = 143, usessl = false, certs = nil, verify = true) -> Net::IMAP
-### def new(host, options) -> Net::IMAP
+### def Net::IMAP.new(host, port = 143, usessl = false, certs = nil, verify = true) -> Net::IMAP
+### def Net::IMAP.new(host, options) -> Net::IMAP
 
 新たな Net::IMAP オブジェクトを生成し、指定したホストの
 指定したポートに接続し、接続語の IMAP オブジェクトを返します。
@@ -252,13 +252,13 @@ imap = Net::IMAP.new('imap.example.com', :port => 993,
 - **param** `verify` -- 真で接続先を検証する
 - **param** `options` -- 各種接続パラメータのハッシュ
 
-### def debug -> bool
+### def Net::IMAP.debug -> bool
 
 デバッグモードが on になっていれば真を返します。
 
 - **SEE** [m:Net::IMAP.debug=]
 
-### def debug=(val)
+### def Net::IMAP.debug=(val)
 
 デバッグモードの on/off をします。
 
@@ -267,7 +267,7 @@ imap = Net::IMAP.new('imap.example.com', :port => 993,
 - **param** `val` -- 設定するデバッグモードの on/off の真偽値
 - **SEE** [m:Net::IMAP.debug]
 
-### def add_authenticator(auth_type, authenticator) -> ()
+### def Net::IMAP.add_authenticator(auth_type, authenticator) -> ()
 
 [m:Net::IMAP#authenticate] で使う 
 認証用クラスを設定します。
@@ -281,7 +281,7 @@ Net::IMAP::LoginAuthenticator などを参考にしてください。
 - **param** `auth_type` -- 認証の種類(文字列)
 - **param** `authenticator` -- 認証クラス(Class オブジェクト)
 
-### def decode_utf7(str) -> String
+### def Net::IMAP.decode_utf7(str) -> String
 
 modified UTF-7 の文字列を UTF-8 の文字列に変換します。
 
@@ -296,7 +296,7 @@ Net::IMAP ではメールボックス名のエンコードを自動的変換「�
 - **param** `str` -- 変換対象の modified UTF-7 でエンコードされた文字列
 - **SEE** [m:Net::IMAP.encode_utf7]
 
-### def encode_utf7(str) -> String
+### def Net::IMAP.encode_utf7(str) -> String
 
 UTF-8 の文字列を modified UTF-7 の文字列に変換します。
 
@@ -308,7 +308,7 @@ UTF-7 を修正したものです。
 - **param** `str` -- 変換対象の UTF-8 でエンコードされた文字列
 - **SEE** [m:Net::IMAP.decode_utf7]
 
-### def format_date(time) -> String
+### def Net::IMAP.format_date(time) -> String
 
 時刻オブジェクトを IMAP の日付フォーマットでの文字列に変換します。
 
@@ -321,7 +321,7 @@ p Net::IMAP.format_date(Time.new(2011, 6, 20))
 
 - **param** `time` -- 変換する時刻オブジェクト
 
-### def format_datetime(time) -> String
+### def Net::IMAP.format_datetime(time) -> String
 
 時刻オブジェクトを IMAP の日付時刻フォーマットでの文字列に変換します
 
@@ -334,7 +334,7 @@ p Net::IMAP.format_datetime(Time.new(2011, 6, 20, 13, 20, 1))
 
 - **param** `time` -- 変換する時刻オブジェクト
 
-### def max_flag_count -> Integer
+### def Net::IMAP.max_flag_count -> Integer
 
 サーバからのレスポンスに含まれる flag の上限を返します。
 
@@ -343,7 +343,7 @@ p Net::IMAP.format_datetime(Time.new(2011, 6, 20, 13, 20, 1))
 
 - **SEE** [m:Net::IMAP.max_flag_count=]
 
-### def max_flag_count=(count)
+### def Net::IMAP.max_flag_count=(count)
 
 サーバからのレスポンスに含まれる flag の上限を設定します。
 
@@ -355,16 +355,16 @@ p Net::IMAP.format_datetime(Time.new(2011, 6, 20, 13, 20, 1))
 - **param** `count` -- 設定する最大値の整数
 - **SEE** [m:Net::IMAP.max_flag_count]
 
-### def default_port -> Integer
-### def default_imap_port -> Integer
+### def Net::IMAP.default_port -> Integer
+### def Net::IMAP.default_imap_port -> Integer
 
 デフォルトの IMAP のポート番号(143)を返します。
 
 - **SEE** [m:Net::IMAP.default_tls_port]
 
-### def default_tls_port -> Integer
-### def default_imaps_port -> Integer
-### def default_ssl_port -> Integer
+### def Net::IMAP.default_tls_port -> Integer
+### def Net::IMAP.default_imaps_port -> Integer
+### def Net::IMAP.default_ssl_port -> Integer
 
 デフォルトの IMAPS のポート番号(993)を返します。
 

--- a/manual/api/net/pop/Net__POP3.md
+++ b/manual/api/net/pop/Net__POP3.md
@@ -10,7 +10,7 @@ POP3 のセッションを表すクラスです。
 
 ## Class Methods
 
-### def new(address, port = nil, apop = false) -> Net::POP3
+### def Net::POP3.new(address, port = nil, apop = false) -> Net::POP3
 
 [c:Net::POP3] オブジェクトを生成します。
 
@@ -26,8 +26,8 @@ port に nil を渡すと、適当なポート(通常は110、SSL利用時には
 
 - **SEE** [m:Net::POP3#start]
 
-### def start(address, port = nil, account=nil, password=nil, isapop=false) -> Net::POP3
-### def start(address, port = nil, account=nil, password=nil, isapop=false) {|pop| .... } -> object
+### def Net::POP3.start(address, port = nil, account=nil, password=nil, isapop=false) -> Net::POP3
+### def Net::POP3.start(address, port = nil, account=nil, password=nil, isapop=false) {|pop| .... } -> object
 
 [c:Net::POP3] オブジェクトを生成し、サーバへ接続します。
 
@@ -72,7 +72,7 @@ Net::POP3.start(addr, port, account, password) {|pop|
 
 - **SEE** [m:Net::POP3#start]
 
-### def APOP(is_apop) -> Class
+### def Net::POP3.APOP(is_apop) -> Class
 
 bool が真なら [c:Net::APOP] クラス、偽なら [c:Net::POP3] クラスを返します。
 
@@ -87,7 +87,7 @@ pop.start(account, password) {
 
 - **param** `is_apop` -- 真の場合に Net::APOP を返します。
 
-### def foreach(address, port = nil, account, password, isapop=false) {|mail| .... } -> ()
+### def Net::POP3.foreach(address, port = nil, account, password, isapop=false) {|mail| .... } -> ()
 
 POP セッションを開始し、
 サーバ上のすべてのメールを取りだし、
@@ -132,8 +132,8 @@ end
 - **raise** `Net::POPBadResponse` -- サーバからの応答がプロトコル上不正であった場合に発生します
 - **SEE** [m:Net::POP3.start], [m:Net::POP3#each_mail]
 
-### def delete_all(address, port = nil, account, password, isapop=false) -> ()
-### def delete_all(address, port = nil, account, password, isapop=false) {|mail| .... } -> ()
+### def Net::POP3.delete_all(address, port = nil, account, password, isapop=false) -> ()
+### def Net::POP3.delete_all(address, port = nil, account, password, isapop=false) {|mail| .... } -> ()
 
 POP セッションを開始し、サーバ上のメールを全て消去します。
 
@@ -163,7 +163,7 @@ end
 - **raise** `Net::POPBadResponse` -- サーバからの応答がプロトコル上不正であった場合に発生します
 - **SEE** [m:Net::POP3.start], [m:Net::POP3#delete_all]
 
-### def auth_only(address, port = nil, account, password, isapop=false)
+### def Net::POP3.auth_only(address, port = nil, account, password, isapop=false)
 
 POP セッションを開き、認証だけを行って接続を切ります。
 
@@ -186,16 +186,16 @@ Net::POP3.auth_only('pop.example.com', nil,     # using default port (110)
 - **raise** `Net::POPError` -- サーバが認証失敗以外のエラーを報告した場合に発生します
 - **raise** `Net::POPBadResponse` -- サーバからの応答がプロトコル上不正であった場合に発生します
 
-### def default_port -> Integer
-### def default_pop3_port -> Integer
+### def Net::POP3.default_port -> Integer
+### def Net::POP3.default_pop3_port -> Integer
 
 POP3 のデフォルトのポート番号(110)を返します。
 
-### def default_pop3s_port -> Integer
+### def Net::POP3.default_pop3s_port -> Integer
 
 デフォルトのPOP3Sのポート番号(995)を返します。
 
-### def certs -> String|nil
+### def Net::POP3.certs -> String|nil
 
 SSL のパラメータの ca_file (なければ ca_path) を返します。
 
@@ -203,7 +203,7 @@ SSL のパラメータの ca_file (なければ ca_path) を返します。
 
 - **SEE** [m:OpenSSL::SSL::SSLContext#ca_file], [m:OpenSSL::SSL::SSLContext#ca_path]
 
-### def verify -> Integer|nil
+### def Net::POP3.verify -> Integer|nil
 
 SSL のパラメータの verify_mode を返します。
 
@@ -211,12 +211,12 @@ SSL のパラメータの verify_mode を返します。
 
 - **SEE** [m:OpenSSL::SSL::SSLContext#verify_mode]
 
-### def use_ssl? -> bool
+### def Net::POP3.use_ssl? -> bool
 
 新しく生成する [c:Net::POP3] オブジェクトが
 SSL による通信利用するならば真を返します。
 
-### def enable_ssl(verify_or_params={}, certs=nil) -> ()
+### def Net::POP3.enable_ssl(verify_or_params={}, certs=nil) -> ()
 
 新しく生成する [c:Net::POP3] オブジェクトが
 SSL による通信利用するように設定します。
@@ -241,7 +241,7 @@ verify_or_params がハッシュでない場合には、接続時に生成され
 
 - **SEE** [m:Net::POP3.disable_ssl], [m:Net::POP3.use_ssl?]
 
-### def ssl_params -> Hash|nil
+### def Net::POP3.ssl_params -> Hash|nil
 
 SSL での接続を有効にしている場合には、
 SSL の設定のハッシュを返します。
@@ -258,14 +258,14 @@ SSL を有効にしていない場合には nil を返します。
 #%# --- create_ssl_params(verify_or_params = {}, certs = nil)
 #%# 
 
-### def disable_ssl -> ()
+### def Net::POP3.disable_ssl -> ()
 
 新しく生成する [c:Net::POP3] オブジェクトが
 SSL を利用しないように設定します。
 
 - **SEE** [m:Net::POP3.enable_ssl], [m:Net::POP3.use_ssl?]
 
-### def socket_type -> Class
+### def Net::POP3.socket_type -> Class
 
 このメソッドは obsolete です。
 使わないでください。

--- a/manual/api/net/smtp/Net__SMTP.md
+++ b/manual/api/net/smtp/Net__SMTP.md
@@ -9,7 +9,7 @@ SMTP のセッションを表現したクラスです。
 
 ## Singleton Methods
 
-### def new(address, port = Net::SMTP.default_port) -> Net::SMTP
+### def Net::SMTP.new(address, port = Net::SMTP.default_port) -> Net::SMTP
 
 新しい SMTP オブジェクトを生成します。
 address はSMTPサーバーのFQDNで、
@@ -25,10 +25,10 @@ port は接続するポート番号です。
 
 - **SEE** [m:Net::SMTP.start], [m:Net::SMTP#start]
 
-### def start(address, port = Net::SMTP.default_port, tls_verify: true, tls_hostname: nil, helo: 'localhost', user: nil, password: nil, authtype: DEFAULT_AUTH_TYPE) -> Net::SMTP
-### def start(address, port = Net::SMTP.default_port, tls_verify: true, tls_hostname: nil, helo: 'localhost', user: nil, password: nil, authtype: DEFAULT_AUTH_TYPE) {|smtp| ... } -> object
-### def start(address, port = Net::SMTP.default_port, helo = 'localhost', user = nil, password = nil, authtype = DEFAULT_AUTH_TYPE) -> Net::SMTP
-### def start(address, port = Net::SMTP.default_port, helo = 'localhost', user = nil, password = nil, authtype = DEFAULT_AUTH_TYPE) {|smtp| .... } -> object
+### def Net::SMTP.start(address, port = Net::SMTP.default_port, tls_verify: true, tls_hostname: nil, helo: 'localhost', user: nil, password: nil, authtype: DEFAULT_AUTH_TYPE) -> Net::SMTP
+### def Net::SMTP.start(address, port = Net::SMTP.default_port, tls_verify: true, tls_hostname: nil, helo: 'localhost', user: nil, password: nil, authtype: DEFAULT_AUTH_TYPE) {|smtp| ... } -> object
+### def Net::SMTP.start(address, port = Net::SMTP.default_port, helo = 'localhost', user = nil, password = nil, authtype = DEFAULT_AUTH_TYPE) -> Net::SMTP
+### def Net::SMTP.start(address, port = Net::SMTP.default_port, helo = 'localhost', user = nil, password = nil, authtype = DEFAULT_AUTH_TYPE) {|smtp| .... } -> object
 
 新しい SMTP オブジェクトを生成し、サーバに接続し、セッションを開始します。
 
@@ -75,20 +75,20 @@ Net::SMTP.start('smtp.example.com') {|smtp|
 
 - **SEE** [m:Net::SMTP#start], [m:Net::SMTP.new]
 
-### def default_port -> Integer
+### def Net::SMTP.default_port -> Integer
 
 SMTPのデフォルトのポート番号(25)を返します。
 
-### def default_submission_port -> Integer
+### def Net::SMTP.default_submission_port -> Integer
 
 デフォルトのサブミッションポート番号(587)を返します。
 
-### def default_ssl_context -> OpenSSL::SSL::SSLContext
+### def Net::SMTP.default_ssl_context -> OpenSSL::SSL::SSLContext
 
 SSL 通信に使われる SSL のコンテキストのデフォルト値を返します。
 
-### def default_tls_port -> Integer
-### def default_ssl_port -> Integer
+### def Net::SMTP.default_tls_port -> Integer
+### def Net::SMTP.default_ssl_port -> Integer
 
 デフォルトのSMTPSのポート番号(465)を返します。
 

--- a/manual/api/open-uri/OpenURI.md
+++ b/manual/api/open-uri/OpenURI.md
@@ -7,8 +7,8 @@ http/ftp に簡単にアクセスするためのモジュールです。
 
 ## Singleton Methods
 
-### def open_uri(name, mode = 'r', perm = nil, options = {})                  -> StringIO
-### def open_uri(name, mode = 'r', perm = nil, options = {}){|sio| ... }     -> nil
+### def OpenURI.open_uri(name, mode = 'r', perm = nil, options = {})                  -> StringIO
+### def OpenURI.open_uri(name, mode = 'r', perm = nil, options = {}){|sio| ... }     -> nil
 
 URI である文字列 name のリソースを取得して [c:StringIO] オブジェクト
 として返します。

--- a/manual/api/open-uri/URI.md
+++ b/manual/api/open-uri/URI.md
@@ -6,8 +6,8 @@ since: "2.5.0"
 
 ## Class Methods
 
-### def open(name, mode = 'r', perm = nil, options = {})                -> StringIO | Tempfile | IO
-### def open(name, mode = 'r', perm = nil, options = {}) {|ouri| ...}   -> object
+### def URI.open(name, mode = 'r', perm = nil, options = {})                -> StringIO | Tempfile | IO
+### def URI.open(name, mode = 'r', perm = nil, options = {}) {|ouri| ...}   -> object
 
 name が http:// や https://、ftp:// で始まっている文字列なら URI のリソースを
 取得した上で [c:StringIO] オブジェクトまたは [c:Tempfile] オブジェクトとして返します。

--- a/manual/api/openssl/ASN1__ASN1Data.md
+++ b/manual/api/openssl/ASN1__ASN1Data.md
@@ -12,7 +12,7 @@ UNIVERSAL なタグを持つ ASN.1 値はこのクラスの2つのサブクラ�
 それ以外の値はこのクラスのインスタンスとして表現されます。
 
 ## Class Methods
-### def new(value, tag, tag_class) -> OpenSSL::ASN1::ASN1Data
+### def OpenSSL::ASN1::ASN1Data.new(value, tag, tag_class) -> OpenSSL::ASN1::ASN1Data
 
 ASN.1 値を表現する [c:OpenSSL::ASN1::ASN1Data] オブジェクトを
 生成します。

--- a/manual/api/openssl/ASN1__ObjectId.md
+++ b/manual/api/openssl/ASN1__ObjectId.md
@@ -9,8 +9,8 @@ ASN.1 のオブジェクト識別子を表すクラス。
 
 ## Class Methods
 
-### def new(value) -> OpenSSL::ASN1::ObjectId
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::ObjectId
+### def OpenSSL::ASN1::ObjectId.new(value) -> OpenSSL::ASN1::ObjectId
+### def OpenSSL::ASN1::ObjectId.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::ObjectId
 
 ASN.1 のオブジェクト識別子を表わす OpenSSL::ASN1::ObjectId の
 オブジェクトを生成します。
@@ -33,7 +33,7 @@ p ASN1::ObjectId.new("dsaWithSHA1").oid             # => "1.2.840.10040.4.3"
 - **param** `tagging` -- タグ付けの方法(:IMPLICIT もしくは :EXPLICIT)
 - **param** `tag_class` -- タグクラス(:UNIVERSAL, :CONTEXT_SPECIFIC, :APPLICATION, :PRIVATE のいずれか)
 
-### def register(oid, short_name, long_name) -> true
+### def OpenSSL::ASN1::ObjectId.register(oid, short_name, long_name) -> true
 
 オブジェクト識別子に対応する名前(short name と long name)を
 OpenSSLの内部テーブルに登録します。

--- a/manual/api/openssl/ASN1__Primitive.md
+++ b/manual/api/openssl/ASN1__Primitive.md
@@ -34,8 +34,8 @@ nil は :IMPLICIT と同義です。
 ASN.1 の Boolean 型(Universal タグのタグ番号1)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::Boolean
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Boolean
+### def OpenSSL::ASN1::Boolean.new(value) ->  OpenSSL::ASN1::Boolean
+### def OpenSSL::ASN1::Boolean.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Boolean
 
 ASN.1 の Boolean 型の値を表現する OpenSSL::ASN1::Boolean オブジェクトを
 生成します。
@@ -53,8 +53,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の Integer 型(Universal タグのタグ番号2)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::Integer
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Integer
+### def OpenSSL::ASN1::Integer.new(value) ->  OpenSSL::ASN1::Integer
+### def OpenSSL::ASN1::Integer.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Integer
 
 ASN.1 の Integer 型の値を表現する OpenSSL::ASN1::Integer オブジェクトを
 生成します。
@@ -72,8 +72,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の Enumerated 型(Universal タグのタグ番号10)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::Boolean
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Boolean
+### def OpenSSL::ASN1::Enumerated.new(value) ->  OpenSSL::ASN1::Boolean
+### def OpenSSL::ASN1::Enumerated.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Boolean
 
 ASN.1 の Enumerated 型の値を表現する OpenSSL::ASN1::Enumerated オブジェクトを
 生成します。
@@ -91,8 +91,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の Bit String 型(Universal タグのタグ番号3)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::BitString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::BitString
+### def OpenSSL::ASN1::BitString.new(value) ->  OpenSSL::ASN1::BitString
+### def OpenSSL::ASN1::BitString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::BitString
 
 ASN.1 の Bit String 型の値を表現する OpenSSL::ASN1::BitString オブジェクトを
 生成します。
@@ -125,8 +125,8 @@ Bit Stringにフラグを設定します。
 ASN.1 の Octet String 型(Universal タグのタグ番号4)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::OctetString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::OctetString
+### def OpenSSL::ASN1::OctetString.new(value) ->  OpenSSL::ASN1::OctetString
+### def OpenSSL::ASN1::OctetString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::OctetString
 
 ASN.1 の Octet String 型の値を表現する OpenSSL::ASN1::OctetString オブジェクトを
 生成します。
@@ -144,8 +144,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の UTF8String 型(Universal タグのタグ番号12)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::UTF8String
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UTF8String
+### def OpenSSL::ASN1::UTF8String.new(value) ->  OpenSSL::ASN1::UTF8String
+### def OpenSSL::ASN1::UTF8String.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UTF8String
 
 ASN.1 の UTF8String 型の値を表現する OpenSSL::ASN1::UTF8String オブジェクトを
 生成します。
@@ -163,8 +163,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の NumericString 型(Universal タグのタグ番号18)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::NumericString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::NumericString
+### def OpenSSL::ASN1::NumericString.new(value) ->  OpenSSL::ASN1::NumericString
+### def OpenSSL::ASN1::NumericString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::NumericString
 
 ASN.1 の NumericString 型の値を表現する OpenSSL::ASN1::NumericString オブジェクトを
 生成します。
@@ -182,8 +182,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の PrintableString 型(Universal タグのタグ番号19)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::PrintableString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::PrintableString
+### def OpenSSL::ASN1::PrintableString.new(value) ->  OpenSSL::ASN1::PrintableString
+### def OpenSSL::ASN1::PrintableString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::PrintableString
 
 ASN.1 の PrintableString 型の値を表現する OpenSSL::ASN1::PrintableString オブジェクトを
 生成します。
@@ -201,8 +201,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の T61String 型(Universal タグのタグ番号20)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::T61String
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::T61String
+### def OpenSSL::ASN1::T61String.new(value) ->  OpenSSL::ASN1::T61String
+### def OpenSSL::ASN1::T61String.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::T61String
 
 ASN.1 の T61String 型の値を表現する OpenSSL::ASN1::T61String オブジェクトを
 生成します。
@@ -220,8 +220,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の VideotexString 型(Universal タグのタグ番号21)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::VideotexString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::VideotexString
+### def OpenSSL::ASN1::VideotexString.new(value) ->  OpenSSL::ASN1::VideotexString
+### def OpenSSL::ASN1::VideotexString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::VideotexString
 
 ASN.1 の VideotexString 型の値を表現する OpenSSL::ASN1::VideotexString オブジェクトを
 生成します。
@@ -239,8 +239,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の IA5String 型(Universal タグのタグ番号22)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::IA5String
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::IA5String
+### def OpenSSL::ASN1::IA5String.new(value) ->  OpenSSL::ASN1::IA5String
+### def OpenSSL::ASN1::IA5String.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::IA5String
 
 ASN.1 の IA5String 型の値を表現する OpenSSL::ASN1::IA5String オブジェクトを
 生成します。
@@ -258,8 +258,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の GraphicString 型(Universal タグのタグ番号25)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::GraphicString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GraphicString
+### def OpenSSL::ASN1::GraphicString.new(value) ->  OpenSSL::ASN1::GraphicString
+### def OpenSSL::ASN1::GraphicString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GraphicString
 
 ASN.1 の GraphicString 型の値を表現する OpenSSL::ASN1::GraphicString オブジェクトを
 生成します。
@@ -277,8 +277,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の ISO64String 型(Universal タグのタグ番号26)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::ISO64String
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::ISO64String
+### def OpenSSL::ASN1::ISO64String.new(value) ->  OpenSSL::ASN1::ISO64String
+### def OpenSSL::ASN1::ISO64String.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::ISO64String
 
 ASN.1 の ISO64String 型の値を表現する OpenSSL::ASN1::ISO64String オブジェクトを
 生成します。
@@ -296,8 +296,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の GeneralString 型(Universal タグのタグ番号27)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::GeneralString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GeneralString
+### def OpenSSL::ASN1::GeneralString.new(value) ->  OpenSSL::ASN1::GeneralString
+### def OpenSSL::ASN1::GeneralString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GeneralString
 
 ASN.1 の GeneralString 型の値を表現する OpenSSL::ASN1::GeneralString オブジェクトを
 生成します。
@@ -315,8 +315,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の UniversalString 型(Universal タグのタグ番号28)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::UniversalString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UniversalString
+### def OpenSSL::ASN1::UniversalString.new(value) ->  OpenSSL::ASN1::UniversalString
+### def OpenSSL::ASN1::UniversalString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UniversalString
 
 ASN.1 の UniversalString 型の値を表現する OpenSSL::ASN1::UniversalString オブジェクトを
 生成します。
@@ -334,8 +334,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の BMPString 型(Universal タグのタグ番号30)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::BMPString
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::BMPString
+### def OpenSSL::ASN1::BMPString.new(value) ->  OpenSSL::ASN1::BMPString
+### def OpenSSL::ASN1::BMPString.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::BMPString
 
 ASN.1 の BMPString 型の値を表現する OpenSSL::ASN1::BMPString オブジェクトを
 生成します。
@@ -353,8 +353,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の Null 型(Universal タグのタグ番号5)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::Null
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Null
+### def OpenSSL::ASN1::Null.new(value) ->  OpenSSL::ASN1::Null
+### def OpenSSL::ASN1::Null.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Null
 
 ASN.1 の Null 型の値を表現する OpenSSL::ASN1::Null オブジェクトを
 生成します。
@@ -372,8 +372,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の UTCTime 型(Universal タグのタグ番号23)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::UTCTime
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UTCTime
+### def OpenSSL::ASN1::UTCTime.new(value) ->  OpenSSL::ASN1::UTCTime
+### def OpenSSL::ASN1::UTCTime.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::UTCTime
 
 ASN.1 の UTCTime 型の値を表現する OpenSSL::ASN1::UTCTime オブジェクトを
 生成します。
@@ -391,8 +391,8 @@ value 以外の引数を省略した場合はタグクラスは :UNIVERSAL、
 ASN.1 の GeneralizedTime 型(Universal タグのタグ番号23)を表すクラスです。
 
 ## Class Methods
-### def new(value) ->  OpenSSL::ASN1::GeneralizedTime
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GeneralizedTime
+### def OpenSSL::ASN1::GeneralizedTime.new(value) ->  OpenSSL::ASN1::GeneralizedTime
+### def OpenSSL::ASN1::GeneralizedTime.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::GeneralizedTime
 
 ASN.1 の GeneralizedTime 型の値を表現する OpenSSL::ASN1::GeneralizedTime オブジェクトを
 生成します。

--- a/manual/api/openssl/Cipher.md
+++ b/manual/api/openssl/Cipher.md
@@ -88,7 +88,7 @@ p decrypted_data
 ```
 
 ## Class Methods
-### def new(name) -> OpenSSL::Cipher
+### def OpenSSL::Cipher.new(name) -> OpenSSL::Cipher
 
 共通鍵暗号のアルゴリズム名を渡し、対応する暗号オブジェクトを生成します。
 
@@ -127,7 +127,7 @@ p decrypted_data
 - **raise** `RuntimeError` -- 利用可能でない暗号化方式名を指定した場合に発生します
 - **raise** `OpenSSL::Cipher::CipherError` -- 初期化に失敗した場合に発生します
 
-### def ciphers -> [String]
+### def OpenSSL::Cipher.ciphers -> [String]
 
 利用可能な暗号方式名を文字列の配列で返します。
 
@@ -297,7 +297,7 @@ IV を乱数で生成し、暗号オブジェクトに設定します。
 AES 暗号を表すクラス
 
 ## Class Methods
-### def new(bit, mode) -> OpenSSL::Cipher::AES
+### def OpenSSL::Cipher::AES.new(bit, mode) -> OpenSSL::Cipher::AES
 
 AES 共通鍵暗号オブジェクトを生成し、返します。
 
@@ -315,7 +315,7 @@ AES の鍵長を整数もしくは文字列(256 or "256") bit で、
 鍵長 128 ビットの AES 暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::AES128
+### def OpenSSL::Cipher::AES128.new(mode) -> OpenSSL::Cipher::AES128
 
 鍵長 128 ビット AES 暗号オブジェクトを生成し、返します。
 
@@ -330,7 +330,7 @@ AES の鍵長を整数もしくは文字列(256 or "256") bit で、
 鍵長 192 ビットの AES 暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::AES192
+### def OpenSSL::Cipher::AES192.new(mode) -> OpenSSL::Cipher::AES192
 
 鍵長 192 ビット AES 暗号オブジェクトを生成し、返します。
 
@@ -345,7 +345,7 @@ AES の鍵長を整数もしくは文字列(256 or "256") bit で、
 鍵長 256 ビットの AES 暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::AES256
+### def OpenSSL::Cipher::AES256.new(mode) -> OpenSSL::Cipher::AES256
 
 鍵長 256 ビット AES 暗号オブジェクトを生成し、返します。
 
@@ -360,7 +360,7 @@ AES の鍵長を整数もしくは文字列(256 or "256") bit で、
 BF(BlowFish)暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::BF
+### def OpenSSL::Cipher::BF.new(mode) -> OpenSSL::Cipher::BF
 
 BF(BlowFish)暗号オブジェクトを生成し、返します。
 
@@ -375,7 +375,7 @@ BF(BlowFish)暗号オブジェクトを生成し、返します。
 CAST5 暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::CAST5
+### def OpenSSL::Cipher::CAST5.new(mode) -> OpenSSL::Cipher::CAST5
 
 CAST5 暗号オブジェクトを生成し、返します。
 
@@ -390,7 +390,7 @@ CAST5 暗号オブジェクトを生成し、返します。
 DES 暗号を表すクラス
 
 ## Class Methods
-### def new(mode) -> OpenSSL::Cipher::DES
+### def OpenSSL::Cipher::DES.new(mode) -> OpenSSL::Cipher::DES
 
 DES 暗号オブジェクトを生成し、返します。
 
@@ -405,7 +405,7 @@ DES 暗号オブジェクトを生成し、返します。
 IDEA 暗号を表すクラス
 
 ## Class Methods
-### def new(*args) -> OpenSSL::Cipher::IDEA
+### def OpenSSL::Cipher::IDEA.new(*args) -> OpenSSL::Cipher::IDEA
 
 IDEA 暗号オブジェクトを生成します。
 
@@ -416,8 +416,8 @@ IDEA 暗号オブジェクトを生成します。
 RC2 暗号を表すクラス
 
 ## Class Methods
-### def new(bit, mode) -> OpenSSL::Cipher::RC2
-### def new(mode) -> OpenSSL::Cipher::RC2
+### def OpenSSL::Cipher::RC2.new(bit, mode) -> OpenSSL::Cipher::RC2
+### def OpenSSL::Cipher::RC2.new(mode) -> OpenSSL::Cipher::RC2
 
 RC2 暗号オブジェクトを生成します。
 
@@ -437,8 +437,8 @@ RC2 暗号オブジェクトを生成します。
 RC4 暗号を表すクラス
 
 ## Class Methods
-### def new() -> OpenSSL::Cipher::RC4
-### def new(bit) -> OpenSSL::Cipher::RC4
+### def OpenSSL::Cipher::RC4.new() -> OpenSSL::Cipher::RC4
+### def OpenSSL::Cipher::RC4.new(bit) -> OpenSSL::Cipher::RC4
 
 RC4 暗号オブジェクトを生成し、返します。
 
@@ -456,7 +456,7 @@ bit で鍵長を指定できます。
 RC5 暗号を表すクラス
 
 ## Class Methods
-### def new(*args) -> OpenSSL::Cipher::RC5
+### def OpenSSL::Cipher::RC5.new(*args) -> OpenSSL::Cipher::RC5
 
 RC5 暗号オブジェクトを生成し、返します。
 

--- a/manual/api/openssl/Digest.md
+++ b/manual/api/openssl/Digest.md
@@ -30,7 +30,7 @@ puts digest.hexdigest
 [lib:digest] も参照してください。
 
 ## Class Method
-### def new(name, data=nil) -> OpenSSL::Digest
+### def OpenSSL::Digest.new(name, data=nil) -> OpenSSL::Digest
 
 ダイジェストオブジェクトを生成します。
 
@@ -42,7 +42,7 @@ data に文字列を渡すと、その文字列でオブジェクトの内部状
 - **param** `data` -- 入力文字列
 - **raise** `RuntimeError` -- サポートされていないアルゴリズムを指定した場合に発生します
 
-### def digest(name, data) -> String
+### def OpenSSL::Digest.digest(name, data) -> String
 
 data のダイジェストを計算します。
 
@@ -80,7 +80,7 @@ data でダイジェストオブジェクトの内部状態を更新します。
 ハッシュ関数 DSS を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::DSS
+### def OpenSSL::Digest::DSS.new(data=nil) -> OpenSSL::Digest::DSS
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -88,13 +88,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::DSS.digest(data) -> String
 
 data のダイジェストを DSS で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::DSS.hexdigest(data) -> String
 
 data のダイジェストを DSS で計算し、16進文字列で返します。
 
@@ -105,7 +105,7 @@ data のダイジェストを DSS で計算し、16進文字列で返します�
 ハッシュ関数 DSS1 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::DSS1
+### def OpenSSL::Digest::DSS1.new(data=nil) -> OpenSSL::Digest::DSS1
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -113,13 +113,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::DSS1.digest(data) -> String
 
 data のダイジェストを DSS1 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::DSS1.hexdigest(data) -> String
 
 data のダイジェストを DSS1 で計算し、16進文字列で返します。
 
@@ -130,7 +130,7 @@ data のダイジェストを DSS1 で計算し、16進文字列で返します�
 ハッシュ関数 MD2 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::MD2
+### def OpenSSL::Digest::MD2.new(data=nil) -> OpenSSL::Digest::MD2
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -138,13 +138,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::MD2.digest(data) -> String
 
 data のダイジェストを MD2 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::MD2.hexdigest(data) -> String
 
 data のダイジェストを MD2 で計算し、16進文字列で返します。
 
@@ -155,7 +155,7 @@ data のダイジェストを MD2 で計算し、16進文字列で返します�
 ハッシュ関数 MD4 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::MD4
+### def OpenSSL::Digest::MD4.new(data=nil) -> OpenSSL::Digest::MD4
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -163,13 +163,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::MD4.digest(data) -> String
 
 data のダイジェストを MD4 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::MD4.hexdigest(data) -> String
 
 data のダイジェストを MD4 で計算し、16進文字列で返します。
 
@@ -180,7 +180,7 @@ data のダイジェストを MD4 で計算し、16進文字列で返します�
 ハッシュ関数 MD5 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::MD5
+### def OpenSSL::Digest::MD5.new(data=nil) -> OpenSSL::Digest::MD5
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -188,13 +188,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::MD5.digest(data) -> String
 
 data のダイジェストを MD5 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::MD5.hexdigest(data) -> String
 
 data のダイジェストを MD5 で計算し、16進文字列で返します。
 
@@ -205,7 +205,7 @@ data のダイジェストを MD5 で計算し、16進文字列で返します�
 ハッシュ関数 MDC2 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::MDC2
+### def OpenSSL::Digest::MDC2.new(data=nil) -> OpenSSL::Digest::MDC2
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -213,13 +213,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::MDC2.digest(data) -> String
 
 data のダイジェストを MDC2 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::MDC2.hexdigest(data) -> String
 
 data のダイジェストを MDC2 で計算し、16進文字列で返します。
 
@@ -230,7 +230,7 @@ data のダイジェストを MDC2 で計算し、16進文字列で返します�
 ハッシュ関数 RIPEMD160 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::RIPEMD160
+### def OpenSSL::Digest::RIPEMD160.new(data=nil) -> OpenSSL::Digest::RIPEMD160
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -238,13 +238,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::RIPEMD160.digest(data) -> String
 
 data のダイジェストを RIPEMD160 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::RIPEMD160.hexdigest(data) -> String
 
 data のダイジェストを RIPEMD160 で計算し、16進文字列で返します。
 
@@ -255,7 +255,7 @@ data のダイジェストを RIPEMD160 で計算し、16進文字列で返し�
 ハッシュ関数 SHA を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA
+### def OpenSSL::Digest::SHA.new(data=nil) -> OpenSSL::Digest::SHA
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -263,13 +263,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA.digest(data) -> String
 
 data のダイジェストを SHA で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA.hexdigest(data) -> String
 
 data のダイジェストを SHA で計算し、16進文字列で返します。
 
@@ -280,7 +280,7 @@ data のダイジェストを SHA で計算し、16進文字列で返します�
 ハッシュ関数 SHA1 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA1
+### def OpenSSL::Digest::SHA1.new(data=nil) -> OpenSSL::Digest::SHA1
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -288,13 +288,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA1.digest(data) -> String
 
 data のダイジェストを SHA1 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA1.hexdigest(data) -> String
 
 data のダイジェストを SHA1 で計算し、16進文字列で返します。
 
@@ -305,7 +305,7 @@ data のダイジェストを SHA1 で計算し、16進文字列で返します�
 ハッシュ関数 SHA224 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA224
+### def OpenSSL::Digest::SHA224.new(data=nil) -> OpenSSL::Digest::SHA224
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -313,13 +313,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA224.digest(data) -> String
 
 data のダイジェストを SHA224 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA224.hexdigest(data) -> String
 
 data のダイジェストを SHA224 で計算し、16進文字列で返します。
 
@@ -330,7 +330,7 @@ data のダイジェストを SHA224 で計算し、16進文字列で返しま�
 ハッシュ関数 SHA256 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA256
+### def OpenSSL::Digest::SHA256.new(data=nil) -> OpenSSL::Digest::SHA256
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -338,13 +338,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA256.digest(data) -> String
 
 data のダイジェストを SHA256 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA256.hexdigest(data) -> String
 
 data のダイジェストを SHA256 で計算し、16進文字列で返します。
 
@@ -355,7 +355,7 @@ data のダイジェストを SHA256 で計算し、16進文字列で返しま�
 ハッシュ関数 SHA384 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA384
+### def OpenSSL::Digest::SHA384.new(data=nil) -> OpenSSL::Digest::SHA384
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -363,13 +363,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA384.digest(data) -> String
 
 data のダイジェストを SHA384 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA384.hexdigest(data) -> String
 
 data のダイジェストを SHA384 で計算し、16進文字列で返します。
 
@@ -380,7 +380,7 @@ data のダイジェストを SHA384 で計算し、16進文字列で返しま�
 ハッシュ関数 SHA512 を表すクラス
 
 ## Class Method
-### def new(data=nil) -> OpenSSL::Digest::SHA512
+### def OpenSSL::Digest::SHA512.new(data=nil) -> OpenSSL::Digest::SHA512
 
 新しいダイジェストオブジェクトを生成します。
 
@@ -388,13 +388,13 @@ data に文字列を渡すとその内容で内部状態を更新します。
 
 - **param** `data` -- 入力文字列
 
-### def digest(data) -> String
+### def OpenSSL::Digest::SHA512.digest(data) -> String
 
 data のダイジェストを SHA512 で計算します。
 
 - **param** `data` -- ダイジェストを計算する文字列
 
-### def hexdigest(data) -> String
+### def OpenSSL::Digest::SHA512.hexdigest(data) -> String
 
 data のダイジェストを SHA512 で計算し、16進文字列で返します。
 

--- a/manual/api/openssl/Digest__Digest.md
+++ b/manual/api/openssl/Digest__Digest.md
@@ -8,7 +8,7 @@ library: openssl
 [c:OpenSSL::Digest] を代わりに利用してください。
 
 ## Class Methods
-### def new(*args) -> OpenSSL::Digest::Digest
+### def OpenSSL::Digest::Digest.new(*args) -> OpenSSL::Digest::Digest
 
 互換性のためのメソッドです。
 

--- a/manual/api/openssl/Engine.md
+++ b/manual/api/openssl/Engine.md
@@ -11,7 +11,7 @@ OpenSSL の Engine (プラグイン)を表すオブジェクトです。
 
 ## Class Methods
 
-### def by_id(id) -> OpenSSL::Engine
+### def OpenSSL::Engine.by_id(id) -> OpenSSL::Engine
 
 id で指定した engine をロードします。
 
@@ -21,7 +21,7 @@ id で指定した engine をロードします。
 - **param** `id` -- engine の名前(文字列)
 - **raise** `OpenSSL::Engine::EngineError` -- ロードが失敗した場合に発生します。
 
-### def cleanup -> nil
+### def OpenSSL::Engine.cleanup -> nil
 
 ロードされている engine を全て破棄します。
 
@@ -29,13 +29,13 @@ engine が利用していたリソースを開放します。
 
 - **SEE** [m:OpenSSL::Engine.load]
 
-### def engines -> [OpenSSL::Engine]
+### def OpenSSL::Engine.engines -> [OpenSSL::Engine]
 
 ロードされていて利用可能な engine を配列で返します。
 
 - **SEE** [m:OpenSSL::Engine.load]
 
-### def load(name = nil) -> true | nil
+### def OpenSSL::Engine.load(name = nil) -> true | nil
 
 Engine をロードします。
 

--- a/manual/api/openssl/HMAC.md
+++ b/manual/api/openssl/HMAC.md
@@ -19,7 +19,7 @@ HMAC は[RFC:2104] で定義されています。
 
 ## Class Methods
 
-### def digest(digest, key, data) -> String
+### def OpenSSL::HMAC.digest(digest, key, data) -> String
 
 渡された digest と key を用いて data の HMAC を計算し、
 その値をバイナリ文字列として返します。
@@ -31,7 +31,7 @@ digest には利用するハッシュ関数を表す文字列("md5", "sha256" �
 - **param** `key` -- 利用する鍵の文字列
 - **param** `data` -- HMAC を計算する文字列
 
-### def hexdigest(digest, key, data) -> String
+### def OpenSSL::HMAC.hexdigest(digest, key, data) -> String
 
 渡された digest と key を用いて data の HMAC を計算し、
 その値を16進文字列で返します。
@@ -43,7 +43,7 @@ digest には利用するハッシュ関数を表す文字列("md5", "sha256" �
 - **param** `key` -- 利用する鍵の文字列
 - **param** `data` -- HMAC を計算する文字列
 
-### def new(key, digest) -> OpenSSL::HMAC
+### def OpenSSL::HMAC.new(key, digest) -> OpenSSL::HMAC
 
 HMAC を計算するためのオブジェクトを生成します。
 

--- a/manual/api/openssl/Netscape__SPKI.md
+++ b/manual/api/openssl/Netscape__SPKI.md
@@ -7,8 +7,8 @@ Netscape SPKI、もしくは SPKAC(Signed Public Key And Challenge) と呼ばれ
 データフォーマットを扱うためのクラスです。
 
 ## Class Methods
-### def new() -> OpenSSL::Netscape::SPKI
-### def new(buf) -> OpenSSL::Netscape::SPKI
+### def OpenSSL::Netscape::SPKI.new() -> OpenSSL::Netscape::SPKI
+### def OpenSSL::Netscape::SPKI.new(buf) -> OpenSSL::Netscape::SPKI
 
 SPKI オブジェクトを生成します。
 

--- a/manual/api/openssl/OCSP.md
+++ b/manual/api/openssl/OCSP.md
@@ -258,7 +258,7 @@ OCSP レスポンダからのレスポンス自体は
 BasicResponse のオブジェクトを得ます。
 
 ## Class Methods
-### def new -> OpenSSL::OCSP::BasicResponse
+### def OpenSSL::OCSP::BasicResponse.new -> OpenSSL::OCSP::BasicResponse
 
 空の BasicResponse オブジェクトを生成します。
 
@@ -406,7 +406,7 @@ CertificateId オブジェクトを複数 [c:OpenSSL::OCSP::Request] に含め�
 同時に問い合わせることができます。
 
 ## Class Methods
-### def new(subject, issuer, digest=nil) -> OpenSSL::OCSP::CertificateId
+### def OpenSSL::OCSP::CertificateId.new(subject, issuer, digest=nil) -> OpenSSL::OCSP::CertificateId
 
 CertificateId オブジェクトを生成します。
 
@@ -451,8 +451,8 @@ OCSP リクエストを表すクラスです。
 形で複数持つことができます。
 
 ## Class Methods
-### def new -> OpenSSL::OCSP::Request
-### def new(der) -> OpenSSL::OCSP::Request
+### def OpenSSL::OCSP::Request.new -> OpenSSL::OCSP::Request
+### def OpenSSL::OCSP::Request.new(der) -> OpenSSL::OCSP::Request
 
 Request オブジェクトを生成します。
 引数なしの場合は、中身が空のオブジェクトを生成します。
@@ -560,8 +560,8 @@ OCSP レスポンダからのレスポンスを表わすオブジェクトです
 
 ## Class Methods
 
-### def new -> OpenSSL::OCSP::Response
-### def new(der) -> OpenSSL::OCSP::Response
+### def OpenSSL::OCSP::Response.new -> OpenSSL::OCSP::Response
+### def OpenSSL::OCSP::Response.new(der) -> OpenSSL::OCSP::Response
 
 Response オブジェクトを生成します。
 
@@ -571,7 +571,7 @@ DER 形式の文字列を渡した場合はその内容を
 - **param** `der` -- DER 形式の文字列
 - **SEE** [m:OpenSSL::OCSP::Response.create]
 
-### def create(status, basic_resp) -> OpenSSL::OCSP::Response
+### def OpenSSL::OCSP::Response.create(status, basic_resp) -> OpenSSL::OCSP::Response
 
 Response オブジェクトを [c:OpenSSL::OCSP::BasicResponse] オブジェクト
 から生成します。

--- a/manual/api/openssl/OpenSSL__ASN1__Sequence.md
+++ b/manual/api/openssl/OpenSSL__ASN1__Sequence.md
@@ -6,8 +6,8 @@ library: openssl
 ASN.1 の Sequence 型(Universal タグのタグ番号16)を表すクラスです。
 
 ## Class method
-### def new(value) ->  OpenSSL::ASN1::Sequence
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Sequence
+### def OpenSSL::ASN1::Sequence.new(value) ->  OpenSSL::ASN1::Sequence
+### def OpenSSL::ASN1::Sequence.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Sequence
 
 ASN.1 の Sequence 型の値を表現する OpenSSL::ASN1::Sequence オブジェクトを
 生成します。

--- a/manual/api/openssl/OpenSSL__ASN1__Set.md
+++ b/manual/api/openssl/OpenSSL__ASN1__Set.md
@@ -6,8 +6,8 @@ library: openssl
 ASN.1 の Set 型(Universal タグのタグ番号17)を表すクラスです。
 
 ## Class method
-### def new(value) ->  OpenSSL::ASN1::Set
-### def new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Set
+### def OpenSSL::ASN1::Set.new(value) ->  OpenSSL::ASN1::Set
+### def OpenSSL::ASN1::Set.new(value, tag, tagging, tag_class) -> OpenSSL::ASN1::Set
 
 ASN.1 の Set 型の値を表現する OpenSSL::ASN1::Set オブジェクトを
 生成します。

--- a/manual/api/openssl/OpenSSL__BN.md
+++ b/manual/api/openssl/OpenSSL__BN.md
@@ -11,7 +11,7 @@ OpenSSL内で利用される多倍長整数クラスです。
 
 ## Class Methods
 
-### def new(str, base=10) -> OpenSSL::BN
+### def OpenSSL::BN.new(str, base=10) -> OpenSSL::BN
 
 文字列を多倍長整数オブジェクト([c:OpenSSL::BN])を生成します。
 
@@ -57,13 +57,13 @@ p OpenSSL::BN.new(1209) # => 1209
 
 - **SEE** [m:OpenSSL::BN#to_s]
 
-### def new(bn) -> OpenSSL::BN
+### def OpenSSL::BN.new(bn) -> OpenSSL::BN
 
 [c:OpenSSL::BN] を複製して返します。
 
 - **param** `bn` -- 複製する [c:OpenSSL::BN] オブジェクト
 
-### def new(integer) -> OpenSSL::BN
+### def OpenSSL::BN.new(integer) -> OpenSSL::BN
 
 整数オブジェクト([c:Integer])から多倍長整数オブジェクト
 ([c:OpenSSL::BN])を生成します。
@@ -71,7 +71,7 @@ p OpenSSL::BN.new(1209) # => 1209
 - **param** `integer` -- 整数オブジェクト
 - **SEE** [m:Integer#to_bn]
 
-### def generate_prime(bits, safe=true, add=nil, rem=nil) -> OpenSSL::BN
+### def OpenSSL::BN.generate_prime(bits, safe=true, add=nil, rem=nil) -> OpenSSL::BN
 
 ランダム(擬似乱数的)な bits ビットの素数を返します。
 
@@ -90,7 +90,7 @@ add に整数を渡すと、 p % add == rem であるような
 - **param** `rem` -- 生成する素数の剰余の条件
 - **raise** `OpenSSL::BNError` -- 素数の生成に失敗した場合に発生します
 
-### def pseudo_rand(bits, fill=0, odd=false) -> OpenSSL::BN
+### def OpenSSL::BN.pseudo_rand(bits, fill=0, odd=false) -> OpenSSL::BN
 
 乱数を生成し、返します。
 
@@ -114,7 +114,7 @@ odd が真なら、生成される整数は奇数のみとなります。
 - **raise** `OpenSSL::BNError` -- 乱数の生成に失敗した場合に発生します
 - **SEE** [m:OpenSSL::BN.rand], [m:OpenSSL::BN.pseudo_rand_range]
 
-### def pseudo_rand_range(range) -> OpenSSL::BN
+### def OpenSSL::BN.pseudo_rand_range(range) -> OpenSSL::BN
 
 乱数を 0 から range-1 までの間で生成し、返します。
 
@@ -124,7 +124,7 @@ odd が真なら、生成される整数は奇数のみとなります。
 - **raise** `OpenSSL::BNError` -- 乱数の生成に失敗した場合に発生します
 - **SEE** [m:OpenSSL::BN.pseudo_rand], [m:OpenSSL::BN.rand_range]
 
-### def rand(bits, fill=0, odd=false) -> OpenSSL::BN
+### def OpenSSL::BN.rand(bits, fill=0, odd=false) -> OpenSSL::BN
 
 暗号論的に強い擬似乱数を生成し、返します。
 
@@ -144,7 +144,7 @@ odd が真なら、生成される整数は奇数のみとなります。
 - **raise** `OpenSSL::BNError` -- 乱数の生成に失敗した場合に発生します
 - **SEE** [m:OpenSSL::BN.pseudo_rand], [m:OpenSSL::BN.rand_range]
 
-### def rand_range(range) -> OpenSSL::BN
+### def OpenSSL::BN.rand_range(range) -> OpenSSL::BN
 
 暗号論的に強い擬似乱数を 0 から range-1 までの間で生成し、返します。
 

--- a/manual/api/openssl/OpenSSL__Config.md
+++ b/manual/api/openssl/OpenSSL__Config.md
@@ -21,8 +21,8 @@ p conf.get_value("CA_default", "default_days") # => "365"
 
 ## Class Methods
 
-### def load(filename = nil) -> OpenSSL::Config
-### def new(filename = nil) -> OpenSSL::Config
+### def OpenSSL::Config.load(filename = nil) -> OpenSSL::Config
+### def OpenSSL::Config.new(filename = nil) -> OpenSSL::Config
 
 OpenSSL::Config オブジェクトを生成します。
 
@@ -33,7 +33,7 @@ filename を省略した場合は空のオブジェクトが生成されます�
 - **param** `filename` -- ファイル名文字列
 - **raise** `OpenSSL::ConfigError` -- 設定ファイルの文法が正しくない場合に発生します
 
-### def parse(str) -> OpenSSL::Config
+### def OpenSSL::Config.parse(str) -> OpenSSL::Config
 
 文字列から OpenSSL::Config オブジェクトを生成します。
 

--- a/manual/api/openssl/OpenSSL__PKCS7.md
+++ b/manual/api/openssl/OpenSSL__PKCS7.md
@@ -24,8 +24,8 @@ S/MIME には以下の種類のメッセージがあります
 
 ## Class Methods
 
-### def new -> OpenSSL::PKCS7
-### def new(obj) -> OpenSSL::PKCS7
+### def OpenSSL::PKCS7.new -> OpenSSL::PKCS7
+### def OpenSSL::PKCS7.new(obj) -> OpenSSL::PKCS7
 
 PKCS7 オブジェクトを生成します。
 
@@ -37,7 +37,7 @@ PKCS7 オブジェクトを生成します。
 
 - **param** `obj` -- データを読みこむ文字列もしくは IO オブジェクト
 
-### def read_smime(obj) -> OpenSSL::PKCS7
+### def OpenSSL::PKCS7.read_smime(obj) -> OpenSSL::PKCS7
 
 S/MIME 形式のデータを読み込み、PKCS7 オブジェクトを返します。
 
@@ -47,7 +47,7 @@ S/MIME 形式のデータを読み込み、PKCS7 オブジェクトを返しま�
 - **param** `obj` -- データを読み出すオブジェクト
 - **raise** `OpenSSL::PKCS7::PKCS7Error` -- 読み込みに失敗した場合に発生します
 
-### def write_smime(p7sig, data=nil, flags = 0) -> String
+### def OpenSSL::PKCS7.write_smime(p7sig, data=nil, flags = 0) -> String
 
 PKCS7 オブジェクトから S/MIME 形式の文字列を返します。
 
@@ -79,7 +79,7 @@ smime = PKCS7.write_smime(p7)
 - **param** `flags` -- フラグ(整数値)
 - **raise** `OpenSSL::PKCS::PKCS7Error` -- S/MIME形式への変換に失敗した場合に発生します
 
-### def sign(cert, key, data, certs = [], flags = 0) -> OpenSSL::PKCS7
+### def OpenSSL::PKCS7.sign(cert, key, data, certs = [], flags = 0) -> OpenSSL::PKCS7
 
 data に証明書と秘密鍵で署名します。
 
@@ -116,7 +116,7 @@ flags は以下の値の OR を渡します。
 - **param** `flags` -- フラグ(整数値)
 - **raise** `OpenSSL::PKCS7::PKCS7Error` -- 署名に失敗した場合に発生します
 
-### def encrypt(certs, data, cipher=nil, flags=0) -> OpenSSL::PKCS7
+### def OpenSSL::PKCS7.encrypt(certs, data, cipher=nil, flags=0) -> OpenSSL::PKCS7
 
 data を証明書の公開鍵で暗号化します。
 

--- a/manual/api/openssl/OpenSSL__PKCS7__RecipientInfo.md
+++ b/manual/api/openssl/OpenSSL__PKCS7__RecipientInfo.md
@@ -8,7 +8,7 @@ PKCS7 の送信先を表すクラスです。
 S/MIME 暗号化する場合に指定した送信先を意味します。
 
 ## Class Methods
-### def new(cert) -> RecipientInfo
+### def OpenSSL::PKCS7::RecipientInfo.new(cert) -> RecipientInfo
 
 送信先オブジェクトを証明書から生成します。
 

--- a/manual/api/openssl/OpenSSL__PKCS7__SignerInfo.md
+++ b/manual/api/openssl/OpenSSL__PKCS7__SignerInfo.md
@@ -8,7 +8,7 @@ alias:
 署名者の情報を表すクラスです。
 
 ## Class Methods
-### def new(cert, key, digest) -> OpenSSL::PKCS7::SignerInfo
+### def OpenSSL::PKCS7::SignerInfo.new(cert, key, digest) -> OpenSSL::PKCS7::SignerInfo
 
 署名者オブジェクトを証明書、秘密鍵、ダイジェスト方式から生成します。
 

--- a/manual/api/openssl/OpenSSL__SSL__SSLSocket.md
+++ b/manual/api/openssl/OpenSSL__SSL__SSLSocket.md
@@ -42,8 +42,8 @@ soc.close
 
 ## Class Methods
 
-### def new(socket) -> OpenSSL::SSL::SSLSocket
-### def new(socket, context) -> OpenSSL::SSL::SSLSocket
+### def OpenSSL::SSL::SSLSocket.new(socket) -> OpenSSL::SSL::SSLSocket
+### def OpenSSL::SSL::SSLSocket.new(socket, context) -> OpenSSL::SSL::SSLSocket
 
 socket をラップして SSLSocket オブジェクトを生成します。
 

--- a/manual/api/openssl/PKCS12.md
+++ b/manual/api/openssl/PKCS12.md
@@ -14,7 +14,7 @@ PKCS#12 (秘密鍵、証明書、関連するCA証明書を1つのファイル�
 
 ## Class methods
 
-### def create(pass, name, pkey, cert, ca=nil, key_nid=nil, cert_nid=nil, key_iter=nil, mac_iter=nil, keytype=nil) -> OpenSSL::PKCS12
+### def OpenSSL::PKCS12.create(pass, name, pkey, cert, ca=nil, key_nid=nil, cert_nid=nil, key_iter=nil, mac_iter=nil, keytype=nil) -> OpenSSL::PKCS12
 
 PKCS#12 オブジェクトを生成します。
 
@@ -47,7 +47,7 @@ mac_iter がデフォルトで1なのは古いソフトウェアとの互換性�
 - **param** `keytype` -- 鍵の種類(整数)
 - **raise** `OpenSSL::PKCS12::PKCS12Error` -- オブジェクト生成に失敗した場合に発生します
 
-### def new(obj=nil, pass=nil) -> OpenSSL::PKCS12
+### def OpenSSL::PKCS12.new(obj=nil, pass=nil) -> OpenSSL::PKCS12
 
 文字列もしくは [c:IO] オブジェクトから PKCS#12 オブジェクトを生成します。
 

--- a/manual/api/openssl/PKey__DH.md
+++ b/manual/api/openssl/PKey__DH.md
@@ -53,8 +53,8 @@ p(key1 == key2)
 
 ## Class Methods
 
-### def generate(size, generator = 2) -> PKey::DH
-### def generate(size, generator = 2){|u,n| ... } -> PKey::DH
+### def OpenSSL::PKey::DH.generate(size, generator = 2) -> PKey::DH
+### def OpenSSL::PKey::DH.generate(size, generator = 2){|u,n| ... } -> PKey::DH
 
 DH 鍵共有プロトコルのパラメータを生成し、DH オブジェクトを返します。
 
@@ -83,9 +83,9 @@ DH パラメータの生成には時間がかかるため、鍵生成の途中�
 - **raise** `OpenSSL::PKey::DHError` -- パラメータの生成に失敗した場合に発生します
 - **SEE** [m:OpenSSL::PKey::DH#generate_key!]
 
-### def new(size, generator = 2) -> OpenSSL::PKey::DH
-### def new(obj) -> OpenSSL::PKey::DH
-### def new() -> OpenSSL::PKey::DH
+### def OpenSSL::PKey::DH.new(size, generator = 2) -> OpenSSL::PKey::DH
+### def OpenSSL::PKey::DH.new(obj) -> OpenSSL::PKey::DH
+### def OpenSSL::PKey::DH.new() -> OpenSSL::PKey::DH
 
 DH オブジェクトを生成します。
 

--- a/manual/api/openssl/PKey__DSA.md
+++ b/manual/api/openssl/PKey__DSA.md
@@ -19,8 +19,8 @@ p dsa512.verify('dss1', sign, data)
 
 ## Class Methods
 
-### def generate(size) -> OpenSSL::PKey::DSA
-### def generate(size){|u,n| ... } -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.generate(size) -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.generate(size){|u,n| ... } -> OpenSSL::PKey::DSA
 
 乱数により DSA 公開鍵と秘密鍵のペアを生成して、DSA オブジェクトとして
 返します。
@@ -48,10 +48,10 @@ size は DSA パラメータの素数のビット数を指定します。最大 
 DSA パラメータの生成には時間がかかるため、生成の途中経過を
 ユーザに表示したい場合にこの機能を使います。
 
-### def new -> OpenSSL::PKey::DSA
-### def new(size) -> OpenSSL::PKey::DSA
-### def new(obj, pass=nil) -> OpenSSL::PKey::DSA
-### def new(obj, pass=nil){|flag| ... } -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.new -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.new(size) -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.new(obj, pass=nil) -> OpenSSL::PKey::DSA
+### def OpenSSL::PKey::DSA.new(obj, pass=nil){|flag| ... } -> OpenSSL::PKey::DSA
 
 DSA オブジェクトを生成します。
 

--- a/manual/api/openssl/PKey__EC.md
+++ b/manual/api/openssl/PKey__EC.md
@@ -9,7 +9,7 @@ EC(Ellicptic Curve,楕円曲線)暗号鍵のクラスです。
 の対応する関数の項を見てください。
 
 ## Class methods
-### def builtin_curves -> [[String, String]]
+### def OpenSSL::PKey::EC.builtin_curves -> [[String, String]]
 
 組み込みの曲線の名前と、それに対する説明を文字列の配列ペアの配列で返します。
 
@@ -26,8 +26,8 @@ p OpenSSL::PKey::EC.builtin_curves
 
 - **SEE** [m:OpenSSL::PKey::EC::Group.new]
 
-### def new -> OpenSSL::PKey::EC
-### def new(obj) -> OpenSSL::PKey::EC
+### def OpenSSL::PKey::EC.new -> OpenSSL::PKey::EC
+### def OpenSSL::PKey::EC.new(obj) -> OpenSSL::PKey::EC
 
 OpenSSL::PKey::EC オブジェクトを生成します。
 
@@ -220,8 +220,8 @@ data のダイジェストを取る処理はこのメソッドに含まれてい
 楕円曲線暗号のパラメータとしての役割をはたします。
 
 ## Class methods
-### def new(obj) -> OpenSSL::PKey::EC::Group
-### def new(sym, p, a, b) -> OpenSSL::PKey::EC::Group
+### def OpenSSL::PKey::EC::Group.new(obj) -> OpenSSL::PKey::EC::Group
+### def OpenSSL::PKey::EC::Group.new(sym, p, a, b) -> OpenSSL::PKey::EC::Group
 
 楕円曲線から定義される群を表すオブジェクトを生成します。
 
@@ -384,9 +384,9 @@ seed を設定します。
 楕円曲線暗号の公開鍵となる曲線上の点を表します。
 
 ## Class methods
-### def new(point) -> OpenSSL::PKey::EC::Point
-### def new(group) -> OpenSSL::PKey::EC::Point
-### def new(group, bn) -> OpenSSL::PKey::EC::Point
+### def OpenSSL::PKey::EC::Point.new(point) -> OpenSSL::PKey::EC::Point
+### def OpenSSL::PKey::EC::Point.new(group) -> OpenSSL::PKey::EC::Point
+### def OpenSSL::PKey::EC::Point.new(group, bn) -> OpenSSL::PKey::EC::Point
 
 Point オブジェクトを生成します。
 

--- a/manual/api/openssl/PKey__RSA.md
+++ b/manual/api/openssl/PKey__RSA.md
@@ -42,8 +42,8 @@ p public_key.verify("sha256", sign, "foobarbaz")
 
 ## Class Methods
 
-### def generate(size, exponent = 65537) -> OpenSSL::PKey::RSA
-### def generate(size, exponent = 65537){|u,n| ... } -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.generate(size, exponent = 65537) -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.generate(size, exponent = 65537){|u,n| ... } -> OpenSSL::PKey::RSA
 
 乱数により RSA 公開鍵と秘密鍵のペアを生成して、RSA オブジェクトを返します。
 
@@ -73,12 +73,12 @@ RSA 鍵ペアの生成には時間がかかるため、鍵生成の途中経過�
 - **param** `exponent` -- public exponent
 
 #%until 4.0
-### def new -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.new -> OpenSSL::PKey::RSA
 #%end
-### def new(size, exponent = 65537) -> OpenSSL::PKey::RSA
-### def new(size, exponent = 65537){|u,n| ... }  -> OpenSSL::PKey::RSA
-### def new(obj, pass = nil) -> OpenSSL::PKey::RSA
-### def new(obj, pass = nil){|flag| ... } -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.new(size, exponent = 65537) -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.new(size, exponent = 65537){|u,n| ... }  -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.new(obj, pass = nil) -> OpenSSL::PKey::RSA
+### def OpenSSL::PKey::RSA.new(obj, pass = nil){|flag| ... } -> OpenSSL::PKey::RSA
 
 RSA 暗号鍵オブジェクトを生成します。
 

--- a/manual/api/openssl/SSL__SSLContext.md
+++ b/manual/api/openssl/SSL__SSLContext.md
@@ -819,7 +819,7 @@ end
 [m:OpenSSL::X509::Store#set_default_paths] でシステムが提供する
 証明書を利用するように設定されています。
 
-### def DEFAULT_PARAMS -> { Symbol -> object }
+### const DEFAULT_PARAMS -> { Symbol -> object }
 
 [m:OpenSSL::SSL::SSLContext#set_params] でデフォルト値として使われる
 パラメータです。

--- a/manual/api/openssl/SSL__SSLContext.md
+++ b/manual/api/openssl/SSL__SSLContext.md
@@ -23,8 +23,8 @@ verify_mode= と options= で指定できる定数に関しては [c:OpenSSL::SS
 
 ## Class Methods
 
-### def new(ssl_method) -> OpenSSL::SSL::SSLContext
-### def new -> OpenSSL::SSL::SSLContext
+### def OpenSSL::SSL::SSLContext.new(ssl_method) -> OpenSSL::SSL::SSLContext
+### def OpenSSL::SSL::SSLContext.new -> OpenSSL::SSL::SSLContext
 
 SSL コンテキストオブジェクトを生成します。
 

--- a/manual/api/openssl/SSL__SSLServer.md
+++ b/manual/api/openssl/SSL__SSLServer.md
@@ -37,7 +37,7 @@ end
 
 ## Class Methods
 
-### def new(svr, ctx) -> OpenSSL::SSL::SSLServer
+### def OpenSSL::SSL::SSLServer.new(svr, ctx) -> OpenSSL::SSL::SSLServer
 
 [c:TCPServer] オブジェクトをラップする SSLServer オブジェクトを生成します。
 

--- a/manual/api/openssl/SSL__Session.md
+++ b/manual/api/openssl/SSL__Session.md
@@ -72,7 +72,7 @@ SSL/TLS ハンドシェイク終了時に [c:OpenSSL::SSL::SSLContext] 内の
 #%# ここにコード例を書く
 
 ## Class Methods
-### def new(obj) -> OpenSSL::SSL::Session
+### def OpenSSL::SSL::Session.new(obj) -> OpenSSL::SSL::Session
 
 新しいセッションオブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Attribute.md
+++ b/manual/api/openssl/X509__Attribute.md
@@ -10,8 +10,8 @@ X.509 証明書署名要求の attribute を表すクラスです。
 
 ## Class Methods
 
-### def new(der) -> OpenSSL::X509::Attribute
-### def new(oid, value) -> OpenSSL::X509::Attribute
+### def OpenSSL::X509::Attribute.new(der) -> OpenSSL::X509::Attribute
+### def OpenSSL::X509::Attribute.new(oid, value) -> OpenSSL::X509::Attribute
 
 attribute オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__CRL.md
+++ b/manual/api/openssl/X509__CRL.md
@@ -17,8 +17,8 @@ CRL とは、危殆化した等なんらかの理由で失効した証明書の�
 
 ## Class Methods
 
-### def new -> OpenSSL::X509::CRL
-### def new(obj) -> OpenSSL::X509::CRL
+### def OpenSSL::X509::CRL.new -> OpenSSL::X509::CRL
+### def OpenSSL::X509::CRL.new(obj) -> OpenSSL::X509::CRL
 
 CRL(証明書失効リスト)オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Certificate.md
+++ b/manual/api/openssl/X509__Certificate.md
@@ -9,8 +9,8 @@ X509 証明書クラス
 
 ## Class Methods
 
-### def new -> OpenSSL::X509::Certificate
-### def new(obj) -> OpenSSL::X509::Certificate
+### def OpenSSL::X509::Certificate.new -> OpenSSL::X509::Certificate
+### def OpenSSL::X509::Certificate.new(obj) -> OpenSSL::X509::Certificate
 
 証明書オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Extension.md
+++ b/manual/api/openssl/X509__Extension.md
@@ -21,8 +21,8 @@ X.509 v3 証明書の拡張領域のためのクラスです。
 
 ## Class Methods
 
-### def new(der) -> OpenSSL::X509::Extension
-### def new(oid, value, critical=false) -> OpenSSL::X509::Extension
+### def OpenSSL::X509::Extension.new(der) -> OpenSSL::X509::Extension
+### def OpenSSL::X509::Extension.new(oid, value, critical=false) -> OpenSSL::X509::Extension
 
 [c:OpenSSL::X509::Extension] オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__ExtensionFactory.md
+++ b/manual/api/openssl/X509__ExtensionFactory.md
@@ -39,7 +39,7 @@ newcert.add_extension(factory.create_extension("basicConstraints", "CA:FALSE"))
 
 ## Class Methods
 
-### def new(issuer_cert=nil, subject_cert=nil, subject_req=nil, crl=nil) -> OpenSSL::X509::ExtensionFactory
+### def OpenSSL::X509::ExtensionFactory.new(issuer_cert=nil, subject_cert=nil, subject_req=nil, crl=nil) -> OpenSSL::X509::ExtensionFactory
 
 ExtensionFactory オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Name.md
+++ b/manual/api/openssl/X509__Name.md
@@ -12,8 +12,8 @@ eql? と hash が定義されているため、[c:Hash] のキーとして
 #%# インターネットにおけるドメイン名のように、階層的な識別子である。
 ## Class Methods
 
-### def parse(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
-### def parse_openssl(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.parse(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.parse_openssl(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
 
 文字列をパースして [c:OpenSSL::X509::Name] オブジェクトを返します。
 
@@ -25,7 +25,7 @@ OpenSSL::X509::Name.parse('/C=JP/ST=Kanagawa/L=Yokohama/O=Example Company/OU=Lab
 - **param** `str` -- パースする文字列
 - **param** `template` -- 属性型に対応するデータ型を表わすハッシュ
 
-### def parse_rfc2253(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.parse_rfc2253(str, template=OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
 
 RFC2253形式の文字列を
 パースして [c:OpenSSL::X509::Name] オブジェクトを返します。
@@ -33,9 +33,9 @@ RFC2253形式の文字列を
 - **param** `str` -- パースする文字列
 - **param** `template` -- 属性型に対応するデータ型を表わすハッシュ
 
-### def new -> OpenSSL::X509::Name
-### def new(ary, template = OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
-### def new(obj) -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.new -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.new(ary, template = OBJECT_TYPE_TEMPLATE) -> OpenSSL::X509::Name
+### def OpenSSL::X509::Name.new(obj) -> OpenSSL::X509::Name
 
 [c:OpenSSL::X509::Name] オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Name.md
+++ b/manual/api/openssl/X509__Name.md
@@ -139,7 +139,7 @@ OpenSSL 0.9.8 と互換な古い方式のハッシュ関数の
 
 ## Constants
 
-### def OBJECT_TYPE_TEMPLATE -> { String => Integer }
+### const OBJECT_TYPE_TEMPLATE -> { String => Integer }
 
 属性型に対応する ASN.1の型を格納したハッシュです。
 

--- a/manual/api/openssl/X509__Request.md
+++ b/manual/api/openssl/X509__Request.md
@@ -39,8 +39,8 @@ puts csr.to_pem
 
 ## Class Methods
 
-### def new -> OpenSSL::X509::Request
-### def new(obj) -> OpenSSL::X509::Request
+### def OpenSSL::X509::Request.new -> OpenSSL::X509::Request
+### def OpenSSL::X509::Request.new(obj) -> OpenSSL::X509::Request
 
 新しい OpenSSL::X509::Request オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__Revoked.md
+++ b/manual/api/openssl/X509__Revoked.md
@@ -10,7 +10,7 @@ library: openssl
 
 ## Class Methods
 
-### def new -> OpenSSL::X509::Revoked
+### def OpenSSL::X509::Revoked.new -> OpenSSL::X509::Revoked
 
 空の Revoked オブジェクトを生成し、返します。
 

--- a/manual/api/openssl/X509__Store.md
+++ b/manual/api/openssl/X509__Store.md
@@ -11,7 +11,7 @@ library: openssl
 
 ## Class Methods
 
-### def new -> OpenSSL::X509::Store
+### def OpenSSL::X509::Store.new -> OpenSSL::X509::Store
 
 空の Store オブジェクトを生成します。
 

--- a/manual/api/openssl/X509__StoreContext.md
+++ b/manual/api/openssl/X509__StoreContext.md
@@ -15,7 +15,7 @@ library: openssl
 検証結果の詳細情報を保持するためにも使われます。
 
 ## Class Methods
-### def new(store, cert, chain=nil) -> OpenSSL::X509::StoreContext
+### def OpenSSL::X509::StoreContext.new(store, cert, chain=nil) -> OpenSSL::X509::StoreContext
 
 証明書ストアコンテキストを生成します。
 

--- a/manual/api/optparse.md
+++ b/manual/api/optparse.md
@@ -79,7 +79,7 @@ opt で置き換えます。そうでない場合は先頭に opt を追加し�
 
 ## Class Methods
 
-### def filter_backtrace(array) -> [String]
+### def OptionParser::ParseError.filter_backtrace(array) -> [String]
 
 array で指定されたバックトレースから optparse ライブラリに関する行を除
 外します。

--- a/manual/api/optparse/OptionParser.md
+++ b/manual/api/optparse/OptionParser.md
@@ -45,8 +45,8 @@ opts.parse!(ARGV)                            # 実際にコマンドラインの
 
 ## Class Methods
 
-### def new(banner = nil, width = 32, indent = ' ' * 4)              -> OptionParser
-### def new(banner = nil, width = 32, indent = ' ' * 4) {|opt| ...}  -> OptionParser
+### def OptionParser.new(banner = nil, width = 32, indent = ' ' * 4)              -> OptionParser
+### def OptionParser.new(banner = nil, width = 32, indent = ' ' * 4) {|opt| ...}  -> OptionParser
 
 OptionParser オブジェクトを生成して返します。
 
@@ -70,7 +70,7 @@ end
 
 - **param** `indent` -- サマリのインデントを文字列で与えます。
 
-### def accept(klass, pat = /.*/){|str| ...}    -> ()
+### def OptionParser.accept(klass, pat = /.*/){|str| ...}    -> ()
 
 オプションの引数を文字列から Ruby のオブジェクトに変換するための
 ブロックを登録します。すべての OptionParser インスタンスに共通です。
@@ -109,7 +109,7 @@ opts.parse!(ARGV)
 
 - **param** `pat` -- match メソッドを持ったオブジェクト([c:Regexp] オブジェクトなど)を与えます。
 
-### def reject(klass)    -> ()
+### def OptionParser.reject(klass)    -> ()
 
 [m:OptionParser.accept] メソッドで登録したブロックを削除します。
 
@@ -141,8 +141,8 @@ opts2 = OptionParser.new
 parse(opts2) # => unsupported argument type: Time (ArgumentError)
 ```
 
-### def getopts(argv, *opts)   -> Hash
-### def getopts(*opts)         -> Hash
+### def OptionParser.getopts(argv, *opts)   -> Hash
+### def OptionParser.getopts(*opts)         -> Hash
 
 引数をパースした結果を、Hash として返します。(self.new.getopts と同じです)
 

--- a/manual/api/ostruct.md
+++ b/manual/api/ostruct.md
@@ -76,7 +76,7 @@ p o.class!        # => OpenStruct
 以上の理由から OpenStruct を一切使用しないことを検討してください。
 
 ## Class Methods
-### def new(hash = nil) -> OpenStruct
+### def OpenStruct.new(hash = nil) -> OpenStruct
 
 OpenStruct オブジェクトを生成します。
 

--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -55,7 +55,7 @@ p Pathname("foo/bar")   # => #<Pathname:foo/bar>
 
 ## Class Methods
 
-### def new(path) -> Pathname
+### def Pathname.new(path) -> Pathname
 
 文字列 path を元に Pathname オブジェクトを生成します。
 
@@ -70,8 +70,8 @@ require "pathname"
 p Pathname.new(__FILE__) # => #<Pathname:/path/to/file.rb>
 ```
 
-### def getwd -> Pathname
-### def pwd   -> Pathname
+### def Pathname.getwd -> Pathname
+### def Pathname.pwd   -> Pathname
 
 カレントディレクトリを元に Pathname オブジェクトを生成します。
 Pathname.new(Dir.getwd) と同じです。
@@ -84,8 +84,8 @@ p Pathname.getwd #=> #<Pathname:/home/zzak/projects/ruby>
 
 - **SEE** [m:Dir.getwd]
 
-### def glob(pattern, flags=0) -> [Pathname]
-### def glob(pattern, flags=0) {|pathname| ...} -> nil
+### def Pathname.glob(pattern, flags=0) -> [Pathname]
+### def Pathname.glob(pattern, flags=0) {|pathname| ...} -> nil
 
 ワイルドカードの展開を行なった結果を、
 Pathname オブジェクトの配列として返します。

--- a/manual/api/pp.md
+++ b/manual/api/pp.md
@@ -135,7 +135,7 @@ pp h
 オブジェクトなどを見やすく出力するためのクラスです。
 
 ## Class Methods
-### def pp(obj, out = $>, width = 79)    -> object
+### def PP.pp(obj, out = $>, width = 79)    -> object
 
 指定されたオブジェクト obj を出力先 out に幅 width で出力します。
 出力先 out を返します。
@@ -161,8 +161,8 @@ puts str
 
 - **SEE** [m:$>]
 
-### def sharing_detection                 -> bool
-### def sharing_detection=(boolean)
+### def PP.sharing_detection                 -> bool
+### def PP.sharing_detection=(boolean)
 
 共有検出フラグを表すアクセサです。
 デフォルトは false です。true である場合、
@@ -181,7 +181,7 @@ PP.sharing_detection = true
 pp a                        #=> [[1, 2, 3], [...]]
 ```
 
-### def singleline_pp(obj, out=$>)    -> object
+### def PP.singleline_pp(obj, out=$>)    -> object
 
 指定されたオブジェクト obj を出力先 out に出力します。
 ただし、インデントも改行もしません。

--- a/manual/api/prettyprint.md
+++ b/manual/api/prettyprint.md
@@ -65,8 +65,8 @@ pretty printing アルゴリズムのためのクラスです。
 - 文字以外の整形
 
 ## Class Methods
-### def new(output = '', maxwidth = 79, newline = "\n")               -> PrettyPrint
-### def new(output = '', maxwidth = 79, newline = "\n"){|width| ...}  -> PrettyPrint
+### def PrettyPrint.new(output = '', maxwidth = 79, newline = "\n")               -> PrettyPrint
+### def PrettyPrint.new(output = '', maxwidth = 79, newline = "\n"){|width| ...}  -> PrettyPrint
 
 pretty printing のためのバッファを生成します。
 output は出力先です。output は << メソッドを持っていなければなりません。
@@ -85,7 +85,7 @@ output は出力先です。output は << メソッドを持っていなけれ�
 
 - **param** `newline` -- 改行に使われます。
 
-### def format(output = '', maxwidth = 79, newline = "\n", genspace = lambda{|n| ' ' * n}) {|pp| ...}    -> object
+### def PrettyPrint.format(output = '', maxwidth = 79, newline = "\n", genspace = lambda{|n| ' ' * n}) {|pp| ...}    -> object
 
 PrettyPrint オブジェクトを生成し、それを引数としてブロックを実行します。
 与えられた output を返します。
@@ -113,7 +113,7 @@ end
 - **param** `genspace` -- 空白の生成に使われる [c:Proc] オブジェクトを指定します。
                 生成したい空白の幅を表す整数を引数として呼ばれます。
 
-### def singleline_format(output = '', maxwidth = 79, newline = "\n", genspace = lambda{|n| ' ' * n}) {|pp| ...}    -> object
+### def PrettyPrint.singleline_format(output = '', maxwidth = 79, newline = "\n", genspace = lambda{|n| ' ' * n}) {|pp| ...}    -> object
 
 PrettyPrint オブジェクトを生成し、それを引数としてブロックを実行します。
 [m:PrettyPrint.format] に似ていますが、改行しません。

--- a/manual/api/prime/Integer.md
+++ b/manual/api/prime/Integer.md
@@ -5,7 +5,7 @@ library: prime
 
 ## Class Methods
 
-### def from_prime_division(pd) -> Integer
+### def Integer.from_prime_division(pd) -> Integer
 
 素因数分解された結果を元の数値に戻します。
 
@@ -20,8 +20,8 @@ p Prime.int_from_prime_division([[2,2], [3,1]])  #=> 12
 p Prime.int_from_prime_division([[2,2], [3,2]])  #=> 36
 ```
 
-### def each_prime(upper_bound){|prime| ... } -> object
-### def each_prime(upper_bound) -> Enumerator
+### def Integer.each_prime(upper_bound){|prime| ... } -> object
+### def Integer.each_prime(upper_bound) -> Enumerator
 
 全ての素数を列挙し、それぞれの素数をブロックに渡して評価します。
 

--- a/manual/api/prime/Prime.md
+++ b/manual/api/prime/Prime.md
@@ -22,12 +22,12 @@ p Prime.prime?(2)         #=> true
 
 ## Class Methods
 
-### def instance -> Prime
+### def Prime.instance -> Prime
 
 [c:Prime] のデフォルトのインスタンスを返します。
 
-### def each(upper_bound = nil, generator = EratosthenesGenerator.new){|prime| ... } -> object
-### def each(upper_bound = nil, generator = EratosthenesGenerator.new)               -> Enumerator
+### def Prime.each(upper_bound = nil, generator = EratosthenesGenerator.new){|prime| ... } -> object
+### def Prime.each(upper_bound = nil, generator = EratosthenesGenerator.new)               -> Enumerator
 
 Prime.instance.each と同じです。
 
@@ -43,7 +43,7 @@ Prime.instance.each と同じです。
 
 - **SEE** [m:Prime#each]
 
-### def int_from_prime_division(pd) -> Integer
+### def Prime.int_from_prime_division(pd) -> Integer
 
 Prime.instance.int_from_prime_division と同じです。
 
@@ -54,7 +54,7 @@ Prime.instance.int_from_prime_division と同じです。
 
 - **SEE** [m:Prime#int_from_prime_division]
 
-### def prime?(value, generator = Prime::Generator23.new) -> bool
+### def Prime.prime?(value, generator = Prime::Generator23.new) -> bool
 
 Prime.instance.prime? と同じです。
 
@@ -69,7 +69,7 @@ Prime.instance.prime? と同じです。
 
 - **SEE** [m:Prime#prime?]
 
-### def prime_division(value, generator= Prime::Generator23.new) -> [[Integer, Integer]]
+### def Prime.prime_division(value, generator= Prime::Generator23.new) -> [[Integer, Integer]]
 
 Prime.instance.prime_division と同じです。
 

--- a/manual/api/prime/Prime__PseudoPrimeGenerator.md
+++ b/manual/api/prime/Prime__PseudoPrimeGenerator.md
@@ -14,7 +14,7 @@ include:
 
 ## Class Methods
 
-### def new(upper_bound = nil) -> Prime::PseudoPrimeGenerator
+### def Prime::PseudoPrimeGenerator.new(upper_bound = nil) -> Prime::PseudoPrimeGenerator
 
 自身を初期化します。
 

--- a/manual/api/pstore.md
+++ b/manual/api/pstore.md
@@ -31,7 +31,7 @@ end
 
 ## Class Methods
 
-### def new(file, thread_safe = false) -> PStore
+### def PStore.new(file, thread_safe = false) -> PStore
 
 ファイル名 file に対してデータベースを読み書きします。
 

--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -105,7 +105,7 @@ libyaml のバージョン。
 
 ## Class Methods
 
-### def libyaml_version -> [Integer, Integer, Integer]
+### def Psych.libyaml_version -> [Integer, Integer, Integer]
 
 libyaml のバージョンを返します。
 
@@ -113,9 +113,9 @@ libyaml のバージョンを返します。
 
 - **SEE** [m:Psych::LIBYAML_VERSION]
 
-### def load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
+### def Psych.load(yaml, filename: nil, fallback: false, symbolize_names: false) -> object
 #%until 3.1
-### def load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
+### def Psych.load(yaml, filename = nil, fallback: false, symbolize_names: false) -> object
 #%end
 
 YAML ドキュメントを Ruby のデータ構造(オブジェクト)に変換します。
@@ -155,8 +155,8 @@ p Psych.load("---\n foo: bar")                       # => {"foo"=>"bar"}
 p Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 ```
 
-### def safe_load(yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false) -> object
-### def safe_load(yaml, legacy_permitted_classes=[], legacy_permitted_symbols=[], legacy_aliases=false, legacy_filename=nil) -> object
+### def Psych.safe_load(yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false) -> object
+### def Psych.safe_load(yaml, legacy_permitted_classes=[], legacy_permitted_symbols=[], legacy_aliases=false, legacy_filename=nil) -> object
 
 安全に YAML フォーマットの文書を読み込み Ruby のオブジェクトを生成して返します。
 
@@ -251,7 +251,7 @@ Psych.safe_load("", [Date])
 - **param** `freeze` -- true を指定すると再帰的に freeze されたオブジェクトを返します。
               デフォルトは false です。
 
-### def parse(yaml, filename = nil) -> Psych::Nodes::Document
+### def Psych.parse(yaml, filename = nil) -> Psych::Nodes::Document
 
 YAML ドキュメントをパースし、YAML の AST を返します。
 
@@ -278,19 +278,19 @@ rescue Psych::SyntaxError => ex
 end
 ```
 
-### def parse_file(filename) -> Psych::Nodes::Document
+### def Psych.parse_file(filename) -> Psych::Nodes::Document
 
 filename で指定したファイルをパースして YAML の AST を返します。
 
 - **param** `filename` -- パースするファイルの名前
 - **raise** `Psych::SyntaxError` -- YAMLドキュメントに文法エラーが発見されたときに発生します
 
-### def parser -> Psych::Parser
+### def Psych.parser -> Psych::Parser
 
 デフォルトで使われるのパーサを返します。
 
-### def parse_stream(yaml) -> Psych::Nodes::Stream
-### def parse_stream(yaml){|node| ... } -> ()
+### def Psych.parse_stream(yaml) -> Psych::Nodes::Stream
+### def Psych.parse_stream(yaml){|node| ... } -> ()
 
 YAML ドキュメントをパースします。
 yaml が 複数の YAML ドキュメントを含む場合を取り扱うことができます。
@@ -308,8 +308,8 @@ yaml が 複数の YAML ドキュメントを含む場合を取り扱うこと�
 p Psych.parse_stream("---\n - a\n - b") # => #<Psych::Nodes::Stream:0x00>
 ```
 
-### def dump(o, options = {}) -> String
-### def dump(o, io, options = {}) -> ()
+### def Psych.dump(o, options = {}) -> String
+### def Psych.dump(o, io, options = {}) -> ()
 
 Ruby のオブジェクト o を YAML ドキュメントに変換します。
 
@@ -340,7 +340,7 @@ p Psych.dump(['a', ['b']], :indentation => 3) # => "---\n- a\n-  - b\n"
 Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
 ```
 
-### def dump_stream(*objects) -> String
+### def Psych.dump_stream(*objects) -> String
 
 オブジェクト列を YAML ドキュメント列に変換します。
 
@@ -350,14 +350,14 @@ Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
 p Psych.dump_stream("foo\n  ", {}) # => "--- ! \"foo\\n  \"\n--- {}\n"
 ```
 
-### def to_json(o) -> String
+### def Psych.to_json(o) -> String
 
 Ruby のオブジェクト o を JSON の文字列に変換します。
 
 - **param** `o` -- 変換対象となるオブジェクト
 
-### def load_stream(yaml, filename=nil) -> [object]
-### def load_stream(yaml, filename=nil){|obj| ... } -> ()
+### def Psych.load_stream(yaml, filename=nil) -> [object]
+### def Psych.load_stream(yaml, filename=nil){|obj| ... } -> ()
 
 複数の YAML ドキュメントを含むデータを
 Ruby のオブジェクトに変換します。
@@ -384,7 +384,7 @@ filename はパース中に発生した例外のメッセージに用います�
 - **param** `filename` -- [c:Psych::SyntaxError] 発生時にファイル名として表示する文字列。
 - **raise** `Psych::SyntaxError` -- YAMLドキュメントに文法エラーが発見されたときに発生します
 
-### def load_file(filename) -> object
+### def Psych.load_file(filename) -> object
 
 filename で指定したファイルを YAML ドキュメントとして
 Ruby のオブジェクトに変換します。

--- a/manual/api/psych/Psych__Handler.md
+++ b/manual/api/psych/Psych__Handler.md
@@ -357,7 +357,7 @@ puts output.string
 
 ## Class Methods
 
-### def new(io) -> Psych::Emitter
+### def Psych::Emitter.new(io) -> Psych::Emitter
 
 Emitter オブジェクトを生成して返します。
 

--- a/manual/api/psych/Psych__Nodes__Alias.md
+++ b/manual/api/psych/Psych__Nodes__Alias.md
@@ -11,7 +11,7 @@ alias は YAML の AST の葉のノードであり、子ノードを持ちませ
 
 ## Class Methods
 
-### def new(anchor) -> Psych::Nodes::Alias
+### def Psych::Nodes::Alias.new(anchor) -> Psych::Nodes::Alias
 
 新たな Alias オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Nodes__Document.md
+++ b/manual/api/psych/Psych__Nodes__Document.md
@@ -15,7 +15,7 @@ YAML ドキュメントを表すクラスです。
 アクセスできます。
 
 ## Class Methods
-### def new(version=[], tag_directives=[], implicit=false) -> Psych::Nodes::Document
+### def Psych::Nodes::Document.new(version=[], tag_directives=[], implicit=false) -> Psych::Nodes::Document
 
 Document オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Nodes__Mapping.md
+++ b/manual/api/psych/Psych__Nodes__Mapping.md
@@ -27,7 +27,7 @@ p ast.root.children.map{|v| v.value } # => ["x", "y", "u", "v"]
 ```
 
 ## Class Methods
-### def new(anchor=nil, tag=nil, implicit=true, style=BLOCK) -> Psych::Nodes::Mapping
+### def Psych::Nodes::Mapping.new(anchor=nil, tag=nil, implicit=true, style=BLOCK) -> Psych::Nodes::Mapping
 
 新たな mapping オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Nodes__Scalar.md
+++ b/manual/api/psych/Psych__Nodes__Scalar.md
@@ -8,7 +8,7 @@ YAML の scalar <https://yaml.org/spec/1.1/#id858081> を表すクラスです�
 これは AST の葉にあたるノードであり、子ノードを持ちません。
 
 ## Class Methods
-### def new(value, anchor=nil, tag=nil, plain=true, quoted=false, style=ANY) -> Psych::Nodes:Scalar
+### def Psych::Nodes::Scalar.new(value, anchor=nil, tag=nil, plain=true, quoted=false, style=ANY) -> Psych::Nodes:Scalar
 
 Scalar オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Nodes__Sequence.md
+++ b/manual/api/psych/Psych__Nodes__Sequence.md
@@ -47,7 +47,7 @@ Psych::Nodes::Sequence は 0 個以上の子ノードを持つことができま
   - [c:Psych::Nodes::Alias]
 
 ## Class Methods
-### def new(anchor=nil, tag=nil, implicit=true, style=BLOCK) -> Psych::Nodes::Sequence
+### def Psych::Nodes::Sequence.new(anchor=nil, tag=nil, implicit=true, style=BLOCK) -> Psych::Nodes::Sequence
 
 新たな sequence オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Nodes__Stream.md
+++ b/manual/api/psych/Psych__Nodes__Stream.md
@@ -10,7 +10,7 @@ YAML の AST のルートノードとなるオブジェクトのクラス。
 [c:Psych::Nodes::Document] オブジェクトでなければなりません。
 
 ## Class Methods
-### def new(encoding = Psych::Nodes::Stream::UTF8) -> Psych::Nodes::Stream
+### def Psych::Nodes::Stream.new(encoding = Psych::Nodes::Stream::UTF8) -> Psych::Nodes::Stream
 
 Psych::Nodes::Stream オブジェクトを生成して返します。
 

--- a/manual/api/psych/Psych__Parser.md
+++ b/manual/api/psych/Psych__Parser.md
@@ -67,7 +67,7 @@ UTF-16BE エンコーディングを表します。
 
 ## Class Methods
 
-### def new(handler = Handler.new) -> Psych::Parser
+### def Psych::Parser.new(handler = Handler.new) -> Psych::Parser
 
 新たなパーサオブジェクトを生成して返します。
 

--- a/manual/api/psych/Psych__ScalarScanner.md
+++ b/manual/api/psych/Psych__ScalarScanner.md
@@ -13,7 +13,7 @@ YAML の scalar 型を読み込んで Ruby の built-in 型に変換するクラ
 
 ## Class Methods
 
-### def new
+### def Psych::ScalarScanner.new
 
 新たな ScalarScanner オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Stream.md
+++ b/manual/api/psych/Psych__Stream.md
@@ -32,7 +32,7 @@ end
 
 #%# Psych::Streaming のメソッドはここに記述しています。
 ## Class Methods
-### def new(io) -> Psych::Stream
+### def Psych::Stream.new(io) -> Psych::Stream
 
 新たな Stream オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__TreeBuilder.md
+++ b/manual/api/psych/Psych__TreeBuilder.md
@@ -20,7 +20,7 @@ parser.handler.root # => #<Psych::Nodes::Stream:0x00000001400000 ... >
   
 ## Class Methods
 
-### def new -> Psych::TreeBuilder
+### def Psych::TreeBuilder.new -> Psych::TreeBuilder
 
 TreeBuilder オブジェクトを生成します。
 

--- a/manual/api/psych/Psych__Visitors.md
+++ b/manual/api/psych/Psych__Visitors.md
@@ -30,7 +30,7 @@ puts tree.to_yaml
 ```
 
 ## Class Methods
-### def new(options = {}, emitter = Psych::TreeBuilder.new, ss = Psych::ScalarScanner.new) -> Psych::Visitors::YAMLTree
+### def Psych::Visitors::YAMLTree.new(options = {}, emitter = Psych::TreeBuilder.new, ss = Psych::ScalarScanner.new) -> Psych::Visitors::YAMLTree
 
 YAMLTree オブジェクトを生成します。
 

--- a/manual/api/psych/core_ext.md
+++ b/manual/api/psych/core_ext.md
@@ -5,7 +5,7 @@ library: psych
 
 ## Class Methods
  
-### def yaml_tag(tag) -> ()
+### def Object.yaml_tag(tag) -> ()
 
 クラスと tag の間を関連付けます。
 

--- a/manual/api/pty.md
+++ b/manual/api/pty.md
@@ -31,7 +31,7 @@ category: CUI
 - **SEE** [m:Kernel?.spawn], [m:Kernel?.system], [m:IO.popen], [man:signal(2)]
 
 ## Singleton Methods
-### def check(pid, raise = false) -> Process::Status | nil
+### def PTY.check(pid, raise = false) -> Process::Status | nil
 
 pid で指定された子プロセスの状態をチェックし、変化があれば変化したステータスを
 返します。実行中、あるいは変化なしであれば nil を返します。
@@ -49,8 +49,8 @@ pid で指定された子プロセスの状態をチェックし、変化があ�
              (なお、バグにより、1.9.2 pXXX より古い ruby では、終了または停止して
              いなくても、ただちに例外が発生します)
 
-### def open -> [IO, File]
-### def open{|master_io, slave_file| ... } -> object
+### def PTY.open -> [IO, File]
+### def PTY.open{|master_io, slave_file| ... } -> object
 
 仮想 tty を確保し、マスター側に対応する [c:IO] オブジェクトとスレーブ側に
 対応する [c:File] オブジェクトの配列を返します。

--- a/manual/api/racc/parser.md
+++ b/manual/api/racc/parser.md
@@ -7,7 +7,7 @@ type: library
 
 ## Class Methods
 
-### def racc_runtime_type
+### def Racc::Parser.racc_runtime_type
 #%todo
 
 ## Private Instance Methods

--- a/manual/api/ractor/Port.md
+++ b/manual/api/ractor/Port.md
@@ -8,7 +8,7 @@ Ractor 間でメッセージを交換するための仕組みを提供するク�
 
 ## Class Methods
 
-### def new -> Ractor::Port
+### def Ractor::Port.new -> Ractor::Port
 
 ## Instance Methods
 

--- a/manual/api/rake/Rake.md
+++ b/manual/api/rake/Rake.md
@@ -7,7 +7,7 @@ Rake の主要なモジュールです。
 
 ## Singleton Methods
 
-### def application -> Rake::Application
+### def Rake.application -> Rake::Application
 
 現在の Rake アプリケーションを返します。
 
@@ -45,7 +45,7 @@ end
 #     @tty_output=false>
 ```
 
-### def application=(app)
+### def Rake.application=(app)
 
 現在の Rake アプリケーションをセットします。
 
@@ -87,7 +87,7 @@ end
 #     @tty_output=true>
 ```
 
-### def original_dir -> String
+### def Rake.original_dir -> String
 
 Rake アプリケーションを開始したディレクトリを返します。
 

--- a/manual/api/rake/RakeFileUtils.md
+++ b/manual/api/rake/RakeFileUtils.md
@@ -63,7 +63,7 @@ end
 
 ## Singleton Methods
 
-### def nowrite_flag -> bool
+### def RakeFileUtils.nowrite_flag -> bool
 
 この値が真の場合、実際のファイル書き込みをともなう操作は行いません。
 そうでない場合、ファイル書き込みを行います。
@@ -77,7 +77,7 @@ file :sample_file_task do |t|
 end
 ```
 
-### def nowrite_flag=(flag)
+### def RakeFileUtils.nowrite_flag=(flag)
 
 実際に動作を行うかどうか設定します。
 
@@ -95,7 +95,7 @@ file :sample_file_task do |t|
 end
 ```
 
-### def verbose_flag -> bool
+### def RakeFileUtils.verbose_flag -> bool
 
 この値が真の場合、詳細を表示します。
 
@@ -110,7 +110,7 @@ file :sample_file_task do |t|
 end
 ```
 
-### def verbose_flag=(flag)
+### def RakeFileUtils.verbose_flag=(flag)
 
 詳細を表示するかどうか設定します。
 

--- a/manual/api/rake/Rake__FileList.md
+++ b/manual/api/rake/Rake__FileList.md
@@ -364,7 +364,7 @@ end
 
 ## Singleton Methods
 
-### def new(*patterns){|self| ... }
+### def Rake::FileList.new(*patterns){|self| ... }
 
 与えられたパターンをもとにして自身を初期化します。
 
@@ -380,7 +380,7 @@ pkg_files = FileList.new('lib/**/*') do |fl|
 end
 ```
 
-### def [](*args) -> Rake::FileList
+### def Rake::FileList.[](*args) -> Rake::FileList
 
 与えられたパターンをもとにして自身を初期化します。
 

--- a/manual/api/rake/Rake__FileTask.md
+++ b/manual/api/rake/Rake__FileTask.md
@@ -46,6 +46,6 @@ end
 
 ## Singleton Methods
 
-### def scope_name(scope, task_name) -> String
+### def Rake::FileTask.scope_name(scope, task_name) -> String
 
 ファイルタスクはスコープを無視します。

--- a/manual/api/rake/Rake__InvocationChain.md
+++ b/manual/api/rake/Rake__InvocationChain.md
@@ -67,7 +67,7 @@ end
 
 ## Singleton Methods
 
-### def new(task_name, tail)
+### def Rake::InvocationChain.new(task_name, tail)
 
 与えられたタスク名と一つ前の [c:Rake::InvocationChain] を用いて自身を初期化します。
 
@@ -87,7 +87,7 @@ task :test_rake_app do
 end
 ```
 
-### def append(task_name, chain) -> Rake::InvocationChain
+### def Rake::InvocationChain.append(task_name, chain) -> Rake::InvocationChain
 
 与えられたタスク名を第二引数の [c:Rake::InvocationChain] に追加します。
 

--- a/manual/api/rake/Rake__NameSpace.md
+++ b/manual/api/rake/Rake__NameSpace.md
@@ -46,7 +46,7 @@ end
 
 ## Singleton Methods
 
-### def new(task_manager, scope_list)
+### def Rake::NameSpace.new(task_manager, scope_list)
 
 自身を初期化します。
 

--- a/manual/api/rake/Rake__Task.md
+++ b/manual/api/rake/Rake__Task.md
@@ -138,7 +138,7 @@ library: rake
 
 ## Singleton Methods
 
-### def new(task_name, app)
+### def Rake::Task.new(task_name, app)
 
 与えられたタスク名とアプリケーションで自身を初期化します。
 
@@ -147,7 +147,7 @@ library: rake
 
 - **SEE** [m:Rake::Task#enhance]
 
-### def [](task_name) -> Rake::Task
+### def Rake::Task.[](task_name) -> Rake::Task
 
 与えられた名前のタスクを返します。
 
@@ -157,17 +157,17 @@ library: rake
 
 - **param** `task_name` -- タスクの名前を指定します。
 
-### def clear
+### def Rake::Task.clear
 
 タスクリストをクリアします。
 
 このメソッドはユニットテスト用です。
 
-### def create_rule(*args){ ... } -> Rake::Task
+### def Rake::Task.create_rule(*args){ ... } -> Rake::Task
 
 タスクを合成するためのルールを作成します。
 
-### def define_task(*args){ ... } -> Rake::Task
+### def Rake::Task.define_task(*args){ ... } -> Rake::Task
 
 与えられたパラメータと省略可能なブロックを用いてタスクを定義します。
 
@@ -175,17 +175,17 @@ library: rake
 
 - **param** `args` -- パラメータを指定します。
 
-### def scope_name(scope, task_name) -> String
+### def Rake::Task.scope_name(scope, task_name) -> String
 
 与えられたスコープとタスク名をコロンで連結して返します。
 
-### def task_defined?(task_name) -> bool
+### def Rake::Task.task_defined?(task_name) -> bool
 
 与えられたタスク名が既に定義されている場合は真を返します。
 そうでない場合は偽を返します。
 
 - **param** `task_name` -- タスク名を指定します。
 
-### def tasks -> Array
+### def Rake::Task.tasks -> Array
 
 定義されているタスクのリストを返します。

--- a/manual/api/rake/Rake__TaskArguments.md
+++ b/manual/api/rake/Rake__TaskArguments.md
@@ -119,7 +119,7 @@ end
 
 ## Singleton Methods
 
-### def new(names, values, parent = nil)
+### def Rake::TaskArguments.new(names, values, parent = nil)
 
 自身を初期化します。
 

--- a/manual/api/rake/gempackagetask.md
+++ b/manual/api/rake/gempackagetask.md
@@ -74,7 +74,7 @@ gemspec をセットします。
 
 ## Singleton Methods
 
-### def new(gem_spec){|t| ... } -> Rake::GemPackageTask
+### def Rake::GemPackageTask.new(gem_spec){|t| ... } -> Rake::GemPackageTask
 
 自身を初期化してタスクを定義します。
 

--- a/manual/api/rake/packagetask.md
+++ b/manual/api/rake/packagetask.md
@@ -347,7 +347,7 @@ zip ファイル用のファイル名を返します。
 
 ## Singleton Methods
 
-### def new(name = nil, version = nil){|t| ... } -> Rake::PackageTask
+### def Rake::PackageTask.new(name = nil, version = nil){|t| ... } -> Rake::PackageTask
 
 自身を初期化してタスクを定義します。
 

--- a/manual/api/rake/rdoctask.md
+++ b/manual/api/rake/rdoctask.md
@@ -139,7 +139,7 @@ RDoc のタイトルをセットします。
 
 ## Singleton Methods
 
-### def new(name = :rdoc){|pkg| ... } -> Rake::RDocTask
+### def Rake::RDocTask.new(name = :rdoc){|pkg| ... } -> Rake::RDocTask
 
 自身を初期化して RDoc タスクを定義します。
 

--- a/manual/api/rake/testtask.md
+++ b/manual/api/rake/testtask.md
@@ -139,7 +139,7 @@ rake test TESTOPTS="--runner=fox"   # use the fox test runner
 
 ## Singleton Methods
 
-### def new(name = :test){|t| ... } -> Rake::TestTask
+### def Rake::TestTask.new(name = :test){|t| ... } -> Rake::TestTask
 
 自身を初期化します。
 

--- a/manual/api/rbconfig.md
+++ b/manual/api/rbconfig.md
@@ -11,7 +11,7 @@ RbConfig モジュールを定義します。
 
 ## Singleton Methods
 
-### def expand(val, config = CONFIG) -> String
+### def RbConfig.expand(val, config = CONFIG) -> String
 
 与えられたパスを展開します。
 
@@ -25,7 +25,7 @@ p RbConfig.expand("$(bindir)") # => /home/foobar/all-ruby/ruby19x/bin
   
 - **SEE** [m:RbConfig::MAKEFILE_CONFIG]
 
-### def ruby -> String
+### def RbConfig.ruby -> String
 
 ruby コマンドのフルパスを返します。
 

--- a/manual/api/rdoc/RDoc__CodeObject.md
+++ b/manual/api/rdoc/RDoc__CodeObject.md
@@ -30,7 +30,7 @@ RDoc のコードツリーを表現するクラスの基本クラスです。
 
 ## Class Methods
 
-### def new -> RDoc::CodeObject
+### def RDoc::CodeObject.new -> RDoc::CodeObject
 
 自身を初期化します。
 

--- a/manual/api/rdoc/RDoc__Context.md
+++ b/manual/api/rdoc/RDoc__Context.md
@@ -21,7 +21,7 @@ include:
 
 ## Class Methods
 
-### def new -> RDoc::Context
+### def RDoc::Context.new -> RDoc::Context
 
 自身を初期化します。
 

--- a/manual/api/rdoc/RDoc__Context__Section.md
+++ b/manual/api/rdoc/RDoc__Context__Section.md
@@ -17,7 +17,7 @@ section に関する情報を保持するクラスです。
 
 ## Class Methods
 
-### def new(parent, title, comment) -> RDoc::Context::Section
+### def RDoc::Context::Section.new(parent, title, comment) -> RDoc::Context::Section
 
 自身を初期化します。
 

--- a/manual/api/rdoc/RDoc__KNOWN_CLASSES.md
+++ b/manual/api/rdoc/RDoc__KNOWN_CLASSES.md
@@ -6,7 +6,7 @@ library:
 
 ## Constants
 
-### def KNOWN_CLASSES -> {String => String}
+### const KNOWN_CLASSES -> {String => String}
 
 Ruby の組み込みクラスの内部的な変数名がキー、クラス名が値のハッシュです。
 

--- a/manual/api/rdoc/RDoc__RDoc.md
+++ b/manual/api/rdoc/RDoc__RDoc.md
@@ -37,7 +37,7 @@ doc 以下に出力します。
 
 ## Class Methods
 
-### def add_generator(klass) -> klass
+### def RDoc::RDoc.add_generator(klass) -> klass
 
 引数 klass で指定したクラスをジェネレータとして登録します。
 

--- a/manual/api/rdoc/RDoc__Stats.md
+++ b/manual/api/rdoc/RDoc__Stats.md
@@ -8,7 +8,7 @@ RDoc のステータスを管理するクラスです。
 
 ## Class Methods
 
-### def new -> RDoc::Stats
+### def RDoc::Stats.new -> RDoc::Stats
 
 自身を初期化します。
 

--- a/manual/api/rdoc/RDoc__TopLevel.md
+++ b/manual/api/rdoc/RDoc__TopLevel.md
@@ -8,24 +8,24 @@ library:
 
 ## Class Methods
 
-### def all_classes_and_modules -> [RDoc::NormalClass | RDoc::SingleClass | RDoc::NormalModule]
+### def RDoc::TopLevel.all_classes_and_modules -> [RDoc::NormalClass | RDoc::SingleClass | RDoc::NormalModule]
 
 RDoc が収集したクラス、モジュールを配列で返します。
 
-### def find_class_named(name) -> RDoc::NormalClass | RDoc::SingleClass | nil
+### def RDoc::TopLevel.find_class_named(name) -> RDoc::NormalClass | RDoc::SingleClass | nil
 
 RDoc が収集したクラスの内、name で指定した名前のクラスを返します。見つ
 からなかった場合は nil を返します。
 
 - **param** `name` -- クラス名を文字列で指定します。
 
-### def new(file_name) -> RDoc::TopLevel
+### def RDoc::TopLevel.new(file_name) -> RDoc::TopLevel
 
 自身を初期化します。
 
 - **param** `file_name` -- ファイル名を文字列で指定します。
 
-### def reset -> ()
+### def RDoc::TopLevel.reset -> ()
 
 RDoc が収集した [c:RDoc::TopLevel] の情報(クラス、モジュール、ファイ
 ル)をクリアします。

--- a/manual/api/rdoc/generator/json_index.md
+++ b/manual/api/rdoc/generator/json_index.md
@@ -89,7 +89,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ## Class Methods
 
-### def new(parent_generator, options) -> RDoc::Generator::JsonIndex
+### def RDoc::Generator::JsonIndex.new(parent_generator, options) -> RDoc::Generator::JsonIndex
 
 [c:RDoc::Generator::JsonIndex] オブジェクトを初期化します。
 

--- a/manual/api/rdoc/markdown.md
+++ b/manual/api/rdoc/markdown.md
@@ -179,21 +179,21 @@ Markdown 形式で記述されたドキュメントを [lib:rdoc] 上で解析�
 
 ## Class Methods
 
-### def extension(name) -> nil
+### def RDoc::Markdown.extension(name) -> nil
 
 引数 name で指定した拡張を有効/無効にするためのインスタンスメソッドを定
 義します。
 
 ライブラリ内部で使用します。
 
-### def parse(markdown) -> RDoc::Markup::Document
+### def RDoc::Markdown.parse(markdown) -> RDoc::Markup::Document
 
 引数 markdown で指定したドキュメントを解析して
 `RDoc::Markup::Document` オブジェクトを返します。
 
 - **param** `markdown` -- 解析の対象になるドキュメントを文字列で指定します。
 
-### def new(extensions = DEFAULT_EXTENSIONS, debug = false)
+### def RDoc::Markdown.new(extensions = DEFAULT_EXTENSIONS, debug = false)
 
 引数 extensions で与えられた拡張を有効にした [c:RDoc::Markdown] オブ
 ジェクトを初期化します。

--- a/manual/api/rdoc/markdown/entities.md
+++ b/manual/api/rdoc/markdown/entities.md
@@ -7,7 +7,7 @@ HTML の実体参照のマッピングを表す情報を定義するサブライ
 
 ## Constants
 
-### def HTML_ENTITIES -> {String => [Integer]}
+### const HTML_ENTITIES -> {String => [Integer]}
 
 HTML の実体参照のマッピングを表す [c:Hash] オブジェクトです。
 [c:RDoc::Markdown] で使用します。

--- a/manual/api/rdoc/markup/formatter.md
+++ b/manual/api/rdoc/markup/formatter.md
@@ -14,7 +14,7 @@ RDoc 形式のドキュメントを整形するための基本クラスです。
 
 ## Class Methods
 
-### def new(markup = nil) -> RDoc::Markup::Formatter
+### def RDoc::Markup::Formatter.new(markup = nil) -> RDoc::Markup::Formatter
 
 自身を初期化します。
 

--- a/manual/api/rdoc/markup/simple_markup.md
+++ b/manual/api/rdoc/markup/simple_markup.md
@@ -91,7 +91,7 @@ puts "<body>#{wh.convert ARGF.read}</body>"
 
 ## Class Methods
 
-### def new(attribute_manager = nil) -> RDoc::Markup
+### def RDoc::Markup.new(attribute_manager = nil) -> RDoc::Markup
 
 自身を初期化します。
 

--- a/manual/api/rdoc/markup/to_ansi.md
+++ b/manual/api/rdoc/markup/to_ansi.md
@@ -20,7 +20,7 @@ RDoc 形式のドキュメントを ANSI エスケープシーケンスで色付
 
 ## Class Methods
 
-### def new(markup = nil) -> RDoc::Markup::ToAnsi
+### def RDoc::Markup::ToAnsi.new(markup = nil) -> RDoc::Markup::ToAnsi
 
 自身を初期化します。
 

--- a/manual/api/rdoc/markup/to_bs.md
+++ b/manual/api/rdoc/markup/to_bs.md
@@ -27,7 +27,7 @@ RDoc 形式のドキュメントをエスケープシーケンスで太字やア
 
 ## Class Methods
 
-### def new(markup = nil) -> RDoc::Markup::ToBs
+### def RDoc::Markup::ToBs.new(markup = nil) -> RDoc::Markup::ToBs
 
 自身を初期化します。
 

--- a/manual/api/rdoc/markup/to_html.md
+++ b/manual/api/rdoc/markup/to_html.md
@@ -20,6 +20,6 @@ RDoc 形式のドキュメントを HTML に整形するクラスです。
 
 ## Class Methods
 
-### def new -> RDoc::Markup::ToHtml
+### def RDoc::Markup::ToHtml.new -> RDoc::Markup::ToHtml
 
 自身を初期化します。

--- a/manual/api/rdoc/markup/to_html_crossref.md
+++ b/manual/api/rdoc/markup/to_html_crossref.md
@@ -14,7 +14,7 @@ RDoc 形式のドキュメントを HTML に整形するクラスです。
 
 ## Class Methods
 
-### def new(path, context, show_hash) -> RDoc::Markup::ToHtmlCrossref
+### def RDoc::Markup::ToHtmlCrossref.new(path, context, show_hash) -> RDoc::Markup::ToHtmlCrossref
 
 自身を初期化します。
 

--- a/manual/api/rdoc/markup/to_rdoc.md
+++ b/manual/api/rdoc/markup/to_rdoc.md
@@ -13,7 +13,7 @@ RDoc 形式のドキュメントをマークアップ記法を保持したまま
 
 ## Class Methods
 
-### def new(markup = nil) -> RDoc::Markup::ToRdoc
+### def RDoc::Markup::ToRdoc.new(markup = nil) -> RDoc::Markup::ToRdoc
 
 自身を初期化します。
 

--- a/manual/api/rdoc/options.md
+++ b/manual/api/rdoc/options.md
@@ -535,7 +535,7 @@ $stderr に出力します。
 
 ## Constants
 
-### def DEPRECATED -> {String -> String}
+### const DEPRECATED -> {String -> String}
 
 非推奨のオプションの一覧を返します。
 

--- a/manual/api/rdoc/parsers/parse_c.md
+++ b/manual/api/rdoc/parsers/parse_c.md
@@ -98,7 +98,7 @@ C 言語で記述されたソースコードから組み込みクラス/モジ�
 
 ## Class Methods
 
-### def new(top_level, file_name, body, options, stats) -> RDoc::Parser::C
+### def RDoc::Parser::C.new(top_level, file_name, body, options, stats) -> RDoc::Parser::C
 
 自身を初期化します。
 

--- a/manual/api/rdoc/parsers/parse_rb.md
+++ b/manual/api/rdoc/parsers/parse_rb.md
@@ -105,7 +105,7 @@ RDoc::SingleClass type
 
 ## Class Methods
 
-### def new(top_level, file_name, body, options, stats) -> RDoc::Parser::Ruby
+### def RDoc::Parser::Ruby.new(top_level, file_name, body, options, stats) -> RDoc::Parser::Ruby
 
 自身を初期化します。
 

--- a/manual/api/rdoc/parsers/parse_simple.md
+++ b/manual/api/rdoc/parsers/parse_simple.md
@@ -13,7 +13,7 @@ require:
 
 ## Class Methods
 
-### def new(top_level, file_name, body, options, stats) -> RDoc::Parser::Simple
+### def RDoc::Parser::Simple.new(top_level, file_name, body, options, stats) -> RDoc::Parser::Simple
 
 自身を初期化します。
 

--- a/manual/api/rdoc/parsers/parserfactory.md
+++ b/manual/api/rdoc/parsers/parserfactory.md
@@ -58,14 +58,14 @@ end
 
 ## class Methods
 
-### def can_parse(file_name) -> RDoc::Parser | nil
+### def RDoc::Parser.can_parse(file_name) -> RDoc::Parser | nil
 
 file_name を解析できるパーサクラスを返します。見つからなかった場合は
 nil を返します。
 
 - **param** `file_name` -- 解析するファイルの名前を指定します。
 
-### def alias_extension(old_ext, new_ext) -> bool
+### def RDoc::Parser.alias_extension(old_ext, new_ext) -> bool
 
 old_ext に登録されたパーサを new_ext でも解析できるようにエイリアスを登
 録します。
@@ -78,7 +78,7 @@ old_ext に登録されたパーサを new_ext でも解析できるようにエ
         が登録されていない場合、エイリアスが登録されずに false を返しま
         す。
 
-### def parser_for(top_level, file_name, body, options, stats) -> RDoc::Parser
+### def RDoc::Parser.parser_for(top_level, file_name, body, options, stats) -> RDoc::Parser
 
 file_name を解析できるパーサのインスタンスを返します。
 見つからなかった場合は [c:RDoc::Parser::Simple] のインスタンスを返します。
@@ -93,7 +93,7 @@ file_name を解析できるパーサのインスタンスを返します。
 
 - **param** `stats` -- [c:RDoc::Stats] オブジェクトを指定します。
 
-### def parsers -> [[Regexp, RDoc::Parser]]
+### def RDoc::Parser.parsers -> [[Regexp, RDoc::Parser]]
 
 [m:RDoc::Parser#parse_files_matching] で登録した正規表現とパーサクラ
 スの配列の配列を返します。

--- a/manual/api/readline/Readline.md
+++ b/manual/api/readline/Readline.md
@@ -438,7 +438,7 @@ GNU Readline のデフォルト値は nil(NULL) です。
 
 - **SEE** GNU Readline ライブラリの rl_set_screen_size 関数
 
-### const Readline.get_screen_size -> [Integer, Integer]
+### def Readline.get_screen_size -> [Integer, Integer]
 
 端末のサイズを [rows, columns] で返します。
 

--- a/manual/api/readline/Readline.md
+++ b/manual/api/readline/Readline.md
@@ -168,21 +168,21 @@ end
 
 ## Singleton Methods
 
-### def input=(input)
+### def Readline.input=(input)
 
 readline メソッドで使用する入力用の [c:File] オブジェクト input を指定します。
 戻り値は指定した [c:File] オブジェクト input です。
 
 - **param** `input` -- [c:File] オブジェクトを指定します。
 
-### def output=(output)
+### def Readline.output=(output)
 
 readline メソッドで使用する出力用の [c:File] オブジェクト output を指定します。
 戻り値は指定した [c:File] オブジェクト output です。
 
 - **param** `output` -- [c:File] オブジェクトを指定します。
 
-### def completion_proc=(proc)
+### def Readline.completion_proc=(proc)
 
 ユーザからの入力を補完する時の候補を取得する [c:Proc] オブジェクト
 proc を指定します。
@@ -218,14 +218,14 @@ end
 
 - **SEE** [m:Readline.completion_proc]
 
-### def completion_proc -> Proc
+### def Readline.completion_proc -> Proc
 
 ユーザからの入力を補完する時の候補を取得する [c:Proc] オブジェクト
 proc を取得します。
 
 - **SEE** [m:Readline.completion_proc=]
 
-### def completion_case_fold=(bool)
+### def Readline.completion_case_fold=(bool)
 
 ユーザの入力を補完する際、大文字と小文字を同一視する／しないを指定します。
 bool が真ならば同一視します。bool が偽ならば同一視しません。
@@ -234,7 +234,7 @@ bool が真ならば同一視します。bool が偽ならば同一視しませ�
 
 - **SEE** [m:Readline.completion_case_fold]
 
-### def completion_case_fold -> bool
+### def Readline.completion_case_fold -> bool
 
 ユーザの入力を補完する際、大文字と小文字を同一視する／しないを取得します。
 bool が真ならば同一視します。bool が偽ならば同一視しません。
@@ -250,7 +250,7 @@ p Readline.completion_case_fold # => "This is a String."
 
 - **SEE** [m:Readline.completion_case_fold=]
 
-### def vi_editing_mode -> nil
+### def Readline.vi_editing_mode -> nil
 
 編集モードを vi モードにします。
 vi モードの詳細は、GNU Readline のマニュアルを参照してください。
@@ -259,7 +259,7 @@ vi モードの詳細は、GNU Readline のマニュアルを参照してくだ�
 
 - **raise** `NotImplementedError` -- サポートしていない環境で発生します。
 
-### def emacs_editing_mode -> nil
+### def Readline.emacs_editing_mode -> nil
 
 編集モードを Emacs モードにします。デフォルトは Emacs モードです。
 
@@ -269,7 +269,7 @@ Emacs モードの詳細は、 GNU Readline のマニュアルを参照してく
 
 - **raise** `NotImplementedError` -- サポートしていない環境で発生します。
 
-### def completion_append_character=(string)
+### def Readline.completion_append_character=(string)
 
 ユーザの入力の補完が完了した場合に、最後に付加する文字 string を指定します。
 
@@ -302,7 +302,7 @@ p Readline.completion_append_character # => "s"
 
 - **SEE** [m:Readline.completion_append_character]
 
-### def completion_append_character -> String
+### def Readline.completion_append_character -> String
 
 ユーザの入力の補完が完了した場合に、最後に付加する文字を取得します。
 
@@ -310,7 +310,7 @@ p Readline.completion_append_character # => "s"
 
 - **SEE** [m:Readline.completion_append_character=]
 
-### def basic_word_break_characters=(string)
+### def Readline.basic_word_break_characters=(string)
 
 ユーザの入力の補完を行う際、
 単語の区切りを示す複数の文字で構成される文字列 string を指定します。
@@ -324,7 +324,7 @@ GNU Readline のデフォルト値は、Bash の補完処理で使用してい�
 
 - **SEE** [m:Readline.basic_word_break_characters]
 
-### def basic_word_break_characters -> String
+### def Readline.basic_word_break_characters -> String
 
 ユーザの入力の補完を行う際、
 単語の区切りを示す複数の文字で構成される文字列を取得します。
@@ -333,7 +333,7 @@ GNU Readline のデフォルト値は、Bash の補完処理で使用してい�
 
 - **SEE** [m:Readline.basic_word_break_characters=]
 
-### def completer_word_break_characters=(string)
+### def Readline.completer_word_break_characters=(string)
 
 ユーザの入力の補完を行う際、
 単語の区切りを示す複数の文字で構成される文字列 string を指定します。
@@ -349,7 +349,7 @@ GNU Readline のデフォルトの値は、
 
 - **SEE** [m:Readline.completer_word_break_characters]
 
-### def completer_word_break_characters -> String
+### def Readline.completer_word_break_characters -> String
 
 ユーザの入力の補完を行う際、
 単語の区切りを示す複数の文字で構成された文字列を取得します。
@@ -360,7 +360,7 @@ GNU Readline の rl_complete_internal 関数で使用されることです。
 
 - **SEE** [m:Readline.completer_word_break_characters=]
 
-### def basic_quote_characters=(string)
+### def Readline.basic_quote_characters=(string)
 
 スペースなどの単語の区切りをクオートするための
 複数の文字で構成される文字列 string を指定します。
@@ -373,7 +373,7 @@ GNU Readline のデフォルト値は、「"'」です。
 
 - **SEE** [m:Readline.basic_quote_characters]
 
-### def basic_quote_characters -> String
+### def Readline.basic_quote_characters -> String
 
 スペースなどの単語の区切りをクオートするための
 複数の文字で構成される文字列を取得します。
@@ -382,7 +382,7 @@ GNU Readline のデフォルト値は、「"'」です。
 
 - **SEE** [m:Readline.basic_quote_characters=]
 
-### def completer_quote_characters=(string)
+### def Readline.completer_quote_characters=(string)
 
 ユーザの入力の補完を行う際、スペースなどの単語の区切りを
 クオートするための複数の文字で構成される文字列 string を指定します。
@@ -395,7 +395,7 @@ GNU Readline のデフォルト値は、「"'」です。
 
 - **SEE** [m:Readline.completer_quote_characters]
 
-### def completer_quote_characters -> String
+### def Readline.completer_quote_characters -> String
 
 ユーザの入力の補完を行う際、スペースなどの単語の区切りを
 クオートするための複数の文字で構成される文字列を取得します。
@@ -404,7 +404,7 @@ GNU Readline のデフォルト値は、「"'」です。
 
 - **SEE** [m:Readline.completer_quote_characters=]
 
-### def filename_quote_characters=(string)
+### def Readline.filename_quote_characters=(string)
 
 ユーザの入力時にファイル名の補完を行う際、スペースなどの単語の区切りを
 クオートするための複数の文字で構成される文字列 string を指定します。
@@ -417,7 +417,7 @@ GNU Readline のデフォルト値は nil(NULL) です。
 
 - **SEE** [m:Readline.filename_quote_characters]
 
-### def filename_quote_characters -> String
+### def Readline.filename_quote_characters -> String
 
 ユーザの入力時にファイル名の補完を行う際、スペースなどの単語の区切りを
 クオートするための複数の文字で構成される文字列を取得します。

--- a/manual/api/readline/Readline__HISTORY.md
+++ b/manual/api/readline/Readline__HISTORY.md
@@ -10,7 +10,7 @@ Readline::HISTORY を使用してヒストリにアクセスできます。
 [c:Array] クラスのように振る舞うことができます。
 例えば、HISTORY[4] により 5 番目に入力した内容を取り出すことができます。
 
-### def to_s -> "HISTORY"
+### def Readline::HISTORY.to_s -> "HISTORY"
 
 文字列"HISTORY"を返します。
 
@@ -19,7 +19,7 @@ require 'readline'
 p Readline::HISTORY.to_s #=> "HISTORY"
 ```
 
-### def [](index) -> String
+### def Readline::HISTORY.[](index) -> String
 
 ヒストリから index で指定したインデックスの内容を取得します。
 例えば index に 0 を指定すると最初の入力内容が取得できます。
@@ -67,7 +67,7 @@ require "readline"
 Readline::HISTORY[2 ** 64 + 1] # ~> RangeError
 ```
 
-### def []=(index, string)
+### def Readline::HISTORY.[]=(index, string)
 
 ヒストリの index で指定したインデックスの内容を string で指定した文字列で書き換えます。
 例えば index に 0 を指定すると最初の入力内容が書き換えます。
@@ -86,7 +86,7 @@ Readline::HISTORY[2 ** 64 + 1] # ~> RangeError
 
 - **raise** `NotImplementedError` -- サポートしていない環境で発生します。
 
-### def <<(string) -> self
+### def Readline::HISTORY.<<(string) -> self
 
 ヒストリの最後に string で指定した文字列を追加します。
 self を返します。
@@ -114,7 +114,7 @@ p Readline::HISTORY[-2] #=> "foo"
 
 - **SEE** [m:Readline::HISTORY.push]
 
-### def push(*string) -> self
+### def Readline::HISTORY.push(*string) -> self
 
 ヒストリの最後に string で指定した文字列を追加します。複数の string を指定できます。
 self を返します。
@@ -142,7 +142,7 @@ p Readline::HISTORY[-2] #=> "foo"
 
 - **SEE** [m:Readline::HISTORY.<<]
 
-### def pop -> String
+### def Readline::HISTORY.pop -> String
 
 ヒストリの最後の内容を取り出します。
 最後の内容は、ヒストリから取り除かれます。
@@ -161,7 +161,7 @@ p Readline::HISTORY.pop #=> "foo"
 - **SEE** [m:Readline::HISTORY.push]、[m:Readline::HISTORY.shift]、
      [m:Readline::HISTORY.delete_at]
 
-### def shift -> String
+### def Readline::HISTORY.shift -> String
 
 ヒストリの最初の内容を取り出します。
 最初の内容は、ヒストリから取り除かれます。
@@ -180,8 +180,8 @@ p Readline::HISTORY.shift #=> "baz"
 - **SEE** [m:Readline::HISTORY.push]、[m:Readline::HISTORY.pop]、
      [m:Readline::HISTORY.delete_at]
 
-### def each -> Enumerator
-### def each {|string| ... }
+### def Readline::HISTORY.each -> Enumerator
+### def Readline::HISTORY.each {|string| ... }
 
 ヒストリの内容に対してブロックを評価します。
 ブロックパラメータにはヒストリの最初から最後までの内容を順番に渡します。
@@ -207,8 +207,8 @@ e.each do |s|
 end
 ```
 
-### def length -> Integer
-### def size -> Integer
+### def Readline::HISTORY.length -> Integer
+### def Readline::HISTORY.size -> Integer
 
 ヒストリに格納された内容の数を取得します。
 
@@ -221,7 +221,7 @@ p Readline::HISTORY.length #=> 3
 
 - **SEE** [m:Readline::HISTORY.empty?]
 
-### def empty? -> bool
+### def Readline::HISTORY.empty? -> bool
 
 ヒストリに格納された内容の数が 0 の場合は true を、
 そうでない場合は false を返します。
@@ -236,7 +236,7 @@ p Readline::HISTORY.empty? #=> false
 
 - **SEE** [m:Readline::HISTORY.length]
 
-### def delete_at(index) -> String | nil
+### def Readline::HISTORY.delete_at(index) -> String | nil
 
 index で指定したインデックスの内容をヒストリから削除し、その内容を返します。
 該当する index の内容がヒストリになければ、 nil を返します。
@@ -258,7 +258,7 @@ Readline::HISTORY.delete_at(1)
 p Readline::HISTORY.to_a #=> ["foo", "baz"]
 ```
 
-### def clear -> self
+### def Readline::HISTORY.clear -> self
 
 ヒストリの内容をすべて削除して空にします。
 

--- a/manual/api/resolv-replace.md
+++ b/manual/api/resolv-replace.md
@@ -8,7 +8,7 @@ category: Network
 
 ## Class Methods
 
-### def getaddress(host) -> String
+### def IPSocket.getaddress(host) -> String
 
 [m:IPSocket.getaddress] を置きかえ、
 [lib:resolv] ライブラリを使い名前解決します。
@@ -20,8 +20,8 @@ category: Network
 
 ## Class Methods
 
-### def open(host, serv, local_host=nil, local_service=nil) -> TCPSocket
-### def new(host, serv, local_host=nil, local_service=nil) -> TCPSocket
+### def TCPSocket.open(host, serv, local_host=nil, local_service=nil) -> TCPSocket
+### def TCPSocket.new(host, serv, local_host=nil, local_service=nil) -> TCPSocket
 
 [m:TCPSocket.new] のパラメータ host と local_host 
 の名前解決に [lib:resolv] ライブラリを使います。
@@ -71,7 +71,7 @@ category: Network
 
 ## Class Methods
 
-### def new(host, serv) -> SOCKSSocket
+### def SOCKSSocket.new(host, serv) -> SOCKSSocket
 
 [m:SOCKSSocket.new]のパラメータ host の名前解決に [lib:resolv] 
 ライブラリを使います。

--- a/manual/api/resolv.md
+++ b/manual/api/resolv.md
@@ -36,7 +36,7 @@ NIS はサポートされていません。
 問い合わせをしません。
 
 ## Class Methods
-### def new(resolvers = [Hosts.new, DNS.new]) -> Resolv
+### def Resolv.new(resolvers = [Hosts.new, DNS.new]) -> Resolv
 
 resolvers に与えたリゾルバの配列を先頭から順に
 名前解決を試すような、新しいリゾルバオブジェクトを返します。
@@ -46,7 +46,7 @@ resolvers の各要素は each_address と each_name という
 
 - **param** `resolvers` -- リゾルバの配列
 
-### def getaddress(name) -> String
+### def Resolv.getaddress(name) -> String
 
 ホスト名 name の IP アドレスをルックアップし、
 ルックアップ結果の最初のアドレスを返します。
@@ -62,7 +62,7 @@ p Resolv.getaddress("www.ruby-lang.org") #=> "221.186.184.68"
 - **param** `name` -- ホスト名を文字列で与えます。
 - **raise** `Resolv::ResolvError` -- ルックアップに失敗したときに発生します。
 
-### def getaddresses(name) -> [String]
+### def Resolv.getaddresses(name) -> [String]
 
 ホスト名 name の IP アドレスをルックアップし、
 ルックアップ結果のアドレスリストを返します。
@@ -72,7 +72,7 @@ p Resolv.getaddress("www.ruby-lang.org") #=> "221.186.184.68"
 
 - **param** `name` -- ホスト名を文字列で与えます。
 
-### def each_address(name) {|address| ...} -> ()
+### def Resolv.each_address(name) {|address| ...} -> ()
 
 ホスト名 name の IP アドレスをルックアップし、
 各ルックアップ結果のアドレスに対してブロックを評価します。
@@ -81,7 +81,7 @@ p Resolv.getaddress("www.ruby-lang.org") #=> "221.186.184.68"
 
 - **param** `name` -- ホスト名を文字列で与えます。
 
-### def getname(address) -> String
+### def Resolv.getname(address) -> String
 
 IP アドレス address のホスト名をルックアップし、
 ルックアップ結果の最初のホスト名を文字列で返します。
@@ -96,7 +96,7 @@ p Resolv.getname("221.186.184.68") #=> "carbon.ruby-lang.org"
 - **param** `address` -- IPアドレスを文字列で与えます。
 - **raise** `Resolv::ResolvError` -- ルックアップに失敗したときに発生します。
 
-### def getnames(address) -> [String]
+### def Resolv.getnames(address) -> [String]
 
 IP アドレス address のホスト名をルックアップし、
 ルックアップ結果のホスト名リストを返します。
@@ -105,7 +105,7 @@ IP アドレス address のホスト名をルックアップし、
 
 - **param** `address` -- IPアドレスを文字列で与えます。
 
-### def each_name(address) {|name| ...} -> ()
+### def Resolv.each_name(address) {|name| ...} -> ()
 
 IP アドレス address のホスト名をルックアップし、
 各ルックアップ結果のホスト名に対してブロックを評価します。
@@ -192,7 +192,7 @@ IPアドレスにマッチする正規表現です。
 
 ## Class Methods
 
-### def new(hosts = DefaultFileName) -> Resolv::Hosts
+### def Resolv::Hosts.new(hosts = DefaultFileName) -> Resolv::Hosts
 
 hosts というファイル名のファイルを情報源とする
 リゾルバを生成し、返します。
@@ -278,7 +278,7 @@ DNSについては以下を参照してください。
 
 ## Class Methods
 
-### def new(resolv_conf = nil) -> Resolv::DNS
+### def Resolv::DNS.new(resolv_conf = nil) -> Resolv::DNS
 
 新しい DNS リゾルバを生成します。
 
@@ -305,8 +305,8 @@ Resolv::DNS.new(:nameserver_port => [['8.8.8.8', 53], ['8.8.4.4', 53]],
 
 - **param** `resolv_conf` -- DNSの設定を与えます。
 
-### def open(*args) -> Resolv::DNS
-### def open(*args){|dns| ...} -> object
+### def Resolv::DNS.open(*args) -> Resolv::DNS
+### def Resolv::DNS.open(*args){|dns| ...} -> object
 
 新しい DNS リゾルバを生成します。
 ブロックを与えた場合は生成したリゾルバでブロックを呼びだし、
@@ -713,7 +713,7 @@ DNS リソースの SOA (Start Of Authority) レコード
 
 ## Class Methods
 
-### def new(mname, rname, serial, refresh, retry_, expire, minimum) -> Resolv::DNS::Resource::SOA
+### def Resolv::DNS::Resource::SOA.new(mname, rname, serial, refresh, retry_, expire, minimum) -> Resolv::DNS::Resource::SOA
 
 Resolv::DNS::Resource::SOA のインスタンスを生成して返します。
 
@@ -804,7 +804,7 @@ DNS リソースの HINFO レコード
 
 ## Class Methods
 
-### def new(cpu, os) -> Resolv::DNS::Resource::HINFO
+### def Resolv::DNS::Resource::HINFO.new(cpu, os) -> Resolv::DNS::Resource::HINFO
 
 Resolv::DNS::Resource::HINFO のインスタンスを生成します。
 
@@ -847,7 +847,7 @@ DNS リソースの MINFO レコード
 
 ## Class Methods
 
-### def new(rmailbx, emailbx) -> Resolv::DNS::Resource::MINFO
+### def Resolv::DNS::Resource::MINFO.new(rmailbx, emailbx) -> Resolv::DNS::Resource::MINFO
 
 Resolv::DNS::Resource::MINFO のインスタンスを生成します。
 
@@ -892,7 +892,7 @@ DNS リソースの MX レコード
 
 ## Class Methods
 
-### def new(preference, exchange) -> Resolv::DNS::Resource::MX
+### def Resolv::DNS::Resource::MX.new(preference, exchange) -> Resolv::DNS::Resource::MX
 
 Resolv::DNS::Resource::MX のインスタンスを返します。
 
@@ -934,7 +934,7 @@ DNS リソースの TXT レコード
 
 ## Class Methods
 
-### def new(first_string, *rest_strings) -> Resolv::DNS::Resource::TXT
+### def Resolv::DNS::Resource::TXT.new(first_string, *rest_strings) -> Resolv::DNS::Resource::TXT
 
 Resolv::DNS::Resource::TXTのインスタンスを生成します。
 
@@ -1051,7 +1051,7 @@ IPv4アドレスリソースを表します。
 
 ## Class Methods
 
-### def new(address) -> Resolv::DNS::Resource::IN::A
+### def Resolv::DNS::Resource::IN::A.new(address) -> Resolv::DNS::Resource::IN::A
 
 Resolv::DNS::Resource::IN::A のインスタンスを
 生成します。
@@ -1086,7 +1086,7 @@ DNS リソースのクラス IN、タイプ WKS に対応する
 
 ## Class Methods
 
-### def new(address, protocol, bitmap) -> Resolv::DNS::Resource::IN::WKS
+### def Resolv::DNS::Resource::IN::WKS.new(address, protocol, bitmap) -> Resolv::DNS::Resource::IN::WKS
 
 Resolv::DNS::Resource::IN::WKS のインスタンスを生成します。
 
@@ -1141,7 +1141,7 @@ IPv6アドレスリソースを表します。
 
 ## Class Methods
 
-### def new(address) -> Resolv::DNS::Resource::IN::AAAA
+### def Resolv::DNS::Resource::IN::AAAA.new(address) -> Resolv::DNS::Resource::IN::AAAA
 
 Resolv::DNS::Resource::IN::AAAA のインスタンスを
 生成します。
@@ -1177,7 +1177,7 @@ DNS リソースのクラス IN、タイプ SRV に対応する
 
 ## Class Methods
 
-### def new(priority, weight, port, target) -> Resolv::DNS::Resource::IN::SRV
+### def Resolv::DNS::Resource::IN::SRV.new(priority, weight, port, target) -> Resolv::DNS::Resource::IN::SRV
 
 Resolv::DNS::Resource::IN::SRV のインスタンスを生成します。
 
@@ -1545,13 +1545,13 @@ DNSクエリを表す抽象クラスです。
 
 ## Class Methods
 
-### def create(name) -> Resolv::DNS::Name
+### def Resolv::DNS::Name.create(name) -> Resolv::DNS::Name
 
 文字列 name から Resolv::DNS::Name のインスタンスを生成します。
 
 - **param** `name` -- ドメイン名の文字列。最後に"."を置くと絶対パス形式、そうでなければ相対パス形式とみなされます。
 
-### def new(labels, absolute = true) -> Resolv::DNS::Name
+### def Resolv::DNS::Name.new(labels, absolute = true) -> Resolv::DNS::Name
 
 Resolv::DNS::Nameのインスタンスを生成します。
 labels は `Resolv::DNS::Label::Str` の配列を与えます。
@@ -1632,14 +1632,14 @@ IPv4のアドレスを表すクラスです。
 
 ## Class Methods
 
-### def create(address) -> Resolv::IPv4
+### def Resolv::IPv4.create(address) -> Resolv::IPv4
 
 "192.168.0.1" のように "." で区切られた IPv4 表記の文字列 address から
 Resolv::IPv4 のインスタンスを生成します。
 
 - **param** `address` -- IPv4 表記の文字列
 
-### def new(address) -> Resolv::IPv4
+### def Resolv::IPv4.new(address) -> Resolv::IPv4
 
 4 byte の文字列 address から Resolv::IPv4 のインスタンスを生成します。
 
@@ -1672,7 +1672,7 @@ IPv6 のアドレスを表すクラスです。
 
 ## Class Methods
 
-### def create(address) -> Resolv::IPv6
+### def Resolv::IPv6.create(address) -> Resolv::IPv6
 
 引数 address で指定した文字列から Resolv::IPv6 のインスタンスを生成しま
 す。
@@ -1685,7 +1685,7 @@ IPv6 のアドレスを表すクラスです。
   - 6Hex4Dec
   - CompressedHex4Dec
 
-### def new(address) -> Resolv::IPv6
+### def Resolv::IPv6.new(address) -> Resolv::IPv6
 
 16 byte の文字列 address から Resolv::IPv6 のインスタンスを生成します。
 

--- a/manual/api/rexml/REXML__Attributes.md
+++ b/manual/api/rexml/REXML__Attributes.md
@@ -10,7 +10,7 @@ library: rexml/document
 
 ## Class Methods
 
-### def new(element) -> REXML::Attributes
+### def REXML::Attributes.new(element) -> REXML::Attributes
 
 空の Attributes オブジェクトを生成します。
 

--- a/manual/api/rexml/REXML__DocType.md
+++ b/manual/api/rexml/REXML__DocType.md
@@ -336,7 +336,7 @@ name という名前を持つ記法宣言が存在しない場合は nil を返�
 #%# --- PUBLIC
 #%# #@todo
 
-### def DEFAULT_ENTITIES -> { String => REXML::Entity }
+### const DEFAULT_ENTITIES -> { String => REXML::Entity }
 
 XML の仕様上デフォルトで定義されている実体の Hash table。
 

--- a/manual/api/rexml/REXML__DocType.md
+++ b/manual/api/rexml/REXML__DocType.md
@@ -22,7 +22,7 @@ XML schema や RELAX NG などを使ってください。
 
 ## Class Methods
 
-### def new(source, parent = nil) -> REXML::DocType
+### def REXML::DocType.new(source, parent = nil) -> REXML::DocType
 
 DocType オブジェクトを生成します。
 

--- a/manual/api/rexml/REXML__Element.md
+++ b/manual/api/rexml/REXML__Element.md
@@ -17,7 +17,7 @@ XML の要素(エレメント、element)を表すクラス。
 
 ## Class Methods
 
-### def new(arg = UNDEFINED, parent = nil, context = nil) -> REXML::Element
+### def REXML::Element.new(arg = UNDEFINED, parent = nil, context = nil) -> REXML::Element
 
 要素オブジェクトを生成します。
 

--- a/manual/api/rexml/REXML__ElementDecl.md
+++ b/manual/api/rexml/REXML__ElementDecl.md
@@ -7,7 +7,7 @@ DTD の要素宣言(Element Declaration)を表すクラスです。
 
 ## Class Methods
 
-### def new(src) -> REXML::ElementDecl
+### def REXML::ElementDecl.new(src) -> REXML::ElementDecl
 
 新たな要素宣言オブジェクトを作ります。
 

--- a/manual/api/rexml/REXML__Elements.md
+++ b/manual/api/rexml/REXML__Elements.md
@@ -15,7 +15,7 @@ XPath で相対パスを指定した場合は、この REXML::Element#elements �
 
 ## Class Methods
 
-### def new(parent) -> REXML::Elements
+### def REXML::Elements.new(parent) -> REXML::Elements
 
 空の要素の集合を表すオブジェクトを生成します。
 

--- a/manual/api/rexml/REXML__Entity.md
+++ b/manual/api/rexml/REXML__Entity.md
@@ -50,8 +50,8 @@ p entities["zz"].normalized # => "%z;%z;&f;"
 
 ## Class Methods
 
-### def new(name, value, parent=nil, reference=false) -> REXML::Entity
-### def new(array) -> REXML::Entity
+### def REXML::Entity.new(name, value, parent=nil, reference=false) -> REXML::Entity
+### def REXML::Entity.new(array) -> REXML::Entity
 
 新たな Entity オブジェクトを生成して返します。
 
@@ -81,7 +81,7 @@ reference でその実体宣言がパラメータ実体(parameter entity)かど�
 REXML::Entity.new("gt", ">")
 ```
 
-### def matches?(string) -> bool
+### def REXML::Entity.matches?(string) -> bool
 
 string が実体宣言の文法に従う文字列であれば真を返します。
 

--- a/manual/api/rexml/REXML__ExternalEntity.md
+++ b/manual/api/rexml/REXML__ExternalEntity.md
@@ -34,7 +34,7 @@ p doctype.children.find_all{|child| REXML::ExternalEntity === child }.map(&:to_s
 
 ## Class Methods
 
-### def new(src) -> REXML::ExternalEntity
+### def REXML::ExternalEntity.new(src) -> REXML::ExternalEntity
 
 新たな ExternalEntity オブジェクトを生成します。
 

--- a/manual/api/rexml/REXML__NotationDecl.md
+++ b/manual/api/rexml/REXML__NotationDecl.md
@@ -38,7 +38,7 @@ p foobar.system # => "http://example.org/foobar.dtd"
 
 ## Class Methods
 
-### def new(name, middle, pub, sys) -> REXML::NotationDecl
+### def REXML::NotationDecl.new(name, middle, pub, sys) -> REXML::NotationDecl
 
 NotationDecl オブジェクトを生成します。
 

--- a/manual/api/rexml/attlistdecl.md
+++ b/manual/api/rexml/attlistdecl.md
@@ -9,7 +9,7 @@ DTD の属性リスト宣言を表すクラスです。
 
 ## Class Methods
 
-### def new(source) -> REXML::AttlistDecl
+### def REXML::AttlistDecl.new(source) -> REXML::AttlistDecl
 
 このメソッドは内部用なので使わないでください。
 

--- a/manual/api/rexml/attribute.md
+++ b/manual/api/rexml/attribute.md
@@ -16,8 +16,8 @@ include:
 
 ## Class Methods
 
-### def new(attribute_to_clone, parent = nil) -> REXML::Attribute
-### def new(attribute, value, parent = nil) -> REXML::Attribute
+### def REXML::Attribute.new(attribute_to_clone, parent = nil) -> REXML::Attribute
+### def REXML::Attribute.new(attribute, value, parent = nil) -> REXML::Attribute
 
 新たな属性オブジェクトを生成します。
 

--- a/manual/api/rexml/cdata.md
+++ b/manual/api/rexml/cdata.md
@@ -9,7 +9,7 @@ cdata とは <![CDATA[ と ]]> で囲まれたテキストデータのことで�
 
 ## Class Methods
 
-### def new(text, respect_whitespace = true, parent = nil) -> REXML::CData
+### def REXML::CData.new(text, respect_whitespace = true, parent = nil) -> REXML::CData
 
 text をテキストとして持つ CData オブジェクトを生成します。
 

--- a/manual/api/rexml/child.md
+++ b/manual/api/rexml/child.md
@@ -12,7 +12,7 @@ include:
 
 ## Class Methods
 
-### def new(parent = nil) -> REXML::Child
+### def REXML::Child.new(parent = nil) -> REXML::Child
 
 REXML::Child オブジェクトを生成します。
 

--- a/manual/api/rexml/comment.md
+++ b/manual/api/rexml/comment.md
@@ -28,8 +28,8 @@ p doc.root[3].string # => " zz "
 ## Class Methods
 
 #%# --- new(source) -> REXML::Comment
-### def new(string, parent = nil) -> REXML::Comment
-### def new(comment, parent = nil) -> REXML::Comment
+### def REXML::Comment.new(string, parent = nil) -> REXML::Comment
+### def REXML::Comment.new(comment, parent = nil) -> REXML::Comment
 
 Comment オブジェクトを生成します。
 

--- a/manual/api/rexml/document.md
+++ b/manual/api/rexml/document.md
@@ -75,7 +75,7 @@ DTD(文書型定義、Document Type Definition)、
 
 ## Class Methods
 
-### def new(source = nil, context = {}) -> REXML::Document
+### def REXML::Document.new(source = nil, context = {}) -> REXML::Document
 
 Document オブジェクトを生成します。
 
@@ -95,7 +95,7 @@ context で「コンテキスト」を指定します。テキストノードの
 - **raise** `REXML::UndefinedNamespaceException` -- XML文書のパース中に、定義されていない名前空間
        が現れた場合に発生します
 
-### def parse_stream(source, listener) -> ()
+### def REXML::Document.parse_stream(source, listener) -> ()
 
 XML文書を source から読み込み、パースした結果を
 listener にコールバックで伝えます。
@@ -114,7 +114,7 @@ Parsers::StreamParser.new( source, listener ).parse
 - **param** `source` -- 入力(文字列、IO、IO互換オブジェクト(StringIOなど))
 - **param** `listener` -- コールバックオブジェクト
 
-### def entity_expansion_limit -> Integer
+### def REXML::Document.entity_expansion_limit -> Integer
 
 実体参照の展開回数の上限を返します。
 
@@ -131,7 +131,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 
 - **SEE** [m:REXML::Document.entity_expansion_limit=]
 
-### def entity_expansion_limit=(val)
+### def REXML::Document.entity_expansion_limit=(val)
 
 実体参照の展開回数の上限を指定します。
 
@@ -146,7 +146,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 - **param** `val` -- 設定する上限値(整数)
 - **SEE** [m:REXML::Document.entity_expansion_limit]
 
-### def entity_expansion_text_limit -> Integer
+### def REXML::Document.entity_expansion_text_limit -> Integer
 
 実体参照の展開による文字列の増分(テキストのバイト数)の
 最大値を指定します。
@@ -165,7 +165,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 - **SEE** [m:REXML::Document.entity_expansion_text_limit=],
      <http://www.ruby-lang.org/ja/news/2013/02/22/rexml-dos-2013-02-22/>
 
-### def entity_expansion_text_limit=(val)
+### def REXML::Document.entity_expansion_text_limit=(val)
 
 実体参照の展開による文字列の増分(テキストのバイト数)の
 最大値を指定します。

--- a/manual/api/rexml/dtd/dtd.md
+++ b/manual/api/rexml/dtd/dtd.md
@@ -3,8 +3,8 @@
 #%# ちゃんと使えるものではないように思われる
 ## Class Methods
 
-### def parse(input)
+### def REXML::DTD::Parser.parse(input)
 #%todo
 
-### def parse_helper(input)
+### def REXML::DTD::Parser.parse_helper(input)
 #%todo

--- a/manual/api/rexml/dtd/elementdecl.md
+++ b/manual/api/rexml/dtd/elementdecl.md
@@ -2,7 +2,7 @@
 
 ## Class Methods
 
-### def new(match)
+### def REXML::DTD::ElementDecl.new(match)
 #%todo
 
 ## Constants

--- a/manual/api/rexml/dtd/entitydecl.md
+++ b/manual/api/rexml/dtd/entitydecl.md
@@ -2,10 +2,10 @@
 
 ## Class Methods
 
-### def new(src)
+### def REXML::DTD::EntityDecl.new(src)
 #%todo
 
-### def parse_source(source, listener)
+### def REXML::DTD::EntityDecl.parse_source(source, listener)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/dtd/notationdecl.md
+++ b/manual/api/rexml/dtd/notationdecl.md
@@ -2,10 +2,10 @@
 
 ## Class Methods
 
-### def new(src)
+### def REXML::DTD::NotationDecl.new(src)
 #%todo
 
-### def parse_source(source, listener)
+### def REXML::DTD::NotationDecl.parse_source(source, listener)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/formatters/default.md
+++ b/manual/api/rexml/formatters/default.md
@@ -38,7 +38,7 @@ p output.string
 ```
 
 ## Class Method
-### def new(ie_hack=false) -> REXML::Formatter::Default
+### def REXML::Formatters::Default.new(ie_hack=false) -> REXML::Formatter::Default
 
 フォーマッタオブジェクトを生成して返します。
 

--- a/manual/api/rexml/formatters/pretty.md
+++ b/manual/api/rexml/formatters/pretty.md
@@ -28,7 +28,7 @@ p output.string
 ```
 
 ## Class Method
-### def new(indentation=2, ie_hack=false) -> REXML::Formatter::Pretty
+### def REXML::Formatters::Pretty.new(indentation=2, ie_hack=false) -> REXML::Formatter::Pretty
 
 フォーマッタオブジェクトを生成して返します。
 

--- a/manual/api/rexml/formatters/transitive.md
+++ b/manual/api/rexml/formatters/transitive.md
@@ -42,7 +42,7 @@ p output.string
 ```
 
 ## Class Method
-### def new(indentation=2, ie_hack=false) -> REXML::Formatter::Transitive
+### def REXML::Formatters::Transitive.new(indentation=2, ie_hack=false) -> REXML::Formatter::Transitive
 
 フォーマッタオブジェクトを生成して返します。
 

--- a/manual/api/rexml/instruction.md
+++ b/manual/api/rexml/instruction.md
@@ -25,7 +25,7 @@ p doc[2].content # => "type=\"text/css\" href=\"style.css\""
 
 ## Class Methods
 
-### def new(target, content = nil) -> REXML::Instruction
+### def REXML::Instruction.new(target, content = nil) -> REXML::Instruction
 
 新たな Instruction オブジェクトを生成します。
 

--- a/manual/api/rexml/light/node.md
+++ b/manual/api/rexml/light/node.md
@@ -4,7 +4,7 @@
 
 ## Class Methods
 
-### def new(node = nil)
+### def REXML::Light::Node.new(node = nil)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/parent.md
+++ b/manual/api/rexml/parent.md
@@ -11,7 +11,7 @@ include:
 
 ## Class Methods
 
-### def new(parent = nil) -> REXML::Parent
+### def REXML::Parent.new(parent = nil) -> REXML::Parent
 
 REXML::Parent オブジェクトを生成します。
 

--- a/manual/api/rexml/parsers/lightparser.md
+++ b/manual/api/rexml/parsers/lightparser.md
@@ -4,7 +4,7 @@
 
 ## Class Methods
 
-### def new(stream)
+### def REXML::Parsers::LightParser.new(stream)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/parsers/pullparser/REXML__Parsers__PullParser.md
+++ b/manual/api/rexml/parsers/pullparser/REXML__Parsers__PullParser.md
@@ -11,7 +11,7 @@ extend:
 
 ## Class Methods
 
-### def new(stream) -> REXML::Parsers::PullParser
+### def REXML::Parsers::PullParser.new(stream) -> REXML::Parsers::PullParser
 
 新たな PullParser オブジェクトを生成して返します。
 

--- a/manual/api/rexml/parsers/sax2parser.md
+++ b/manual/api/rexml/parsers/sax2parser.md
@@ -152,7 +152,7 @@ SAX2 と同等の API を持つストリーム式の XML パーサクラス。
 
 ## Class Methods
 
-### def new(source) -> REXML::Parsers::SAX2Parser
+### def REXML::Parsers::SAX2Parser.new(source) -> REXML::Parsers::SAX2Parser
 
 SAX2 パーサオブジェクトを生成します。
 

--- a/manual/api/rexml/parsers/streamparser.md
+++ b/manual/api/rexml/parsers/streamparser.md
@@ -149,7 +149,7 @@ REXML::Parsers::StreamParser.new(xml, Listener.new).parse
 
 ## Class Methods
 
-### def new(source, listener) -> REXML::Parsers::StreamParser
+### def REXML::Parsers::StreamParser.new(source, listener) -> REXML::Parsers::StreamParser
 
 ストリームパーサオブジェクトを生成します。
 

--- a/manual/api/rexml/parsers/ultralightparser.md
+++ b/manual/api/rexml/parsers/ultralightparser.md
@@ -88,7 +88,7 @@ pp parser.parse
 
 ## Class Methods
 
-### def new(stream) -> REXML::Parsers::UltraLightParser
+### def REXML::Parsers::UltraLightParser.new(stream) -> REXML::Parsers::UltraLightParser
 
 パーサオブジェクトを返します。
 

--- a/manual/api/rexml/security.md
+++ b/manual/api/rexml/security.md
@@ -7,7 +7,7 @@ since: "2.1.0"
 REXML のセキュリティ関連の限界値を設定/参照するためのモジュールです。
 
 ## Singleton Methods
-### def entity_expansion_limit -> Integer
+### def REXML::Security.entity_expansion_limit -> Integer
 
 実体参照の展開回数の上限を返します。
 
@@ -21,7 +21,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 
 - **SEE** [m:REXML::Document.entity_expansion_limit]
 
-### def entity_expansion_limit=(val)
+### def REXML::Security.entity_expansion_limit=(val)
 
 実体参照の展開回数の上限を指定します。
 
@@ -33,7 +33,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 - **param** `val` -- 設定する上限値(整数)
 - **SEE** [m:REXML::Document.entity_expansion_limit]
 
-### def entity_expansion_text_limit -> Integer
+### def REXML::Security.entity_expansion_text_limit -> Integer
 
 実体参照の展開による文字列の増分(テキストのバイト数)の
 最大値を指定します。
@@ -49,7 +49,7 @@ XML 文書([c:REXML::Document])ごとの展開回数がこの値を越えると
 - **SEE** [m:REXML::Document.entity_expansion_text_limit=],
      <http://www.ruby-lang.org/ja/news/2013/02/22/rexml-dos-2013-02-22/>
 
-### def entity_expansion_text_limit=(val)
+### def REXML::Security.entity_expansion_text_limit=(val)
 
 実体参照の展開による文字列の増分(テキストのバイト数)の
 最大値を指定します。

--- a/manual/api/rexml/text.md
+++ b/manual/api/rexml/text.md
@@ -11,7 +11,7 @@ XML のテキストノードを表すクラスです。
 
 ## Class Methods
 
-### def new(arg, respect_whitespace = false, parent = nil, raw = nil, entity_filter = nil, illegal = REXML::Text::NEEDS_A_SECOND_CHECK)
+### def REXML::Text.new(arg, respect_whitespace = false, parent = nil, raw = nil, entity_filter = nil, illegal = REXML::Text::NEEDS_A_SECOND_CHECK)
 
 テキストノードオブジェクトを生成します。
 
@@ -87,7 +87,7 @@ p REXML::Text.new("quzz", false, doc.root, true).to_s # => "quzz"
 #%# --- read_with_substitution(input, illegal = nil)
 #%# #@todo
 
-### def normalize(input, doctype = nil, entity_filter = nil) -> String
+### def REXML::Text.normalize(input, doctype = nil, entity_filter = nil) -> String
 
 input を正規化(すべての entity をエスケープ)したものを
 返します。
@@ -96,7 +96,7 @@ input を正規化(すべての entity をエスケープ)したものを
 - **param** `doctype` -- DTD([c:REXML::DocType] オブジェクト)
 - **param** `entity_filter` -- 置換したい実体の名前の配列
 
-### def unnormalize(string, doctype = nil, filter = nil, illegal = nil) -> String
+### def REXML::Text.unnormalize(string, doctype = nil, filter = nil, illegal = nil) -> String
 
 string を非正規化(すべての entity をアンエスケープ)したものを
 返します。

--- a/manual/api/rexml/validation/relaxng.md
+++ b/manual/api/rexml/validation/relaxng.md
@@ -75,7 +75,7 @@ parser.parse
 
 ## Class Methods
 
-### def new(source)
+### def REXML::Validation::RelaxNG.new(source)
 #%todo
 
 ## Instance Methods
@@ -109,7 +109,7 @@ parser.parse
 
 ## Class Methods
 
-### def new(context)
+### def REXML::Validation::State.new(context)
 #%todo
 
 ## Instance Methods
@@ -180,7 +180,7 @@ parser.parse
 
 ## Class Methods
 
-### def new(context)
+### def REXML::Validation::OneOrMore.new(context)
 #%todo
 
 ## Instance Methods
@@ -201,7 +201,7 @@ parser.parse
 
 ## Class Methods
 
-### def new(context)
+### def REXML::Validation::Choice.new(context)
 #%todo
 
 ## Instance Methods
@@ -233,7 +233,7 @@ parser.parse
 
 ## Class methods
 
-### def new(context)
+### def REXML::Validation::Interleave.new(context)
 #%todo
 
 ## Instance Methods
@@ -260,7 +260,7 @@ parser.parse
 
 ## Class Methods
 
-### def new(value)
+### def REXML::Validation::Ref.new(value)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/validation/validation.md
+++ b/manual/api/rexml/validation/validation.md
@@ -20,7 +20,7 @@
 
 ## Class Methods
 
-### def new(event_type, event_arg = nil)
+### def REXML::Validation::Event.new(event_type, event_arg = nil)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rexml/validation/validationexception.md
+++ b/manual/api/rexml/validation/validationexception.md
@@ -2,5 +2,5 @@
 
 ## Class Methods
 
-### def new(msg)
+### def REXML::Validation::ValidationException.new(msg)
 #%todo

--- a/manual/api/rexml/xmldecl.md
+++ b/manual/api/rexml/xmldecl.md
@@ -52,7 +52,7 @@ p xml_decl.writethis # => true
 
 ## Class Methods
 
-### def new(version = REXML::XMLDecl::DEFAULT_VERSION, encoding = nil, standalone = nil)
+### def REXML::XMLDecl.new(version = REXML::XMLDecl::DEFAULT_VERSION, encoding = nil, standalone = nil)
 
 新たな XMLDecl オブジェクトを生成して返します。
 
@@ -62,7 +62,7 @@ version 以外は省略可能です。
 - **param** `encoding` -- エンコーディング(文字列 or nil)
 - **param** `standalone` -- スタンドアロン文章かどうか("yes", "no", nil)
 
-### def default -> REXML::XMLDecl
+### def REXML::XMLDecl.default -> REXML::XMLDecl
 
 XML宣言を含まない文章でデフォルトで使うための
 XMLDecl オブジェクトを生成して返します。

--- a/manual/api/rexml/xpath.md
+++ b/manual/api/rexml/xpath.md
@@ -11,7 +11,7 @@ XPath を取り扱うためのクラスです。
 
 ## Class Methods
 
-### def first(element, path = nil, namespaces = {}, variables = {}) -> Node | nil
+### def REXML::XPath.first(element, path = nil, namespaces = {}, variables = {}) -> Node | nil
 
 element の path で指定した XPath 文字列にマッチする最初のノードを
 返します。
@@ -62,7 +62,7 @@ p b2 # => <b> ... </>
 p b2.text # => "b2"
 ```
 
-### def each(element, path = nil, namespaces = {}, variables = {}) {|e| ... } -> ()
+### def REXML::XPath.each(element, path = nil, namespaces = {}, variables = {}) {|e| ... } -> ()
 
 element の path で指定した XPath 文字列にマッチする各ノード
 に対してブロックを呼び出します。
@@ -103,7 +103,7 @@ REXML::XPath.each(doc, "/root/a/b"){|e| p e.text }
 # >> "b2"
 ```
 
-### def match(element, path = nil, namespaces = {}, variables = {}) -> [Node]
+### def REXML::XPath.match(element, path = nil, namespaces = {}, variables = {}) -> [Node]
 
 element の path で指定した XPath 文字列にマッチするノードの配列を
 返します。

--- a/manual/api/rinda/Rinda__DRbObjectTemplate.md
+++ b/manual/api/rinda/Rinda__DRbObjectTemplate.md
@@ -5,7 +5,7 @@ library: rinda/rinda
 
 ## Class Methods
 
-### def new(uri = nil, ref = nil)
+### def Rinda::DRbObjectTemplate.new(uri = nil, ref = nil)
 #%todo
 
 Creates a new DRbObjectTemplate that will match against +uri+ and

--- a/manual/api/rinda/Rinda__SimpleRenewer.md
+++ b/manual/api/rinda/Rinda__SimpleRenewer.md
@@ -13,7 +13,7 @@ include:
 
 ## Class Methods
 
-### def new(sec = 180) -> Rinda::SimpleRenewer
+### def Rinda::SimpleRenewer.new(sec = 180) -> Rinda::SimpleRenewer
 
 新たな SimpleRenewer オブジェクトを生成します。
 

--- a/manual/api/rinda/Rinda__TupleSpace.md
+++ b/manual/api/rinda/Rinda__TupleSpace.md
@@ -42,7 +42,7 @@ sec には秒数の代わりに renewer を指定することもできます。
 
 ## Class Methods
 
-### def new(period = 60) -> Rinda::TupleSpace
+### def Rinda::TupleSpace.new(period = 60) -> Rinda::TupleSpace
 
 [c:Rinda::TupleSpace] オブジェクトを生成します。
 

--- a/manual/api/rinda/Rinda__TupleSpaceProxy.md
+++ b/manual/api/rinda/Rinda__TupleSpaceProxy.md
@@ -11,7 +11,7 @@ library: rinda/rinda
 
 ## Class Methods
 
-### def new(ts) -> Rinda::TupleSpaceProxy
+### def Rinda::TupleSpaceProxy.new(ts) -> Rinda::TupleSpaceProxy
 
 ts を wrap した新たな TupleSpaceProxy オブジェクトを生成します。
 

--- a/manual/api/ripper.md
+++ b/manual/api/ripper.md
@@ -19,7 +19,7 @@ Ruby プログラムをテキストとして扱いたい場合、
 
 ## Class Methods
 
-### def new(src, filename = "(ripper)", lineno = 1) -> Ripper
+### def Ripper.new(src, filename = "(ripper)", lineno = 1) -> Ripper
 
 Ripper オブジェクトを作成します。
 
@@ -33,7 +33,7 @@ src の解析を行うには更に [m:Ripper#parse] などの呼び出しが必�
 
 - **SEE** [m:Ripper.parse], [m:Ripper#parse]
 
-### def parse(src, filename = '(ripper)', lineno = 1) -> nil
+### def Ripper.parse(src, filename = '(ripper)', lineno = 1) -> nil
 
 指定された文字列を解析します。常に nil を返します。
 

--- a/manual/api/ripper.md
+++ b/manual/api/ripper.md
@@ -147,7 +147,7 @@ ripper の扱う全てのイベント ID (シンボル) のリストを返しま
 
 パーサイベントのイベント ID (シンボル) のリストを返します。
 
-### def PARSER_EVENT_TABLE -> {Symbol => Integer}
+### const PARSER_EVENT_TABLE -> {Symbol => Integer}
 
 パーサイベントのイベント ID (シンボル) と対応するハンドラの引数の個数の
 リストをハッシュで返します。
@@ -156,7 +156,7 @@ ripper の扱う全てのイベント ID (シンボル) のリストを返しま
 
 スキャナイベントのイベント ID (シンボル) のリストを返します。
 
-### def SCANNER_EVENT_TABLE -> {Symbol => Integer}
+### const SCANNER_EVENT_TABLE -> {Symbol => Integer}
 
 スキャナイベントのイベント ID (シンボル) と対応するハンドラの引数の個数
 のリストをハッシュで返します。

--- a/manual/api/ripper/filter.md
+++ b/manual/api/ripper/filter.md
@@ -46,7 +46,7 @@ Ruby プログラムを解析して、[m:Ripper::SCANNER_EVENTS] にあるスキ
 
 ## Class Methods
 
-### def new(src, filename = '-', lineno = 1) -> Ripper::Filter
+### def Ripper::Filter.new(src, filename = '-', lineno = 1) -> Ripper::Filter
 
 Ripper::Filter オブジェクトを作成します。
 

--- a/manual/api/rss/Parser.md
+++ b/manual/api/rss/Parser.md
@@ -3,10 +3,10 @@ library: rss
 ---
 # class RSS::Parser < Object
 ## Class Methods
-### def parse
+### def RSS::Parser.parse
 #%todo
 
-### def new
+### def RSS::Parser.new
 #%todo
 
 ## Instance Methods

--- a/manual/api/rss/maker/Maker.md
+++ b/manual/api/rss/maker/Maker.md
@@ -4,7 +4,7 @@ library: rss
 # module RSS::Maker
 
 ## Singleton Methods
-### def make(version, &block)
+### def RSS::Maker.make(version, &block)
 #%todo
 versionには"1.0"または"0.9"または
 "0.91"または"2.0"を指定します。"0.9"

--- a/manual/api/rubygems.md
+++ b/manual/api/rubygems.md
@@ -426,7 +426,7 @@ prelude.c で定義されている内部用のメソッドです。
 
 ## Singleton Methods
 
-### def load_full_rubygems_library
+### def Gem::QuickLoader.load_full_rubygems_library
 
 prelude.c で定義されている内部用のメソッドです。
 

--- a/manual/api/rubygems/builder.md
+++ b/manual/api/rubygems/builder.md
@@ -12,7 +12,7 @@ include:
 
 ## Singleton Methods
 
-### def new(spec) -> Gem::Builder
+### def Gem::Builder.new(spec) -> Gem::Builder
 
 与えられた [c:Gem::Specification] のインスタンスによって
 [c:Gem::Builder] のインスタンスを生成します。

--- a/manual/api/rubygems/command.md
+++ b/manual/api/rubygems/command.md
@@ -181,14 +181,14 @@ Gem が見つからなかった場合、メッセージを表示するために�
 
 ## Singleton Methods
 
-### def add_common_option(*args){|value, options| ... }
+### def Gem::Command.add_common_option(*args){|value, options| ... }
 #%# -> discard
 
 全てのコマンドに共通するオプションを登録するためのメソッドです。
 
 - **param** `args` -- 追加するオプションの情報を指定します。
 
-### def add_specific_extra_args(cmd, args)
+### def Gem::Command.add_specific_extra_args(cmd, args)
 #%# -> discard
 
 与えられたコマンドに対応する追加の引数を追加します。
@@ -197,31 +197,31 @@ Gem が見つからなかった場合、メッセージを表示するために�
 
 - **param** `args` -- 追加の引数を配列か、空白で区切った文字列で指定します。
 
-### def build_args -> Array
+### def Gem::Command.build_args -> Array
 
 Gem をビルドするときに使用するパラメータを返します。
 
-### def build_args=(value)
+### def Gem::Command.build_args=(value)
 
 Gem をビルドするときに使用するパラメータをセットします。
 
 - **param** `value` -- Gem をビルドするときに使用するパラメータを指定します。
 
-### def common_options -> Array
+### def Gem::Command.common_options -> Array
 
 共通の引数を返します。
 
-### def extra_args -> Array
+### def Gem::Command.extra_args -> Array
 
 追加の引数を返します。
 
-### def extra_args=(value)
+### def Gem::Command.extra_args=(value)
 
 追加の引数をセットします。
 
 - **param** `value` -- 配列を指定します。
 
-### def specific_extra_args(cmd) -> Array
+### def Gem::Command.specific_extra_args(cmd) -> Array
 
 与えられたコマンドに対応する追加の引数を返します。
 
@@ -229,7 +229,7 @@ Gem をビルドするときに使用するパラメータをセットします�
 
 - **param** `cmd` -- コマンド名を指定します。
 
-### def specific_extra_args_hash -> Hash
+### def Gem::Command.specific_extra_args_hash -> Hash
 
 特別な追加引数へのアクセスを提供します。
 

--- a/manual/api/rubygems/command_manager.md
+++ b/manual/api/rubygems/command_manager.md
@@ -58,7 +58,7 @@ gem コマンドによってサポートされているサブコマンドを管�
 
 ## Singleton Methods
 
-### def instance -> Gem::CommandManager
+### def Gem::CommandManager.instance -> Gem::CommandManager
 
 自身をインスタンス化します。
 

--- a/manual/api/rubygems/config_file.md
+++ b/manual/api/rubygems/config_file.md
@@ -164,13 +164,13 @@ Gem を探索するパスをセットします。
 
 ログレベルのデフォルト値です。
 
-### def OPERATING_SYSTEM_DEFAULTS -> {}
+### const OPERATING_SYSTEM_DEFAULTS -> {}
 
 Ruby をパッケージングしている人がデフォルトの設定値をセットするために使用します。
 
 使用するファイルは rubygems/defaults/operating_system.rb です。
 
-### def PLATFORM_DEFAULTS -> {}
+### const PLATFORM_DEFAULTS -> {}
 
 Ruby の実装者がデフォルトの設定値をセットするために使用します。
 

--- a/manual/api/rubygems/defaults.md
+++ b/manual/api/rubygems/defaults.md
@@ -7,38 +7,38 @@ RubyGems ライブラリで使用するデフォルト値を返すメソッド�
 
 ## Singleton Methods
 
-### def default_sources -> [String]
+### def Gem.default_sources -> [String]
 
 デフォルトのパッケージ情報取得先のリストを返します。
 
-### def default_dir -> String
+### def Gem.default_dir -> String
 
 デフォルトの Gem パッケージをインストールするディレクトリを返します。
 
-### def user_dir -> String
+### def Gem.user_dir -> String
 
 ユーザのホームディレクトリの中の Gem のパスを返します。
 
-### def default_path -> [String]
+### def Gem.default_path -> [String]
 
 デフォルトの Gem パッケージをロードするディレクトリのリストを返します。
 
-### def default_exec_format -> String
+### def Gem.default_exec_format -> String
 
 デフォルトのインストールするコマンド名を決めるためのフォーマット文字列を返します。
 
-### def default_bindir -> String
+### def Gem.default_bindir -> String
 
 実行ファイルのデフォルトのパスを返します。
 
-### def default_system_source_cache_dir -> String
+### def Gem.default_system_source_cache_dir -> String
 
 デフォルトのシステム全体のソースキャッシュファイルのパスを返します。
 
-### def default_user_source_cache_dir -> String
+### def Gem.default_user_source_cache_dir -> String
 
 デフォルトのユーザ専用のソースキャッシュファイルのパスを返します。
 
-### def ruby_engine -> String
+### def Gem.ruby_engine -> String
 
 Ruby処理系実装の種類を表す文字列を返します。

--- a/manual/api/rubygems/dependency_installer.md
+++ b/manual/api/rubygems/dependency_installer.md
@@ -61,7 +61,7 @@ Gem が依存している Gem の情報を集めて返します。
 
 ## Singleton Methods
 
-### def new(options = {}) -> Gem::DependencyInstaller
+### def Gem::DependencyInstaller.new(options = {}) -> Gem::DependencyInstaller
 
 自身を初期化します。
 

--- a/manual/api/rubygems/dependency_list.md
+++ b/manual/api/rubygems/dependency_list.md
@@ -81,7 +81,7 @@ spec.
 
 ## Singleton Methods
 
-### def from_source_index(src_index) -> Gem::DependencyList
+### def Gem::DependencyList.from_source_index(src_index) -> Gem::DependencyList
 
 与えられた [c:Gem::SourceIndex] のインスタンスから自身を作成します。
 

--- a/manual/api/rubygems/digest/digest_adapter.md
+++ b/manual/api/rubygems/digest/digest_adapter.md
@@ -34,6 +34,6 @@ Ruby 1.8.6 以降ではこのライブラリは使用されません。
 
 ## Singleton Methods
 
-### def new(digest_class)
+### def Gem::DigestAdapter.new(digest_class)
 
 自身を初期化します。

--- a/manual/api/rubygems/doc_manager.md
+++ b/manual/api/rubygems/doc_manager.md
@@ -61,7 +61,7 @@ RDoc と RI 用のデータを削除します。
 
 ## Singleton Methods
 
-### def new(spec, rdoc_args = "") -> Gem::DocManager
+### def Gem::DocManager.new(spec, rdoc_args = "") -> Gem::DocManager
 
 自身を初期化します。
 
@@ -69,17 +69,17 @@ RDoc と RI 用のデータを削除します。
 
 - **param** `rdoc_args` -- RDoc に渡すオプションを指定します。
 
-### def configured_args -> Array
+### def Gem::DocManager.configured_args -> Array
 
 RDoc に渡す引数を返します。
 
-### def configured_args=(args)
+### def Gem::DocManager.configured_args=(args)
 
 RDoc に渡す引数をセットします。
 
 - **param** `args` -- 文字列の配列か空白区切りの文字列を指定します。
 
-### def load_rdoc
+### def Gem::DocManager.load_rdoc
 #%# -> discard
 
 Gem の RDoc が使用可能な場合は使用します。
@@ -87,7 +87,7 @@ Gem の RDoc が使用可能な場合は使用します。
 
 - **raise** `Gem::DocumentError` -- RDoc が使用できない場合に発生します。
 
-### def update_ri_cache
+### def Gem::DocManager.update_ri_cache
 #%# -> discard
 
 RDoc 2 がインストールされている場合は RI のキャッシュを更新します。

--- a/manual/api/rubygems/ext/builder.md
+++ b/manual/api/rubygems/ext/builder.md
@@ -12,12 +12,12 @@ require:
 
 ## Singleton Methods
 
-### def class_name -> String
+### def Gem::Ext::Builder.class_name -> String
 #%todo
 
 ビルダーのクラス名を返します。
 
-### def make(dest_path, results)
+### def Gem::Ext::Builder.make(dest_path, results)
 #%todo
 
 Makefile を編集して make, make install を実行します。
@@ -30,12 +30,12 @@ Makefile を編集して make, make install を実行します。
 
 - **raise** `Gem::InstallError` -- make の実行に失敗した場合に発生します。
 
-### def redirector -> String
+### def Gem::Ext::Builder.redirector -> String
 #%todo
 
 '2>&1' という文字列を返します。
 
-### def run(command, results)
+### def Gem::Ext::Builder.run(command, results)
 #%todo
 
 与えられたコマンドを実行します。

--- a/manual/api/rubygems/ext/configure_builder.md
+++ b/manual/api/rubygems/ext/configure_builder.md
@@ -11,7 +11,7 @@ configure スクリプトを元に拡張ライブラリをビルドするクラ�
 
 ## Singleton Methods
 
-### def build(extension, directory, dest_path, results) -> Array
+### def Gem::Ext::ConfigureBuilder.build(extension, directory, dest_path, results) -> Array
 #%todo
 
 Makefile が存在しない場合は、configure スクリプトを実行して

--- a/manual/api/rubygems/ext/ext_conf_builder.md
+++ b/manual/api/rubygems/ext/ext_conf_builder.md
@@ -11,7 +11,7 @@ extconf.rb を元にして拡張ライブラリをビルドするためのクラ
 
 ## Singleton Methods
 
-### def build(extension, directory, dest_path, results) -> Array
+### def Gem::Ext::ExtConfBuilder.build(extension, directory, dest_path, results) -> Array
 #%todo
 
 Makefile が存在しない場合は、extconf.rb を実行して

--- a/manual/api/rubygems/ext/rake_builder.md
+++ b/manual/api/rubygems/ext/rake_builder.md
@@ -11,7 +11,7 @@ Rake を使用して拡張ライブラリをビルドするためのクラスで
 
 ## Singleton Methods
 
-### def build(extension, directory, dest_path, results) -> Array
+### def Gem::Ext::RakeBuilder.build(extension, directory, dest_path, results) -> Array
 #%todo
 
 mkrf_conf が存在する場合は、それを実行してから Rake を実行します。

--- a/manual/api/rubygems/format.md
+++ b/manual/api/rubygems/format.md
@@ -45,7 +45,7 @@ Gem の [c:Gem::Specification] をセットします。
 
 ## Singleton Methods
 
-### def from_file_by_path(file_path, security_policy = nil) -> Gem::Format
+### def Gem::Format.from_file_by_path(file_path, security_policy = nil) -> Gem::Format
 #%todo security_policy
 
 Gem ファイルのパスからデータを読み込んで、自身を初期化して返します。
@@ -54,7 +54,7 @@ Gem ファイルのパスからデータを読み込んで、自身を初期化�
 
 - **param** `security_policy` -- ???
 
-### def from_io(io, gem_path = '(io)', security_policy = nil) -> Gem::Format
+### def Gem::Format.from_io(io, gem_path = '(io)', security_policy = nil) -> Gem::Format
 #%todo security_policy
 
 Gem ファイルからデータを読み込んだ IO を受け取り、自身を初期化して返します。
@@ -65,7 +65,7 @@ Gem ファイルからデータを読み込んだ IO を受け取り、自身を
 
 - **param** `security_policy` -- ???
 
-### def new(gem_path)
+### def Gem::Format.new(gem_path)
 
 自身を初期化します。
 

--- a/manual/api/rubygems/gem_openssl.md
+++ b/manual/api/rubygems/gem_openssl.md
@@ -8,12 +8,12 @@ OpenSSL が使えるかどうかを確認するためのライブラリです。
 
 ## Singleton Methods
 
-### def ssl_available? -> bool
+### def Gem.ssl_available? -> bool
 
 現在実行中のプラットフォームで OpenSSL が有効である場合は真を返します。
 そうでない場合は偽を返します。
 
-### def ensure_ssl_available
+### def Gem.ensure_ssl_available
 
 OpenSSL が使用可能でない場合は例外を発生させます。
 

--- a/manual/api/rubygems/gem_path_searcher.md
+++ b/manual/api/rubygems/gem_path_searcher.md
@@ -56,6 +56,6 @@ Gem パッケージに含まれているファイルのうちロード可能な�
 
 ## Singleton Methods
 
-### def new -> Gem::GemPathSearcher
+### def Gem::GemPathSearcher.new -> Gem::GemPathSearcher
 
 検索を行うのに必要なデータを初期化します。

--- a/manual/api/rubygems/indexer.md
+++ b/manual/api/rubygems/indexer.md
@@ -102,7 +102,7 @@ non-ASCII の文字列を XML エンティティに置換します。
 
 ## Singleton Methods
 
-### def new(directory) -> Gem::Indexer
+### def Gem::Indexer.new(directory) -> Gem::Indexer
 
 与えられたディレクトリに Gem リポジトリのインデックスを作成するために
 自身を初期化します。

--- a/manual/api/rubygems/installer/Gem__Installer.md
+++ b/manual/api/rubygems/installer/Gem__Installer.md
@@ -149,7 +149,7 @@ Ruby スクリプト形式で .gemspec ファイルを作成します。
 
 ## Singleton Methods
 
-### def new(gem, options = {}) -> Gem::Installer
+### def Gem::Installer.new(gem, options = {}) -> Gem::Installer
 #%todo 書いてないオプションがいっぱいある
 
 与えられた引数で自身を初期化します。
@@ -183,34 +183,34 @@ Ruby スクリプト形式で .gemspec ファイルを作成します。
 
 - **raise** `Gem::FilePermissionError` -- 書き込み先のディレクトリに書き込み権限がない場合に発生します。
 
-### def exec_format -> String
+### def Gem::Installer.exec_format -> String
 
 実行ファイル名のフォーマットを返します。
 
 指定しない場合は ruby コマンドと同じフォーマットを使用します。
 
-### def exec_format=(format)
+### def Gem::Installer.exec_format=(format)
 
 実行ファイル名のフォーマットをセットします。
 
 - **param** `format` -- 実行ファイル名のフォーマットを指定します。
 
-### def home_install_warning -> bool
+### def Gem::Installer.home_install_warning -> bool
 
 この値が真の場合、ホームディレクトリに Gem をインストールしようとすると警告を表示します。
 
-### def home_install_warning=(flag)
+### def Gem::Installer.home_install_warning=(flag)
 
 ホームディレクトリに Gem をインストールしようとすると警告を表示するかどうかセットします。
 
 - **param** `flag` -- 真を指定するとホームディレクトリに Gem をインストールしよう
             とすると警告を表示するようになります。
 
-### def path_warning -> bool
+### def Gem::Installer.path_warning -> bool
 
 この値が 真の場合は Gem.bindir が PATH に含まれていない場合に警告を表示します。
 
-### def path_warning=(flag)
+### def Gem::Installer.path_warning=(flag)
 
 Gem.bindir が PATH に含まれていない場合に警告を表示するかどうかセットします。
 

--- a/manual/api/rubygems/old_format.md
+++ b/manual/api/rubygems/old_format.md
@@ -45,13 +45,13 @@ Gem の [c:Gem::Specification] をセットします。
 
 ## Singleton Methods
 
-### def from_file_by_path(file_path) -> Gem::OldFormat
+### def Gem::OldFormat.from_file_by_path(file_path) -> Gem::OldFormat
 
 Gem ファイルのパスからデータを読み込んで、自身を初期化して返します。
 
 - **param** `file_path` -- Gem ファイルへのパスを指定します。
 
-### def from_io(io, gem_path = '(io)') -> Gem::OldFormat
+### def Gem::OldFormat.from_io(io, gem_path = '(io)') -> Gem::OldFormat
 
 Gem ファイルからデータを読み込んだ IO を受け取り、自身を初期化して返します。
 
@@ -59,7 +59,7 @@ Gem ファイルからデータを読み込んだ IO を受け取り、自身を
 
 - **param** `gem_path` -- Gem ファイルのパスを指定します。
 
-### def new(gem_path) -> Gem::OldFormat
+### def Gem::OldFormat.new(gem_path) -> Gem::OldFormat
 
 自身を初期化します。
 

--- a/manual/api/rubygems/package.md
+++ b/manual/api/rubygems/package.md
@@ -22,7 +22,7 @@ require:
 
 ## Singleton Methods
 
-### def new(logger = nil) -> Gem::FileOperations
+### def Gem::FileOperations.new(logger = nil) -> Gem::FileOperations
 
 このクラスを初期化します。
 
@@ -32,7 +32,7 @@ require:
 
 ## Singleton Methods
 
-### def open(io, mode = 'r', signer = nil){|tar_io| ... }
+### def Gem::Package.open(io, mode = 'r', signer = nil){|tar_io| ... }
 #%todo ???
 
 io を開いて与えられたブロックに渡してブロックを評価します。
@@ -43,7 +43,7 @@ io を開いて与えられたブロックに渡してブロックを評価し�
 
 - **param** `signer` -- ???
 
-### def pack(src, destname, signer = nil)
+### def Gem::Package.pack(src, destname, signer = nil)
 #%todo
 
 ???

--- a/manual/api/rubygems/package/tar_header.md
+++ b/manual/api/rubygems/package/tar_header.md
@@ -97,7 +97,7 @@ tar のヘッダに含まれる version を返します。
 
 ## Singleton Methods
 
-### def from(stream) -> Gem::Package::TarHeader
+### def Gem::Package::TarHeader.from(stream) -> Gem::Package::TarHeader
 
 stream から先頭 512 バイトを読み込んで [c:Gem::Package::TarHeader] の
 インスタンスを作成して返します。

--- a/manual/api/rubygems/package/tar_input.md
+++ b/manual/api/rubygems/package/tar_input.md
@@ -14,7 +14,7 @@ gem-format な tar ファイルを読み込む [c:Gem::Package::TarReader] の�
 
 ## Singleton Methods
 
-### def open(io, security_policy = nil){|is| ... }
+### def Gem::Package::TarInput.open(io, security_policy = nil){|is| ... }
 #%todo ???
 ブロックに [c:Gem::Package::TarInput] のインスタンスを与えて評価します。
 
@@ -24,7 +24,7 @@ gem-format な tar ファイルを読み込む [c:Gem::Package::TarReader] の�
 
 ## Private Singleton Methods
 
-### def new(io, security_policy = nil)
+### def Gem::Package::TarInput.new(io, security_policy = nil)
 #%todo ???
 このクラスを初期化します。
 

--- a/manual/api/rubygems/package/tar_output.md
+++ b/manual/api/rubygems/package/tar_output.md
@@ -41,7 +41,7 @@ gem-format な tar ファイルに data.tar.gz.sig, metadata.gz.sig を追加し
 
 ## Singleton Methods
 
-### def open(io, signer = nil){|data_tar_writer| ... }
+### def Gem::Package::TarOutput.open(io, signer = nil){|data_tar_writer| ... }
 #%# -> discard
 
 gem-format な tar ファイル内の data.tar.gz にファイルを追加するためのメ
@@ -53,7 +53,7 @@ gem-format な tar ファイル内の data.tar.gz にファイルを追加する
 
 - **SEE** [m:Gem::Package::TarOutput#add_gem_contents]
 
-### def new(io, signer) -> Gem::Package::TarOutput
+### def Gem::Package::TarOutput.new(io, signer) -> Gem::Package::TarOutput
 
 gem-format な tar ファイル内の data.tar.gz にファイルを追加するために
 自身を初期化します。

--- a/manual/api/rubygems/package/tar_reader/Gem__Package__TarReader.md
+++ b/manual/api/rubygems/package/tar_reader/Gem__Package__TarReader.md
@@ -33,7 +33,7 @@ gem-format な tar ファイルを読むためのクラスです。
 
 ## Singleton Methods
 
-### def new(io) -> Gem::Package::TarReader
+### def Gem::Package::TarReader.new(io) -> Gem::Package::TarReader
 
 io に関連付けて [c:Gem::Package::TarReader] を初期化します。
 

--- a/manual/api/rubygems/package/tar_writer.md
+++ b/manual/api/rubygems/package/tar_writer.md
@@ -68,7 +68,7 @@ tar ファイルを書き込むためのクラスです。
 
 ## Singleton Methods
 
-### def new(io) -> Gem::Package::TarWriter
+### def Gem::Package::TarWriter.new(io) -> Gem::Package::TarWriter
 
 自身を初期化します。
 
@@ -80,7 +80,7 @@ tar ファイルを書き込むためのクラスです。
 
 ## Singleton Methods
 
-### def new(io, limit) -> Gem::Package::TarWriter::BoundedStream
+### def Gem::Package::TarWriter::BoundedStream.new(io, limit) -> Gem::Package::TarWriter::BoundedStream
 
 自身を初期化します。
 
@@ -115,7 +115,7 @@ write メソッドのみを提供する [c:IO] のラッパークラスです。
 
 ## Singleton Methods
 
-### def new(io) -> Gem::Package::TarWriter::RestrictedStream
+### def Gem::Package::TarWriter::RestrictedStream.new(io) -> Gem::Package::TarWriter::RestrictedStream
 
 自身を初期化します。
 

--- a/manual/api/rubygems/platform.md
+++ b/manual/api/rubygems/platform.md
@@ -86,13 +86,13 @@ OS の種類をセットします。
 
 ## Singleton Methods
 
-### def local -> Gem::Platform
+### def Gem::Platform.local -> Gem::Platform
 #%todo ???
 
-### def match(platform) -> bool
+### def Gem::Platform.match(platform) -> bool
 #%todo ???
 
-### def new(arch)-> Gem::Platform
+### def Gem::Platform.new(arch)-> Gem::Platform
 
 自身を初期化します。
 

--- a/manual/api/rubygems/remote_fetcher/Gem__RemoteFetcher.md
+++ b/manual/api/rubygems/remote_fetcher/Gem__RemoteFetcher.md
@@ -9,7 +9,7 @@ include:
 
 ## Singleton Methods
 
-### def fetcher -> Gem::RemoteFetcher
+### def Gem::RemoteFetcher.fetcher -> Gem::RemoteFetcher
 
 このクラスの唯一のインスタンスを返します。
 

--- a/manual/api/rubygems/remote_fetcher/Gem__RemoteFetcher__FetchError.md
+++ b/manual/api/rubygems/remote_fetcher/Gem__RemoteFetcher__FetchError.md
@@ -7,7 +7,7 @@ library: rubygems/remote_fetcher
 
 ## Singleton Methods
 
-### def new(message, uri) -> Gem::RemoteFetcher::FetchError
+### def Gem::RemoteFetcher::FetchError.new(message, uri) -> Gem::RemoteFetcher::FetchError
 
 この例外クラスを初期化します。
 

--- a/manual/api/rubygems/requirement.md
+++ b/manual/api/rubygems/requirement.md
@@ -44,7 +44,7 @@ p Gem::Requirement::OPS["~>"].call(Gem::Version.new('3.1'), Gem::Version.new('3.
 
 ## Singleton Methods
 
-### def create(input) -> Gem::Requirement
+### def Gem::Requirement.create(input) -> Gem::Requirement
 
 [c:Gem::Requirement] のインスタンスを作成するためのファクトリメソッドです。
 
@@ -60,7 +60,7 @@ pp Gem::Requirement.create("~> 3.2.1")
 
 - **SEE** [m:Gem::Requirement.new], [m:Gem::Requirement.default]
 
-### def default -> Gem::Requirement
+### def Gem::Requirement.default -> Gem::Requirement
 
 ゼロ以上 ( '>= 0' ) を指定して作成された [c:Gem::Requirement] のインスタンスを返します。
 
@@ -69,7 +69,7 @@ pp Gem::Requirement.default
 # => Gem::Requirement.new([">= 0"])
 ```
 
-### def new(requirements) -> Gem::Requirement
+### def Gem::Requirement.new(requirements) -> Gem::Requirement
 
 [c:Gem::Requirement] のインスタンスを作成します。
 
@@ -82,7 +82,7 @@ pp Gem::Requirement.new("~> 3.2.1")
 
 - **SEE** [m:Gem::Requirement.parse], [m:Gem::Requirement.create]
 
-### def parse(obj) -> Array
+### def Gem::Requirement.parse(obj) -> Array
 
 バージョンの必要上件をパースして比較演算子とバージョンを要素とする二要素の配列を返します。
 

--- a/manual/api/rubygems/security.md
+++ b/manual/api/rubygems/security.md
@@ -298,7 +298,7 @@ $ openssl rsa -in input_key.pem -noout -text
 
 ## Singleton Methods
 
-### def add_trusted_cert(cert, options = {}) -> nil
+### def Gem::Security.add_trusted_cert(cert, options = {}) -> nil
 
 信頼済み証明書リストに与えられた証明書を追加します。
 
@@ -308,7 +308,7 @@ Note: しばらくの間 OPT[:trust_dir] に保存されますが、今後変更
 
 - **param** `options` -- オプションを指定します。
 
-### def build_cert(name, key, options = {}) -> OpenSSL::X509::Certificate
+### def Gem::Security.build_cert(name, key, options = {}) -> OpenSSL::X509::Certificate
 
 与えられた DN と秘密鍵を使用して証明書を作成します。
 
@@ -318,7 +318,7 @@ Note: しばらくの間 OPT[:trust_dir] に保存されますが、今後変更
 
 - **param** `options` -- オプションを指定します。
 
-### def build_self_signed_cert(email_addr, options = {}) -> Hash
+### def Gem::Security.build_self_signed_cert(email_addr, options = {}) -> Hash
 
 与えられたメールアドレスを元にして自己署名証明書を作成します。
 
@@ -328,7 +328,7 @@ Note: しばらくの間 OPT[:trust_dir] に保存されますが、今後変更
 
 - **return** -- 鍵と証明書とそれらを保存したパスを表すハッシュを返します。
 
-### def sign_cert(cert, signing_key, signing_cert, options = {}) -> OpenSSL::X509::Certificate
+### def Gem::Security.sign_cert(cert, signing_key, signing_cert, options = {}) -> OpenSSL::X509::Certificate
 
 与えられた署名用の鍵と証明書を用いて証明書に署名します。
 
@@ -342,7 +342,7 @@ Note: しばらくの間 OPT[:trust_dir] に保存されますが、今後変更
 
 - **return** -- 署名された証明書を返します。
 
-### def verify_trust_dir(path, perms)
+### def Gem::Security.verify_trust_dir(path, perms)
 #%# -> discard
 信頼するディレクトリが存在することを確認します。
 
@@ -546,13 +546,13 @@ Note: しばらくの間 OPT[:trust_dir] に保存されますが、今後変更
 
 ## Singleton Methods
 
-### def new(policy = {}, options = {}) -> Gem::Security::Policy
+### def Gem::Security::Policy.new(policy = {}, options = {}) -> Gem::Security::Policy
 
 - **param** `policy` -- モードを指定します。
 
 - **param** `options` -- その他のオプションを指定します。
 
-### def trusted_cert_path(cert, options) -> String
+### def Gem::Security::Policy.trusted_cert_path(cert, options) -> String
 
 与えられた証明書へのパスを返します。
 
@@ -592,7 +592,7 @@ OpenSSL の署名者を扱うためのクラスです。
 
 ## Singleton Methods
 
-### def new(key, cert_chain) -> Gem::Security::Signer
+### def Gem::Security::Signer.new(key, cert_chain) -> Gem::Security::Signer
 
 与えられた鍵と証明書チェーンを用いて自身を初期化します。
 

--- a/manual/api/rubygems/server.md
+++ b/manual/api/rubygems/server.md
@@ -94,7 +94,7 @@ Gem パッケージを配布したり Gem パッケージに同梱されてい�
 
 ## Singleton Methods
 
-### def new(gem_dirs, port, daemon, addresses = nil) -> Gem::Server
+### def Gem::Server.new(gem_dirs, port, daemon, addresses = nil) -> Gem::Server
 
 サーバーを初期化します。
 
@@ -107,7 +107,7 @@ Gem パッケージを配布したり Gem パッケージに同梱されてい�
 
 - **param** `addresses` -- 
 
-### def run(options) -> Gem::Server
+### def Gem::Server.run(options) -> Gem::Server
 
 与えられたオプションを使用してサーバを起動します。
 

--- a/manual/api/rubygems/source_index.md
+++ b/manual/api/rubygems/source_index.md
@@ -134,20 +134,20 @@ Gem パッケージのフルネームと それぞれの [c:Gem::Specification] 
 
 ## Singleton Methods
 
-### def new(specifications = {}) -> Gem::SourceIndex
+### def Gem::SourceIndex.new(specifications = {}) -> Gem::SourceIndex
 
 与えられたハッシュを元に自身を初期化します。
 
 - **param** `specifications` -- キーを Gem の名前、値を [c:Gem::Specification] のインスタンスとするハッシュを指定します。
 
-### def from_gems_in(*spec_dirs) -> Gem::SourceIndex
+### def Gem::SourceIndex.from_gems_in(*spec_dirs) -> Gem::SourceIndex
 
 引数で与えられたディレクトリに置かれている Ruby スクリプト形式の gemspec ファイルを使用して
 新しいインスタンスを作成します。
 
 - **param** `spec_dirs` -- gemspec ファイルが置かれているディレクトリを一つ以上指定します。
 
-### def from_installed_gems(*deprecated) -> Gem::SourceIndex
+### def Gem::SourceIndex.from_installed_gems(*deprecated) -> Gem::SourceIndex
 
 与えられたパスをもとに、インスタンスを作成するファクトリメソッドです。
 
@@ -155,13 +155,13 @@ Gem パッケージのフルネームと それぞれの [c:Gem::Specification] 
 
 - **SEE** [m:Gem::SourceIndex.from_gems_in]
 
-### def installed_spec_directories -> [String]
+### def Gem::SourceIndex.installed_spec_directories -> [String]
 
 gemspec ファイルがインストールされているディレクトリのリストを返します。
 
 - **SEE** [m:Gem?.path]
 
-### def load_specification(file_name) -> Gem::Specification | nil
+### def Gem::SourceIndex.load_specification(file_name) -> Gem::Specification | nil
 
 与えられたファイル名から Ruby スクリプト形式の gemspec をロードして
 [c:Gem::Specification] のインスタンスを返します。

--- a/manual/api/rubygems/source_info_cache.md
+++ b/manual/api/rubygems/source_info_cache.md
@@ -157,29 +157,29 @@ RubyGems ライブラリの結合テストをするのに便利です。
 
 ## Singleton Methods
 
-### def cache(all = false) -> Gem::SourceInfoCache
+### def Gem::SourceInfoCache.cache(all = false) -> Gem::SourceInfoCache
 
 自身のインスタンスを生成するためのメソッドです。
 
 - **param** `all` -- 真を指定すると、インスタンス生成時に全てのキャッシュを再作成します。
 
-### def cache_data -> Hash
+### def Gem::SourceInfoCache.cache_data -> Hash
 
 キャッシュしているデータを返します。
 
-### def latest_system_cache_file -> String
+### def Gem::SourceInfoCache.latest_system_cache_file -> String
 
 最新のシステムキャッシュのファイル名を返します。
 
-### def latest_user_cache_file -> String
+### def Gem::SourceInfoCache.latest_user_cache_file -> String
 
 最新のユーザーキャッシュのファイル名を返します。
 
-### def reset -> nil
+### def Gem::SourceInfoCache.reset -> nil
 
 自身の内容をクリアします。
 
-### def search(*args) -> [Gem::Specification]
+### def Gem::SourceInfoCache.search(*args) -> [Gem::Specification]
 
 与えられた条件を満たす [c:Gem::Specification] のリストを返します。
 
@@ -187,7 +187,7 @@ RubyGems ライブラリの結合テストをするのに便利です。
 
 - **SEE** [m:Gem::SourceInfoCache#search]
 
-### def search_with_source(*args) -> Array
+### def Gem::SourceInfoCache.search_with_source(*args) -> Array
 
 与えられた条件を満たす [c:Gem::Specification] と URL のリストを返します。
 
@@ -195,10 +195,10 @@ RubyGems ライブラリの結合テストをするのに便利です。
 
 - **SEE** [m:Gem::SourceInfoCache#search_with_source]
 
-### def system_cache_file -> String
+### def Gem::SourceInfoCache.system_cache_file -> String
 
 システムキャッシュのファイル名を返します。
 
-### def user_cache_file -> String
+### def Gem::SourceInfoCache.user_cache_file -> String
 
 ユーザーキャッシュのファイル名を返します。

--- a/manual/api/rubygems/source_info_cache_entry.md
+++ b/manual/api/rubygems/source_info_cache_entry.md
@@ -33,7 +33,7 @@ require:
 
 ## Singleton Methods
 
-### def new(si, size) -> Gem::SourceInfoCacheEntry
+### def Gem::SourceInfoCacheEntry.new(si, size) -> Gem::SourceInfoCacheEntry
 
 キャッシュのエントリを作成します。
 

--- a/manual/api/rubygems/spec_fetcher.md
+++ b/manual/api/rubygems/spec_fetcher.md
@@ -15,13 +15,13 @@ require:
 
 ## Singleton Methods
 
-### def fetcher -> Gem::SpecFetcher
+### def Gem::SpecFetcher.fetcher -> Gem::SpecFetcher
 
 このクラスの唯一のインスタンスを返します。
 
 #%# singleton ?
 
-### def fetcher=(fetcher)
+### def Gem::SpecFetcher.fetcher=(fetcher)
 #%todo
 
 ## Instance Methods

--- a/manual/api/rubygems/specification.md
+++ b/manual/api/rubygems/specification.md
@@ -555,13 +555,13 @@ API ドキュメントを生成するときに rdoc コマンドに与えるオ�
 
 ## Singleton Methods
 
-### def _load(str) -> Gem::Specification
+### def Gem::Specification._load(str) -> Gem::Specification
 
 マーシャルされたデータをロードするためのメソッドです。
 
 - **param** `str` -- マーシャルされたデータを指定します。
 
-### def array_attribute(name) -> ()
+### def Gem::Specification.array_attribute(name) -> ()
 
 [m:Gem::Specification.attribute] と同じですが、値を配列に格納するアクセサを作ります。
 
@@ -569,13 +569,13 @@ API ドキュメントを生成するときに rdoc コマンドに与えるオ�
 
 - **SEE** [m:Gem::Specification.attribute]
 
-### def array_attributes -> Array
+### def Gem::Specification.array_attributes -> Array
 
 @@array_attributes の複製を返します。
 
 - **SEE** [m:Object#dup]
 
-### def attribute(name) -> ()
+### def Gem::Specification.attribute(name) -> ()
 
 デフォルト値を指定したアクセサを定義するために使用します。
 
@@ -585,7 +585,7 @@ API ドキュメントを生成するときに rdoc コマンドに与えるオ�
 - 通常の属性書き込みメソッドを定義します。
 - デフォルト値を持つ属性読み取りメソッドのように振る舞うメソッドを定義します。
 
-### def attribute_alias_singular(singular, plural) -> ()
+### def Gem::Specification.attribute_alias_singular(singular, plural) -> ()
 
 既に存在する複数形の属性の単数形バージョンを定義します。
 
@@ -604,16 +604,16 @@ s.require_path = 'mylib'
 
 - **param** `plural` -- 属性名の複数形を指定します。
 
-### def attribute_defaults -> Array
+### def Gem::Specification.attribute_defaults -> Array
 #%todo
 
 @@attributes の複製を返します。
 
-### def attribute_names -> Array
+### def Gem::Specification.attribute_names -> Array
 
 属性名の配列を返します。
 
-### def attributes(*args) -> ()
+### def Gem::Specification.attributes(*args) -> ()
 
 複数の属性を一度に作成するために使用します。
 
@@ -621,13 +621,13 @@ s.require_path = 'mylib'
 
 - **param** `args` -- 属性名を一つ以上指定します。
 
-### def default_value(name) -> object
+### def Gem::Specification.default_value(name) -> object
 
 与えられた名前の属性のデフォルト値を返します。
 
 - **param** `name` -- 属性名を指定します。
 
-### def from_yaml(input) -> Gem::Specification
+### def Gem::Specification.from_yaml(input) -> Gem::Specification
 
 YAML ファイルから gemspec をロードします。
 
@@ -637,11 +637,11 @@ gemspec のバージョンチェックも行います。
 
 - **param** `input` -- 文字列か [c:IO] オブジェクトを指定します。
 
-### def list -> Array
+### def Gem::Specification.list -> Array
 
 実行中の Ruby のインスタンスで作成された [c:Gem::Specification] のインスタンスを返します。
 
-### def load(filename) -> Gem::Specification
+### def Gem::Specification.load(filename) -> Gem::Specification
 
 gemspec ファイルをロードします。
 
@@ -649,13 +649,13 @@ gemspec ファイルをロードします。
 
 - **raise** `StandardError` -- gemspec ファイル内でこのメソッドを呼んでいる場合に発生します。
 
-### def normalize_yaml_input(input) -> String
+### def Gem::Specification.normalize_yaml_input(input) -> String
 
 YAML 形式の gemspec を正しくフォーマットします。
 
 - **param** `input` -- 文字列か [c:IO] オブジェクトを指定します。
 
-### def overwrite_accessor(name){ ... } -> ()
+### def Gem::Specification.overwrite_accessor(name){ ... } -> ()
 
 呼び出し時に特別な動作をする必要のある属性があります。
 このメソッドはそういうことを可能にします。
@@ -664,13 +664,13 @@ YAML 形式の gemspec を正しくフォーマットします。
 
 - **param** `name` -- 属性名を指定します。
 
-### def read_only(*names) -> ()
+### def Gem::Specification.read_only(*names) -> ()
 
 与えられた属性名を読み取り専用にします。
 
 - **param** `names` -- 属性名を一つ以上指定します。
 
-### def required_attribute(name, default = nil) -> ()
+### def Gem::Specification.required_attribute(name, default = nil) -> ()
 
 必須の属性を作成します。
 
@@ -680,17 +680,17 @@ YAML 形式の gemspec を正しくフォーマットします。
 
 - **SEE** [m:Gem::Specification.attribute]
 
-### def required_attribute?(name) -> bool
+### def Gem::Specification.required_attribute?(name) -> bool
 
 必須属性であれば真を返します。
 
 - **param** `name` -- 属性名を指定します。
 
-### def required_attributes -> Array
+### def Gem::Specification.required_attributes -> Array
 
 必須属性のリストを返します。
 
-### def stubs -> Array
+### def Gem::Specification.stubs -> Array
 
 インストールされている全ての Gem の情報を、Gem::StubSpecification（gemspec ファイルの内容を遅延読み込みする軽量なスタブオブジェクト）の配列として返します。
 
@@ -706,7 +706,7 @@ p Gem::Specification.stubs.first.name
 
 - **SEE** [m:Gem::Specification.list], [m:Gem::Specification.stubs_for]
 
-### def stubs_for(name) -> Array
+### def Gem::Specification.stubs_for(name) -> Array
 
 指定した名前を持つ Gem の Gem::StubSpecification の配列を返します。
 

--- a/manual/api/rubygems/test_utilities.md
+++ b/manual/api/rubygems/test_utilities.md
@@ -16,7 +16,7 @@ require:
 
 ## Singleton Methods
 
-### def fetcher=(fetcher)
+### def Gem::RemoteFetcher.fetcher=(fetcher)
 
 テスト用のメソッドです。
 

--- a/manual/api/rubygems/uninstaller.md
+++ b/manual/api/rubygems/uninstaller.md
@@ -96,7 +96,7 @@ Gem をアンインストールします。
 
 ## Singleton Methods
 
-### def new(gem, options = {})
+### def Gem::Uninstaller.new(gem, options = {})
 
 自身を初期化します。
 

--- a/manual/api/rubygems/user_interaction/Gem__DefaultUserInteraction.md
+++ b/manual/api/rubygems/user_interaction/Gem__DefaultUserInteraction.md
@@ -7,11 +7,11 @@ library: rubygems/user_interaction
 
 ## Singleton Methods
 
-### def ui -> Gem::ConsoleUI
+### def Gem::DefaultUserInteraction.ui -> Gem::ConsoleUI
 
 デフォルトの UI を返します。
 
-### def ui=(new_ui)
+### def Gem::DefaultUserInteraction.ui=(new_ui)
 
 デフォルトの UI を新しくセットします。
 
@@ -20,7 +20,7 @@ library: rubygems/user_interaction
 
 - **param** `new_ui` -- 新しい UI を指定します。
 
-### def use_ui(new_ui){ ... }
+### def Gem::DefaultUserInteraction.use_ui(new_ui){ ... }
 #%# -> discard
 
 与えられたブロックを評価している間だけ UI として new_ui を使用します。

--- a/manual/api/rubygems/user_interaction/Gem__StreamUI.md
+++ b/manual/api/rubygems/user_interaction/Gem__StreamUI.md
@@ -7,7 +7,7 @@ library: rubygems/user_interaction
 
 ## Singleton Methods
 
-### def new(in_stream, out_stream, err_stream = STDERR)
+### def Gem::StreamUI.new(in_stream, out_stream, err_stream = STDERR)
 
 このクラスを初期化します。
 

--- a/manual/api/rubygems/user_interaction/Gem__StreamUI__SilentProgressReporter.md
+++ b/manual/api/rubygems/user_interaction/Gem__StreamUI__SilentProgressReporter.md
@@ -7,7 +7,7 @@ library: rubygems/user_interaction
 
 ## Singleton Methods
 
-### def new(out_stream, size, initial_message, terminal_message = nil)
+### def Gem::StreamUI::SilentProgressReporter.new(out_stream, size, initial_message, terminal_message = nil)
 
 何もしません。
 

--- a/manual/api/rubygems/user_interaction/Gem__StreamUI__SimpleProgressReporter.md
+++ b/manual/api/rubygems/user_interaction/Gem__StreamUI__SimpleProgressReporter.md
@@ -7,7 +7,7 @@ library: rubygems/user_interaction
 
 ## Singleton Methods
 
-### def new(out_stream, size, initial_message, terminal_message = nil)
+### def Gem::StreamUI::SimpleProgressReporter.new(out_stream, size, initial_message, terminal_message = nil)
 
 このクラスを初期化します。
 

--- a/manual/api/rubygems/user_interaction/Gem__StreamUI__VerboseProgressReporter.md
+++ b/manual/api/rubygems/user_interaction/Gem__StreamUI__VerboseProgressReporter.md
@@ -7,7 +7,7 @@ library: rubygems/user_interaction
 
 ## Singleton Methods
 
-### def new(out_stream, size, initial_message, terminal_message = nil)
+### def Gem::StreamUI::VerboseProgressReporter.new(out_stream, size, initial_message, terminal_message = nil)
 
 このクラスを初期化します。
 

--- a/manual/api/rubygems/version/Gem__Version.md
+++ b/manual/api/rubygems/version/Gem__Version.md
@@ -40,7 +40,7 @@ p versions.sort_by{ |v| Gem::Version.new(v) }
 
 ## Singleton Methods
 
-### def correct?(version) -> bool
+### def Gem::Version.correct?(version) -> bool
 
 version が正しいバージョンであれば true を返します。そうでなければ false を返します。
 
@@ -55,7 +55,7 @@ p Gem::Version.correct?(nil)         # => true
 
 - **param** `version` -- バージョンを文字列か数値で指定します。
 
-### def create(input) -> Gem::Version | nil
+### def Gem::Version.create(input) -> Gem::Version | nil
 
 [c:Gem::Version] のインスタンスを作成するためのファクトリメソッドです。
 
@@ -71,7 +71,7 @@ ver3 = Gem::Version.create(nil)        # => nil
 
 - **SEE** [m:Gem::Version.correct?]
 
-### def new(version) -> Gem::Version
+### def Gem::Version.new(version) -> Gem::Version
 
 バージョンを表す文字列から、Gem::Version インスタンスを作成します。
 

--- a/manual/api/scanf/Scanf__FormatString.md
+++ b/manual/api/scanf/Scanf__FormatString.md
@@ -6,7 +6,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(str)
+### def Scanf::FormatString.new(str)
 #%todo
 
 ## Instance Methods

--- a/manual/api/sdbm/SDBM.md
+++ b/manual/api/sdbm/SDBM.md
@@ -15,7 +15,7 @@ SDBM ファイルをアクセスするクラス。
 
 ## Class Methods
 
-### def new(dbname, mode = 0666) -> SDBM
+### def SDBM.new(dbname, mode = 0666) -> SDBM
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 
@@ -24,8 +24,8 @@ dbname で指定したデータベースをモードを mode に設定してオ�
 - **param** `mode` -- 省略値は 0666 です。mode として nil を指定するとデータベースが
             存在しない時には新たなデータベースを作らず nil を返します。
 
-### def open(dbname, mode = 0666) -> SDBM
-### def open(dbname, mode = 0666) {|db| ... } -> object
+### def SDBM.open(dbname, mode = 0666) -> SDBM
+### def SDBM.open(dbname, mode = 0666) {|db| ... } -> object
 
 dbname で指定したデータベースをモードを mode に設定してオープンします。
 

--- a/manual/api/securerandom.md
+++ b/manual/api/securerandom.md
@@ -44,7 +44,7 @@ p SecureRandom.random_bytes(10) #=> "\323U\030TO\234\357\020\a\337"
 
 ## Singleton Methods
 
-### def base64(n = nil)    -> String
+### def SecureRandom.base64(n = nil)    -> String
 
 ランダムな base64 文字列を生成して返します。
 
@@ -61,7 +61,7 @@ p SecureRandom.base64(3)    #=> "4pYO"  (文字列のサイズは 3 でない)
 
 - **SEE** [rfc:3548]
 
-### def urlsafe_base64(n = nil, padding = false)  -> String
+### def SecureRandom.urlsafe_base64(n = nil, padding = false)  -> String
 
 ランダムで URL-safe な base64 文字列を生成して返します。
 
@@ -84,7 +84,7 @@ p SecureRandom.urlsafe_base64(nil, true) #=> "-M8rLhr7JEpJlqFGUMmOxg=="
 
 - **SEE** [m:SecureRandom.base64],  [rfc:3548]
 
-### def hex(n = nil)    -> String
+### def SecureRandom.hex(n = nil)    -> String
 
 ランダムな hex 文字列を生成して返します。
 
@@ -99,7 +99,7 @@ require 'securerandom'
 p SecureRandom.hex(3)    #=> "f72233"   (文字列のサイズは 3 でない)
 ```
 
-### def random_bytes(n = nil)    -> String
+### def SecureRandom.random_bytes(n = nil)    -> String
 
 ランダムなバイト列を生成して返します。
 
@@ -113,7 +113,7 @@ require 'securerandom'
 p SecureRandom.random_bytes(3)    #=> "\321\020\203"
 ```
 
-### def random_number(n = 0)     -> Integer | Float
+### def SecureRandom.random_number(n = 0)     -> Integer | Float
 
 ランダムな数値を生成して返します。
 n が 1 以上の整数の場合、0 以上 n 未満の整数を返します。
@@ -128,7 +128,7 @@ require 'securerandom'
 p SecureRandom.random_number(1 << 64)    #=> 4078466195356651249
 ```
 
-### def uuid   -> String
+### def SecureRandom.uuid   -> String
 
 バージョン 4 の UUID (Universally Unique IDentifier) を生成して返します。
 
@@ -146,9 +146,9 @@ p SecureRandom.uuid #=> "62936e70-1815-439b-bf89-8492855a7e6b"
 - **SEE** [rfc:4122]
 
 #%since 3.3
-### def alphanumeric(n = nil, chars: Random::Formatter::ALPHANUMERIC)    -> String
+### def SecureRandom.alphanumeric(n = nil, chars: Random::Formatter::ALPHANUMERIC)    -> String
 #%else
-### def alphanumeric(n = nil)    -> String
+### def SecureRandom.alphanumeric(n = nil)    -> String
 #%end
 
 ランダムな英数字を生成して返します。

--- a/manual/api/set/Set.md
+++ b/manual/api/set/Set.md
@@ -9,8 +9,8 @@ until: "3.2"
 集合を表すクラスです。要素の間に順序関係はありません。
 
 ## Class Methods
-### def new(enum = nil) -> Set
-### def new(enum = nil) {|o| ... } -> Set
+### def Set.new(enum = nil) -> Set
+### def Set.new(enum = nil) {|o| ... } -> Set
 
 引数 enum で与えられた要素を元に、新しい集合を作ります。
 
@@ -35,7 +35,7 @@ p Set.new([1, 2])              # => #<Set: {1, 2}>
 p Set.new([1, 2]) {|o| o * 2}  # => #<Set: {2, 4}>
 ```
 
-### def [](*ary) -> Set
+### def Set.[](*ary) -> Set
 
 与えられたオブジェクトを要素とする新しい集合を作ります。
 

--- a/manual/api/shell.md
+++ b/manual/api/shell.md
@@ -86,7 +86,7 @@ Shell オブジェクトはカレントディレクトリを持ち,
 
 ## Class Methods
 
-### def def_system_command(command, path = command) -> nil
+### def Shell.def_system_command(command, path = command) -> nil
 
 Shell のメソッドとして command を登録します.
 
@@ -117,7 +117,7 @@ sh.transact {
 }
 ```
 
-### def undef_system_command(command) -> Shell::CommandProcessor
+### def Shell.undef_system_command(command) -> Shell::CommandProcessor
 
 commandを削除します.
 
@@ -142,7 +142,7 @@ rescue NameError => err
 end
 ```
 
-### def alias_command(alias, command, *opts) {...} -> self
+### def Shell.alias_command(alias, command, *opts) {...} -> self
 
 コマンドの別名(エイリアス)を作成します。
 コマンドが無い場合は、[m:Shell.def_system_command] などであらかじめ作成します.
@@ -168,7 +168,7 @@ sh.transact {
 }
 ```
 
-### def unalias_command(alias) -> ()
+### def Shell.unalias_command(alias) -> ()
 
 commandのaliasを削除します.
 
@@ -197,7 +197,7 @@ rescue NameError => err
 end
 ```
 
-### def install_system_commands(pre = "sys_") -> ()
+### def Shell.install_system_commands(pre = "sys_") -> ()
 
 system_path上にある全ての実行可能ファイルをShellに定義する. メソッ
 ド名は元のファイル名の頭にpreをつけたものとなる.
@@ -218,7 +218,7 @@ sh.transact {
 }
 ```
 
-### def new(pwd = Dir.pwd, umask = nil) -> Shell
+### def Shell.new(pwd = Dir.pwd, umask = nil) -> Shell
 
 プロセスのカレントディレクトリをpwd で指定されたディレクトリとするShellオ
 ブジェクトを生成します.
@@ -228,7 +228,7 @@ sh.transact {
 
 - **param** `umask` -- ファイル作成の際に用いられる umask を使用します。
 
-### def cd(path = nil, verbose = self.verbose) -> self
+### def Shell.cd(path = nil, verbose = self.verbose) -> self
 
 pathをカレントディレクトリとするShellオブジェクトを生成します.
 
@@ -242,13 +242,13 @@ sh = Shell.new
 sh.cd("/tmp")
 ```
 
-### def debug -> bool | Integer
-### def debug? -> bool | Integer
+### def Shell.debug -> bool | Integer
+### def Shell.debug? -> bool | Integer
 #%todo
 
 デバッグ用フラグを参照します。
 
-### def debug=(val) 
+### def Shell.debug=(val) 
 
 デバッグ用のフラグを設定します。
 
@@ -260,8 +260,8 @@ sh.cd("/tmp")
 # debug: 2    -> detail inspect debug
 ```
 
-### def default_record_separator -> String
-### def default_record_separator=(rs)
+### def Shell.default_record_separator -> String
+### def Shell.default_record_separator=(rs)
 
 執筆者募集
 
@@ -270,8 +270,8 @@ Shell で用いられる入力レコードセパレータを表す文字列を�
 
 - **param** `rs` -- Shell で用いられる入力レコードセパレータを表す文字列を指定します。
 
-### def default_system_path -> Array
-### def default_system_path=(path)
+### def Shell.default_system_path -> Array
+### def Shell.default_system_path=(path)
 
 Shellでもちいられるコマンドを検索する対象のパスを設定および、参照します。
 
@@ -287,46 +287,46 @@ p Shell.default_system_path
 # => "/Users/kouya/bin"
 ```
 
-### def verbose -> bool  
-### def verbose? -> bool
+### def Shell.verbose -> bool  
+### def Shell.verbose? -> bool
 #%todo
 
-### def verbose=(flag)
+### def Shell.verbose=(flag)
 
 true ならば冗長な出力の設定を行います。
 
 - **param** `flag` -- true ならば冗長な出力の設定を行います。
 
-### def cascade -> bool
+### def Shell.cascade -> bool
 #%todo
 
-### def cascade=(flag)
+### def Shell.cascade=(flag)
 #%todo
 
-### def notify(*opts){|message| ... } -> String
+### def Shell.notify(*opts){|message| ... } -> String
 #%todo
 
-### def debug_output_lock -> Mutex
+### def Shell.debug_output_lock -> Mutex
 #%todo
 
 - **SEE** [m:Thread::Mutex#lock]
 
-### def debug_output_locked? -> bool
+### def Shell.debug_output_locked? -> bool
 #%todo
 
 - **SEE** [m:Thread::Mutex#locked?]
 
-### def debug_output_synchronize
+### def Shell.debug_output_synchronize
 #%todo
 
 - **SEE** [m:Thread::Mutex#synchronize]
 
-### def debug_output_try_lock -> bool
+### def Shell.debug_output_try_lock -> bool
 #%todo
 
 - **SEE** [m:Thread::Mutex#try_lock]
 
-### def debug_output_unlock -> Mutex | nil
+### def Shell.debug_output_unlock -> Mutex | nil
 #%todo
 
 - **SEE** [m:Thread::Mutex#unlock]

--- a/manual/api/shell/builtin-command.md
+++ b/manual/api/shell/builtin-command.md
@@ -20,7 +20,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, filename)
+### def Shell::AppendFile.new(sh, filename)
 #%todo
 
 ## Instance Methods
@@ -32,7 +32,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, filename)
+### def Shell::AppendIO.new(sh, filename)
 #%todo
 
 ## Instance Methods
@@ -44,7 +44,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, *filenames)
+### def Shell::Cat.new(sh, *filenames)
 #%todo
 
 ## Instance Methods
@@ -56,7 +56,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, *jobs)
+### def Shell::Concat.new(sh, *jobs)
 #%todo
 
 ## Instance Methods
@@ -68,7 +68,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, *strings)
+### def Shell::Echo.new(sh, *strings)
 #%todo
 
 ## Instance Methods
@@ -80,7 +80,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, pattern)
+### def Shell::Glob.new(sh, pattern)
 #%todo
 
 ## Instance Methods
@@ -92,7 +92,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, filename)
+### def Shell::Tee.new(sh, filename)
 #%todo
 
 ## Instance Methods
@@ -106,7 +106,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, *opts)
+### def Shell::Void.new(sh, *opts)
 
 ## Instance Methods
 

--- a/manual/api/shell/command-processor.md
+++ b/manual/api/shell/command-processor.md
@@ -13,10 +13,10 @@ require:
 
 ## Singleton Methods
 
-### def new(shell)
+### def Shell::CommandProcessor.new(shell)
 #%todo
 
-### def add_delegate_command_to_shell(id)
+### def Shell::CommandProcessor.add_delegate_command_to_shell(id)
 #%todo
 
 [c:Shell] 自体を初期化する時に呼び出されるメソッドです。
@@ -24,8 +24,8 @@ require:
 
 - **param** `id` -- メソッド名を指定します。
 
-### def alias_command(alias, command, *opts) -> self
-### def alias_command(alias, command, *opts){ ... } -> self
+### def Shell::CommandProcessor.alias_command(alias, command, *opts) -> self
+### def Shell::CommandProcessor.alias_command(alias, command, *opts){ ... } -> self
 #%todo
 
 - **param** `alias` -- エイリアスの名前を指定します。
@@ -36,11 +36,11 @@ require:
 
 - **raise** `SyntaxError` -- コマンドのエイリアス作成に失敗した時に発生します。
 
-### def alias_map -> Hash
+### def Shell::CommandProcessor.alias_map -> Hash
 
 [m:Shell::CommandProcessor.alias_command] で定義したエイリアスの一覧を返します。
 
-### def def_builtin_commands(delegation_class, commands_specs) -> ()
+### def Shell::CommandProcessor.def_builtin_commands(delegation_class, commands_specs) -> ()
 #%todo
 
 - **param** `delegation_class` -- 処理を委譲したいクラスかモジュールを指定します。
@@ -48,7 +48,7 @@ require:
 - **param** `commands_specs` -- コマンドの仕様を文字列の配列で指定します。
                       [[コマンド名, [引数1, 引数2, ...]], ...]
 
-### def def_system_command(command, path = command) -> ()
+### def Shell::CommandProcessor.def_system_command(command, path = command) -> ()
 #%todo
 
 与えられたコマンドをメソッドとして定義します。
@@ -57,16 +57,16 @@ require:
 
 - **param** `path` -- command のパスを指定します。省略すると環境変数 PATH から command を探します。
 
-### def initialize -> ()
+### def Shell::CommandProcessor.initialize -> ()
 #%todo
 
 このクラスを初期化します。
 
-### def install_builtin_commands -> ()
+### def Shell::CommandProcessor.install_builtin_commands -> ()
 
 ビルトインコマンドを定義します。
 
-### def install_system_commands(prefix = "sys_") -> ()
+### def Shell::CommandProcessor.install_system_commands(prefix = "sys_") -> ()
 
 全てのシステムコマンドをメソッドとして定義します。
 
@@ -77,25 +77,25 @@ require:
 
 - **param** `prefix` -- プレフィクスを指定します。
 
-### def method_added(id)
+### def Shell::CommandProcessor.method_added(id)
 #%todo
 このクラスに定義されたメソッドを [c:Shell] にも定義するためのフックです。
 
 - **param** `id` -- メソッド名を指定します。
 
-### def run_config -> ()
+### def Shell::CommandProcessor.run_config -> ()
 
 ユーザのホームディレクトリに "~/.rb_shell" というファイルが存在すれば、それを [m:Kernel?.load] します。
 
 存在しない時は何もしません。
 
-### def unalias_command(alias) -> self
+### def Shell::CommandProcessor.unalias_command(alias) -> self
 
 エイリアスを削除します。
 
 - **param** `alias` -- 削除したいエイリアスを指定します。
 
-### def undef_system_command(command) -> self
+### def Shell::CommandProcessor.undef_system_command(command) -> self
 
 与えられたコマンドを削除します。
 

--- a/manual/api/shell/filter.md
+++ b/manual/api/shell/filter.md
@@ -12,7 +12,7 @@ until: "2.7.0"
 
 ## Class Methods
 
-### def new(sh) -> Shell::Filter
+### def Shell::Filter.new(sh) -> Shell::Filter
 
 [c:Shell::Filter] クラスのインスタンスを返します。
 通常このメソッドを直接使う機会は少ないでしょう。

--- a/manual/api/shell/process-controller.md
+++ b/manual/api/shell/process-controller.md
@@ -8,31 +8,31 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(shell)
+### def Shell::ProcessController.new(shell)
 
 自身を初期化します。
 
 - **param** `shell` -- [c:Shell] のインスタンスを指定します。
 
-### def activate(pc) -> ()
+### def Shell::ProcessController.activate(pc) -> ()
 #%todo
 
-### def each_active_object{|ref| ... } -> ()
+### def Shell::ProcessController.each_active_object{|ref| ... } -> ()
 #%todo
 
-### def inactivate(pc) -> ()
+### def Shell::ProcessController.inactivate(pc) -> ()
 #%todo
 
-### def process_controllers_exclusive -> ()
+### def Shell::ProcessController.process_controllers_exclusive -> ()
 #%todo
 
-### def active_process_controllers -> ()
+### def Shell::ProcessController.active_process_controllers -> ()
 #%todo
 
-### def block_output_synchronize{ ... } -> ()
+### def Shell::ProcessController.block_output_synchronize{ ... } -> ()
 #%todo
 
-### def wait_to_finish_all_process_controllers -> ()
+### def Shell::ProcessController.wait_to_finish_all_process_controllers -> ()
 #%todo
 
 ## Instance Methods

--- a/manual/api/shell/system-command.md
+++ b/manual/api/shell/system-command.md
@@ -6,7 +6,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def new(sh, command, *opts)
+### def Shell::SystemCommand.new(sh, command, *opts)
 #%todo
 
 - **param** `sh` --

--- a/manual/api/shellwords.md
+++ b/manual/api/shellwords.md
@@ -92,7 +92,7 @@ puts Shellwords.shelljoin(['grep', pattern, file])
 
 ## Singleton Methods
 
-### def split(line) -> [String]
+### def Shellwords.split(line) -> [String]
 
 Bourne シェルの単語分割規則に従った空白区切りの単語分割を行い、
 単語 (文字列) の配列を返します。
@@ -104,7 +104,7 @@ Bourne シェルの単語分割規則に従った空白区切りの単語分割�
 - **raise** `ArgumentError` -- 引数の中に対でないシングルクォートまたはダブル
        クォートが現れた場合に発生します。
 
-### def escape(str) -> String
+### def Shellwords.escape(str) -> String
 
 文字列を Bourne シェルのコマンドライン中で安全に使えるようにエスケープします。
 
@@ -113,7 +113,7 @@ Bourne シェルの単語分割規則に従った空白区切りの単語分割�
 - **param** `str` -- エスケープの対象となる文字列を指定します。
 - **return** -- エスケープされた文字列を返します。
 
-### def join(array) -> String
+### def Shellwords.join(array) -> String
 
 配列の各要素である文字列に対して、Bourne シェルのコマンドライン中で安全に
 使えるためのエスケープを適用し、空白文字を介してそれらを連結したコマンド

--- a/manual/api/singleton.md
+++ b/manual/api/singleton.md
@@ -44,7 +44,7 @@ a = SomeSingletonClass.new  # ~> NoMethodError: private method `new' called for 
 
 ## Singleton Methods
 
-### def instance -> object
+### def Singleton.instance -> object
 
 そのクラスの唯一のインスタンスを返します。
 最初に呼ばれたときはそのインスタンスを生成します。

--- a/manual/api/socket/Addrinfo.md
+++ b/manual/api/socket/Addrinfo.md
@@ -12,7 +12,7 @@ IPv4/IPv6/Unix domain socketなどのアドレス情報を保持できます。
 struct addrinfo に対応します。
 
 ## Class methods
-### def new(sockaddr, family=Socket::PF_UNSPEC, socktype=0, protocol=0) -> Addrinfo
+### def Addrinfo.new(sockaddr, family=Socket::PF_UNSPEC, socktype=0, protocol=0) -> Addrinfo
 
 新たな Addrinfo オブジェクトを返します。
 
@@ -59,7 +59,7 @@ family や socktype と異なり、整数でなければなりません。
 - **param** `protocol` -- プロトコル(整数)
 - **raise** `SocketError` -- 不適なファミリーやソケットタイプなどを渡した場合に発生します
 
-### def ip(host) -> Addrinfo
+### def Addrinfo.ip(host) -> Addrinfo
 
 IP アドレスに対する Addrinfo オブジェクトを返します。
 
@@ -75,7 +75,7 @@ p Addrinfo.ip("localhost") #=> #<Addrinfo: 127.0.0.1 (localhost)>
 - **param** `host` -- ホスト(IP アドレスもしくはホスト名)
 - **SEE** [m:Addrinfo.new]
 
-### def tcp(host, port) -> Addrinfo
+### def Addrinfo.tcp(host, port) -> Addrinfo
 
 TCP アドレスに対する Addrinfo オブジェクトを返します。
 
@@ -89,7 +89,7 @@ p Addrinfo.tcp("localhost", "smtp")
 - **param** `host` -- ホスト(IP アドレスもしくはホスト名)
 - **param** `port` -- ポート番号(整数)もしくはサービス名(文字列)
 
-### def udp(host, port) -> Addrinfo
+### def Addrinfo.udp(host, port) -> Addrinfo
 
 UDP アドレスに対する Addrinfo オブジェクトを返します。
 
@@ -103,7 +103,7 @@ p Addrinfo.udp("localhost", "daytime")
 - **param** `host` -- ホスト(IP アドレスもしくはホスト名)
 - **param** `port` -- ポート番号(整数)もしくはサービス名(文字列)
 
-### def unix(path, socktype=Socket::SOCK_STREAM) -> Addrinfo
+### def Addrinfo.unix(path, socktype=Socket::SOCK_STREAM) -> Addrinfo
 
 Unix ソケットアドレスに対応する Addrinfo オブジェクトを返します。
 
@@ -121,8 +121,8 @@ p Addrinfo.unix("/tmp/sock", :DGRAM) #=> #<Addrinfo: /tmp/sock SOCK_DGRAM>
 
 - **SEE** [m:Addrinfo.new]
 
-### def foreach(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0) -> Enumerator
-### def foreach(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0){|addrinfo| ... } -> [Addrinfo]
+### def Addrinfo.foreach(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0) -> Enumerator
+### def Addrinfo.foreach(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0){|addrinfo| ... } -> [Addrinfo]
 
 [m:Addrinfo.getaddrinfo] で得られる配列の各要素を繰り返します。
 
@@ -135,7 +135,7 @@ p Addrinfo.unix("/tmp/sock", :DGRAM) #=> #<Addrinfo: /tmp/sock SOCK_DGRAM>
 - **param** `protocol` -- プロトコル(整数、もしくは nil)
 - **param** `flags` -- フラグ(整数)
 
-### def getaddrinfo(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0) -> [Addrinfo]
+### def Addrinfo.getaddrinfo(nodename, service, family=nil, socktype=nil, protocol=nil, flags=0) -> [Addrinfo]
 
 パラメータから複数の Addrinfo オブジェクトを生成し、その配列を返します。
 

--- a/manual/api/socket/BasicSocket.md
+++ b/manual/api/socket/BasicSocket.md
@@ -11,7 +11,7 @@ library: socket
 
 ## Class Methods
 
-### def do_not_reverse_lookup -> bool
+### def BasicSocket.do_not_reverse_lookup -> bool
 
 [m:BasicSocket#do_not_reverse_lookup] の Socket オブジェクト生成時の
 デフォルト値を返します。
@@ -20,7 +20,7 @@ library: socket
 
 デフォルトは true です。
 
-### def do_not_reverse_lookup=(bool)
+### def BasicSocket.do_not_reverse_lookup=(bool)
 
 [m:BasicSocket#do_not_reverse_lookup] の値を変更します。
 
@@ -37,7 +37,7 @@ p TCPSocket.new('localhost', 'telnet').addr
    ["AF_INET", 2254, "127.0.0.1", "127.0.0.1"]
 ```
 
-### def for_fd(fd) -> BasicSocket
+### def BasicSocket.for_fd(fd) -> BasicSocket
 
 ファイルディスクリプタ fd に対する新しいソケットを生成します。
 

--- a/manual/api/socket/IPSocket.md
+++ b/manual/api/socket/IPSocket.md
@@ -9,7 +9,7 @@ library: socket
 
 ## Class Methods
 
-### def getaddress(host) -> String
+### def IPSocket.getaddress(host) -> String
 
 ホスト名からホストのアドレスを返します。ホストのアドレスは文
 字列は octet decimal の文字列 (例: 127.0.0.1) です。

--- a/manual/api/socket/SOCKSSocket.md
+++ b/manual/api/socket/SOCKSSocket.md
@@ -7,8 +7,8 @@ library: socket
 
 ## Class Methods
 
-### def open(host, service) -> SOCKSSocket
-### def new(host, service) -> SOCKSSocket
+### def SOCKSSocket.open(host, service) -> SOCKSSocket
+### def SOCKSSocket.new(host, service) -> SOCKSSocket
 
 host で指定したホストの service で指定したポートと接続したソケッ
 トを返します。host はホスト名、またはインターネットアドレスを

--- a/manual/api/socket/Socket.md
+++ b/manual/api/socket/Socket.md
@@ -22,8 +22,8 @@ library: socket
 
 ## Class Methods
 
-### def open(domain, type, protocol=0) -> Socket
-### def new(domain, type, protocol=0) -> Socket
+### def Socket.open(domain, type, protocol=0) -> Socket
+### def Socket.new(domain, type, protocol=0) -> Socket
 
 新しいソケットを生成します。domain、type、
 protocol はインクルードファイルにある定数で指定しま
@@ -50,7 +50,7 @@ Stevens の「UNIX ネットワークプログラミング第2版 Vol.1」4.2節
 - **param** `type` --   例えば、<sys/socket.h> のようなインクルードファイルに定義されている定数を指定します。
 - **param** `protocol` -- プロトコルに使用する数値を指定します。
 
-### def getaddrinfo(nodename, servname, family=nil, socktype=nil, protocol=nil, flags=nil) -> Array
+### def Socket.getaddrinfo(nodename, servname, family=nil, socktype=nil, protocol=nil, flags=nil) -> Array
 
 [RFC:2553]で定義された
 getaddrinfo() の機能を提供するクラスメソッド。この関数は
@@ -139,7 +139,7 @@ pp Socket.getaddrinfo(Socket.gethostname, nil)
 #    ["AF_INET", 0, "helium.ruby-lang.org", "210.251.121.214", 2, 3, 0]]
 ```
 
-### def getnameinfo(sa, flags = 0) -> Array
+### def Socket.getnameinfo(sa, flags = 0) -> Array
 
 [RFC:2553] で定義された getnameinfo() の機能を提供するク
 ラスメソッド。 gethostbyaddr() や getservbyport() の代
@@ -218,7 +218,7 @@ p Socket.getnameinfo([nil, 21,'127.0.0.1'])
 #=> ["localhost", "ftp"]
 ```
 
-### def gethostbyaddr(host, type = Socket::AF_INET) -> Array
+### def Socket.gethostbyaddr(host, type = Socket::AF_INET) -> Array
 
 このメソッドは deprecated です。[m:Addrinfo#getnameinfo] を使用してください。
 
@@ -233,7 +233,7 @@ Socket::AF_INET)を指定します。
 
 - **raise** `SocketError` -- [man:gethostbyaddr(3)] の呼び出しにエラーがあった場合に発生します。
 
-### def gethostbyname(host) -> Array
+### def Socket.gethostbyname(host) -> Array
 
 このメソッドは deprecated です。[m:Addrinfo.getaddrinfo] を使用してください。
 
@@ -271,7 +271,7 @@ irb(main):009:0> Socket.unpack_sockaddr_in(Socket.gethostbyname("210.251.121.214
 "210.251.121.214"
 ```
 
-### def gethostname -> String
+### def Socket.gethostname -> String
 
 システムの標準のホスト名を取得します。
 
@@ -285,7 +285,7 @@ require 'socket'
 p Socket.gethostname   #=> "helium.ruby-lang.org"
 ```
 
-### def getservbyname(service, proto = "tcp") -> Integer
+### def Socket.getservbyname(service, proto = "tcp") -> Integer
 
 service, protoに対応するポート番号を返
 します。protoの省略値は"tcp"です。
@@ -295,8 +295,8 @@ service, protoに対応するポート番号を返
 
 - **return** -- ポート番号を整数で返します。
 
-### def sockaddr_in(port, host) -> String
-### def pack_sockaddr_in(port, host) -> String
+### def Socket.sockaddr_in(port, host) -> String
+### def Socket.pack_sockaddr_in(port, host) -> String
 
 指定したアドレスを[ref:lib:socket#pack_string]
 で返します。port は、ポート番号を表す [c:Integer] あるいは、ポート
@@ -316,8 +316,8 @@ p Socket.sockaddr_in("echo", "::1")
 => "\n\000\000\a\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\001\000\000\000\000"
 ```
 
-### def sockaddr_un(path) -> String
-### def pack_sockaddr_un(path) -> String
+### def Socket.sockaddr_un(path) -> String
+### def Socket.pack_sockaddr_un(path) -> String
 
 指定したアドレスを[ref:lib:socket#pack_string]
 で返します。
@@ -330,8 +330,8 @@ p Socket.sockaddr_un("/tmp/.X11-unix/X0")
 => "\001\000/tmp/.X11-unix/X0\000...."
 ```
 
-### def pair(domain, type, protocol=0) -> Array
-### def socketpair(domain, type, protocol=0) -> Array
+### def Socket.pair(domain, type, protocol=0) -> Array
+### def Socket.socketpair(domain, type, protocol=0) -> Array
 
 相互に結合されたソケットのペアを含む2要素の配列を返します。
 引数の指定は [m:Socket.open] と同じです。
@@ -344,7 +344,7 @@ p Socket.sockaddr_un("/tmp/.X11-unix/X0")
 
 - **SEE** [m:Socket.open]
 
-### def unpack_sockaddr_in(sockaddr) -> Array
+### def Socket.unpack_sockaddr_in(sockaddr) -> Array
 
 [ref:lib:socket#pack_string]を
 unpack したアドレスを返します。返される値は [port, ipaddr]
@@ -360,7 +360,7 @@ p Socket.unpack_sockaddr_in(Socket.sockaddr_in("echo", "::1"))
 => [7, "::1"]
 ```
 
-### def unpack_sockaddr_un(sockaddr) -> String
+### def Socket.unpack_sockaddr_un(sockaddr) -> String
 
 [ref:lib:socket#pack_string]を
 unpack したソケットパス名を返します。
@@ -373,7 +373,7 @@ p Socket.unpack_sockaddr_un(Socket.sockaddr_un("/tmp/.X11-unix/X0"))
 => "/tmp/.X11-unix/X0"
 ```
 
-### def getservbyport(port, protocol_name="tcp") -> String
+### def Socket.getservbyport(port, protocol_name="tcp") -> String
 
 ポート番号に対応するサービスの正式名を返します。
 #%#rdoc の Obtains the port number for _port_. って変?
@@ -390,7 +390,7 @@ p Socket.getservbyport(514, "tcp") #=> "shell"
 p Socket.getservbyport(514, "udp") #=> "syslog"
 ```
 
-### def accept_loop(sockets) {|sock, client_addrinfo| ...} -> ()
+### def Socket.accept_loop(sockets) {|sock, client_addrinfo| ...} -> ()
 
 sockets でサーバソケットを受け取り、接続を待ち受け、
 クライアントとの接続が確立するたびにブロックにその接続
@@ -409,21 +409,21 @@ sockets でサーバソケットを受け取り、接続を待ち受け、
 
 - **SEE** [m:Socket.tcp_server_loop], [m:Socket.unix_server_loop]
 
-### def ip_address_list -> [Addrinfo]
+### def Socket.ip_address_list -> [Addrinfo]
 
 ローカルの IP アドレスを配列で返します。
 
 #%version 4.0...
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) -> Socket
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) {|socket| ... } -> object
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) -> Socket
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, open_timeout: nil, fast_fallback: true) {|socket| ... } -> object
 #%end
 #%version 3.4...4.0
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) -> Socket
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) {|socket| ... } -> object
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) -> Socket
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil, fast_fallback: true) {|socket| ... } -> object
 #%end
 #%until 3.4
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) -> Socket
-### def tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) {|socket| ... } -> object
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) -> Socket
+### def Socket.tcp(host, port, local_host=nil, local_port=nil, connect_timeout: nil, resolv_timeout: nil) {|socket| ... } -> object
 #%end
 TCP/IP で host:port に接続するソケットオブジェクトを作成します。
 
@@ -457,8 +457,8 @@ Socket.tcp("www.ruby-lang.org", 80) {|sock|
 }
 ```
 
-### def tcp_server_loop(port){|sock,addr| ...} -> ()
-### def tcp_server_loop(host, port){|sock,addr| ...} -> ()
+### def Socket.tcp_server_loop(port){|sock,addr| ...} -> ()
+### def Socket.tcp_server_loop(host, port){|sock,addr| ...} -> ()
 
 TCP/IP で host:port で待ち受けるサーバ側のソケットを作成し、
 新しい接続を受け入れるごとにブロックを呼び出します。
@@ -517,10 +517,10 @@ Socket.tcp_server_loop(16807) {|sock, client_addrinfo|
 - **param** `port` -- 割り当てるポート番号
 - **SEE** [m:Socket.tcp_server_sockets], [m:Socket.accept_loop]
 
-### def tcp_server_sockets(port) -> [Socket]
-### def tcp_server_sockets(host, port) -> [Socket]
-### def tcp_server_sockets(port){|sockets| ...}  -> object
-### def tcp_server_sockets(host, port){|sockets| ...}  -> object
+### def Socket.tcp_server_sockets(port) -> [Socket]
+### def Socket.tcp_server_sockets(host, port) -> [Socket]
+### def Socket.tcp_server_sockets(port){|sockets| ...}  -> object
+### def Socket.tcp_server_sockets(host, port){|sockets| ...}  -> object
 
 TCP/IP で host:port で待ち受けるサーバ側のソケットを
 作成します。
@@ -562,8 +562,8 @@ Socket.tcp_server_sockets(0) {|sockets|
 - **param** `port` -- 割り当てるポート番号
 - **SEE** [m:Socket.tcp_server_loop]
 
-### def udp_server_loop(port) {|msg, msg_src| ... } -> ()
-### def udp_server_loop(host, port) {|msg, msg_src| ... } -> ()
+### def Socket.udp_server_loop(port) {|msg, msg_src| ... } -> ()
+### def Socket.udp_server_loop(host, port) {|msg, msg_src| ... } -> ()
 
 UDP のサーバを起動して、メッセージが来るごとに
 ブロックを呼び出します。
@@ -576,7 +576,7 @@ msg は受け取ったメッセージ文字列で、 msg_src は
 - **param** `port` -- 割り当てるポート番号
 - **SEE** [m:Socket.udp_server_sockets], [m:Socket.udp_server_loop_on]
 
-### def udp_server_loop_on(sockets) {|msg, msg_src| ... } -> ()
+### def Socket.udp_server_loop_on(sockets) {|msg, msg_src| ... } -> ()
 
 sockets (UDP のソケット)に対し、通信を待ち受けます。
 
@@ -592,7 +592,7 @@ msg は受け取ったメッセージ文字列で、 msg_src は
 - **param** `sockets` -- 通信を待ち受けるソケットの配列
 - **SEE** [m:Socket.udp_server_recv], [m:Socket.udp_server_loop]
 
-### def udp_server_recv(sockets){|msg, msg_src| ... } -> ()
+### def Socket.udp_server_recv(sockets){|msg, msg_src| ... } -> ()
 
 socketsで与えられた各 UDP ソケットからデータを読み取ります。
 
@@ -617,10 +617,10 @@ udp_server_sockets(host, port) {|sockets|
 
 - **param** `sockets` -- 読み込むソケットの配列
 
-### def udp_server_sockets(port) -> [Sockets]
-### def udp_server_sockets(host, port) -> [Sockets]
-### def udp_server_sockets(port) {|sockets| ... } -> object
-### def udp_server_sockets(host, port) {|sockets| ... } -> object
+### def Socket.udp_server_sockets(port) -> [Sockets]
+### def Socket.udp_server_sockets(host, port) -> [Sockets]
+### def Socket.udp_server_sockets(port) {|sockets| ... } -> object
+### def Socket.udp_server_sockets(host, port) {|sockets| ... } -> object
 
 UDP で host:port を待ち受けるサーバ側のソケットを作成します。
 
@@ -647,8 +647,8 @@ Socket.udp_server_sockets(0) {|sockets|
 - **param** `host` -- 割り当てるホスト名
 - **param** `port` -- 割り当てるポート番号
 
-### def unix(path) -> Socket
-### def unix(path){|sock| ... } -> object
+### def Socket.unix(path) -> Socket
+### def Socket.unix(path){|sock| ... } -> object
 
 Unix クライアントソケットを生成します。
 
@@ -672,7 +672,7 @@ Socket.unix("/tmp/sock") {|sock|
 
 - **param** `path` -- 接続対象のパス(文字列)
 
-### def unix_server_loop(path) {|socket, client_addrinfo| ... } -> ()
+### def Socket.unix_server_loop(path) {|socket, client_addrinfo| ... } -> ()
 
 Unix サーバソケットを生成し、
 新しい接続を受け入れるごとにブロックを呼び出します。
@@ -693,8 +693,8 @@ path という名前のファイルが既に存在するときは、
 
 - **param** `path` -- 接続を待ち受けるパス(文字列)
 
-### def unix_server_socket(path) -> Socket
-### def unix_server_socket(path){|sock| ... } -> object
+### def Socket.unix_server_socket(path) -> Socket
+### def Socket.unix_server_socket(path){|sock| ... } -> object
 
 Unix サーバソケットを生成します。
 
@@ -720,7 +720,7 @@ Socket.unix_server_socket("/tmp/sock") {|s|
 
 - **param** `path` -- 接続を待ち受けるパス(文字列)
 
-### def getifaddrs -> [Socket::Ifaddr]
+### def Socket.getifaddrs -> [Socket::Ifaddr]
 
 インターフェイスのアドレスを [c:Socket::Ifaddr] の配列で返します。
 

--- a/manual/api/socket/Socket__AncillaryData.md
+++ b/manual/api/socket/Socket__AncillaryData.md
@@ -15,7 +15,7 @@ since: "1.9.2"
 といった要素を持ちます。
 
 ## Class Methods
-### def new(family, cmsg_level, cmsg_type, cmsg_data) -> Socket::AncillaryData
+### def Socket::AncillaryData.new(family, cmsg_level, cmsg_type, cmsg_data) -> Socket::AncillaryData
 
 新たな Socket::AncillaryData オブジェクトを生成します。
 
@@ -58,7 +58,7 @@ p Socket::AncillaryData.new(:INET6, :IPV6, :PKTINFO, "")
 - **param** `cmsg_type` -- 補助データの種類
 - **param** `cmsg_data` -- データ内容
 
-### def int(family, cmsg_level, cmsg_type, integer) -> Socket::AncillaryData
+### def Socket::AncillaryData.int(family, cmsg_level, cmsg_type, integer) -> Socket::AncillaryData
 
 データとして整数を保持する
 Socket::AncillaryData オブジェクトを生成します。
@@ -79,7 +79,7 @@ p Socket::AncillaryData.int(:UNIX, :SOCKET, :RIGHTS, STDERR.fileno)
 
 - **SEE** [m:Socket::AncillaryData.new]
 
-### def unix_rights(*ios) -> Socket::AncillaryData
+### def Socket::AncillaryData.unix_rights(*ios) -> Socket::AncillaryData
 
 ios で指定したファイルのファイルデスクリプタを
 データとして持つ family=AF_UNIX, level=SOL_SOCKET, type=SCM_RIGHTS
@@ -96,7 +96,7 @@ p Socket::AncillaryData.unix_rights(STDERR)
 - **SEE** [m:Socket::AncillaryData#unix_rights],
      [m:Socket::Constants::SCM_RIGHTS]
 
-### def ip_pktinfo(addr, ifindex, spec_dst=addr) -> Socket::AncillaryData
+### def Socket::AncillaryData.ip_pktinfo(addr, ifindex, spec_dst=addr) -> Socket::AncillaryData
 
 type が IP_PKTINFO である AncillaryData を生成します。
 
@@ -119,7 +119,7 @@ p Socket::AncillaryData.ip_pktinfo(addr, ifindex, spec_dst)
 - **SEE** [m:Socket::AncillaryData#ip_pktinfo],
      [m:Socket::Constants::IP_PKTINFO]
 
-### def ipv6_pktinfo(addr, ifindex) -> Socket::AncillaryData
+### def Socket::AncillaryData.ipv6_pktinfo(addr, ifindex) -> Socket::AncillaryData
 
 type が IPV6_PKTINFO である AncillaryData を生成します。
 

--- a/manual/api/socket/Socket__Option.md
+++ b/manual/api/socket/Socket__Option.md
@@ -11,7 +11,7 @@ since: "1.9.2"
 自身の使っているシステムのドキュメントを見てください。
 
 ## Class Methods
-### def new(family, level, optname, data) -> Socket::Option
+### def Socket::Option.new(family, level, optname, data) -> Socket::Option
 
 Socket::Option オブジェクト新たに生成し返します。
 
@@ -33,7 +33,7 @@ sockopt = Socket::Option.new(:INET, :SOCKET, :KEEPALIVE, [1].pack("i"))
 p sockopt #=> #<Socket::Option: INET SOCKET KEEPALIVE 1>
 ```
 
-### def int(family, level, optname, integer) -> Socket::Option
+### def Socket::Option.int(family, level, optname, integer) -> Socket::Option
 
 整数をデータとして持つ Socket::Option オブジェクト新たに生成し返します。
 
@@ -46,7 +46,7 @@ family, level, optname には Socket::SOL_SOCKET のような整数の他、
 - **param** `optname` -- オプションの名前
 - **param** `integer` -- データ(整数)
 
-### def bool(family, level, optname, boolean) -> Socket::Option
+### def Socket::Option.bool(family, level, optname, boolean) -> Socket::Option
 
 整数をデータとして持つ Socket::Option オブジェクト新たに生成し返します。
 
@@ -69,7 +69,7 @@ p Socket::Option.bool(:INET, :SOCKET, :KEEPALIVE, false)
 # => #<Socket::Option: AF_INET SOCKET KEEPALIVE 0>
 ```
 
-### def linger(onoff, secs) -> Socket::Option
+### def Socket::Option.linger(onoff, secs) -> Socket::Option
 
 SOL_SOCKET/SO_LINGER 用の Socket::Option オブジェクト
 を新たに生成し返します。

--- a/manual/api/socket/Socket__UDPSource.md
+++ b/manual/api/socket/Socket__UDPSource.md
@@ -7,7 +7,7 @@ since: "1.9.1"
 [m:Socket.udp_server_loop] で使われるアドレス情報を保持するクラスです。
 
 ## Class methods
-### def new(remote_addr, local_addr) {|msg| ... } -> Socket::UDPSource
+### def Socket::UDPSource.new(remote_addr, local_addr) {|msg| ... } -> Socket::UDPSource
 
 Socket::UDPSource オブジェクトを生成します。
 

--- a/manual/api/socket/TCPServer.md
+++ b/manual/api/socket/TCPServer.md
@@ -63,8 +63,8 @@ end
 
 ## Class Methods
 
-### def new(host=nil, service) -> TCPServer
-### def open(host=nil, service) -> TCPServer
+### def TCPServer.new(host=nil, service) -> TCPServer
+### def TCPServer.open(host=nil, service) -> TCPServer
 
 新しいサーバー接続をオープンします。service は
 /etc/services (または NIS) に登録されているサービ

--- a/manual/api/socket/TCPSocket.md
+++ b/manual/api/socket/TCPSocket.md
@@ -30,16 +30,16 @@ s.close
 ## Class Methods
 
 #%version 4.0...
-### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
-### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
+### def TCPSocket.open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
+### def TCPSocket.new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, open_timeout: nil, fast_fallback: true) -> TCPSocket
 #%end
 #%version 3.4...4.0
-### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
-### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
+### def TCPSocket.open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
+### def TCPSocket.new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true) -> TCPSocket
 #%end
 #%until 3.4
-### def open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
-### def new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
+### def TCPSocket.open(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
+### def TCPSocket.new(host, service, local_host=nil, local_service=nil, resolv_timeout: nil, connect_timeout: nil) -> TCPSocket
 #%end
 
 host で指定したホストの service で指定したポートと接続したソケッ
@@ -67,7 +67,7 @@ host で指定したホストの service で指定したポートと接続した
 - **param** `fast_fallback` -- Happy Eyeballs Version 2 ([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305)) を有効にします。
 #%end
 
-### def gethostbyname(host) -> Array
+### def TCPSocket.gethostbyname(host) -> Array
 
 このメソッドは deprecated です。[m:Addrinfo.getaddrinfo] を使用してください。
 

--- a/manual/api/socket/UDPSocket.md
+++ b/manual/api/socket/UDPSocket.md
@@ -7,8 +7,8 @@ UDP/IPデータグラム型ソケットのクラス。
 
 ## Class Methods
 
-### def open(address_family=Socket::AF_INET) -> UDPSocket
-### def new(address_family=Socket::AF_INET) -> UDPSocket
+### def UDPSocket.open(address_family=Socket::AF_INET) -> UDPSocket
+### def UDPSocket.new(address_family=Socket::AF_INET) -> UDPSocket
 
 新しい UDP ソケットを返します。
 

--- a/manual/api/socket/UNIXServer.md
+++ b/manual/api/socket/UNIXServer.md
@@ -7,10 +7,10 @@ UNIXストリーム型接続のサーバ側のソケットのクラス。
 
 ## Class Methods
 
-### def open(path) -> UNIXServer
-### def new(path) -> UNIXServer
-### def open(path){|sock| ...} -> object
-### def new(path){|sock| ...} -> object
+### def UNIXServer.open(path) -> UNIXServer
+### def UNIXServer.new(path) -> UNIXServer
+### def UNIXServer.open(path){|sock| ...} -> object
+### def UNIXServer.new(path){|sock| ...} -> object
 
 path で指定したパス名を用いて接続を受け付けるソケット
 を作成します。

--- a/manual/api/socket/UNIXSocket.md
+++ b/manual/api/socket/UNIXSocket.md
@@ -9,10 +9,10 @@ UNIX ドメインのストリーム型ソケットのクラス。
 
 ## Class Methods
 
-### def open(path) -> UNIXSocket
-### def new(path)  -> UNIXSocket
-### def open(path){|sock| ...} -> object
-### def new(path){|sock| ...} -> object
+### def UNIXSocket.open(path) -> UNIXSocket
+### def UNIXSocket.new(path)  -> UNIXSocket
+### def UNIXSocket.open(path){|sock| ...} -> object
+### def UNIXSocket.new(path){|sock| ...} -> object
 
 path で指定したパス名を用いてソケットを接続します。
 
@@ -31,8 +31,8 @@ s = UNIXSocket.new("/tmp/sock")
 s.send("hello", 0)
 ```
 
-### def pair(type=Socket::SOCK_STREAM, protocol=0) -> [UNIXSocket, UNIXSocket]
-### def socketpair(type=Socket::SOCK_STREAM, protocol=0) -> [UNIXSocket, UNIXSocket]
+### def UNIXSocket.pair(type=Socket::SOCK_STREAM, protocol=0) -> [UNIXSocket, UNIXSocket]
+### def UNIXSocket.socketpair(type=Socket::SOCK_STREAM, protocol=0) -> [UNIXSocket, UNIXSocket]
 
 相互に結合された UNIX ソケットのペアを含む2要素の配列を返します。
 

--- a/manual/api/stringio.md
+++ b/manual/api/stringio.md
@@ -42,9 +42,9 @@ sio.write("a")
 
 ## Class Methods
 
-### def new(string = '', mode = 'r+')                 -> StringIO
-### def open(string = '', mode = 'r+')                -> StringIO
-### def open(string = '', mode = 'r+') {|io| ... }    -> object
+### def StringIO.new(string = '', mode = 'r+')                 -> StringIO
+### def StringIO.open(string = '', mode = 'r+')                -> StringIO
+### def StringIO.open(string = '', mode = 'r+') {|io| ... }    -> object
 
 StringIO オブジェクトを生成して返します。
 

--- a/manual/api/strscan.md
+++ b/manual/api/strscan.md
@@ -132,7 +132,7 @@ p s.scan(/\w+/)   #=> nil
 p s.scan(/\s+/)   #=> " "
 ```
 
-### def StringScanner. must_C_version -> self
+### def StringScanner.must_C_version -> self
 
 このメソッドは後方互換性のために定義されています。
 

--- a/manual/api/strscan.md
+++ b/manual/api/strscan.md
@@ -112,7 +112,7 @@ StringScanner は $~ $& $1 $2 …… などの正規表現関連変数を
 
 ## Class Methods
 
-### def new(str, dup = false) -> StringScanner
+### def StringScanner.new(str, dup = false) -> StringScanner
 
 新しい StringScanner オブジェクトを生成します。
 
@@ -132,7 +132,7 @@ p s.scan(/\w+/)   #=> nil
 p s.scan(/\s+/)   #=> " "
 ```
 
-### def  must_C_version -> self
+### def StringScanner. must_C_version -> self
 
 このメソッドは後方互換性のために定義されています。
 

--- a/manual/api/sync/Sync.md
+++ b/manual/api/sync/Sync.md
@@ -13,7 +13,7 @@ until: "2.7.0"
 
 ## Class Methods
 #%# bc-rdoc: detected missing name: new
-### def new -> Sync
+### def Sync.new -> Sync
 
 [c:Sync_m]をincludeしたクラスのオブジェクトを返します。
 使い方は[c:Sync_m]を参照してください。

--- a/manual/api/sync/Sync_m__Err.md
+++ b/manual/api/sync/Sync_m__Err.md
@@ -8,7 +8,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def Fail(*options) -> ()
+### def Sync_m::Err.Fail(*options) -> ()
 
 自身に定義されているメッセージをセットして例外を発生させます。
 

--- a/manual/api/sync/Sync_m__LockModeFailer.md
+++ b/manual/api/sync/Sync_m__LockModeFailer.md
@@ -8,7 +8,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def Fail(*options) -> ()
+### def Sync_m::LockModeFailer.Fail(*options) -> ()
 
 自身に定義されているメッセージをセットして例外を発生させます。
 

--- a/manual/api/sync/Sync_m__UnknownLocker.md
+++ b/manual/api/sync/Sync_m__UnknownLocker.md
@@ -8,7 +8,7 @@ until: "2.7.0"
 
 ## Singleton Methods
 
-### def Fail(*options) -> ()
+### def Sync_m::UnknownLocker.Fail(*options) -> ()
 
 自身に定義されているメッセージをセットして例外を発生させます。
 

--- a/manual/api/syslog/logger.md
+++ b/manual/api/syslog/logger.md
@@ -50,7 +50,7 @@ log.info 'this line will be logged via syslog(3)'
 
 ## Class Methods
 
-### def new(program_name = 'ruby') -> Syslog::Logger
+### def Syslog::Logger.new(program_name = 'ruby') -> Syslog::Logger
 
 [c:Syslog::Logger] オブジェクトを初期化します。
 
@@ -60,20 +60,20 @@ log.info 'this line will be logged via syslog(3)'
                     トされます(syslog の仕様で 1 つのプログラム名のみが
                     採用されます)。
 
-### def syslog -> Syslog
+### def Syslog::Logger.syslog -> Syslog
 
 内部の [c:Syslog] オブジェクトを返します。
 
 デフォルトでは、最初の [c:Syslog::Logger] オブジェクトの作成時に作ら
 れたものを返します。
 
-### def syslog=(syslog)
+### def Syslog::Logger.syslog=(syslog)
 
 内部の [c:Syslog] オブジェクトを引数 syslog で指定したものに設定します。
 
 - **param** `syslog` -- [c:Syslog] オブジェクトを指定します。
 
-### def make_methods(meth)
+### def Syslog::Logger.make_methods(meth)
 
 ライブラリ内部で使用します。
 

--- a/manual/api/syslog/logger.md
+++ b/manual/api/syslog/logger.md
@@ -265,7 +265,7 @@ call メソッドは文字列を返す必要があります。
 
 [c:Syslog::Logger] のバージョンを表す文字列です。
 
-### def LEVEL_MAP -> {Integer => Integer}
+### const LEVEL_MAP -> {Integer => Integer}
 
 [c:Logger] のログレベルと [man:syslog(3)] のログレベルのマッピング
 を表す [c:Hash] オブジェクトです。

--- a/manual/api/tempfile.md
+++ b/manual/api/tempfile.md
@@ -26,9 +26,9 @@ require:
 
 ## Class Methods
 
-### def new(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
-### def open(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
-### def open(basename = '', tempdir = nil, mode: 0, **options){|fp| ...} -> object
+### def Tempfile.new(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
+### def Tempfile.open(basename = '', tempdir = nil, mode: 0, **options) -> Tempfile
+### def Tempfile.open(basename = '', tempdir = nil, mode: 0, **options){|fp| ...} -> object
 
 テンポラリファイルを作成し、それを表す Tempfile オブジェクトを生成して返します。
 ファイル名のプレフィクスには指定された basename が使われます。
@@ -74,11 +74,11 @@ p File.read(tf.path) #=> "hoge\n"
 - **SEE** [m:Tempfile.create]
 
 #%since 3.4
-### def create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options) -> File
-### def create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options){|fp| ...} -> object
+### def Tempfile.create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options) -> File
+### def Tempfile.create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options){|fp| ...} -> object
 #%else
-### def create(basename="", tmpdir=nil, mode: 0, **options) -> File
-### def create(basename="", tmpdir=nil, mode: 0, **options){|fp| ...} -> object
+### def Tempfile.create(basename="", tmpdir=nil, mode: 0, **options) -> File
+### def Tempfile.create(basename="", tmpdir=nil, mode: 0, **options){|fp| ...} -> object
 #%end
 
 テンポラリファイルを作成し、それを表す File オブジェクトを生成して返します(Tempfileではありません)。

--- a/manual/api/thread/ConditionVariable.md
+++ b/manual/api/thread/ConditionVariable.md
@@ -135,7 +135,7 @@ recv Milk
 
 ## Class Methods
 
-### def new -> Thread::ConditionVariable
+### def Thread::ConditionVariable.new -> Thread::ConditionVariable
 
 状態変数を生成して返します。
 

--- a/manual/api/thread/Mutex.md
+++ b/manual/api/thread/Mutex.md
@@ -28,7 +28,7 @@ m.synchronize {
 
 ## Class Methods
 
-### def new -> Thread::Mutex
+### def Thread::Mutex.new -> Thread::Mutex
 
 新しい mutex を生成して返します。
 

--- a/manual/api/thread/Queue.md
+++ b/manual/api/thread/Queue.md
@@ -41,9 +41,9 @@ resource3
 
 ## Class Methods
 
-### def new -> Thread::Queue
+### def Thread::Queue.new -> Thread::Queue
 #%since 3.1
-### def new(items) -> Thread::Queue
+### def Thread::Queue.new(items) -> Thread::Queue
 #%end
 
 新しいキューオブジェクトを生成します。

--- a/manual/api/thread/SizedQueue.md
+++ b/manual/api/thread/SizedQueue.md
@@ -33,7 +33,7 @@ th.join
 
 ## Class Methods
 
-### def new(max) -> Thread::SizedQueue
+### def Thread::SizedQueue.new(max) -> Thread::SizedQueue
 
 Thread::SizedQueue オブジェクトを生成します。
 

--- a/manual/api/thwait/ThreadsWait.md
+++ b/manual/api/thwait/ThreadsWait.md
@@ -12,8 +12,8 @@ until: "2.7.0"
 
 ## Class Methods
 
-### def all_waits(*threads) -> ()
-### def all_waits(*threads){|thread| ...} -> ()
+### def ThreadsWait.all_waits(*threads) -> ()
+### def ThreadsWait.all_waits(*threads){|thread| ...} -> ()
 
 指定されたスレッドすべてが終了するまで待ちます。
 ブロックが与えられた場合、スレッド終了時にブロックを評価します。
@@ -42,7 +42,7 @@ ThreadsWait.all_waits(*threads) {|th| printf("end %s\n", th.inspect) }
 #=> end #<Thread:0x214f8 dead>
 ```
 
-### def new(*threads) -> ThreadsWait
+### def ThreadsWait.new(*threads) -> ThreadsWait
 
 指定されたスレッドの終了をまつための、スレッド同期オブジェクトをつくります。
 

--- a/manual/api/time.md
+++ b/manual/api/time.md
@@ -16,8 +16,8 @@ category: Date/Time
 
 ## Class Methods
 
-### def parse(date, now = Time.now) -> Time
-### def parse(date, now = Time.now) {|year| year } -> Time
+### def Time.parse(date, now = Time.now) -> Time
+### def Time.parse(date, now = Time.now) {|year| year } -> Time
 
 date を [m:Date._parse] によって
 パースして [c:Time]オブジェクトに変換します。
@@ -75,8 +75,8 @@ Time.xmlschema(date) rescue Time.parse(date)
 
 従って [m:Time.parse] の失敗はチェックすべきです。
 
-### def rfc2822(date) -> Time
-### def rfc822(date) -> Time
+### def Time.rfc2822(date) -> Time
+### def Time.rfc822(date) -> Time
 
 [RFC:2822]で定義されているdate-timeとしてdateをパースして
 [c:Time]オブジェクトに変換します。
@@ -108,7 +108,7 @@ rescue ArgumentError => err
 end
 ```
 
-### def httpdate(date) -> Time
+### def Time.httpdate(date) -> Time
 
 [RFC:2616]で定義されているHTTP-dateとしてdateをパースして
 [c:Time]オブジェクトに変換します。
@@ -136,8 +136,8 @@ rescue ArgumentError => err
 end
 ```
 
-### def xmlschema(date) -> Time
-### def iso8601(date) -> Time
+### def Time.xmlschema(date) -> Time
+### def Time.iso8601(date) -> Time
 
 XML Schema で定義されている dateTime として
 date をパースして [c:Time] オブジェクトに変換します。
@@ -175,8 +175,8 @@ end
 
 - **SEE** [m:Time#xmlschema], [m:Time#iso8601]
 
-### def strptime(date, format, now=self.now) -> Time
-### def strptime(date, format, now=self.now){|y| ... } -> Time
+### def Time.strptime(date, format, now=self.now) -> Time
+### def Time.strptime(date, format, now=self.now){|y| ... } -> Time
 
 文字列を [m:Date._strptime] を用いて [c:Time] オブジェクト
 に変換します。

--- a/manual/api/tmpdir.md
+++ b/manual/api/tmpdir.md
@@ -8,8 +8,8 @@ category: File
 
 ## Class Methods
 
-### def mktmpdir(prefix_suffix = nil, tmpdir = nil)             -> String
-### def mktmpdir(prefix_suffix = nil, tmpdir = nil){|dir| ... } -> object
+### def Dir.mktmpdir(prefix_suffix = nil, tmpdir = nil)             -> String
+### def Dir.mktmpdir(prefix_suffix = nil, tmpdir = nil){|dir| ... } -> object
 
 一時ディレクトリを作成します。
 
@@ -88,7 +88,7 @@ p FileTest.directory?(dir) #=> false
                      アプリケーションは一時ディレクトリを他のユーザか
                      ら書き込める権限に変更すべきではありません。
 
-### def tmpdir    -> String
+### def Dir.tmpdir    -> String
 
 テンポラリファイルを作成するのに使うディレクトリ(テンポラリディレクトリ)の絶対パスを
 文字列として返します。

--- a/manual/api/tracer.md
+++ b/manual/api/tracer.md
@@ -71,12 +71,12 @@ Tracer.off
 
 ## Class Methods
 
-### def new
+### def Tracer.new
 
 自身を初期化します。
 
-### def on -> nil
-### def on {...}
+### def Tracer.on -> nil
+### def Tracer.on {...}
 
 トレース出力を開始します。
 ブロックを与えられた場合はそのブロック内のみトレース出力を行います。
@@ -97,15 +97,15 @@ t.test
 
 - **SEE** [m:Tracer.off]
 
-### def off -> nil
+### def Tracer.off -> nil
 
 トレース出力を中断します。
 トレース出力を開始するには、[m:Tracer.on]を使用します。
 
 - **SEE** [m:Tracer.on]
 
-### def set_get_line_procs(filename, proc)
-### def set_get_line_procs(filename) {|line| .... }
+### def Tracer.set_get_line_procs(filename, proc)
+### def Tracer.set_get_line_procs(filename) {|line| .... }
 
 あるファイルについて利用する、行番号からソースのその行の内容を返す
 手続きを指定します。何も指定しなければデフォルトの動作が利用されます。
@@ -140,8 +140,8 @@ end
 =end
 ```
 
-### def add_filter(proc)
-### def add_filter {|event, file, line, id, binding, klass| .... }
+### def Tracer.add_filter(proc)
+### def Tracer.add_filter {|event, file, line, id, binding, klass| .... }
 
 トレース出力するかどうかを決定するフィルタを追加します。
 何もフィルタを与えない場合はすべての行についてトレース情報が出力されます。
@@ -191,12 +191,12 @@ end
 - **`klass`**:
   現在呼び出されているメソッドのクラスオブジェクト。
 
-### def verbose -> bool
-### def verbose? -> bool
+### def Tracer.verbose -> bool
+### def Tracer.verbose? -> bool
 
 真ならばトレース出力の開始や終了を知らせます。
 
-### def verbose=(flag)
+### def Tracer.verbose=(flag)
 
 トレース出力の開始や終了を知らせる文字列("Trace on"または"Trace off")が必要なら真を設定します。
 
@@ -223,11 +223,11 @@ Hello#0:t5.rb:7:IO:<:   puts "Hello"
 Trace off
 ```
 
-### def stdout -> object
+### def Tracer.stdout -> object
 
 トレース出力先を参照します。
 
-### def stdout=(fp)
+### def Tracer.stdout=(fp)
 
 トレース出力先を変更します。
 
@@ -244,43 +244,43 @@ Tracer.on {
 fp.close
 ```
 
-### def display_c_call -> bool
-### def display_c_call? -> bool
+### def Tracer.display_c_call -> bool
+### def Tracer.display_c_call? -> bool
 
 真ならば、ビルトインメソッドの呼び出しを表示します。
 デフォルトは偽です。
 
-### def display_c_call=(flag)
+### def Tracer.display_c_call=(flag)
 
 ビルトインメソッドの呼び出しを表示するかどうかを設定します。
 
 - **param** `flag` -- ビルトインメソッドの呼び出しを表示するならば、真を指定します。
 
-### def display_process_id -> bool
-### def display_process_id? -> bool
+### def Tracer.display_process_id -> bool
+### def Tracer.display_process_id? -> bool
 
 真ならば、プロセス ID を表示します。
 デフォルトは、偽です。
 
-### def display_process_id=(flag)
+### def Tracer.display_process_id=(flag)
 
 プロセス ID を表示するかどうかを設定します。
 
 - **param** `flag` -- プロセス ID を表示するならば、真を指定します。
 
-### def display_thread_id -> bool
-### def display_thread_id? -> bool
+### def Tracer.display_thread_id -> bool
+### def Tracer.display_thread_id? -> bool
 
 真ならば、スレッド ID を表示します。
 デフォルトは、真です。
 
-### def display_thread_id=(flag)
+### def Tracer.display_thread_id=(flag)
 
 スレッド ID を表示するかどうかを設定します。
 
 - **param** `flag` -- スレッド ID を表示するならば、真を指定します。
 
-### def stdout_mutex -> Mutex
+### def Tracer.stdout_mutex -> Mutex
 #%todo
 
 ## Instance Methods

--- a/manual/api/tsort.md
+++ b/manual/api/tsort.md
@@ -131,7 +131,7 @@ TSort がオブジェクトをグラフとして解釈するには2つのメソ�
 これは TSort が内部でハッシュを用いているからです。
 
 ## Class Methods
-### def tsort(each_node, each_child) -> Array
+### def TSort.tsort(each_node, each_child) -> Array
 
 頂点をトポロジカルソートして得られる配列を返します。
 この配列は子から親に向かってソートされています。
@@ -163,8 +163,8 @@ p TSort.tsort(each_node, each_child) # raises TSort::Cyclic
 
 - **SEE** [m:TSort#tsort]
 
-### def tsort_each(each_node, each_child) {|node| ...} -> nil
-### def tsort_each(each_node, each_child) -> Enumerator
+### def TSort.tsort_each(each_node, each_child) {|node| ...} -> nil
+### def TSort.tsort_each(each_node, each_child) -> Enumerator
 
 [m:TSort.tsort] メソッドのイテレータ版です。
 
@@ -193,7 +193,7 @@ TSort.tsort_each(each_node, each_child) {|n| p n }
 
 - **SEE** [m:TSort#tsort_each]
 
-### def strongly_connected_components(each_node, each_child) -> Array
+### def TSort.strongly_connected_components(each_node, each_child) -> Array
 
 強連結成分の集まりを配列の配列として返します。
 この配列は子から親に向かってソートされています。
@@ -225,8 +225,8 @@ p TSort.strongly_connected_components(each_node, each_child)
 
 - **SEE** [m:TSort#strongly_connected_components]
 
-### def each_strongly_connected_component(each_node, each_child) {|nodes| ...} -> nil
-### def each_strongly_connected_component(each_node, each_child) -> Enumerator
+### def TSort.each_strongly_connected_component(each_node, each_child) {|nodes| ...} -> nil
+### def TSort.each_strongly_connected_component(each_node, each_child) -> Enumerator
 
 [m:TSort.strongly_connected_components] メソッドのイテレータ版です。
 
@@ -263,8 +263,8 @@ TSort.each_strongly_connected_component(each_node, each_child) {|scc| p scc }
 
 - **SEE** [m:TSort#each_strongly_connected_component]
 
-### def each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) {|nodes| ...} -> ()
-### def each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) -> Enumerator
+### def TSort.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) {|nodes| ...} -> ()
+### def TSort.each_strongly_connected_component_from(node, each_child, id_map={}, stack=[]) -> Enumerator
 
 node から到達可能な強連結成分についてのイテレータです。
 

--- a/manual/api/uri/FTP.md
+++ b/manual/api/uri/FTP.md
@@ -7,8 +7,8 @@ FTP URI を表すクラスです。
 
 ## Class Methods
 
-### def build(ary)     -> URI::FTP
-### def build(hash)    -> URI::FTP
+### def URI::FTP.build(ary)     -> URI::FTP
+### def URI::FTP.build(hash)    -> URI::FTP
 
 引数で与えられた URI 構成要素から URI::FTP オブジェクトを生成します。
 引数の正当性を検査します。
@@ -46,7 +46,7 @@ p URI::FTP.build([nil, 'example.com', nil, '/foo', 'i']).to_s
 
 - **raise** `ArgumentError` -- typecode に定められた以外の文字を与えると発生します。
 
-### def new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)    -> URI::FTP
+### def URI::FTP.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)    -> URI::FTP
 
 汎用的な構成要素から URI::FTP オブジェクトを生成します。build
 と異なり、デフォルトでは引数の正当性を検査しません。
@@ -83,7 +83,7 @@ p ftp.typecode
 
 - **raise** `URI::InvalidComponentError` -- 各要素が適合しない場合に発生します。
 
-### def new2(user, password, host, port, path, typecode = nil, arg_check = true)    -> URI::FTP
+### def URI::FTP.new2(user, password, host, port, path, typecode = nil, arg_check = true)    -> URI::FTP
 
 URI::FTP オブジェクトを生成して返します。
 引数の正当性を検査します。

--- a/manual/api/uri/Generic.md
+++ b/manual/api/uri/Generic.md
@@ -12,7 +12,7 @@ hash と eql? が再定義されているため、[c:Hash] のキーとして
 
 ## Class Methods
 
-### def default_port    -> Integer | nil
+### def URI::Generic.default_port    -> Integer | nil
 
 スキームに対応するデフォルトのポート番号を整数で返します。
 
@@ -27,7 +27,7 @@ p URI::LDAPS.default_port     # => 636
 p URI::MailTo.default_port    # => nil
 ```
 
-### def component     -> [Symbol]
+### def URI::Generic.component     -> [Symbol]
 
 URI の構成要素を表すシンボルの配列を返します。
 
@@ -40,13 +40,13 @@ p URI::MailTo.component
 # => [:scheme, :to, :headers]
 ```
 
-### def use_registry    -> bool
+### def URI::Generic.use_registry    -> bool
 
 構成要素 registry を受け付けるなら true を返します。
 URI::Generic クラスでは false です。
 
-### def build2(ary)     -> URI::Generic
-### def build2(hash)    -> URI::Generic
+### def URI::Generic.build2(ary)     -> URI::Generic
+### def URI::Generic.build2(hash)    -> URI::Generic
 
 URI::Generic.build と同じですが、例外 URI::InvalidComponentError
 が発生した場合に、引数の各要素を URI.escape して再度 build を試み
@@ -63,8 +63,8 @@ URI::Generic.build と同じですが、例外 URI::InvalidComponentError
         :scheme, :userinfo, :host, :port, :registry, :path, :opaque, :query, :fragment 
   ```
 
-### def build(ary)     -> URI::Generic
-### def build(hash)    -> URI::Generic
+### def URI::Generic.build(ary)     -> URI::Generic
+### def URI::Generic.build(hash)    -> URI::Generic
 
 引数で与えられた URI 構成要素から URI::Generic オブジェクトを生成します。
 
@@ -81,7 +81,7 @@ URI::Generic.build と同じですが、例外 URI::InvalidComponentError
 
 - **raise** `URI::InvalidComponentError` -- 各要素が適合しない場合に発生します。
 
-### def new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, parser = URI::DEFAULT_PARSER, arg_check = false)    -> URI::Generic
+### def URI::Generic.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, parser = URI::DEFAULT_PARSER, arg_check = false)    -> URI::Generic
 
 各引数を成分とする URI::Generic オブジェクトを生成して返します。
 

--- a/manual/api/uri/HTTP.md
+++ b/manual/api/uri/HTTP.md
@@ -7,8 +7,8 @@ HTTP URI を表すクラスです。
 
 ## Class Methods
 
-### def build(ary)     -> URI::HTTP
-### def build(hash)    -> URI::HTTP
+### def URI::HTTP.build(ary)     -> URI::HTTP
+### def URI::HTTP.build(hash)    -> URI::HTTP
 
 引数で与えられた URI 構成要素から URI::HTTP オブジェクトを生成します。
 引数の正当性を検査します。
@@ -27,7 +27,7 @@ newuri = URI::HTTP.build({:host => 'www.example.com', :path => '/foo/bar'})
 newuri = URI::HTTP.build([nil, "www.example.com", nil, "/path", "query", 'fragment'])
 ```
 
-### def new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)     -> URI::HTTP   
+### def URI::HTTP.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)     -> URI::HTTP   
 
 汎用的な構成要素から URI::HTTP オブジェクトを生成します。build
 と異なり、デフォルトでは引数の正当性を検査しません。

--- a/manual/api/uri/LDAP.md
+++ b/manual/api/uri/LDAP.md
@@ -11,8 +11,8 @@ ldap://<host>/<dn>[?<attrs>[?<scope>[?<filter>[?<extensions>]]]]
 
 ## Class Methods
 
-### def build(ary)   -> URI::LDAP
-### def build(hash)  -> URI::LDAP
+### def URI::LDAP.build(ary)   -> URI::LDAP
+### def URI::LDAP.build(hash)  -> URI::LDAP
 
 引数で与えられた URI 構成要素から URI::LDAP オブジェクトを生成します。
 引数の正当性を検査します。
@@ -35,7 +35,7 @@ p URI::LDAP.build(["example.com", "1", "/a", "b", "c", "d", "e=f"]).to_s
 #=> "ldap://example.com:1/a?b?c?d?e=f"
 ```
 
-### def new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)   -> URI::LDAP
+### def URI::LDAP.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)   -> URI::LDAP
 
 汎用的な構成要素から URI::LDAP オブジェクトを生成します。
 build と異なり、デフォルトでは引数の正当性を検査しません。

--- a/manual/api/uri/MailTo.md
+++ b/manual/api/uri/MailTo.md
@@ -7,8 +7,8 @@ mailto URI を表すクラスです。[RFC:2368]。
 
 ## Class Methods
 
-### def build(ary)     -> URI::MailTo 
-### def build(hash)    -> URI::MailTo 
+### def URI::MailTo.build(ary)     -> URI::MailTo 
+### def URI::MailTo.build(hash)    -> URI::MailTo 
 
 引数で与えられた URI 構成要素から URI::MailTo オブジェクトを生成します。
 引数の正当性をチェックします。
@@ -28,7 +28,7 @@ mailto URI を表すクラスです。[RFC:2368]。
 
 - **raise** `URI::InvalidComponentError` -- 不正な引数に対して発生します。
 
-### def new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)    -> URI::MailTo
+### def URI::MailTo.new(scheme, userinfo, host, port, registry, path, opaque, query, fragment, arg_check = false)    -> URI::MailTo
 
 汎用的な構成要素から URI::MailTo オブジェクトを生成します。
 build と異なり、デフォルトでは引数の正当性を検査しません。

--- a/manual/api/uri/URI.md
+++ b/manual/api/uri/URI.md
@@ -16,7 +16,7 @@ URI を扱うためのモジュールです。
 
 ## Singleton Methods
 
-### def split(url)    -> [String | nil]
+### def URI.split(url)    -> [String | nil]
 
 URI を要素に分割した文字列の配列を返します。
 
@@ -42,7 +42,7 @@ p URI.split("http://www.ruby-lang.org/")
 #=> ["http", nil, "www.ruby-lang.org", nil, nil, "/", nil, nil, nil]
 ```
 
-### def parse(uri_str)    -> object
+### def URI.parse(uri_str)    -> object
 
 与えられた URI から該当する [c:URI::Generic] のサブクラスのインスタンスを生成して
 返します。scheme が指定されていない場合は、[c:URI::Generic] オブジェクトを返します。
@@ -64,7 +64,7 @@ p uri.port      # => 80
 p uri.path      # => "/"
 ```
 
-### def join(uri_str, *path)    -> object
+### def URI.join(uri_str, *path)    -> object
 
 文字列 uri_str と path ... を URI として連結して得られる
 URI オブジェクトを返します。
@@ -92,10 +92,10 @@ p URI.join('http://www.ruby-lang.org/', '/ja/man-1.6/')
 => #<URI::HTTP:0x2010017a URL:http://www.ruby-lang.org/ja/man-1.6/>
 ```
 
-### def extract(str)                               -> [String]
-### def extract(str, schemes)                      -> [String]
-### def extract(str) {|uri_str| ... }              -> nil
-### def extract(str, schemes) {|uri_str| ... }     -> nil
+### def URI.extract(str)                               -> [String]
+### def URI.extract(str, schemes)                      -> [String]
+### def URI.extract(str) {|uri_str| ... }              -> nil
+### def URI.extract(str, schemes) {|uri_str| ... }     -> nil
 
 文字列 str に対して正規表現によるマッチを試み、
 絶対URIにマッチした部分文字列からなる配列として返します。
@@ -125,8 +125,8 @@ p URI.extract(str, ["http"])
 => ["http://www.ruby-lang.org/", "http://www.ruby-lang.org/man-1.6/"]
 ```
 
-### def regexp             -> Regexp
-### def regexp(schemes)    -> Regexp
+### def URI.regexp             -> Regexp
+### def URI.regexp(schemes)    -> Regexp
 
 URIにマッチする正規表現を返します。
 
@@ -151,7 +151,7 @@ require 'uri'
 p URI.regexp =~ "http://www.ruby-lang.org/"  #=> 0
 ```
 
-### def decode_www_form(str, enc=Encoding::UTF_8) -> [[String, String]]
+### def URI.decode_www_form(str, enc=Encoding::UTF_8) -> [[String, String]]
 
 文字列から URL-encoded form data をデコードします。
 
@@ -180,7 +180,7 @@ p Hash[ary]           #=> {"a"=>"2", "b"=>"3"}
 - **raise** `ArgumentError` -- str のフォーマットが不正である場合に発生します
 - **SEE** [m:URI.decode_www_form_component], [m:URI.encode_www_form]
 
-### def decode_www_form_component(str, enc=Encoding::UTF_8) -> String
+### def URI.decode_www_form_component(str, enc=Encoding::UTF_8) -> String
 
 URL-encoded form data の文字列の各コンポーネント
 をデコードした文字列を返します。
@@ -212,7 +212,7 @@ p URI.decode_www_form_component(enc)
 - **raise** `ArgumentError` -- str のフォーマットが不正である場合に発生します
 - **SEE** [m:URI.encode_www_form_component], [m:URI.decode_www_form]
 
-### def encode_www_form(enum, enc=nil) -> String
+### def URI.encode_www_form(enum, enc=nil) -> String
 
 enum から URL-encoded form data を生成します。
 
@@ -260,7 +260,7 @@ UTF-8 に変換する場合など)。
 - **param** `enc` -- 指定された場合、パーセントエンコーディングする前に、このエンコーディングに変換
 - **SEE** [m:URI.encode_www_form_component], [m:URI.decode_www_form]
 
-### def encode_www_form_component(str, enc=nil) -> String
+### def URI.encode_www_form_component(str, enc=nil) -> String
 
 文字列を URL-encoded form data の1コンポーネント
 としてエンコードした文字列を返します。

--- a/manual/api/weakref.md
+++ b/manual/api/weakref.md
@@ -27,7 +27,7 @@ ref.some_method_of_foo
 
 ## Class Methods
 
-### def new(orig) -> WeakRef
+### def WeakRef.new(orig) -> WeakRef
 
 与えられたオブジェクトを使って自身を初期化します。
 

--- a/manual/api/webrick/cgi.md
+++ b/manual/api/webrick/cgi.md
@@ -169,7 +169,7 @@ MyCGI.new.start()
 
 ## Class Methods
 
-### def new(config = {}, *options)    -> WEBrick::CGI
+### def WEBrick::CGI.new(config = {}, *options)    -> WEBrick::CGI
 
 WEBrick::CGI オブジェクトを生成してかえします。
 

--- a/manual/api/webrick/cookie.md
+++ b/manual/api/webrick/cookie.md
@@ -10,7 +10,7 @@ RFC2109 は [rfc:2965] により破棄されましたが、WEBrick::Cookie ク�
 
 ## Class Methods
 
-### def new(name, value)    -> WEBrick::Cookie
+### def WEBrick::Cookie.new(name, value)    -> WEBrick::Cookie
 
 新しい [c:WEBrick::Cookie] オブジェクトを生成して返します。
 name にクッキーの名前を、value にクッキーで保持する値を与える。
@@ -19,7 +19,7 @@ name にクッキーの名前を、value にクッキーで保持する値を与
 
 - **param** `value` -- Cookie の値を文字列で指定します。
 
-### def parse(str)    -> [WEBrick::Cookie]
+### def WEBrick::Cookie.parse(str)    -> [WEBrick::Cookie]
 
 ユーザーエージェントから送られてきた Cookie ヘッダの値 str をパースし、
 新しく [c:WEBrick::Cookie] オブジェクトを生成しその配列を返します。
@@ -38,7 +38,7 @@ p c[1].name, c[1].path
 "/foo/hoge"
 ```
 
-### def parse_set_cookie(str)    -> WEBrick::Cookie
+### def WEBrick::Cookie.parse_set_cookie(str)    -> WEBrick::Cookie
 
 サーバから送られてくる Set-Cookie ヘッダの値 str をパースし、
 新しく [c:WEBrick::Cookie] オブジェクトを生成し返します。
@@ -56,7 +56,7 @@ p c.name, c.value
 "FedEx"
 ```
 
-### def parse_set_cookies(str)    -> [WEBrick::Cookie]
+### def WEBrick::Cookie.parse_set_cookies(str)    -> [WEBrick::Cookie]
 
 サーバから送られてくる Set-Cookie ヘッダの値 str をパースし、
 新しく [c:WEBrick::Cookie] オブジェクトの配列を生成し返します。

--- a/manual/api/webrick/httpauth/basicauth/HTTPAuth__BasicAuth.md
+++ b/manual/api/webrick/httpauth/basicauth/HTTPAuth__BasicAuth.md
@@ -25,7 +25,7 @@ srv.start # http://127.0.0.1:10080/basic_auth
 
 ## Class Methods
 
-### def make_passwd(realm, user, pass) -> String
+### def WEBrick::HTTPAuth::BasicAuth.make_passwd(realm, user, pass) -> String
 
 pass をランダムなソルトで crypt した文字列を返します。
 
@@ -35,7 +35,7 @@ pass をランダムなソルトで crypt した文字列を返します。
 
 - **param** `pass` -- パスワードを指定します。
 
-### def new(config, default = Config::BasicAuth) -> WEBrick::HTTPAuth::BasicAuth
+### def WEBrick::HTTPAuth::BasicAuth.new(config, default = Config::BasicAuth) -> WEBrick::HTTPAuth::BasicAuth
 
 BasicAuth オブジェクトを生成します。config は設定を保存したハッシュです。
 

--- a/manual/api/webrick/httpauth/digestauth/HTTPAuth__DigestAuth.md
+++ b/manual/api/webrick/httpauth/digestauth/HTTPAuth__DigestAuth.md
@@ -30,7 +30,7 @@ digest_auth = WEBrick::HTTPAuth::DigestAuth.new config
 
 ## Class Methods
 
-### def make_passwd(realm, user, pass) -> String
+### def WEBrick::HTTPAuth::DigestAuth.make_passwd(realm, user, pass) -> String
 
 与えられた情報を使用してハッシュ化したパスワードを生成します。
 
@@ -40,7 +40,7 @@ digest_auth = WEBrick::HTTPAuth::DigestAuth.new config
 
 - **param** `pass` -- パスワードを指定します。
 
-### def new(config, default = WEBrick::Config::DigestAuth) -> WEBrick::HTTPAuth::DigestAuth
+### def WEBrick::HTTPAuth::DigestAuth.new(config, default = WEBrick::Config::DigestAuth) -> WEBrick::HTTPAuth::DigestAuth
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpauth/htdigest.md
+++ b/manual/api/webrick/httpauth/htdigest.md
@@ -24,7 +24,7 @@ p htd2.get_passwd('realm', 'username', false) == '65fe03e5b0a199462186848cc7fda4
 
 ## Class Methods
 
-### def new(path) -> WEBrick::HTTPAuth::Htdigest
+### def WEBrick::HTTPAuth::Htdigest.new(path) -> WEBrick::HTTPAuth::Htdigest
 
 Htdigest オブジェクトを生成します。
 

--- a/manual/api/webrick/httpauth/htgroup.md
+++ b/manual/api/webrick/httpauth/htgroup.md
@@ -12,7 +12,7 @@ Apache で証認に使用するユーザグループの一覧が格納されて�
 
 ## Class Methods
 
-### def new(path) -> WEBrick::HTTPAuth::Htgroup
+### def WEBrick::HTTPAuth::Htgroup.new(path) -> WEBrick::HTTPAuth::Htgroup
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpauth/htpasswd.md
+++ b/manual/api/webrick/httpauth/htpasswd.md
@@ -27,7 +27,7 @@ p pass == 'supersecretpass'.crypt(pass[0,2])
 
 ## Class Methods
 
-### def new(path) -> WEBrick::HTTPAuth::Htpasswd
+### def WEBrick::HTTPAuth::Htpasswd.new(path) -> WEBrick::HTTPAuth::Htpasswd
 
 Htpasswd オブジェクトを生成します。
 

--- a/manual/api/webrick/httpproxy/HTTPProxyServer.md
+++ b/manual/api/webrick/httpproxy/HTTPProxyServer.md
@@ -22,7 +22,7 @@ s.start
 
 ## Class Methods
 
-### def new(config, default = WEBrick::Config::HTTP)    -> WEBrick::HTTPProxyServer
+### def WEBrick::HTTPProxyServer.new(config, default = WEBrick::Config::HTTP)    -> WEBrick::HTTPProxyServer
 
 プロクシオブジェクトを生成して返します。
 

--- a/manual/api/webrick/httpproxy/NullReader.md
+++ b/manual/api/webrick/httpproxy/NullReader.md
@@ -5,8 +5,8 @@ library: webrick/httpproxy
 
 空のソケットのふりをするオブジェクトです。
 
-### def read(*args) -> nil
-### def gets(*args) -> nil
+### def WEBrick::NullReader.read(*args) -> nil
+### def WEBrick::NullReader.gets(*args) -> nil
 
 常に nil を返します。
 

--- a/manual/api/webrick/httprequest.md
+++ b/manual/api/webrick/httprequest.md
@@ -17,7 +17,7 @@ HTTP リクエストのためのクラスです。
 
 ## Class Methods
 
-### def new(config) -> WEBrick::HTTPRequest
+### def WEBrick::HTTPRequest.new(config) -> WEBrick::HTTPRequest
 
 WEBrick::HTTPRequest を生成して返します。
 

--- a/manual/api/webrick/httpresponse.md
+++ b/manual/api/webrick/httpresponse.md
@@ -17,7 +17,7 @@ HTTP のレスポンスを表すためのクラスです。
 
 ## Class Methods
 
-### def new(config) -> WEBrick::HTTPResponse
+### def WEBrick::HTTPResponse.new(config) -> WEBrick::HTTPResponse
 
 HTTPResponse オブジェクトを生成して返します。
 

--- a/manual/api/webrick/httpserver/HTTPServer.md
+++ b/manual/api/webrick/httpserver/HTTPServer.md
@@ -19,7 +19,7 @@ srv.start
 
 ## Class Methods
 
-### def new(config = {}, default = WEBrick::Config::HTTP)    -> WEBrick::HTTPServer
+### def WEBrick::HTTPServer.new(config = {}, default = WEBrick::Config::HTTP)    -> WEBrick::HTTPServer
 
 HTTPServer オブジェクトを生成して返します。
 

--- a/manual/api/webrick/httpserver/HTTPServer__MountTable.md
+++ b/manual/api/webrick/httpserver/HTTPServer__MountTable.md
@@ -7,7 +7,7 @@ library: webrick/httpserver
 
 ## Class Methods
 
-### def new -> WEBrick::HTTPServer::MountTable
+### def WEBrick::HTTPServer::MountTable.new -> WEBrick::HTTPServer::MountTable
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpservlet/abstract.md
+++ b/manual/api/webrick/httpservlet/abstract.md
@@ -41,7 +41,7 @@ srv.start
 
 ## Class Methods
 
-### def new(server, *options)    -> WEBrick::HTTPServlet::AbstractServlet
+### def WEBrick::HTTPServlet::AbstractServlet.new(server, *options)    -> WEBrick::HTTPServlet::AbstractServlet
 
 サーブレットを生成して返します。
 [c:WEBrick::HTTPServer] オブジェクトは server に自身を指定してサーブレットを生成します。
@@ -50,7 +50,7 @@ srv.start
 
 - **param** `options` -- [m:WEBrick::HTTPServer#mount] 第3引数以降に指定された値がそのまま与えられます。
 
-### def get_instance(server, *options)    -> WEBrick::HTTPServlet::AbstractServlet
+### def WEBrick::HTTPServlet::AbstractServlet.get_instance(server, *options)    -> WEBrick::HTTPServlet::AbstractServlet
 
 new(server, *options) を呼び出してサーブレットを生成して返します。
 [c:WEBrick::HTTPServer] オブジェクトは実際にはこの get_instance メソッドを呼び出して

--- a/manual/api/webrick/httpservlet/cgihandler.md
+++ b/manual/api/webrick/httpservlet/cgihandler.md
@@ -12,7 +12,7 @@ CGI を扱うためのサーブレットです。
 
 ## Class Methods
 
-### def new(server, name) -> WEBrick::HTTPServlet::CGIHandler
+### def WEBrick::HTTPServlet::CGIHandler.new(server, name) -> WEBrick::HTTPServlet::CGIHandler
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpservlet/erbhandler.md
+++ b/manual/api/webrick/httpservlet/erbhandler.md
@@ -11,7 +11,7 @@ ERB を扱うためのサーブレットです。
 
 ## Class Methods
 
-### def new(server, name) -> WEBrick::HTTPServlet::ERBHandler
+### def WEBrick::HTTPServlet::ERBHandler.new(server, name) -> WEBrick::HTTPServlet::ERBHandler
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpservlet/filehandler/HTTPServlet__DefaultFileHandler.md
+++ b/manual/api/webrick/httpservlet/filehandler/HTTPServlet__DefaultFileHandler.md
@@ -8,7 +8,7 @@ library: webrick/httpservlet/filehandler
 
 ## Class Methods
 
-### def new(server, local_path) -> WEBrick::HTTPServlet::DefaultFileHandler
+### def WEBrick::HTTPServlet::DefaultFileHandler.new(server, local_path) -> WEBrick::HTTPServlet::DefaultFileHandler
 
 DefaultFileHandler サーブレットを生成します。ユーザが直接使うことはあま
 りありません。

--- a/manual/api/webrick/httpservlet/filehandler/HTTPServlet__FileHandler.md
+++ b/manual/api/webrick/httpservlet/filehandler/HTTPServlet__FileHandler.md
@@ -7,7 +7,7 @@ library: webrick/httpservlet/filehandler
 
 ## Class Methods
 
-### def add_handler(suffix, handler)
+### def WEBrick::HTTPServlet::FileHandler.add_handler(suffix, handler)
 #%# -> discard
 与えられた拡張子のファイルを処理するためのサーブレットを登録します。
 
@@ -15,13 +15,13 @@ library: webrick/httpservlet/filehandler
 
 - **param** `handler` -- サーブレットを指定します。
 
-### def remove_handler(suffix) -> Class
+### def WEBrick::HTTPServlet::FileHandler.remove_handler(suffix) -> Class
 
 与えられた拡張子に対応するサーブレットを削除します。
 
 - **param** `suffix` -- 拡張子を指定します。
 
-### def new(server, root, options = {}, default = WEBrick::Config::FileHandler)
+### def WEBrick::HTTPServlet::FileHandler.new(server, root, options = {}, default = WEBrick::Config::FileHandler)
 
 FileHandler サーブレットを生成します。ユーザが直接使うことはあまりあり
 ません。

--- a/manual/api/webrick/httpservlet/prochandler.md
+++ b/manual/api/webrick/httpservlet/prochandler.md
@@ -14,7 +14,7 @@ require:
 
 ## Class Methods
 
-### def new(proc) -> WEBrick::HTTPServlet::ProcHandler
+### def WEBrick::HTTPServlet::ProcHandler.new(proc) -> WEBrick::HTTPServlet::ProcHandler
 
 自身を初期化します。
 

--- a/manual/api/webrick/httpstatus.md
+++ b/manual/api/webrick/httpstatus.md
@@ -23,7 +23,7 @@ StandardError
 
 ## Singleton Methods
 
-### def [](code)    -> Class
+### def WEBrick::HTTPStatus.[](code)    -> Class
 
 指定された整数が表すステータスコードに対応する WEBrick::HTTPStatus::Status
 のサブクラスを返します。

--- a/manual/api/webrick/httputils/HTTPUtils__FormData.md
+++ b/manual/api/webrick/httputils/HTTPUtils__FormData.md
@@ -23,7 +23,7 @@ library: webrick/httputils
 
 ## Class Methods
 
-### def new(*args)   -> WEBrick::HTTPUtils::FormData
+### def WEBrick::HTTPUtils::FormData.new(*args)   -> WEBrick::HTTPUtils::FormData
 
 WEBrick::HTTPUtils の内部で使われます。ユーザがこのメソッドを直接呼ぶことはありません。
 

--- a/manual/api/webrick/httpversion.md
+++ b/manual/api/webrick/httpversion.md
@@ -9,13 +9,13 @@ HTTP のバージョンのための小さなクラスです。
 バージョン同士の比較のために使います。
 
 ## Class Methods
-### def new(version)    -> WEBrick::HTTPVersion
+### def WEBrick::HTTPVersion.new(version)    -> WEBrick::HTTPVersion
 
 HTTPVersion オブジェクトを生成します。version は文字列か HTTPVersion オブジェクトです。
 
 - **param** `version` -- HTTP のバージョンを WEBrick::HTTPVersion オブジェクトか文字列で指定します。
 
-### def convert(version)    -> WEBrick::HTTPVersion
+### def WEBrick::HTTPVersion.convert(version)    -> WEBrick::HTTPVersion
 
 指定された version を HTTPVersion オブジェクトに変換して返します。
 version が HTTPVersion オブジェクトの場合はそのまま version を返します。

--- a/manual/api/webrick/log/BasicLog.md
+++ b/manual/api/webrick/log/BasicLog.md
@@ -7,7 +7,7 @@ library: webrick/log
 
 ## Class Methods
 
-### def new(log_file = nil, level = WEBrick::BasicLog::INFO)    -> WEBrick::BasicLog
+### def WEBrick::BasicLog.new(log_file = nil, level = WEBrick::BasicLog::INFO)    -> WEBrick::BasicLog
 
 WEBrick::BasicLog オブジェクトを生成して返します。
 

--- a/manual/api/webrick/server/GenericServer.md
+++ b/manual/api/webrick/server/GenericServer.md
@@ -8,7 +8,7 @@ library: webrick/server
 
 ## Class Methods
 
-### def new(config = {}, default = WEBrick::Config::General) -> WEBrick::GenericServer
+### def WEBrick::GenericServer.new(config = {}, default = WEBrick::Config::General) -> WEBrick::GenericServer
 
 GenericServer オブジェクトを生成して返します。
 

--- a/manual/api/webrick/ssl.md
+++ b/manual/api/webrick/ssl.md
@@ -11,7 +11,7 @@ ruby 1.8.3 以降では単に require するだけでは SSL/TLS は有効では
 
 ## Class Methods
 
-### def new(config = {}, default = WEBrick::Config::General) -> WEBrick::GenericServer
+### def WEBrick::GenericServer.new(config = {}, default = WEBrick::Config::General) -> WEBrick::GenericServer
 
 GenericServer オブジェクトを生成して返します。
 

--- a/manual/api/win32/registry/Win32__Registry.md
+++ b/manual/api/win32/registry/Win32__Registry.md
@@ -8,10 +8,10 @@ include:
 
 ## Class Methods
 
-### def new(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED)
-### def new(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED) {|reg| ... }
-### def open(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED)
-### def open(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED) {|reg| ... }
+### def Win32::Registry.new(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED)
+### def Win32::Registry.new(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED) {|reg| ... }
+### def Win32::Registry.open(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED)
+### def Win32::Registry.open(key, subkey, desired = KEY_READ, opt = REG_OPTION_RESERVED) {|reg| ... }
 #%todo
 
 レジストリキー key 下のキー subkey を開き、
@@ -26,8 +26,8 @@ desired はアクセスマスクです。opt はキーのオプションです�
 
 ブロックが与えられると、キーは自動的に閉じられます。
 
-### def create(key, subkey, desired = KEY_ALL_ACCESS, opt = REG_OPTION_RESERVED)
-### def create(key, subkey, desired = KEY_ALL_ACCESS, opt = REG_OPTION_RESERVED) {|reg| ... }
+### def Win32::Registry.create(key, subkey, desired = KEY_ALL_ACCESS, opt = REG_OPTION_RESERVED)
+### def Win32::Registry.create(key, subkey, desired = KEY_ALL_ACCESS, opt = REG_OPTION_RESERVED) {|reg| ... }
 #%todo
 
 レジストリキー key 下にキー subkey を作成し、
@@ -40,7 +40,7 @@ key は親のキーを Win32::Registry オブジェクトで指定します。
 
 ブロックが与えられると、キーは自動的に閉じられます。
 
-### def expand_environ(str)
+### def Win32::Registry.expand_environ(str)
 #%todo
 
 str の %\w+% という並びを環境変数に置換します。
@@ -50,12 +50,12 @@ REG_EXPAND_SZ で用いられます。
 
 - ExpandEnvironmentStrings: <http://msdn.microsoft.com/library/en-us/sysinfo/base/expandenvironmentstrings.asp>
 
-### def type2name(type)
+### def Win32::Registry.type2name(type)
 #%todo
 
 レジストリ値の型を整数から可読文字列に変換します。
 
-### def wtime2time(wtime)
+### def Win32::Registry.wtime2time(wtime)
 #%todo
 
 64bit の FILETIME を Time オブジェクトに変換します。
@@ -64,7 +64,7 @@ REG_EXPAND_SZ で用いられます。
 
 - FILETIME Structure: <http://msdn.microsoft.com/library/en-us/sysinfo/base/filetime_str.asp>
 
-### def time2wtime(time)
+### def Win32::Registry.time2wtime(time)
 #%todo
 
 Time オブジェクトまたは Integer オブジェクトを受け取り、

--- a/manual/api/win32/registry/Win32__Registry__PredefinedKey.md
+++ b/manual/api/win32/registry/Win32__Registry__PredefinedKey.md
@@ -5,7 +5,7 @@ library: win32/registry
 
 ## Class Methods
 
-### def new(hkey, keyname)
+### def Win32::Registry::PredefinedKey.new(hkey, keyname)
 #%todo
 
 ## Instance Methods

--- a/manual/api/win32ole/WIN32OLE.md
+++ b/manual/api/win32ole/WIN32OLE.md
@@ -73,7 +73,7 @@ excel.Quit
 
 ## Class Methods
 
-### def create_guid -> String
+### def WIN32OLE.create_guid -> String
 
 GUID(グローバル一意識別子：Global Unique Identifier)を生成します。
 
@@ -94,7 +94,7 @@ FFはGUIDの先頭からのバイト位置を示します。これはレジス�
 p WIN32OLE.create_guid # => "{????????-????-????-????-????????????}"
 ```
 
-### def locale -> Integer
+### def WIN32OLE.locale -> Integer
 
 WIN32OLEがオートメーション呼び出し時に設定するロケール識別子(LCID)を取
 得します。
@@ -113,7 +113,7 @@ OLEオートメーションでは、UNIXで利用される"ja_JP"などの国名
 lcid = WIN32OLE.locale
 ```
 
-### def locale=(lcid)
+### def WIN32OLE.locale=(lcid)
 
 WIN32OLEがオートメーション呼び出し時に設定するロケール識別子(LCID)を設
 定します。
@@ -135,7 +135,7 @@ obj = WIN32OLE_VARIANT.new("$100,000", WIN32OLE::VARIANT::VT_CY)
 
 オブジェクトがサポートしていないロケールを設定した場合、オブジェクトのメソッド呼び出し時にDISP_E_UNKNOWNLCID(HRESULT error code:0x8002000C)や、TYPE_E_INVDATAREAD(HRESULT error code:0x80028018)などを理由としたWIN32OLERuntimeError例外となります。ほとんどすべての場合において、既定値を変更する必要はありません。
 
-### def codepage -> Integer
+### def WIN32OLE.codepage -> Integer
 
 WIN32OLEがOLEオートメーションのインターフェイスに利用するコードページを
 取得します。
@@ -156,7 +156,7 @@ Encoding.default_internalがnilの場合はEncoding.default_externalによって
 p WIN32OLE.codepage # => 932 （日本語Windowsの既定値）
 ```
 
-### def codepage=(cp)
+### def WIN32OLE.codepage=(cp)
 
 WIN32OLEがOLEオートメーションのインターフェイスに利用するコードページを
 設定します。
@@ -175,7 +175,7 @@ Encoding.default_internalまたはEncoding.default_externalから適切なコー
 WIN32OLE.codepage = WIN32OLE::CP_UTF8
 ```
 
-### def connect(ole) -> WIN32OLE
+### def WIN32OLE.connect(ole) -> WIN32OLE
 
 現在実行中のOLEオートメーションサーバに接続します。
 
@@ -207,7 +207,7 @@ p WIN32OLE.connect('Excel.Application') # => WIN32OLE object which represents ru
   <http://msdn.microsoft.com/en-us/library/ms691261(v=VS.85).aspx>
   を参照してください。
 
-### def const_load(ole, mod = WIN32OLE) -> ()
+### def WIN32OLE.const_load(ole, mod = WIN32OLE) -> ()
 
 OLEオートメーションサーバが保持する定数を読み込み、指定されたモジュール
 に組み込みます。
@@ -256,7 +256,7 @@ WIN32OLE.const_load('Microsoft Office 9.0 Object Library', MSO)
 puts MSO::MsoLineSingle # => 1
 ```
 
-### def new(server, host=nil) -> WIN32OLE
+### def WIN32OLE.new(server, host=nil) -> WIN32OLE
 
 OLEオートメーションサーバを生成します。
 
@@ -285,7 +285,7 @@ p WIN32OLE.new('Excel.Application') # => Excel OLE Automation WIN32OLE object.
 p WIN32OLE.new('{00024500-0000-0000-C000-000000000046}') # => Excel OLE Automation WIN32OLE object.
 ```
 
-### def ole_free(aWIN32OLE) -> Integer
+### def WIN32OLE.ole_free(aWIN32OLE) -> Integer
 
 引数で指定したオブジェクトを解放します。
 
@@ -299,7 +299,7 @@ p WIN32OLE.new('{00024500-0000-0000-C000-000000000046}') # => Excel OLE Automati
 - **return** -- Releaseの戻り値。COMの仕様上は現在のオブジェクトの参照カウント
         値を示します。
 
-### def ole_reference_count(aWIN32OLE) -> Integer
+### def WIN32OLE.ole_reference_count(aWIN32OLE) -> Integer
 
 引数で指定したオブジェクトの現在の参照カウント値を返します。
 
@@ -313,7 +313,7 @@ p WIN32OLE.new('{00024500-0000-0000-C000-000000000046}') # => Excel OLE Automati
 - **return** -- AddRef呼び出し後のReleaseの戻り値。COMの仕様上は現在のオブジェ
         クトの参照カウント値を示します。
 
-### def ole_show_help(obj, helpcontext = nil) -> ()
+### def WIN32OLE.ole_show_help(obj, helpcontext = nil) -> ()
 
 WIN32OLEオブジェクトのヘルプファイルを表示します。
 

--- a/manual/api/win32ole/WIN32OLE_EVENT.md
+++ b/manual/api/win32ole/WIN32OLE_EVENT.md
@@ -38,7 +38,7 @@ end
 
 ## Class Methods
 
-### def message_loop -> ()
+### def WIN32OLE_EVENT.message_loop -> ()
 
 Windowsのメッセージポンプを実行します。
 
@@ -75,7 +75,7 @@ end
 い。message_loopメソッドの呼び出し中はRubyのスレッドの切り替えは行われ
 ません。
 
-### def new(ole, event = nil) -> WIN32OLE_EVENT
+### def WIN32OLE_EVENT.new(ole, event = nil) -> WIN32OLE_EVENT
 
 OLEオートメーションサーバのイベント受信機構をオブジェクト化して返します。
 

--- a/manual/api/win32ole/WIN32OLE_METHOD.md
+++ b/manual/api/win32ole/WIN32OLE_METHOD.md
@@ -33,7 +33,7 @@ SIGNATURE
 
 ## Class Methods
 
-### def new(ole_type,  method) -> WIN32OLE_METHOD
+### def WIN32OLE_METHOD.new(ole_type,  method) -> WIN32OLE_METHOD
 
 [c:WIN32OLE_TYPE]とメソッド名を指定してWIN32OLE_METHODのインスタンス
 を生成します。

--- a/manual/api/win32ole/WIN32OLE_PARAM.md
+++ b/manual/api/win32ole/WIN32OLE_PARAM.md
@@ -26,7 +26,7 @@ puts param1.name # => Filename
 
 ## Class Methods
 
-### def new(ole_method,  index) -> WIN32OLE_PARAM
+### def WIN32OLE_PARAM.new(ole_method,  index) -> WIN32OLE_PARAM
 
 メソッドとパラメータ位置を指定してWIN32OLE_PARAMのインスタンスを作成します。
 

--- a/manual/api/win32ole/WIN32OLE_RECORD.md
+++ b/manual/api/win32ole/WIN32OLE_RECORD.md
@@ -52,7 +52,7 @@ book.cost  # => 20
 
 ## Class Methods
 
-### def new(typename, obj) -> WIN32OLE_RECORD
+### def WIN32OLE_RECORD.new(typename, obj) -> WIN32OLE_RECORD
 
 WIN32OLE_RECORDオブジェクトを生成します。
 

--- a/manual/api/win32ole/WIN32OLE_TYPE.md
+++ b/manual/api/win32ole/WIN32OLE_TYPE.md
@@ -29,7 +29,7 @@ Ruby-1.9.1以降、[c:WIN32OLE_TYPELIB]オブジェクトの
 
 ## Class Methods
 
-### def new(libname, ole_class) -> WIN32OLE_TYPE
+### def WIN32OLE_TYPE.new(libname, ole_class) -> WIN32OLE_TYPE
 
 WIN32OLE_TYPEオブジェクトを生成します。
 
@@ -50,7 +50,7 @@ TypeLibに定義されているすべての型を取得するには、
 [c:WIN32OLE_TYPELIB]オブジェクトの[m:WIN32OLE_TYPELIB#ole_types]メ
 ソッドを利用します。
 
-### def ole_classes(libname) -> [WIN32OLE_TYPE]
+### def WIN32OLE_TYPE.ole_classes(libname) -> [WIN32OLE_TYPE]
 
 TypeLibで定義されているすべての型情報を取得します。
 
@@ -70,7 +70,7 @@ Ruby-1.9.1からは、TypeLibに定義されているすべての型を取得す
 [c:WIN32OLE_TYPELIB]オブジェクトの[m:WIN32OLE_TYPELIB#ole_types]メ
 ソッドを利用してください。
 
-### def progids -> [String]
+### def WIN32OLE_TYPE.progids -> [String]
 
 システムに登録されているすべてのコンポーネントクラスのPROGIDを取得します。
 
@@ -98,7 +98,7 @@ PROGIDは、生成可能なOLEオートメーションサーバのCoClass（コ�
 クラス）が持つレジストリ登録名です。[m:WIN32OLE.new]の引数に指定して
 WIN32OLEオブジェクトを生成できます。
 
-### def typelibs -> [String]
+### def WIN32OLE_TYPE.typelibs -> [String]
 
 システムに登録されているすべてのTypeLibのドキュメント文字列を取得します。
 

--- a/manual/api/win32ole/WIN32OLE_TYPELIB.md
+++ b/manual/api/win32ole/WIN32OLE_TYPELIB.md
@@ -51,7 +51,7 @@ creatable classes:
 
 ## Class Methods
 
-### def new(libname, mjv = nil, miv = nil) -> WIN32OLE_TYPELIB
+### def WIN32OLE_TYPELIB.new(libname, mjv = nil, miv = nil) -> WIN32OLE_TYPELIB
 
 WIN32OLE_TYPELIBオブジェクトを生成します。
 
@@ -89,7 +89,7 @@ TypeLibは、レジストリのHKEY_CLASS_ROOT\TypeLibキーの下にGUIDをキ�
 ドキュメント文字列は、コンテキストヘルプなどに利用可能なTypeLibの簡単な
 説明文で、通常バージョン番号を含みます。
 
-### def typelibs -> [WIN32OLE_TYPELIB]
+### def WIN32OLE_TYPELIB.typelibs -> [WIN32OLE_TYPELIB]
 
 システムに登録されているすべてのTypeLibを取得します。
 

--- a/manual/api/win32ole/WIN32OLE_VARIANT.md
+++ b/manual/api/win32ole/WIN32OLE_VARIANT.md
@@ -62,7 +62,7 @@ Openを実行します。
 
 ## Class Methods
 
-### def array(dims, vt) -> WIN32OLE_VARIANT
+### def WIN32OLE_VARIANT.array(dims, vt) -> WIN32OLE_VARIANT
 
 配列用のVARIANTオブジェクトを生成します。
 
@@ -84,7 +84,7 @@ ruby_ary = ole_ary.value # => [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
 
 - **SEE** [m:WIN32OLE_VARIANT#value], [c:WIN32OLE::VARIANT]
 
-### def new(val, vartype = nil) -> WIN32OLE_VARIANT
+### def WIN32OLE_VARIANT.new(val, vartype = nil) -> WIN32OLE_VARIANT
 
 指定したオブジェクトを値とするWIN32OLE_VARIANTオブジェクトを生成します。
 

--- a/manual/api/yaml/rubytypes.md
+++ b/manual/api/yaml/rubytypes.md
@@ -33,7 +33,7 @@ end
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Object.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -132,7 +132,7 @@ p c.to_yaml_properties
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Hash.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -173,11 +173,11 @@ foo: bar
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Struct.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_class_name -> String
+### def Struct.yaml_tag_class_name -> String
 
 自身のクラス名から Struct:: をのぞいた文字列を返します。
 
@@ -191,13 +191,13 @@ p YStruct::yaml_tag_class_name
 #=> "YStruct"
 ```
 
-### def yaml_tag_subclasses? -> true
+### def Struct.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_read_class(name) -> String
+### def Struct.yaml_tag_read_class(name) -> String
 
 引数 name に Struct:: を加えた文字列を返します。
 
@@ -246,7 +246,7 @@ baz: baz
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Array.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -289,11 +289,11 @@ print [1, 2, 3].to_yaml
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Exception.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def Exception.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -323,11 +323,11 @@ print [1, 2, 3].to_yaml
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def String.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def String.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -396,11 +396,11 @@ print "foo".to_yaml # => --- foo
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Symbol.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def Symbol.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -435,11 +435,11 @@ print :foo.to_yaml # => --- :foo
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Range.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def Range.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -478,11 +478,11 @@ excl: false
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Regexp.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def Regexp.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -517,11 +517,11 @@ print /foo|bar/.to_yaml # => --- !ruby/regexp /foo|bar/
 
 ## Class Methods
 
-### def yaml_new(klass, tag, val)
+### def Time.yaml_new(klass, tag, val)
 
 ライブラリ内部で使用します。
 
-### def yaml_tag_subclasses? -> true
+### def Time.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -556,7 +556,7 @@ print Time.now.to_yaml # => --- 2011-12-31 02:17:31.192322 +09:00
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Date.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -591,7 +591,7 @@ print Date.today.to_yaml # => --- 2011-12-31
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Integer.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -627,7 +627,7 @@ print -1.to_yaml # => --- -1
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def Float.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -666,7 +666,7 @@ print (0.0/0.0).to_yaml  # => --- .NaN
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def TrueClass.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -701,7 +701,7 @@ print true.to_yaml # => --- true
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def FalseClass.yaml_tag_subclasses? -> true
 
 常に true を返します。
 
@@ -736,7 +736,7 @@ print false.to_yaml # => --- false
 
 ## Class Methods
 
-### def yaml_tag_subclasses? -> true
+### def NilClass.yaml_tag_subclasses? -> true
 
 常に true を返します。
 

--- a/manual/api/yaml/store.md
+++ b/manual/api/yaml/store.md
@@ -49,8 +49,8 @@ greeting:
 
 #%# 最終的にPStore.newに渡されるためメソッドシグネチャは2.4.0以前と同様
 #%# にしてある。
-### def new(file_name, yaml_opts = {})                      -> YAML::Store
-### def new(file_name, thread_safe = false, yaml_opts = {}) -> YAML::Store
+### def YAML::Store.new(file_name, yaml_opts = {})                      -> YAML::Store
+### def YAML::Store.new(file_name, thread_safe = false, yaml_opts = {}) -> YAML::Store
 
 自身を初期化します。
 

--- a/manual/api/yaml/stream.md
+++ b/manual/api/yaml/stream.md
@@ -12,7 +12,7 @@ Rubyist Magazine: <https://magazine.rubyist.net/>
 
 ## class methods
 
-### def new(opts = {}) -> Syck::Stream
+### def Syck::Stream.new(opts = {}) -> Syck::Stream
 
 ストリームを返します。ストリームはYAMLドキュメントを複数保持できます。
 

--- a/manual/api/yaml/stringio.md
+++ b/manual/api/yaml/stringio.md
@@ -7,7 +7,7 @@
 
 ## Class Methods
 
-### def make_stream(io) -> StringIO | IO
+### def Syck.make_stream(io) -> StringIO | IO
 
 引数を元にストリームオブジェクトを作成します。
 

--- a/manual/api/yaml/tag.md
+++ b/manual/api/yaml/tag.md
@@ -4,7 +4,7 @@
 
 ## Class Methods
 
-### def tag_class(tag, cls) -> ()
+### def Syck.tag_class(tag, cls) -> ()
 
 tag で指定したタグ URI に　cls で指定したクラスを関連付けます。
 
@@ -14,7 +14,7 @@ tag で指定したタグ URI に　cls で指定したクラスを関連付け�
 
 - **SEE** [m:Syck.tagged_classes]
 
-### def tagged_classes -> {String => Class}
+### def Syck.tagged_classes -> {String => Class}
 
 タグ URI と、それが対応するクラスの一覧を返します。
 

--- a/manual/api/yaml/yamlnode.md
+++ b/manual/api/yaml/yamlnode.md
@@ -12,7 +12,7 @@ YAML のノードを表現するためのクラスです。
 
 ## class methods
 
-### def new(type, val) -> Syck::YamlNode
+### def Syck::YamlNode.new(type, val) -> Syck::YamlNode
 
 自身を初期化します。
 

--- a/manual/api/yaml/ypath.md
+++ b/manual/api/yaml/ypath.md
@@ -43,7 +43,7 @@ Rubyist Magazine: <https://magazine.rubyist.net/>
 
 ## class methods
 
-### def new(str) -> Syck::YPath
+### def Syck::YPath.new(str) -> Syck::YPath
 
 自身を初期化します。
 
@@ -59,7 +59,7 @@ p YAML::YPath.new(str)
 #=> #<YAML::YPath:0x3238cc @predicates=[":hoge", nil, nil], @segments=["ugo", "0", "name"], @flags=nil>
 ```
 
-### def each_path(str) {|ypath| ...} -> Array
+### def Syck::YPath.each_path(str) {|ypath| ...} -> Array
 
 引数 str を [c:Syck::YPath] が
 検索できる複数のパスに再構築して、その各パスに対してブロックを評価します。

--- a/manual/api/zlib/Deflate.md
+++ b/manual/api/zlib/Deflate.md
@@ -7,7 +7,7 @@ library: zlib
 
 ## Class Methods
 
-### def deflate(string, level = Zlib::DEFAULT_COMPRESSION ) -> String
+### def Zlib::Deflate.deflate(string, level = Zlib::DEFAULT_COMPRESSION ) -> String
 
 string を圧縮します。level の有効な値は
 [m:Zlib::NO_COMPRESSION], [m:Zlib::BEST_SPEED],
@@ -58,7 +58,7 @@ p str.size #=> 500
 #=> 194
 ```
 
-### def new(level = Zlib::DEFAULT_COMPRESSION, windowBits = Zlib::MAX_WBITS, memlevel = Zlib::DEF_MEM_LEVEL, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::Deflate
+### def Zlib::Deflate.new(level = Zlib::DEFAULT_COMPRESSION, windowBits = Zlib::MAX_WBITS, memlevel = Zlib::DEF_MEM_LEVEL, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::Deflate
 
 圧縮ストリームを作成します。各引数の詳細は zlib.h を
 参照して下さい。nil の場合はデフォルトの値を使用します。

--- a/manual/api/zlib/GzipFile.md
+++ b/manual/api/zlib/GzipFile.md
@@ -12,7 +12,7 @@ IO クラスのインスタンス (又は IO クラスのインスタンスと�
 
 ## Class Methods
 
-### def new(*args) -> ()
+### def Zlib::GzipFile.new(*args) -> ()
 
 直接使用しません。
 通常、具体的な読み書きをおこなうためには、
@@ -20,7 +20,7 @@ IO クラスのインスタンス (又は IO クラスのインスタンスと�
 
 - **SEE** [m:Zlib::GzipReader.new], [m:Zlib::GzipWriter.new] 
 
-### def wrap(*args) {|gz| ... } -> ()
+### def Zlib::GzipFile.wrap(*args) {|gz| ... } -> ()
 
 直接使用しません。
 通常、具体的な読み書きをおこなうためには、
@@ -28,7 +28,7 @@ IO クラスのインスタンス (又は IO クラスのインスタンスと�
 
 - **SEE** [m:Zlib::GzipReader.wrap],[m:Zlib::GzipWriter.wrap]
 
-### def open(*args) {|gz| ... } -> ()
+### def Zlib::GzipFile.open(*args) {|gz| ... } -> ()
 
 直接使用しません。
 通常、具体的な読み書きをおこなうためには、

--- a/manual/api/zlib/GzipReader.md
+++ b/manual/api/zlib/GzipReader.md
@@ -30,7 +30,7 @@ gz.close
 
 ## Class Methods
 
-### def new(io) -> Zlib::GzipReader
+### def Zlib::GzipReader.new(io) -> Zlib::GzipReader
 
 io と関連付けられた GzipReader オブジェクトを作成します。
 
@@ -59,8 +59,8 @@ rescue Zlib::GzipFile::Error => err
 end
 ```
 
-### def wrap(io) -> Zlib::GzipReader
-### def wrap(io) {|gz| ... } -> object
+### def Zlib::GzipReader.wrap(io) -> Zlib::GzipReader
+### def Zlib::GzipReader.wrap(io) {|gz| ... } -> object
 
 io と関連付けられた GzipReader オブジェクトを作成します。
 
@@ -96,8 +96,8 @@ Zlib::GzipReader.wrap(f){|gz|
 p f.closed? #=> false
 ```
 
-### def open(filename) -> Zlib::GzipReader
-### def open(filename) {|gz| ... } -> object
+### def Zlib::GzipReader.open(filename) -> Zlib::GzipReader
+### def Zlib::GzipReader.open(filename) {|gz| ... } -> object
 
 filename で指定されるファイルを gzip ファイルとして
 オープンします。GzipReader オブジェクトを返します。

--- a/manual/api/zlib/GzipWriter.md
+++ b/manual/api/zlib/GzipWriter.md
@@ -27,7 +27,7 @@ gz.close
 
 ## Class Methods
 
-### def new(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
+### def Zlib::GzipWriter.new(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
 
 io と関連付けられた GzipWriter オブジェクトを作成します。
 level, strategy は [m:Zlib::Deflate.new] と同じです。
@@ -52,8 +52,8 @@ p gz.closed? #=> true
 p FileTest.size(filename) #=> 32
 ```
 
-### def wrap(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
-### def wrap(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) {|gz| ... } -> object
+### def Zlib::GzipWriter.wrap(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
+### def Zlib::GzipWriter.wrap(io, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) {|gz| ... } -> object
 
 io と関連付けられた GzipWriter オブジェクトを作成します。
 ブロックが与えられた場合、
@@ -98,8 +98,8 @@ case1
 case2
 ```
 
-### def open(filename, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
-### def open(filename, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) {|gz| ... } -> object
+### def Zlib::GzipWriter.open(filename, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) -> Zlib::GzipWriter
+### def Zlib::GzipWriter.open(filename, level = Zlib::DEFAULT_COMPRESSION, strategy = Zlib::DEFAULT_STRATEGY) {|gz| ... } -> object
 
 filename で指定されるファイルを gzip 圧縮データの
 書き出し用にオープンします。GzipWriter オブジェクトを返します。

--- a/manual/api/zlib/Inflate.md
+++ b/manual/api/zlib/Inflate.md
@@ -8,7 +8,7 @@ library: zlib
 
 ## Class Methods
 
-### def inflate(string) -> String
+### def Zlib::Inflate.inflate(string) -> String
 
 string を展開します。
 
@@ -37,7 +37,7 @@ cstr = "x\234\313\310OOUH+MOTH\315K\001\000!\251\004\276"
 p Zlib::Inflate.inflate(cstr) #=> "hoge fuga end"
 ```
 
-### def new(window_bits = Zlib::MAX_WBITS) -> Zlib::Inflate
+### def Zlib::Inflate.new(window_bits = Zlib::MAX_WBITS) -> Zlib::Inflate
 
 展開ストリームを作成します。
 

--- a/manual/api/zlib/ZStream.md
+++ b/manual/api/zlib/ZStream.md
@@ -44,7 +44,7 @@ String オブジェクトとして返します。
 
 ## Class Methods
 
-### def new -> ()
+### def Zlib::ZStream.new -> ()
 
 直接使用しません。
 通常、具体的な圧縮/展開を行う場合は、


### PR DESCRIPTION
特異メソッドのエントリを、セクション見出し(`## Class Methods` 等)に頼らず **`def` の行だけを見てメソッド種別が分かる** `### def Klass.name` 形式に統一します(MARKUP_SPEC §3.1 の推奨形式)。#3291 のような分類間違いをビルド時に機械検出するための前提整備で、この後 bitclust 側の検査 PR(rurema/bitclust#310)をマージすると、キーワード不一致(メソッドセクション配下の `const` 等)がエラーになります。

**この PR は現行の bitclust(1.6 系 master)でそのままビルドできる変更のみです。** `def self.name` 対応(rurema/bitclust#309)に依存する `main.md` の書き換え(14 行)は別ブランチに分離しました(#309 マージ後に別 PR として出します)。

## 内容

- **機械置換(1 コミット目)**: 特異メソッドセクション(class/singleton methods 系見出し。大文字小文字・単複の揺れを含む)配下の、プレフィクスなし `### def` 行 **1861 行(432 ファイル)** に、直前の H1 のエンティティ名を前置。コードフェンス内は対象外
- **分類間違いの修正(2 コミット目)**: 特異メソッドセクション配下に `const` で書かれていた `IRB.CurrentContext` と `Readline.get_screen_size` を `def` に修正(#3291 の Thread.DEBUG と同型。型はセクションで決まっているため描画は変わりません)
- **検査で見つかった残りの追随修正(3 コミット目)**: bitclust 側の書式検査を有効にして全 7 版をパースし、さらに見つかったものを修正
  - Constants セクション配下に `def` で書かれていた定数 **14 件**を `const` に(`GC::INTERNAL_CONSTANTS`・`RubyVM::DEFAULT_PARAMS`・`Ripper::PARSER_EVENT_TABLE` など。#3291 と逆方向の分類間違い。描画不変)
  - 取り込み断片への対応: `Fiber.current.md`(特異メソッドセクションへ `#%include` される断片)に `Fiber.` を前置、`functions_pp.md` を `module_function def` に
  - `strscan.md`: `def` の後にスペースが 2 つある行への前置の崩れを修正

## 描画が変わらない理由と検証

- シグネチャ描画は `MethodSignature#friendly_string` がプレフィクスを落とすため、前後でバイト一致します(`Array.[]` のような演算子も `self[*item]` 表示のまま)。エントリの名前・種別もセクション+互換検査により不変です
- 差分の全行が `### def ` 行であることを機械検査(それ以外の変更なし)
- 書き換え後の残りプレフィクスなし特異メソッド行は、分離した `main.md` の 14 行を除きゼロであることをパーサ準拠のスキャンで確認
- lint(`check_filename_case_conflicts` / `check_indent_in_samplecode` / `check_single_space_indent` / `check_blank_lines`)パス
- **現行の bitclust master(1.6.1 相当)で全 7 版(3.0/3.1/3.2/3.3/3.4/4.0/4.1)の manual/api + manual/capi パース(`update --markdowntree`)がパス**(CI マトリクス外の 3.0〜3.2 を含む。プレフィクスの誤りは signature crash で必ず落ちるため、パース成功が正しさの証明になります)
- キーワード検査を含む bitclust ブランチ(rurema/bitclust#310)でも全 7 版パスし、違反ゼロを確認済み

## マージ順

この PR は単独で先にマージできます。マージ後に rurema/bitclust#310(キーワード一致検査)をマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
