### PR TITLE
irb 系文書の require リストに ripper/prism ほかを補う

### DIFF
--- a/manual/api/irb.md
+++ b/manual/api/irb.md
@@ -3,6 +3,11 @@ type: library
 #%# Author: Keiju ISHITSUKA
 category: Development
 require:
+#%until 4.1
+  - ripper
+#%else
+  - prism
+#%end
   - reline
   - irb/init
   - irb/context

--- a/manual/api/irb/completion.md
+++ b/manual/api/irb/completion.md
@@ -1,6 +1,10 @@
 ---
 type: library
 #%# Author: Keiju ISHITSUKA
+require:
+#%since 3.1
+  - irb/ruby-lex
+#%end
 ---
 irb の completion 機能を提供するライブラリです。
 

--- a/manual/api/irb/input-method.md
+++ b/manual/api/irb/input-method.md
@@ -2,6 +2,11 @@
 type: library
 require:
   - reline
+  - io/console
+  - irb/completion
+#%if (version == "3.1")
+  - rdoc
+#%end
 #%until 3.3
   - irb/src_encoding
   - irb/magic-file

--- a/manual/api/irb/ruby-lex.md
+++ b/manual/api/irb/ruby-lex.md
@@ -1,5 +1,11 @@
 ---
 type: library
+require:
+#%until 4.1
+  - ripper
+#%else
+  - prism
+#%end
 ---
 Ruby のソースコードを字句解析するためのサブライブラリです。
 


### PR DESCRIPTION
#3427 の備考に書いた「`lib/irb.rb` は `ripper` も直接 require している」のフォローアップです。irb 系文書のうち、文書のあるライブラリを直接 require しているのに require リストに載っていなかったものを補います。

## 内容(すべて ruby/ruby の v3_0_0〜v3_4_0・ruby/irb の v1.16.0・v1.18.0 の各タグで確認)

- `irb.md`: `ripper`(Ruby 3.0〜4.0)/`prism`(4.1)を追加。**irb 1.18.0(Ruby 4.1 に同梱予定)で irb.rb の require が ripper から prism に置き換わっている**ため、`#%until 4.1` / `#%else` で分岐しています
- `irb/ruby-lex.md`: 同じく `ripper` / `prism` を追加(ruby-lex.rb も irb 1.18.0 で prism に置き換え)
- `irb/input-method.md`: `io/console` と `irb/completion` を追加(いずれも 3.0〜4.1 の全版で直接 require)。`rdoc` は Ruby 3.1 の input-method.rb だけが直接 require しているため `#%if (version == "3.1")` で追加
- `irb/completion.md`: `irb/ruby-lex` を追加(completion.rb が直接 require するのは 3.1 から。3.0 の completion.rb にトップレベルの require はありません)

対象外: irb.rb が require する irb/default_commands・irb/statement・irb/history・irb/color・irb/easter-egg・irb/debug・irb/pager は doctree に文書ページが無いため載せていません(DB に無い名前を書くと Required Libraries が死リンクになるため)。

## 検証

- lint 3 種パス
- 境界となる 5 版(3.0・3.1・3.2・4.0・4.1)で DB を生成し、各版の requires が期待どおりであることを確認(3.0 に rdoc / irb/ruby-lex 無し・3.1 に両方あり・3.2 で rdoc が消える・4.0 は ripper・4.1 は prism)
- require リストのリンクは checklink の検査対象外のため、追加した各ライブラリ名が各版の DB で実際に解決できることを個別に確認
- checklink(capi 込み)で broken links 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
