### PR TITLE
main のメソッドエントリを def main.name 形式にする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: b4b4bf5819b709255380897ea94b325e69fdb84e
+  revision: 021d7c71bd3204c571f0023b7637025305cd4731
   specs:
-    bitclust-core (1.5.0)
+    bitclust-core (1.6.1)
       drb
       json
       nkf
@@ -10,10 +10,10 @@ GIT
       rack
       rouge
       webrick
-    bitclust-dev (1.5.0)
-      bitclust-core (= 1.5.0)
-    refe2 (1.5.0)
-      bitclust-core (= 1.5.0)
+    bitclust-dev (1.6.1)
+      bitclust-core (= 1.6.1)
+    refe2 (1.6.1)
+      bitclust-core (= 1.6.1)
 
 GEM
   remote: https://rubygems.org/

--- a/manual/api/_builtin/main.md
+++ b/manual/api/_builtin/main.md
@@ -32,10 +32,10 @@ p public_methods(false) - basic_public_methods
 # => [:explicit_public_method]
 ```
 
-### def self.public() -> nil
-### def self.public(name) -> String | Symbol
-### def self.public(*name) -> Array
-### def self.public(names) -> Array
+### def main.public() -> nil
+### def main.public(name) -> String | Symbol
+### def main.public(*name) -> Array
+### def main.public(names) -> Array
 
 メソッドを public に設定します。
 
@@ -54,10 +54,10 @@ p public_methods(false) - basic_public_methods
 
 - **SEE** [m:Module#public]
 
-### def self.private() -> nil
-### def self.private(name) -> String | Symbol
-### def self.private(*name) -> Array
-### def self.private(names) -> Array
+### def main.private() -> nil
+### def main.private(name) -> String | Symbol
+### def main.private(*name) -> Array
+### def main.private(names) -> Array
 
 メソッドを private に設定します。
 
@@ -76,15 +76,15 @@ p public_methods(false) - basic_public_methods
 
 - **SEE** [m:Module#private]
 
-### def self.to_s    -> "main"
-### def self.inspect -> "main"
+### def main.to_s    -> "main"
+### def main.inspect -> "main"
 {: since=""}
 
 "main" を返します。
 
 #%#noexample
 
-### def self.include(*modules) -> self
+### def main.include(*modules) -> self
 
 引数 modules で指定したモジュールを後ろから順番に [c:Object] にインクルードします。
 
@@ -101,8 +101,8 @@ p hypot(3, 4)  # => 5.0
 
 - **SEE** [m:Module#include]
 
-### def self.define_method(name, method) -> Symbol
-### def self.define_method(name) { ... } -> Symbol
+### def main.define_method(name, method) -> Symbol
+### def main.define_method(name) { ... } -> Symbol
 {: since="2.0.0"}
 
 インスタンスメソッド name を [c:Object] に定義します。
@@ -124,7 +124,7 @@ p hypot(3, 4)  # => 5.0
 
 - **SEE** [m:Module#define_method]
 
-### def self.using(module) -> self
+### def main.using(module) -> self
 {: since="2.0.0"}
 
 引数で指定したモジュールで定義された拡張を有効にします。

--- a/manual/api/_builtin/main.md
+++ b/manual/api/_builtin/main.md
@@ -32,10 +32,10 @@ p public_methods(false) - basic_public_methods
 # => [:explicit_public_method]
 ```
 
-### def public() -> nil
-### def public(name) -> String | Symbol
-### def public(*name) -> Array
-### def public(names) -> Array
+### def self.public() -> nil
+### def self.public(name) -> String | Symbol
+### def self.public(*name) -> Array
+### def self.public(names) -> Array
 
 メソッドを public に設定します。
 
@@ -54,10 +54,10 @@ p public_methods(false) - basic_public_methods
 
 - **SEE** [m:Module#public]
 
-### def private() -> nil
-### def private(name) -> String | Symbol
-### def private(*name) -> Array
-### def private(names) -> Array
+### def self.private() -> nil
+### def self.private(name) -> String | Symbol
+### def self.private(*name) -> Array
+### def self.private(names) -> Array
 
 メソッドを private に設定します。
 
@@ -76,15 +76,15 @@ p public_methods(false) - basic_public_methods
 
 - **SEE** [m:Module#private]
 
-### def to_s    -> "main"
-### def inspect -> "main"
+### def self.to_s    -> "main"
+### def self.inspect -> "main"
 {: since=""}
 
 "main" を返します。
 
 #%#noexample
 
-### def include(*modules) -> self
+### def self.include(*modules) -> self
 
 引数 modules で指定したモジュールを後ろから順番に [c:Object] にインクルードします。
 
@@ -101,8 +101,8 @@ p hypot(3, 4)  # => 5.0
 
 - **SEE** [m:Module#include]
 
-### def define_method(name, method) -> Symbol
-### def define_method(name) { ... } -> Symbol
+### def self.define_method(name, method) -> Symbol
+### def self.define_method(name) { ... } -> Symbol
 {: since="2.0.0"}
 
 インスタンスメソッド name を [c:Object] に定義します。
@@ -124,7 +124,7 @@ p hypot(3, 4)  # => 5.0
 
 - **SEE** [m:Module#define_method]
 
-### def using(module) -> self
+### def self.using(module) -> self
 {: since="2.0.0"}
 
 引数で指定したモジュールで定義された拡張を有効にします。


### PR DESCRIPTION
#3393 から分離した後半です。

## 内容

`# object main` のページの特異メソッドエントリ 14 行を `### def main.name` 形式にします。#3393 で他の全エンティティは `def Klass.name` 形式に統一しましたが、`main` のエントリはプレフィクスなしのまま残っていました。bitclust の文法は `main` を `fatal`・`ARGF.class` と同様にクラス名として扱うため、`main.` プレフィクスがそのまま使えます(当初は `self.` 形式にしていましたが、レビューでのご提案を受けて `main.` に変更しました)。

描画は `def Klass.name` と同様にプレフィクスが落ちるため変わりません。

## 検証

- master へのマージを想定したツリー(master を merge した状態)で manual/api 全体の `update --markdowntree` パースを実測
  - bitclust master × Ruby 3.0 / 4.1
  - リリース済み bitclust v1.6.1 × Ruby 4.1(`main.` は 1.6.1 でもパースできるため、リリース済み gem の利用者への影響はありません)
- mini md ツリーの E2E で `main.include` 等が singleton method として登録され、表示がプレフィクスなし(`include(*modules) -> self` 等)になること、別名グループ `to_s`/`inspect` の名前解決が保たれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
