### PR TITLE
Kernel#Pathname をモジュール関数として登録する

### DIFF
--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -6,9 +6,9 @@ category: File
 
 # reopen Kernel
 
-## Private Instance Methods
+## Module Functions
 
-### def Pathname(path) -> Pathname
+### module_function def Pathname(path) -> Pathname
 
 文字列 path を元に [c:Pathname] オブジェクトを生成します。
 
@@ -32,7 +32,7 @@ Pathname のインスタンスメソッドには、ディレクトリのパス�
 文字列操作だけで結果を返すものもあれば、ファイルの中身を読み出す [m:Pathname#read] のように
 ファイルシステムにアクセスするものもあります。
 
-Pathname オブジェクトの生成には、[m:Pathname.new] のほかに [m:Kernel#Pathname] も使えます。
+Pathname オブジェクトの生成には、[m:Pathname.new] のほかに [m:Kernel?.Pathname] も使えます。
 
 ```ruby title="例"
 require 'pathname'

--- a/manual/api/pathname.md
+++ b/manual/api/pathname.md
@@ -9,6 +9,7 @@ category: File
 ## Module Functions
 
 ### module_function def Pathname(path) -> Pathname
+{: since=""}
 
 文字列 path を元に [c:Pathname] オブジェクトを生成します。
 

--- a/manual/doc/news/2_7_0.md
+++ b/manual/doc/news/2_7_0.md
@@ -711,7 +711,7 @@ Did you mean?  baz
   - did_you_mean gemはbundled gemからdefault gemになりました。
 
   - [lib:pathname]
-    - [m:Kernel#Pathname]を[c:Pathname]を引数として呼んだとき、
+    - [m:Kernel?.Pathname]を[c:Pathname]を引数として呼んだとき、
       新しい[c:Pathname]を生成するのではなく、引数をそのまま返すようになりました。
       この変更で他の[c:Kernel]のメソッドに近づきます。しかし返り値を変更して
       引数を変更しないことを期待するコードが壊れるかもしれません。


### PR DESCRIPTION
fix #3391

ご指摘のとおり `Pathname()` は module_function です(`Kernel.respond_to?(:Pathname)` と `Kernel.private_instance_methods.include?(:Pathname)` の両方が true であることを確認)。文書が `## Private Instance Methods` セクションに置かれていたため `Kernel#Pathname` として登録・表示されていました。

- セクションを `## Module Functions` に変更し、エントリを `### module_function def Pathname(path)` に
- 参照 2 箇所(pathname.md 本文・NEWS 2.7.0)を `[m:Kernel?.Pathname]` に変更

修正後のツリーで 3.4 の DB を生成し、`Kernel.#Pathname`(type: module_function)として引けることを確認済みです。表示は `Kernel.#Pathname`、URL は `method/Kernel/m/Pathname` に変わります(旧 `method/Kernel/i/Pathname` は次回の静的 HTML 再生成で消えます)。

なお同様に `# reopen Kernel` + `## Private Instance Methods` で書かれている delegate(`DelegateClass`)と rubygems(`gem`)は、実際に module_function ではない(`Kernel.respond_to?` が false)ことを確認したので、現状のままで正しいです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
