### PR TITLE
LoadError に加筆修正

### DIFF
--- a/manual/api/_builtin/LoadError.md
+++ b/manual/api/_builtin/LoadError.md
@@ -3,13 +3,24 @@ library: _builtin
 ---
 # class LoadError < ScriptError
 
-[m:Kernel?.require] や [m:Kernel?.load] が失敗したときに発生します。
+[m:Kernel?.require]、[m:Kernel?.require_relative]、[m:Kernel?.load] が失敗したときに発生します。
+
+```ruby title="LoadError を捕捉する例"
+# lib-a が require できなければ代替の lib-b を使う
+begin
+  require "lib-a"
+rescue LoadError
+  require "lib-b"
+end
+```
+
+`LoadError` は [c:StandardError] のサブクラスではないので、例外型を指定しない `rescue` では捕捉できないことに注意してください。
 
 ## Instance Methods
 
 ### def path -> String | nil
 
-[m:Kernel?.require] や [m:Kernel?.load] に失敗したパスを返します。
+[m:Kernel?.require]、[m:Kernel?.require_relative]、[m:Kernel?.load] に失敗したパスを返します。
 
 ```ruby
 begin
@@ -19,5 +30,13 @@ rescue LoadError => e
 end
 ```
 
-パスが定まらない場合は nil を返します。
-#%# irb 中で [[m:Kernel.#require_relative]] を実行した場合など。
+[m:Kernel?.eval] に与えた文字列中での [m:Kernel?.require_relative] は、読み込み元のファイルが存在しないため、読み込み先のパスが定まらず、`LoadError` が発生し、`LoadError#path` は `nil` を返します。
+
+```ruby title="LoadError#path が nil になる例"
+begin
+  eval "require_relative 'foo'"
+rescue LoadError => e
+  p e.path    # => nil
+  p e.message # => "cannot infer basepath"
+end
+```


### PR DESCRIPTION
LoadError に以下の加筆修正を施します。

* `require`, `load` に `require_relative` を追加
* `rescue LoadError` するサンプルコードを追加
* 引数無しの `rescue` では捕捉できないことを追記
  →初心者はしばしば「平凡な例外は全部 StandardError」と誤解
* `LoadError#path` が `nil` を返すケースを具体的に記述
　* コメントには「irb で require_relative した場合など」とあったが，irb ではそうならない
