### PR TITLE
reline の設定アクセサ群・Reline::HISTORY・Reline::Face を文書化

### DIFF
--- a/manual/api/reline.md
+++ b/manual/api/reline.md
@@ -30,14 +30,14 @@ Emacs モードが用意されています。デフォルトは Emacs モード�
 
 挙動のカスタマイズは Reline モジュールのアトリビュートへの代入で行います。主なものは以下の通りです。
 
-- [m:Reline.completion_proc=]: 補完候補を計算する Proc を設定します。
+- [m:Reline.completion_proc=] -- 補完候補を計算する Proc を設定します。
 #%since 3.1
-- [m:Reline.autocompletion=]: 入力中の自動補完表示を有効にします。
+- [m:Reline.autocompletion=] -- 入力中の自動補完表示を有効にします。
 #%end
-- [m:Reline.prompt_proc=]: 行ごとにプロンプトを動的に差し替える Proc を設定します。
-- [m:Reline.output_modifier_proc=]: 表示前に入力内容を加工(シンタックスハイライトなど)する Proc を設定します。
-- [m:Reline.auto_indent_proc=]: 自動インデントの幅を計算する Proc を設定します。
-- [m:Reline.input=] / [m:Reline.output=]: 入出力先を差し替えます。デフォルトは標準入力/標準出力です。
+- [m:Reline.prompt_proc=] -- 行ごとにプロンプトを動的に差し替える Proc を設定します。
+- [m:Reline.output_modifier_proc=] -- 表示前に入力内容を加工(シンタックスハイライトなど)する Proc を設定します。
+- [m:Reline.auto_indent_proc=] -- 自動インデントの幅を計算する Proc を設定します。
+- [m:Reline.input=] / [m:Reline.output=] -- 入出力先を差し替えます。デフォルトは標準入力/標準出力です。
 
 キーバインドや変数は、GNU Readline と同様に inputrc ファイルで設定できます。inputrc は環境変数 `INPUTRC`、`~/.inputrc`、XDG
 設定ディレクトリの `readline/inputrc` から探索されます。inputrc 内では
@@ -52,11 +52,11 @@ Emacs モードが用意されています。デフォルトは Emacs モード�
 ### def Reline.readline(prompt = "", add_hist = false) -> String | nil
 {: since="2.7"}
 
-prompt を出力し、ユーザからのキー入力を待ちます。
+`prompt` を出力し、ユーザからのキー入力を待ちます。
 エンターキーの押下などでユーザが文字列を入力し終えると、入力した文字列を返します。返り値の末尾に改行は含まれません。
-このとき、add_hist が真であれば、入力した文字列を入力履歴 [c:Reline::HISTORY]
+このとき、`add_hist` が真であれば、入力した文字列を入力履歴 [c:Reline::HISTORY]
 に追加します。空の入力は追加されません。
-何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は nil を返します。
+何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は `nil` を返します。
 
 - **param** `prompt` -- カーソルの前に表示する文字列を指定します。デフォルトは `""` です。
 - **param** `add_hist` -- 真ならば、入力した文字列を入力履歴に追加します。デフォルトは偽です。
@@ -72,14 +72,16 @@ end
 ### def Reline.readmultiline(prompt = "", add_hist = false) { |text| ... } -> String | nil
 {: since="2.7"}
 
-prompt を出力し、ユーザからの複数行の入力を待ちます。
+`prompt` を出力し、ユーザからの複数行の入力を待ちます。
 
-一行の入力が確定するたびに、それまでに入力された全体の文字列を引数としてブロックが呼ばれます。ブロックが真を返すと入力を終了し、入力された複数行全体をひとつの文字列(各行を `"\n"` で連結したもの)として返します。返り値の末尾に改行は含まれません。
+一行の入力が確定するたびに、それまでに入力された全体の文字列 `text`
+を引数としてブロックが呼ばれます。ブロックが真を返すと入力を終了し、入力された複数行全体をひとつの文字列(各行を `"\n"`
+で連結したもの)として返します。返り値の末尾に改行は含まれません。
 
-add_hist が真であれば、入力した複数行全体をひとつのエントリとして入力履歴
+`add_hist` が真であれば、入力した複数行全体をひとつのエントリとして入力履歴
 [c:Reline::HISTORY] に追加します。空の入力は追加されません。
 
-何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は nil を返します。
+何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は `nil` を返します。
 
 - **param** `prompt` -- カーソルの前に表示する文字列を指定します。デフォルトは `""` です。
 - **param** `add_hist` -- 真ならば、入力した文字列を入力履歴に追加します。デフォルトは偽です。
@@ -96,37 +98,39 @@ puts code
 ### def Reline.input=(input)
 {: since="2.7"}
 
-Reline が入力の読み取りに使うオブジェクトを input に変更します。デフォルトは標準入力です。
+Reline が入力の読み取りに使うオブジェクトを `input` に変更します。デフォルトは標準入力です。
 
-- **param** `input` -- `getc` メソッドを持つオブジェクト([c:IO] など)、または nil を指定します。
+- **param** `input` -- `getc` メソッドを持つオブジェクト([c:IO] など)、または `nil` を指定します。
 
-- **raise** `TypeError` -- input が nil でも `getc` メソッドを持つオブジェクトでもない場合に発生します。
+- **raise** `TypeError` -- `input` が `nil` でも `getc` メソッドを持つオブジェクトでもない場合に発生します。
 
 ### def Reline.output=(output)
 {: since="2.7"}
 
-Reline が表示に使うオブジェクトを output に変更します。デフォルトは標準出力です。
+Reline が表示に使うオブジェクトを `output` に変更します。デフォルトは標準出力です。
 
-- **param** `output` -- `write` メソッドを持つオブジェクト([c:IO] など)、または nil を指定します。
+- **param** `output` -- `write` メソッドを持つオブジェクト([c:IO] など)、または `nil` を指定します。
 
-- **raise** `TypeError` -- output が nil でも `write` メソッドを持つオブジェクトでもない場合に発生します。
+- **raise** `TypeError` -- `output` が `nil` でも `write` メソッドを持つオブジェクトでもない場合に発生します。
 
+### def Reline.completion_proc -> Proc | nil
+{: since="2.7"}
 ### def Reline.completion_proc=(proc)
 {: since="2.7"}
 
-ユーザからの入力を補完するときの候補を取得する [c:Proc] オブジェクト
-proc を指定します。デフォルトは nil で、このときは補完を行いません。
+ユーザからの入力を補完するときの候補を取得する [c:Proc]
+オブジェクトを取得/設定します。デフォルトは `nil` で、このときは補完を行いません。
 
