### PR TITLE
irb: ext/history 改名の追随と ReadlineInputMethod の include 乖離を修正

### DIFF
--- a/manual/api/irb/ext/eval_history.md
+++ b/manual/api/irb/ext/eval_history.md
@@ -1,6 +1,6 @@
 ---
 type: library
-until: "3.3"
+since: "3.3"
 ---
 [c:IRB::Context] に実行結果の履歴を保持する機能を提供するサブライブラ
 リです。

--- a/manual/api/irb/extend-command.md
+++ b/manual/api/irb/extend-command.md
@@ -7,7 +7,11 @@ require:
   - irb/cmd/load
   - irb/cmd/pushws
   - irb/cmd/subirb
+#%until 3.3
   - irb/ext/history
+#%else
+  - irb/ext/eval_history
+#%end
   - irb/ext/tracer
   - irb/ext/use-loader
   - irb/ext/save-history

--- a/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
+++ b/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
@@ -1,12 +1,19 @@
 ---
 library: irb/input-method
 include:
+#%until 4.0
   - Readline
+#%end
 ---
 # class IRB::ReadlineInputMethod < IRB::InputMethod
 
 readline を用いた標準入力からの入力を表すクラスです。ライブラリ内部で使
-用します。[lib:readline] の require に失敗した場合は定義されません。
+用します。
+#%until 4.0
+[lib:readline] の require に失敗した場合は定義されません。
+#%else
+[lib:readline] の require に失敗した場合は、Reline が代わりに使われます。
+#%end
 
 ## Class Methods
 


### PR DESCRIPTION
#3408 の残タスク 2 件(ext/history 改名の追随・IRB::ReadlineInputMethod の include 乖離)の対応です。

## 調査結果

| 事実 | 根拠 |
|---|---|
| `lib/irb/ext/history.rb` は **Ruby 3.3.0 で `ext/eval_history.rb` に改名**(3.2.9 まで旧名) | ruby/irb#623「Refactor eval history」(2023-07)。v3_2_9/v3_3_0 の存否で確認 |
| Ruby 3.3 の `extend-command.rb` は既に `ext/eval_history.rb` を参照 | v3_3_0 の実装 325 行目 |
| `IRB::ReadlineInputMethod` の `include ::Readline` は **irb 1.15.2 で廃止**(`const_set` 方式+readline 不在時は Reline にフォールバック) | ruby/irb#1076「Fallback to Reline when `require 'readline'` fails」(2025-01)。タグ compare で 1.15.1=含まず・1.15.2=含む |
| **Ruby 4.0.0 は irb 1.16.0 を bundled gem として同梱** → 4.0 から include は実態と乖離 | v4.0.0 の gems/bundled_gems |

## 内容

- `irb/ext/history.md` に `until: "3.3"` を追加し、同内容の `irb/ext/eval_history.md`(`since: "3.3"`)を新設(機能自体は 3.3 以降も存続するため文書を引き継ぐ)
- `irb/extend-command.md` の require リストを版分岐(〜3.3 は history・3.3〜 は eval_history。extend-command 自体は #3409 で until: "3.4" 済み)
- `IRB__ReadlineInputMethod.md` の front matter `include: - Readline` を `#%until 4.0` でゲートし、本文の「require に失敗した場合は定義されません」を 4.0 以降「Reline が代わりに使われます」に版分岐(Reline は文書未整備のためリンクは張らず。#3410)

## 検証

- 境界版(3.2/3.3/4.0)の DB で存否を機械確認: irb/ext/history=3.2 のみ・irb/ext/eval_history=3.3 から・`IRB::Context#eval_history` メソッドは両版で継続(メソッド単位バッジの算出はライブラリを無視して名前で union するため、ライブラリ改名では途切れません)・4.0 の IRB::ReadlineInputMethod から include が消えること
- 3 版とも checklink(capi 込み)死リンクゼロ・lint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
