### PR TITLE
SystemCallError.=== のサンプルコードを訂正

### DIFF
--- a/manual/api/_builtin/SystemCallError.md
+++ b/manual/api/_builtin/SystemCallError.md
@@ -80,7 +80,7 @@ begin
   raise Errno::EAGAIN, "pseudo error"
 rescue Errno::EWOULDBLOCK
   p $!
-  # => #<Errno::EAGAIN: pseudo error>
+  # => #<Errno::EAGAIN: Resource temporarily unavailable - pseudo error>
 end
 ```
 

--- a/manual/api/_builtin/SystemCallError.md
+++ b/manual/api/_builtin/SystemCallError.md
@@ -72,16 +72,16 @@ other が SystemCallError のサブクラスのインスタンスで、
 
 ```ruby title="例"
 p Errno::EAGAIN::Errno
+# => 11
 p Errno::EWOULDBLOCK::Errno
+# => 11
+
 begin
   raise Errno::EAGAIN, "pseudo error"
 rescue Errno::EWOULDBLOCK
   p $!
+  # => #<Errno::EAGAIN: pseudo error>
 end
-
-# => 11
-     11
-     #<Errno::EAGAIN: pseudo error>
 ```
 
 ## Instance Methods


### PR DESCRIPTION
`p` の結果がコメント形式になっていない箇所があったので，訂正します。
ついでに，`# =>` の箇所を，対応する `p` の直後に移動させました。

なお，`Errno::EAGAIN::Errno` と `Errno::EWOULDBLOCK::Errno` の返り値は私の環境では 11 ではなく 35 でしたが，「システム依存」のようなので，とくに気にしませんでした。