### PR TITLE
Time.iso8601 の使用例のエラーメッセージを実際の出力に合わせる

### DIFF
--- a/manual/api/time.md
+++ b/manual/api/time.md
@@ -158,7 +158,7 @@ begin
   non_iso8601_time = '2008-08-31A12:34:56+09:00'
   Time.iso8601(non_iso8601_time)
 rescue ArgumentError => err
-  puts err #=> invalid date: "2008-08-31A12:34:56+09:00"
+  puts err #=> invalid xmlschema format: "2008-08-31A12:34:56+09:00"
 end
 ```
 


### PR DESCRIPTION
`Time.iso8601` / `Time.xmlschema` の使用例にあるエラーメッセージのコメントを、実際の出力に合わせて修正します。

ruby/time の e04688e1e6 (2020-04) で例外メッセージが `invalid date:` から `invalid xmlschema format:` に変更されています。
https://github.com/ruby/time/commit/e04688e1e6b6720facee694edcffdf43c83fe442

現在対応している Ruby 3.0 以降が同梱する time (0.1.0 以降) はすべて新しいメッセージを出力するため、バージョン分岐は不要と判断しました。

実測 (Ruby 4.0.6):

```console
$ ruby -rtime -e 'begin; Time.iso8601("2008-08-31A12:34:56+09:00"); rescue ArgumentError => e; puts e; end'
invalid xmlschema format: "2008-08-31A12:34:56+09:00"
```

凍結中の refm/api/src/time.rd にも同じ記述がありますが、CONTRIBUTING.md に従い manual/ のみ修正しています。
