### PR TITLE
set/Set.md にも >, >=, <, <= を追加する

### DIFF
--- a/manual/api/set/Set.md
+++ b/manual/api/set/Set.md
@@ -235,14 +235,16 @@ p set.include?('bye')   # => false
 ```
 
 ### def superset?(set) -> bool
+### def >=(set) -> bool
 ### def proper_superset?(set) -> bool
+### def >(set) -> bool
 
 self が集合 set の上位集合 (スーパーセット) である場合に true を
 返します。
 
-superset? は、2 つの集合が等しい場合にも true となります。
+superset? と >= は、2 つの集合が等しい場合にも true となります。
 
-proper_superset? は、2 つの集合が等しい場合には false を返します。
+proper_superset? と > は、2 つの集合が等しい場合には false を返します。
 
 - **param** `set` -- 比較対象の Set オブジェクトを指定します。
 - **raise** `ArgumentError` -- 引数が Set オブジェクトでない場合に発生します。
@@ -261,13 +263,15 @@ p s.proper_superset?(Set[1, 2, 3])  # => false
 - **SEE** [m:Set#subset?]
 
 ### def subset?(set) -> bool
+### def <=(set) -> bool
 ### def proper_subset?(set) -> bool
+### def <(set) -> bool
 
 self が集合 set の部分集合である場合に true を返します。
 
-subset? は、2 つの集合が等しい場合にも true となります。
+subset? と <= は、2 つの集合が等しい場合にも true となります。
 
-proper_subset? は、2 つの集合が等しい場合には false を返します。
+proper_subset? と < は、2 つの集合が等しい場合には false を返します。
 
 - **param** `set` -- 比較対象の Set オブジェクトを指定します。
 - **raise** `ArgumentError` -- 引数が Set オブジェクトでない場合に発生します。


### PR DESCRIPTION
#3388(`_builtin/Set.md` への `>`/`>=`/`<`/`<=` 追加)のフォローアップです。3.2 未満向けの `manual/api/set/Set.md` にも同じ演算子エイリアスを superset?/subset? 系のエントリに追加します(いずれも Ruby 3.0 時点の lib/set.rb に `alias >= superset?` などとして存在)。

検証: 3.0 の DB で `Set#>=` が `[">", ">=", "proper_superset?", "superset?"]` の別名グループとして登録されることを確認・lint パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