-proc は、引数に入力中の単語(カーソル位置までの、[m:Reline.completer_word_break_characters]
+`proc` は、引数に入力中の単語(カーソル位置までの、[m:Reline.completer_word_break_characters]
 に含まれる文字で区切られた文字列)を受け取り、候補の文字列の配列を返すようにします。
-2 個以上の引数を受け取る proc を指定した場合は、第 2 引数に単語より前の文字列が、第 3 引数に単語より後ろの文字列も渡されます。
+2 個以上の引数を受け取る `proc` を指定した場合は、第 2 引数に単語より前の文字列が、第 3 引数に単語より後ろの文字列も渡されます。
 
 補完は Tab キーの押下で実行されます。
 #%since 3.1
 [m:Reline.autocompletion] が真のときは、文字の入力のたびに呼ばれて候補がダイアログに表示されます。
 #%end
 
-- **param** `proc` -- 補完候補を取得する [c:Proc] オブジェクト、または nil を指定します。
+- **param** `proc` -- 補完候補を取得する [c:Proc] オブジェクト、または `nil` を指定します。
 
 ```ruby title="例: foo、foobar、foobaz を補完する"
 require 'reline'
@@ -142,118 +146,78 @@ while buf = Reline.readline("> ")
 end
 ```
 
-- **SEE** [m:Reline.completion_proc]
-
-### def Reline.completion_proc -> Proc | nil
-{: since="2.7"}
-
-設定されている、補完候補を取得する [c:Proc] オブジェクトを返します。
-
-- **SEE** [m:Reline.completion_proc=]
-
 #%since 3.1
+### def Reline.autocompletion -> bool
 ### def Reline.autocompletion=(bool)
 
-入力中に補完候補を自動的にダイアログ表示するかどうかを指定します。デフォルトは false です。
+入力中に補完候補を自動的にダイアログ表示するかどうかを取得/設定します。デフォルトは `false` です。
 
-真を指定すると、文字を入力するたびに [m:Reline.completion_proc]
+`true` を指定すると、文字を入力するたびに [m:Reline.completion_proc]
 が呼ばれ、候補がダイアログに表示されます([lib:irb] の入力補完表示で使われている機能です)。
 
 - **param** `bool` -- 自動補完表示を有効にするかどうかを真偽値で指定します。
 
-- **SEE** [m:Reline.autocompletion]
-
-### def Reline.autocompletion -> bool
-
-入力中に補完候補を自動的にダイアログ表示するかどうかを返します。デフォルトは false です。
-
-- **SEE** [m:Reline.autocompletion=]
-
 #%end
+### def Reline.completion_case_fold -> bool
+{: since="2.7"}
 ### def Reline.completion_case_fold=(bool)
 {: since="2.7"}
 
-ユーザの入力を補完する際、大文字と小文字を同一視するかどうかを指定します。bool が真ならば同一視します。デフォルトは nil です。
+ユーザの入力を補完する際、大文字と小文字を同一視するかどうかを取得/設定します。`bool`
+が真ならば同一視します。デフォルトは `nil` です。
 
 inputrc の `set completion-ignore-case on` でも設定できます。
 
-- **param** `bool` -- 大文字と小文字を同一視する(true)/しない(false)を指定します。
-
-- **SEE** [m:Reline.completion_case_fold]
-
-### def Reline.completion_case_fold -> bool
-{: since="2.7"}
-
-ユーザの入力を補完する際、大文字と小文字を同一視するかどうかを返します。
-
-- **SEE** [m:Reline.completion_case_fold=]
-
-### def Reline.completion_append_character=(string)
-{: since="2.7"}
-
-補完が 1 つの候補に確定したときに、末尾に付加する文字を指定します。デフォルトは nil(何も付加しない)です。
-
-1 文字しか指定できないため、2 文字以上の文字列を指定した場合は最初の
-1 文字だけが使われます。半角スペース `" "` などの単語を区切る文字を指定すれば、補完後に続けて入力する際に便利です。
-
-- **param** `string` -- 付加する 1 文字を指定します。nil を指定すると何も付加しません。
-
-- **SEE** [m:Reline.completion_append_character]
+- **param** `bool` -- 大文字と小文字を同一視する(`true`)/しない(`false`)を指定します。
 
 ### def Reline.completion_append_character -> String | nil
 {: since="2.7"}
+### def Reline.completion_append_character=(string)
+{: since="2.7"}
 
-補完が 1 つの候補に確定したときに、末尾に付加する文字を返します。
+補完が 1 つの候補に確定したときに、末尾に付加する文字を取得/設定します。デフォルトは
+`nil`(何も付加しない)です。
 
-- **SEE** [m:Reline.completion_append_character=]
+1 文字しか指定できないため、`string` に 2 文字以上の文字列を指定した場合は最初の
+1 文字だけが使われます。半角スペース `" "` などの単語を区切る文字を指定すれば、補完後に続けて入力する際に便利です。
+
+- **param** `string` -- 付加する 1 文字を指定します。`nil` を指定すると何も付加しません。
 
 ### def Reline.completion_quote_character -> String | nil
 {: since="2.7"}
 
 ユーザ入力の補完中([m:Reline.completion_proc] の呼び出し中)に、開いたまま閉じられていないクオート文字([m:Reline.completer_quote_characters]
-のいずれか)があればそれを返します。補完中以外は nil を返します。
+のいずれか)があればそれを返します。補完中以外は `nil` を返します。
 
+### def Reline.completer_word_break_characters -> String
+{: since="2.7"}
 ### def Reline.completer_word_break_characters=(string)
 {: since="2.7"}
 
-ユーザの入力の補完を行う際、単語の区切りを示す文字の集合を文字列で指定します。
+ユーザの入力の補完を行う際、単語の区切りを示す文字の集合を取得/設定します。
 
 デフォルトは ``" \t\n`><=;|&{("``(半角スペースを含む)です。
 
 - **param** `string` -- 文字列を指定します。
 
-- **SEE** [m:Reline.completer_word_break_characters]
-
-### def Reline.completer_word_break_characters -> String
+### def Reline.completer_quote_characters -> String
 {: since="2.7"}
-
-ユーザの入力の補完を行う際、単語の区切りを示す文字の集合を返します。
-
-- **SEE** [m:Reline.completer_word_break_characters=]
-
 ### def Reline.completer_quote_characters=(string)
 {: since="2.7"}
 
-ユーザの入力の補完を行う際、クオートとみなす文字の集合を文字列で指定します。クオートの内側では、[m:Reline.completer_word_break_characters=]
+ユーザの入力の補完を行う際、クオートとみなす文字の集合を取得/設定します。クオートの内側では、[m:Reline.completer_word_break_characters=]
 で指定した文字も通常の文字として扱われます。
 
 デフォルトは `"'`(ダブルクオートとシングルクオート)です。
 
 - **param** `string` -- 文字列を指定します。
 
-- **SEE** [m:Reline.completer_quote_characters]
-
-### def Reline.completer_quote_characters -> String
+### def Reline.basic_word_break_characters -> String
 {: since="2.7"}
