### PR TITLE
Encoding のタイポ修正

### DIFF
--- a/manual/api/_builtin/Encoding.md
+++ b/manual/api/_builtin/Encoding.md
@@ -1089,7 +1089,7 @@ MacCroatian エンコーディング。
 
 Mac OS で使われる
 8bit single-byteエンコーディングで、
-クロアチア語、スベロニア語を取り扱うものです。
+クロアチア語、スロベニア語を取り扱うものです。
 
 - **SEE** <https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CROATIAN.TXT>
 


### PR DESCRIPTION
×「スベロニア語」→○「スロベニア語」

なお，Mac OS Croatian がスロベニア語を扱うことは Wikipedia で確認：
https://en.wikipedia.org/wiki/Mac_OS_Croatian_encoding