### PR TITLE
Prism::Node の特異メソッドエントリにクラス名プレフィクスを付ける

### DIFF
--- a/manual/api/prism/Node.md
+++ b/manual/api/prism/Node.md
@@ -32,12 +32,12 @@ p call.compact_child_nodes.size # => 2
 
 ## Class Methods
 
-### def type -> Symbol
+### def Prism::Node.type -> Symbol
 
 [m:Prism::Node#type] のクラスメソッド版です。インスタンスを作らずにノードクラス自体からノードの種類を表すシンボルを得られます。
 
 #%since 3.4
-### def fields -> [Prism::Reflection::Field]
+### def Prism::Node.fields -> [Prism::Reflection::Field]
 
 このノードクラスが持つフィールド(子ノードや属性)を表す
 `Prism::Reflection::Field` の配列を返します。構文木の各ノード・各フィールドを再帰的に処理するツールを書くときのリフレクション用途に使えます。


### PR DESCRIPTION
特異メソッドエントリ 2 件(`Prism::Node.type`・`Prism::Node.fields`)にクラス名プレフィクスを付けます。

## 背景

rurema/bitclust#309(`def self.name` 対応)の後続として準備している「特異メソッドエントリのプレフィクス必須化」検査を現在の master に当てて事前検証したところ、manual/ 全体でこの 2 件だけが引っかかりました(いずれも 2026-08-01 の検証後に追加されたエントリです)。

`def Klass.name` 形式は現行の bitclust 1.6 系でもパースでき、見出しの表示はプレフィクスなしのまま変わらないため、この変更は単独で先行マージできます。

## 検証

- lint 3 種パス
- manual/api 全体を機械スキャンし、Class Methods / Singleton Methods セクション配下の非プレフィクスエントリが他に無いことを確認
- プレフィクス必須検査を含む bitclust ブランチ×(本修正+md-main-self)で全 7 版(3.0〜4.1)のツリーがパースできることを確認
- 4.1 の DB で `Prism::Node.type` の見出し表示がプレフィクスなしのまま変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