-
-ユーザの入力の補完を行う際、クオートとみなす文字の集合を返します。
-
-- **SEE** [m:Reline.completer_quote_characters=]
-
 ### def Reline.basic_word_break_characters=(string)
 {: since="2.7"}
 
-単語の区切りを示す文字の集合を文字列で指定します。
+単語の区切りを示す文字の集合を取得/設定します。
 
 デフォルトは ``" \t\n`><=;|&{("``(半角スペースを含む)です。
 
@@ -262,19 +226,12 @@ inputrc の `set completion-ignore-case on` でも設定できます。
 
 - **param** `string` -- 文字列を指定します。
 
-- **SEE** [m:Reline.basic_word_break_characters]
-
-### def Reline.basic_word_break_characters -> String
+### def Reline.basic_quote_characters -> String
 {: since="2.7"}
-
-単語の区切りを示す文字の集合を返します。
-
-- **SEE** [m:Reline.basic_word_break_characters=]
-
 ### def Reline.basic_quote_characters=(string)
 {: since="2.7"}
 
-クオートとみなす文字の集合を文字列で指定します。
+クオートとみなす文字の集合を取得/設定します。
 
 デフォルトは `"'`(ダブルクオートとシングルクオート)です。
 
@@ -283,150 +240,94 @@ inputrc の `set completion-ignore-case on` でも設定できます。
 
 - **param** `string` -- 文字列を指定します。
 
-- **SEE** [m:Reline.basic_quote_characters]
-
-### def Reline.basic_quote_characters -> String
+### def Reline.filename_quote_characters -> String
 {: since="2.7"}
-
-クオートとみなす文字の集合を返します。
-
-- **SEE** [m:Reline.basic_quote_characters=]
-
 ### def Reline.filename_quote_characters=(string)
 {: since="2.7"}
 
-ファイル名の補完の際にクオートするための文字の集合を文字列で指定します。デフォルトは `""` です。
+ファイル名の補完の際にクオートするための文字の集合を取得/設定します。デフォルトは `""` です。
 
 設定値は保持されますが、現在の reline の補完処理では使用されません。
 
 - **param** `string` -- 文字列を指定します。
-
-- **SEE** [m:Reline.filename_quote_characters]
-
-### def Reline.filename_quote_characters -> String
-{: since="2.7"}
-
-ファイル名の補完の際にクオートするための文字の集合を返します。
-
-- **SEE** [m:Reline.filename_quote_characters=]
-
-### def Reline.special_prefixes=(string)
-{: since="2.7"}
-
-補完対象の単語の一部として扱う接頭辞の文字の集合を文字列で指定します。デフォルトは `""` です。
-
-設定値は保持されますが、現在の reline の補完処理では使用されません。
-
-- **param** `string` -- 文字列を指定します。
-
-- **SEE** [m:Reline.special_prefixes]
 
 ### def Reline.special_prefixes -> String
 {: since="2.7"}
-
-補完対象の単語の一部として扱う接頭辞の文字の集合を返します。
-
-- **SEE** [m:Reline.special_prefixes=]
-
-### def Reline.prompt_proc=(proc)
+### def Reline.special_prefixes=(string)
 {: since="2.7"}
 
-[m:Reline.readmultiline] での複数行編集時に、行ごとのプロンプトを動的に生成する [c:Proc] オブジェクト proc を指定します。デフォルトは nil です。
+補完対象の単語の一部として扱う接頭辞の文字の集合を取得/設定します。デフォルトは `""` です。
 
-proc は、入力中の各行の文字列を要素とする配列を受け取り、行ごとのプロンプト文字列の配列を返すようにします。[m:Reline.readline]
-による一行入力では使われません。
+設定値は保持されますが、現在の reline の補完処理では使用されません。
 
-- **param** `proc` -- プロンプトの配列を返す [c:Proc] オブジェクト、または nil を指定します。
-
-- **SEE** [m:Reline.prompt_proc]
+- **param** `string` -- 文字列を指定します。
 
 ### def Reline.prompt_proc -> Proc | nil
 {: since="2.7"}
-
-行ごとのプロンプトを動的に生成する [c:Proc] オブジェクトを返します。
-
-- **SEE** [m:Reline.prompt_proc=]
-
-### def Reline.output_modifier_proc=(proc)
+### def Reline.prompt_proc=(proc)
 {: since="2.7"}
 
-入力内容を表示する直前に、表示用に加工する [c:Proc] オブジェクト proc
-を指定します。シンタックスハイライトなどに利用できます。デフォルトは nil です。
+[m:Reline.readmultiline] での複数行編集時に、行ごとのプロンプトを動的に生成する
+[c:Proc] オブジェクトを取得/設定します。デフォルトは `nil` です。
 
-proc は、第 1 引数に入力内容全体の文字列(末尾に改行を含む)を、キーワード引数 complete に入力が確定したかどうかの真偽値を受け取り、表示に使う文字列を返すようにします。返した文字列は表示にだけ使われ、[m:Reline.readline]
-などの返り値は変わりません。
+`proc` は、入力中の各行の文字列を要素とする配列を受け取り、行ごとのプロンプト文字列の配列を返すようにします。[m:Reline.readline]
+による一行入力では使われません。
 
-- **param** `proc` -- 表示用の文字列を返す [c:Proc] オブジェクト、または nil を指定します。
-
-- **SEE** [m:Reline.output_modifier_proc]
+- **param** `proc` -- プロンプトの配列を返す [c:Proc] オブジェクト、または `nil` を指定します。
 
 ### def Reline.output_modifier_proc -> Proc | nil
 {: since="2.7"}
+### def Reline.output_modifier_proc=(proc)
+{: since="2.7"}
 
-入力内容を表示する直前に、表示用に加工する [c:Proc] オブジェクトを返します。
+入力内容を表示する直前に、表示用に加工する [c:Proc]
+オブジェクトを取得/設定します。シンタックスハイライトなどに利用できます。デフォルトは `nil` です。
 
-- **SEE** [m:Reline.output_modifier_proc=]
+`proc` は、第 1 引数に入力内容全体の文字列(末尾に改行を含む)を、キーワード引数
+`complete` に入力が確定したかどうかの真偽値を受け取り、表示に使う文字列を返すようにします。返した文字列は表示にだけ使われ、[m:Reline.readline]
+などの返り値は変わりません。
 
+- **param** `proc` -- 表示用の文字列を返す [c:Proc] オブジェクト、または `nil` を指定します。
+
+### def Reline.auto_indent_proc -> Proc | nil
+{: since="2.7"}
 ### def Reline.auto_indent_proc=(proc)
 {: since="2.7"}
 
-複数行編集時に、行頭の自動インデントの幅を計算する [c:Proc] オブジェクト
-proc を指定します。デフォルトは nil です。
+複数行編集時に、行頭の自動インデントの幅を計算する [c:Proc]
+オブジェクトを取得/設定します。デフォルトは `nil` です。
 
