### PR TITLE
NEWS for Ruby 2.0.0 のささいなタイポ修正

### DIFF
--- a/manual/doc/news/2_0_0.md
+++ b/manual/doc/news/2_0_0.md
@@ -60,7 +60,7 @@
 
   - [c:Kernel]
     - 追加: [m:Kernel?.Hash] という変換メソッド。[m:Kernel?.Array], [m:Kernel?.Float] に似ています
-    - 追加: [m:Kernel?.__dir__] 現在のソースファイル(__FILE__)のあるディレクトリ名を正規化された絶対パ スで返します。
+    - 追加: [m:Kernel?.__dir__] 現在のソースファイル(__FILE__)のあるディレクトリ名を正規化された絶対パスで返します。
     - 追加: [m:Kernel?.caller_locations] フレーム情報の配列を返します
     - 拡張: [m:Kernel?.warn] [m:Kernel?.puts] のように複数の引数を受け付けるようになりました
     - 拡張: [m:Kernel?.caller] 第2引数で取得するスタックのサイズを指定できるようになりました


### PR DESCRIPTION
×「パ ス」→○「パス」

どうでもいいようなタイポですが，変更履歴のページでページ内検索することはよくあるので。