### PR TITLE
RegexpError のサンプルコードを Ruby スクリプトに

### DIFF
--- a/manual/api/_builtin/RegexpError.md
+++ b/manual/api/_builtin/RegexpError.md
@@ -5,15 +5,7 @@ library: _builtin
 
 正規表現のコンパイルに失敗したときに発生します。
 
-```console title="例"
-$ ruby -e 'Regexp.compile("*")'
-#%since 3.4
--e:1:in 'initialize': target of repeat operator is not specified: /*/ (RegexpError)
-        from -e:1:in 'Regexp#compile'
-#%else
--e:1:in `initialize': target of repeat operator is not specified: /*/ (RegexpError)
-        from -e:1:in `Regexp#compile'
-#%end
-from -e:1
+```ruby
+Regexp.compile("*")
+# ~> RegexpError: target of repeat operator is not specified: /*/
 ```
-


### PR DESCRIPTION
サンプルコードがコンソールで `ruby -e` する形式だったのをふつうの Ruby スクリプト形式にします。