-proc は次の 4 つの引数を受け取り、インデントに使う半角スペースの個数を整数で返すようにします。nil を返すとインデントを変更しません。対象の行の行頭の空白は、返した個数の半角スペースに置き換えられます。
+`proc` は次の 4 つの引数を受け取り、インデントに使う半角スペースの個数を整数で返すようにします。`nil`
+を返すとインデントを変更しません。対象の行の行頭の空白は、返した個数の半角スペースに置き換えられます。
 
 - `lines`: 入力中の各行の文字列の配列
 - `line_index`: インデントを計算する対象の行の `lines` 内の位置
 - `byte_pointer`: 行内のカーソルのバイト単位の位置
 - `is_newline`: 改行の入力直後かどうか
 
-- **param** `proc` -- インデント幅を返す [c:Proc] オブジェクト、または nil を指定します。
+- **param** `proc` -- インデント幅を返す [c:Proc] オブジェクト、または `nil` を指定します。
 
-- **SEE** [m:Reline.auto_indent_proc]
-
-### def Reline.auto_indent_proc -> Proc | nil
+### def Reline.pre_input_hook -> Proc | nil
 {: since="2.7"}
-
-複数行編集時に、行頭の自動インデントの幅を計算する [c:Proc] オブジェクトを返します。
-
-- **SEE** [m:Reline.auto_indent_proc=]
-
 ### def Reline.pre_input_hook=(proc)
 {: since="2.7"}
 
 [m:Reline.readline] や [m:Reline.readmultiline]
-が入力の受け付けを始める直前に呼ばれる [c:Proc] オブジェクト proc
-を指定します。proc は引数なしで呼ばれます。デフォルトは nil です。
+が入力の受け付けを始める直前に呼ばれる [c:Proc]
+オブジェクトを取得/設定します。`proc` は引数なしで呼ばれます。デフォルトは `nil` です。
 
-- **param** `proc` -- [c:Proc] オブジェクト、または nil を指定します。
+- **param** `proc` -- [c:Proc] オブジェクト、または `nil` を指定します。
 
-- **SEE** [m:Reline.pre_input_hook]
-
-### def Reline.pre_input_hook -> Proc | nil
+### def Reline.dig_perfect_match_proc -> Proc | nil
 {: since="2.7"}
-
-入力の受け付けを始める直前に呼ばれる [c:Proc] オブジェクトを返します。
-
-- **SEE** [m:Reline.pre_input_hook=]
-
 ### def Reline.dig_perfect_match_proc=(proc)
 {: since="2.7"}
 
 補完候補が 1 つに確定している状態で、さらに補完しようとしたときに呼ばれる
-[c:Proc] オブジェクト proc を指定します。proc
-は確定した候補の文字列を引数として呼ばれます。デフォルトは nil です。
+[c:Proc] オブジェクトを取得/設定します。`proc`
+は確定した候補の文字列を引数として呼ばれます。デフォルトは `nil` です。
 
-- **param** `proc` -- [c:Proc] オブジェクト、または nil を指定します。
-
-- **SEE** [m:Reline.dig_perfect_match_proc]
-
-### def Reline.dig_perfect_match_proc -> Proc | nil
-{: since="2.7"}
-
-補完候補が 1 つに確定している状態で、さらに補完しようとしたときに呼ばれる
-[c:Proc] オブジェクトを返します。
-
-- **SEE** [m:Reline.dig_perfect_match_proc=]
+- **param** `proc` -- [c:Proc] オブジェクト、または `nil` を指定します。
 
 ### def Reline.vi_editing_mode -> nil
 {: since="2.7"}

--- a/manual/api/reline.md
+++ b/manual/api/reline.md
@@ -26,19 +26,26 @@ GNU Readline 互換の行編集機能を提供するモジュールです。
 Emacs モードが用意されています。デフォルトは Emacs モードです。
 
 入力した内容は入力履歴(ヒストリ)として記録できます。履歴には定数
-`Reline::HISTORY`([c:Array] のサブクラスのインスタンス)でアクセスできます。
+[c:Reline::HISTORY]([c:Array] のサブクラスのインスタンス)でアクセスできます。
 
-挙動のカスタマイズは Reline モジュールのアトリビュートへの代入で行います。主なものは以下の通りです。これらの詳細は本リファレンスではまだ扱っていません。完全な API については公式ドキュメントを参照してください。
+挙動のカスタマイズは Reline モジュールのアトリビュートへの代入で行います。主なものは以下の通りです。
 
-- `Reline.completion_proc=`: 補完候補を計算する Proc を設定します。
-- `Reline.autocompletion=`: 入力中の自動補完表示を有効にします。
-- `Reline.prompt_proc=`: 行ごとにプロンプトを動的に差し替える Proc を設定します。
-- `Reline.output_modifier_proc=`: 表示前に入力内容を加工(シンタックスハイライトなど)する Proc を設定します。
-- `Reline.auto_indent_proc=`: 自動インデントの幅を計算する Proc を設定します。
-- `Reline.input=` / `Reline.output=`: 入出力先を差し替えます。デフォルトは標準入力/標準出力です。
+- [m:Reline.completion_proc=]: 補完候補を計算する Proc を設定します。
+#%since 3.1
+- [m:Reline.autocompletion=]: 入力中の自動補完表示を有効にします。
+#%end
+- [m:Reline.prompt_proc=]: 行ごとにプロンプトを動的に差し替える Proc を設定します。
+- [m:Reline.output_modifier_proc=]: 表示前に入力内容を加工(シンタックスハイライトなど)する Proc を設定します。
+- [m:Reline.auto_indent_proc=]: 自動インデントの幅を計算する Proc を設定します。
+- [m:Reline.input=] / [m:Reline.output=]: 入出力先を差し替えます。デフォルトは標準入力/標準出力です。
 
-また、Ruby 3.3 以降に同梱されるバージョン(reline 0.4.0 以降)では、
-`Reline::Face` で補完ダイアログなどの表示色をカスタマイズできます。
+キーバインドや変数は、GNU Readline と同様に inputrc ファイルで設定できます。inputrc は環境変数 `INPUTRC`、`~/.inputrc`、XDG
+設定ディレクトリの `readline/inputrc` から探索されます。inputrc 内では
+`$if Ruby`(または `$if Reline`)の条件ブロックも利用できます。
+
+#%since 3.3
+また、[c:Reline::Face] で補完ダイアログなどの表示スタイルをカスタマイズできます(reline 0.4.0 以降)。
+#%end
 
 ## Singleton Methods
 
@@ -47,7 +54,7 @@ Emacs モードが用意されています。デフォルトは Emacs モード�
 
 prompt を出力し、ユーザからのキー入力を待ちます。
 エンターキーの押下などでユーザが文字列を入力し終えると、入力した文字列を返します。返り値の末尾に改行は含まれません。
