### PR TITLE
irb 系文書の require リストに reline を追加

### DIFF
--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -3,6 +3,7 @@ type: library
 #%# Author: Keiju ISHITSUKA
 category: Development
 require:
+  - reline
   - irb/init
   - irb/context
 #%until 3.4

--- a/manual/api/irb/input-method.md
+++ b/manual/api/irb/input-method.md
@@ -1,6 +1,7 @@
 ---
 type: library
 require:
+  - reline
 #%until 3.3
   - irb/src_encoding
   - irb/magic-file

--- a/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
+++ b/manual/api/irb/input-method/IRB__ReadlineInputMethod.md
@@ -11,7 +11,7 @@ readline を用いた標準入力からの入力を表すクラスです。ラ�
 #%until 4.0
 [lib:readline] の require に失敗した場合は定義されません。
 #%else
-[lib:readline] の require に失敗した場合は、Reline が代わりに使われます。
+[lib:readline] の require に失敗した場合は、[c:Reline] が代わりに使われます。
 #%end
 
 ## Class Methods


### PR DESCRIPTION
#3410 の段階 3(最後)です。reline の文書ができた(#3425)ので、#3408・#3409 の時点では死リンクになるため見送っていた reline へのリンクを irb 系文書の require リストに復帰します。

## 内容

- `irb.md` と `irb/input-method.md` の require リストに `reline` を追加
- `IRB::ReadlineInputMethod` の 4.0 以降の説明文にある「Reline」をリンク化

## 根拠(一次ソース確認)

- `lib/irb.rb` と `lib/irb/input-method.rb` は Ruby 3.0(irb 1.3.0)〜4.1(irb 1.18.0)の全対応版で reline を直接 require しています(ruby/ruby の v3_0_0〜v3_4_0 タグと ruby/irb の v1.16.0・v1.18.0 タグで確認)。全版共通のため版分岐は不要です
- `irb/completion.rb` はどの版も reline を require していません(3.3 以降に現れる「Reline」はコメント内の言及のみ)ので追加しません
- `color.rb`・`easter-egg.rb`・`command/ls.rb`・`pager.rb`(4.0 以降)も reline を直接 require していますが、doctree に文書ページが無いため対象外です

## 検証

- lint 3 種パス
- 3.0・4.1 の DB 生成+checklink(capi 込み)で broken links 0
- 生成 DB で irb / irb/input-method の requires に reline が入ること、`IRB::ReadlineInputMethod` ページで Reline がリンクとして描画されることを確認

## 備考

- この PR と #3426(段階 2)は独立で、どちらが先にマージされても問題ありません。両方マージされると #3410 の提案 1〜3 がすべて完了します
- 調査の副産物: `lib/irb.rb` は `ripper` も直接 require していますが(ripper.md は文書あり)、#3410 の範囲外なのでこの PR では触れていません

🤖 Generated with [Claude Code](https://claude.com/claude-code)