-このとき、add_hist が真であれば、入力した文字列を入力履歴 `Reline::HISTORY`
+このとき、add_hist が真であれば、入力した文字列を入力履歴 [c:Reline::HISTORY]
 に追加します。空の入力は追加されません。
 何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は nil を返します。
 
@@ -70,7 +77,7 @@ prompt を出力し、ユーザからの複数行の入力を待ちます。
 一行の入力が確定するたびに、それまでに入力された全体の文字列を引数としてブロックが呼ばれます。ブロックが真を返すと入力を終了し、入力された複数行全体をひとつの文字列(各行を `"\n"` で連結したもの)として返します。返り値の末尾に改行は含まれません。
 
 add_hist が真であれば、入力した複数行全体をひとつのエントリとして入力履歴
-`Reline::HISTORY` に追加します。空の入力は追加されません。
+[c:Reline::HISTORY] に追加します。空の入力は追加されません。
 
 何も入力していない状態で EOF(UNIX では ^D)を入力するなどで、ユーザからの入力がない場合は nil を返します。
 
@@ -85,3 +92,373 @@ require 'reline'
 code = Reline.readmultiline("> ", true) { |text| text.split("\n").last == "end" }
 puts code
 ```
+
+### def Reline.input=(input)
+{: since="2.7"}
+
+Reline が入力の読み取りに使うオブジェクトを input に変更します。デフォルトは標準入力です。
+
+- **param** `input` -- `getc` メソッドを持つオブジェクト([c:IO] など)、または nil を指定します。
+
+- **raise** `TypeError` -- input が nil でも `getc` メソッドを持つオブジェクトでもない場合に発生します。
+
+### def Reline.output=(output)
+{: since="2.7"}
+
+Reline が表示に使うオブジェクトを output に変更します。デフォルトは標準出力です。
+
+- **param** `output` -- `write` メソッドを持つオブジェクト([c:IO] など)、または nil を指定します。
+
+- **raise** `TypeError` -- output が nil でも `write` メソッドを持つオブジェクトでもない場合に発生します。
+
+### def Reline.completion_proc=(proc)
+{: since="2.7"}
+
+ユーザからの入力を補完するときの候補を取得する [c:Proc] オブジェクト
+proc を指定します。デフォルトは nil で、このときは補完を行いません。
+
+proc は、引数に入力中の単語(カーソル位置までの、[m:Reline.completer_word_break_characters]
+に含まれる文字で区切られた文字列)を受け取り、候補の文字列の配列を返すようにします。
+2 個以上の引数を受け取る proc を指定した場合は、第 2 引数に単語より前の文字列が、第 3 引数に単語より後ろの文字列も渡されます。
+
+補完は Tab キーの押下で実行されます。
+#%since 3.1
+[m:Reline.autocompletion] が真のときは、文字の入力のたびに呼ばれて候補がダイアログに表示されます。
+#%end
+
+- **param** `proc` -- 補完候補を取得する [c:Proc] オブジェクト、または nil を指定します。
+
+```ruby title="例: foo、foobar、foobaz を補完する"
+require 'reline'
+
+WORDS = %w(foo foobar foobaz)
+
+Reline.completion_proc = proc { |word|
+  WORDS.grep(/\A#{Regexp.quote(word)}/)
+}
+
+while buf = Reline.readline("> ")
+  print("-> ", buf, "\n")
+end
+```
+
+- **SEE** [m:Reline.completion_proc]
+
+### def Reline.completion_proc -> Proc | nil
+{: since="2.7"}
+
+設定されている、補完候補を取得する [c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.completion_proc=]
+
+#%since 3.1
+### def Reline.autocompletion=(bool)
+
+入力中に補完候補を自動的にダイアログ表示するかどうかを指定します。デフォルトは false です。
+
+真を指定すると、文字を入力するたびに [m:Reline.completion_proc]
+が呼ばれ、候補がダイアログに表示されます([lib:irb] の入力補完表示で使われている機能です)。
+
+- **param** `bool` -- 自動補完表示を有効にするかどうかを真偽値で指定します。
+
+- **SEE** [m:Reline.autocompletion]
+
+### def Reline.autocompletion -> bool
+
+入力中に補完候補を自動的にダイアログ表示するかどうかを返します。デフォルトは false です。
+
+- **SEE** [m:Reline.autocompletion=]
+
+#%end
+### def Reline.completion_case_fold=(bool)
+{: since="2.7"}
+
+ユーザの入力を補完する際、大文字と小文字を同一視するかどうかを指定します。bool が真ならば同一視します。デフォルトは nil です。
+
+inputrc の `set completion-ignore-case on` でも設定できます。
+
+- **param** `bool` -- 大文字と小文字を同一視する(true)/しない(false)を指定します。
+
+- **SEE** [m:Reline.completion_case_fold]
+
+### def Reline.completion_case_fold -> bool
+{: since="2.7"}
+
+ユーザの入力を補完する際、大文字と小文字を同一視するかどうかを返します。
+
+- **SEE** [m:Reline.completion_case_fold=]
+
+### def Reline.completion_append_character=(string)
+{: since="2.7"}
+
+補完が 1 つの候補に確定したときに、末尾に付加する文字を指定します。デフォルトは nil(何も付加しない)です。
+
+1 文字しか指定できないため、2 文字以上の文字列を指定した場合は最初の
+1 文字だけが使われます。半角スペース `" "` などの単語を区切る文字を指定すれば、補完後に続けて入力する際に便利です。
+
+- **param** `string` -- 付加する 1 文字を指定します。nil を指定すると何も付加しません。
+
+- **SEE** [m:Reline.completion_append_character]
+
+### def Reline.completion_append_character -> String | nil
+{: since="2.7"}
+
+補完が 1 つの候補に確定したときに、末尾に付加する文字を返します。
+
+- **SEE** [m:Reline.completion_append_character=]
+
+### def Reline.completion_quote_character -> String | nil
+{: since="2.7"}
+
+ユーザ入力の補完中([m:Reline.completion_proc] の呼び出し中)に、開いたまま閉じられていないクオート文字([m:Reline.completer_quote_characters]
+のいずれか)があればそれを返します。補完中以外は nil を返します。
+
+### def Reline.completer_word_break_characters=(string)
+{: since="2.7"}
+
+ユーザの入力の補完を行う際、単語の区切りを示す文字の集合を文字列で指定します。
+
+デフォルトは ``" \t\n`><=;|&{("``(半角スペースを含む)です。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.completer_word_break_characters]
+
+### def Reline.completer_word_break_characters -> String
+{: since="2.7"}
+
+ユーザの入力の補完を行う際、単語の区切りを示す文字の集合を返します。
+
+- **SEE** [m:Reline.completer_word_break_characters=]
+
+### def Reline.completer_quote_characters=(string)
+{: since="2.7"}
+
+ユーザの入力の補完を行う際、クオートとみなす文字の集合を文字列で指定します。クオートの内側では、[m:Reline.completer_word_break_characters=]
+で指定した文字も通常の文字として扱われます。
+
+デフォルトは `"'`(ダブルクオートとシングルクオート)です。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.completer_quote_characters]
+
+### def Reline.completer_quote_characters -> String
+{: since="2.7"}
+
+ユーザの入力の補完を行う際、クオートとみなす文字の集合を返します。
+
+- **SEE** [m:Reline.completer_quote_characters=]
+
+### def Reline.basic_word_break_characters=(string)
+{: since="2.7"}
+
+単語の区切りを示す文字の集合を文字列で指定します。
+
+デフォルトは ``" \t\n`><=;|&{("``(半角スペースを含む)です。
+
+設定値は保持されますが、現在の reline の補完処理では使用されません。補完の単語の区切りには
+[m:Reline.completer_word_break_characters] が使われます。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.basic_word_break_characters]
+
+### def Reline.basic_word_break_characters -> String
+{: since="2.7"}
+
+単語の区切りを示す文字の集合を返します。
+
+- **SEE** [m:Reline.basic_word_break_characters=]
+
+### def Reline.basic_quote_characters=(string)
+{: since="2.7"}
+
+クオートとみなす文字の集合を文字列で指定します。
+
+デフォルトは `"'`(ダブルクオートとシングルクオート)です。
+
+設定値は保持されますが、現在の reline の補完処理では使用されません。クオートの判定には
+[m:Reline.completer_quote_characters] が使われます。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.basic_quote_characters]
+
+### def Reline.basic_quote_characters -> String
+{: since="2.7"}
+
+クオートとみなす文字の集合を返します。
+
+- **SEE** [m:Reline.basic_quote_characters=]
+
+### def Reline.filename_quote_characters=(string)
+{: since="2.7"}
+
+ファイル名の補完の際にクオートするための文字の集合を文字列で指定します。デフォルトは `""` です。
+
+設定値は保持されますが、現在の reline の補完処理では使用されません。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.filename_quote_characters]
+
+### def Reline.filename_quote_characters -> String
+{: since="2.7"}
+
+ファイル名の補完の際にクオートするための文字の集合を返します。
+
+- **SEE** [m:Reline.filename_quote_characters=]
+
+### def Reline.special_prefixes=(string)
+{: since="2.7"}
+
+補完対象の単語の一部として扱う接頭辞の文字の集合を文字列で指定します。デフォルトは `""` です。
+
+設定値は保持されますが、現在の reline の補完処理では使用されません。
+
+- **param** `string` -- 文字列を指定します。
+
+- **SEE** [m:Reline.special_prefixes]
+
+### def Reline.special_prefixes -> String
+{: since="2.7"}
+
+補完対象の単語の一部として扱う接頭辞の文字の集合を返します。
+
+- **SEE** [m:Reline.special_prefixes=]
+
+### def Reline.prompt_proc=(proc)
+{: since="2.7"}
+
+[m:Reline.readmultiline] での複数行編集時に、行ごとのプロンプトを動的に生成する [c:Proc] オブジェクト proc を指定します。デフォルトは nil です。
+
+proc は、入力中の各行の文字列を要素とする配列を受け取り、行ごとのプロンプト文字列の配列を返すようにします。[m:Reline.readline]
+による一行入力では使われません。
+
+- **param** `proc` -- プロンプトの配列を返す [c:Proc] オブジェクト、または nil を指定します。
+
+- **SEE** [m:Reline.prompt_proc]
+
+### def Reline.prompt_proc -> Proc | nil
+{: since="2.7"}
+
+行ごとのプロンプトを動的に生成する [c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.prompt_proc=]
+
+### def Reline.output_modifier_proc=(proc)
+{: since="2.7"}
+
+入力内容を表示する直前に、表示用に加工する [c:Proc] オブジェクト proc
+を指定します。シンタックスハイライトなどに利用できます。デフォルトは nil です。
+
+proc は、第 1 引数に入力内容全体の文字列(末尾に改行を含む)を、キーワード引数 complete に入力が確定したかどうかの真偽値を受け取り、表示に使う文字列を返すようにします。返した文字列は表示にだけ使われ、[m:Reline.readline]
+などの返り値は変わりません。
+
+- **param** `proc` -- 表示用の文字列を返す [c:Proc] オブジェクト、または nil を指定します。
+
+- **SEE** [m:Reline.output_modifier_proc]
+
+### def Reline.output_modifier_proc -> Proc | nil
+{: since="2.7"}
+
+入力内容を表示する直前に、表示用に加工する [c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.output_modifier_proc=]
+
+### def Reline.auto_indent_proc=(proc)
+{: since="2.7"}
+
+複数行編集時に、行頭の自動インデントの幅を計算する [c:Proc] オブジェクト
+proc を指定します。デフォルトは nil です。
+
+proc は次の 4 つの引数を受け取り、インデントに使う半角スペースの個数を整数で返すようにします。nil を返すとインデントを変更しません。対象の行の行頭の空白は、返した個数の半角スペースに置き換えられます。
+
+- `lines`: 入力中の各行の文字列の配列
+- `line_index`: インデントを計算する対象の行の `lines` 内の位置
+- `byte_pointer`: 行内のカーソルのバイト単位の位置
+- `is_newline`: 改行の入力直後かどうか
+
+- **param** `proc` -- インデント幅を返す [c:Proc] オブジェクト、または nil を指定します。
+
+- **SEE** [m:Reline.auto_indent_proc]
+
+### def Reline.auto_indent_proc -> Proc | nil
+{: since="2.7"}
+
+複数行編集時に、行頭の自動インデントの幅を計算する [c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.auto_indent_proc=]
+
+### def Reline.pre_input_hook=(proc)
+{: since="2.7"}
+
+[m:Reline.readline] や [m:Reline.readmultiline]
+が入力の受け付けを始める直前に呼ばれる [c:Proc] オブジェクト proc
+を指定します。proc は引数なしで呼ばれます。デフォルトは nil です。
+
+- **param** `proc` -- [c:Proc] オブジェクト、または nil を指定します。
+
+- **SEE** [m:Reline.pre_input_hook]
+
+### def Reline.pre_input_hook -> Proc | nil
+{: since="2.7"}
+
+入力の受け付けを始める直前に呼ばれる [c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.pre_input_hook=]
+
+### def Reline.dig_perfect_match_proc=(proc)
+{: since="2.7"}
+
+補完候補が 1 つに確定している状態で、さらに補完しようとしたときに呼ばれる
+[c:Proc] オブジェクト proc を指定します。proc
+は確定した候補の文字列を引数として呼ばれます。デフォルトは nil です。
+
+- **param** `proc` -- [c:Proc] オブジェクト、または nil を指定します。
+
+- **SEE** [m:Reline.dig_perfect_match_proc]
+
+### def Reline.dig_perfect_match_proc -> Proc | nil
+{: since="2.7"}
+
+補完候補が 1 つに確定している状態で、さらに補完しようとしたときに呼ばれる
+[c:Proc] オブジェクトを返します。
+
+- **SEE** [m:Reline.dig_perfect_match_proc=]
+
+### def Reline.vi_editing_mode -> nil
+{: since="2.7"}
+
+編集モードを vi モードにします。
+
+inputrc の `set editing-mode vi` でも設定できます。
+
+- **SEE** [m:Reline.emacs_editing_mode]、[m:Reline.vi_editing_mode?]
+
+### def Reline.emacs_editing_mode -> nil
+{: since="2.7"}
+
+編集モードを Emacs モードにします。デフォルトは Emacs モードです。
+
+- **SEE** [m:Reline.vi_editing_mode]、[m:Reline.emacs_editing_mode?]
+
+### def Reline.vi_editing_mode? -> bool
+{: since="2.7"}
+
+編集モードが vi モードかどうかを返します。
+
+- **SEE** [m:Reline.vi_editing_mode]
+
+### def Reline.emacs_editing_mode? -> bool
+{: since="2.7"}
+
+編集モードが Emacs モードかどうかを返します。
+
+- **SEE** [m:Reline.emacs_editing_mode]
+
+### def Reline.get_screen_size -> [Integer, Integer]
+{: since="2.7"}
+
+端末のサイズを [行数, 桁数] の配列で返します。

--- a/manual/api/reline/Reline__Face.md
+++ b/manual/api/reline/Reline__Face.md
@@ -1,0 +1,74 @@
+---
+library: reline
+since: "3.3"
+---
+# class Reline::Face < Object
+
+補完ダイアログなどの表示スタイル(色・文字装飾)をカスタマイズするためのクラスです。reline 0.4.0(Ruby 3.3 に同梱)で導入されました。
+
+[m:Reline::Face.config] で「face」(表示スタイルの設定の組)を定義します。既定では次の
+2 つの face が定義されています。
+
+- `:default` -- 通常のテキストのスタイル
+- `:completion_dialog` -- 補完ダイアログのスタイル
+
+それぞれの face では、次の 3 つの部分のスタイルを定義します。定義しなかった部分は
+`style: :reset` になります。
+
+- `:default` -- 基本のスタイル(補完ダイアログでは候補一覧の地の部分)
+- `:enhanced` -- 強調部分のスタイル(補完ダイアログでは選択中の候補)
+- `:scrollbar` -- スクロールバーのスタイル
+
+```ruby title="例: 補完ダイアログの配色を変更する"
+require 'reline'
+
+Reline::Face.config(:completion_dialog) do |conf|
+  conf.define :default, foreground: :white, background: :blue
+  conf.define :enhanced, foreground: :white, background: :magenta
+  conf.define :scrollbar, foreground: :white, background: :blue
+end
+```
+
+## Singleton Methods
+
+### def Reline::Face.config(name) { |conf| ... } -> object
+
+名前 name の face を定義します。
+
+ブロックには設定用のオブジェクトが渡されます。`define(part, **attributes)`
+を呼んで、face を構成する部分ごとのスタイルを定義します。
+
+- `part` -- `:default`・`:enhanced`・`:scrollbar` のいずれかを指定します。
+- `attributes` -- スタイルをキーワード引数で指定します。
+  - `foreground:`/`background:` -- 文字色/背景色。色名のシンボル(`:black`・`:red`・`:green`・`:yellow`・`:blue`・`:magenta`・`:cyan`・`:white` と、それぞれの `:bright_*`、`:gray`)、または
+    `"#RRGGBB"` 形式の文字列で指定します。
+  - `style:` -- 文字装飾。`:reset`・`:bold`・`:faint`・`:italicized`・`:underlined`・`:blinking`・`:negative`
+    などのシンボル、またはその配列で指定します。
+
+`"#RRGGBB"` 形式の色指定は、トゥルーカラーとして扱われる端末(環境変数
+`COLORTERM` が `truecolor` または `24bit` の環境、もしくは
+[m:Reline::Face.force_truecolor] を呼んだ場合)では 24 ビットカラーで、それ以外の端末では近似の
+256 色に変換して出力されます。
+
+- **param** `name` -- face の名前をシンボルで指定します。
+
+- **raise** `ArgumentError` -- `define` に不正な色やスタイルを指定した場合に発生します。
+
+### def Reline::Face.configs -> Hash
+
+定義されているすべての face の設定内容をハッシュで返します。
+
+### def Reline::Face.force_truecolor -> ()
+
+端末がトゥルーカラー対応かどうかの判定を、環境変数 `COLORTERM`
+の値によらず強制的に真にします。
+
+- **SEE** [m:Reline::Face.truecolor?]
+
+### def Reline::Face.truecolor? -> bool
+
+端末をトゥルーカラー対応として扱うかどうかを返します。環境変数 `COLORTERM`
+が `truecolor` または `24bit` の場合、もしくは [m:Reline::Face.force_truecolor]
+を呼んだ後に真を返します。
+
+- **SEE** [m:Reline::Face.force_truecolor]

--- a/manual/api/reline/Reline__Face.md
+++ b/manual/api/reline/Reline__Face.md
@@ -33,7 +33,7 @@ end
 
 ### def Reline::Face.config(name) { |conf| ... } -> object
 
-名前 name の face を定義します。
+名前 `name` の face を定義します。
 
 ブロックには設定用のオブジェクトが渡されます。`define(part, **attributes)`
 を呼んで、face を構成する部分ごとのスタイルを定義します。
@@ -54,14 +54,47 @@ end
 
 - **raise** `ArgumentError` -- `define` に不正な色やスタイルを指定した場合に発生します。
 
+```ruby title="例: 補完ダイアログの配色を変更する"
+require 'reline'
+
+Reline::Face.config(:completion_dialog) do |conf|
+  conf.define :default, foreground: :white, background: :blue
+  conf.define :enhanced, foreground: :white, background: :magenta
+  conf.define :scrollbar, foreground: :white, background: :blue
+end
+
+Reline::Face.configs[:completion_dialog][:default]
+# => {foreground: :white, background: :blue, escape_sequence: "\e[0m\e[37;44m"}
+```
+
 ### def Reline::Face.configs -> Hash
 
 定義されているすべての face の設定内容をハッシュで返します。
+
+```ruby title="例"
+require 'reline'
+
+Reline::Face.configs.keys
+# => [:default, :completion_dialog]
+Reline::Face.configs[:default]
+# => {default: {style: :reset, escape_sequence: "\e[0m"},
+#     enhanced: {style: :reset, escape_sequence: "\e[0m"},
+#     scrollbar: {style: :reset, escape_sequence: "\e[0m"}}
+```
 
 ### def Reline::Face.force_truecolor -> ()
 
 端末がトゥルーカラー対応かどうかの判定を、環境変数 `COLORTERM`
 の値によらず強制的に真にします。
+
+```ruby title="例: 24 ビットカラーで補完ダイアログの色を指定する"
+require 'reline'
+
+Reline::Face.force_truecolor
+Reline::Face.config(:completion_dialog) do |conf|
+  conf.define :default, foreground: "#dddddd", background: "#333333"
+end
+```
 
 - **SEE** [m:Reline::Face.truecolor?]
 

--- a/manual/api/reline/Reline__HISTORY.md
+++ b/manual/api/reline/Reline__HISTORY.md
@@ -1,0 +1,30 @@
+---
+library: reline
+---
+# object Reline::HISTORY
+
+Reline で入力した内容(ヒストリ)にアクセスするための定数です。
+
+[c:Array] のサブクラスである Reline::History クラスのインスタンスで、通常の配列と同じように履歴へアクセスできます。例えば
+`Reline::HISTORY[0]` で最初の入力内容を、`Reline::HISTORY.to_a`
+で全履歴を文字列の配列として取得できます。
+
+[m:Reline.readline] や [m:Reline.readmultiline] の引数 add_hist
+に真を指定すると、入力した文字列がここに追加されます。
+
+[c:Array] と異なる点は以下の通りです。
+
+- 要素を追加するとき(`push`・`<<` など)、inputrc の `set history-size`
+  で設定した履歴サイズを超えないよう、古い履歴から削除されます。履歴サイズが
+  0 のときは何も記録されず、負の値のときは無制限です(デフォルトは無制限)。
+- 追加する文字列のエンコーディングは Reline の内部エンコーディングに変換されます。
+- `to_s` は固定の文字列 `"HISTORY"` を返します。
+
+```ruby title="例: 入力のたびにヒストリを配列として表示する"
+require 'reline'
+
+while buf = Reline.readline("> ", true)
+  p Reline::HISTORY.to_a
+  print("-> ", buf, "\n")
+end
+```

--- a/manual/api/reline/Reline__HISTORY.md
+++ b/manual/api/reline/Reline__HISTORY.md
@@ -9,7 +9,7 @@ Reline で入力した内容(ヒストリ)にアクセスするための定数�
 `Reline::HISTORY[0]` で最初の入力内容を、`Reline::HISTORY.to_a`
 で全履歴を文字列の配列として取得できます。
 
-[m:Reline.readline] や [m:Reline.readmultiline] の引数 add_hist
+[m:Reline.readline] や [m:Reline.readmultiline] の引数 `add_hist`
 に真を指定すると、入力した文字列がここに追加されます。
 
 [c:Array] と異なる点は以下の通りです。


### PR DESCRIPTION
#3410 の段階 2 です(#3425 の続き)。reline の設定アクセサ群と `Reline::HISTORY`・`Reline::Face` を文書化します。

## 内容

- `manual/api/reline.md`: Reline モジュールに設定用の特異メソッドのエントリを追加
  - 補完系: `completion_proc`(+=)・`autocompletion`(+=)・`completion_case_fold`(+=)・`completion_append_character`(+=)・`completion_quote_character`・`completer_word_break_characters`(+=)・`completer_quote_characters`(+=)
  - proc 系: `prompt_proc`(+=)・`output_modifier_proc`(+=)・`auto_indent_proc`(+=)・`pre_input_hook`(+=)・`dig_perfect_match_proc`(+=)
  - 入出力・編集モード系: `input=`・`output=`・`vi_editing_mode`・`emacs_editing_mode`・`vi_editing_mode?`・`emacs_editing_mode?`・`get_screen_size`
  - Readline 互換で存在するが現在の reline の補完処理では使用されないもの(`basic_word_break_characters`・`basic_quote_characters`・`filename_quote_characters`・`special_prefixes`)は、その旨を明記した上でエントリ化
- `manual/api/reline/Reline__HISTORY.md`: 新規。Array のサブクラスであること・履歴サイズ制限(inputrc の `set history-size`)・エンコーディング変換・`to_s` が固定文字列 `"HISTORY"` を返すこと
- `manual/api/reline/Reline__Face.md`: 新規(front matter `since: "3.3"`)。`config` / `configs` / `force_truecolor` / `truecolor?`
- モジュール概要に inputrc(探索パスと `$if Ruby` 条件ブロック)の説明を追加し、アトリビュート一覧・履歴・Face への言及をリンク化

## バージョン分岐

- `autocompletion` / `autocompletion=` は reline 0.3.0(Ruby 3.1 同梱)で追加のため `#%since 3.1` でゲート(概要のリストと `completion_proc=` 本文中の言及も同様)
- `Reline::Face` は reline 0.4.0(Ruby 3.3 同梱)で追加のため front matter の `since: "3.3"` でゲートし、概要からのリンクも `#%since 3.3` でゲート
- それ以外はすべて reline 0.1.2(Ruby 2.7 同梱)から存在するため、#3425 と同じ理由で `{: since="2.7"}` を明示

## 内容の裏取り

- 版別の存否は ruby/reline の各タグ(v0.1.2・v0.2.0・v0.3.0・v0.3.2・v0.4.1・v0.6.3)の `lib/reline.rb` の定義行で確認しました(0.3.0 で autocompletion、0.4.0 で Face が追加。それ以外は 0.1.2 から存在)
- デフォルト値は Ruby 3.4.8(reline 0.6.3)で実測し、初期化コードが v0.2.0〜v0.6.3 で同一であることをソースで確認しました
- `basic_word_break_characters` など 4 アクセサが補完処理で未使用であることは、v0.2.0・v0.4.1・v0.6.3 の `line_editor.rb` に一切出現しないことで確認しました(単語区切りは `completer_word_break_characters`、クオート判定は `completer_quote_characters` のみが使われます)
- proc 系の呼び出し方(prompt_proc が複数行編集専用・output_modifier_proc の `complete` キーワード引数・auto_indent_proc の 4 引数と返り値の意味・completion_proc の引数の個数による可変引数)は 0.6.3 の呼び出し箇所で確認しました
- Face の `"#RRGGBB"` が非トゥルーカラー端末では 256 色に近似変換されること・`define` しなかった部分が `style: :reset` になることをソースで確認しました(0.4.1・0.6.3 とも同じ)

## 検証

- `rake check_blank_lines check_indent_in_samplecode check_filename_case_conflicts` パス
- 3.0・3.1・3.3・4.1 の DB 生成+checklink(capi 込み)で broken links 0
- 3.0 の DB に `autocompletion` と `Reline::Face` が無いこと、3.1 に `autocompletion` があり `Reline::Face` が無いこと、3.3 以降に両方あることを確認
- 「since Ruby 2.7」バッジの描画を確認

## この PR でやらないこと

- 行編集用メソッド(`insert_text`・`delete_text`・`line_buffer`・`point`・`redisplay` など)とダイアログ API(`add_dialog_proc`・`dialog_proc`)のエントリ化
- irb 系文書の require リストへの reline リンク復帰(#3410 段階 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
