### PR TITLE
メモリビューのコードブロックに言語指定を追加

### DIFF
--- a/manual/capi/memory_view.md
+++ b/manual/capi/memory_view.md
@@ -20,7 +20,7 @@
 
 `flags` は以下をビット OR で組み合わせて指定します。
 
-```
+```c
 RUBY_MEMORY_VIEW_SIMPLE            = 0
 RUBY_MEMORY_VIEW_WRITABLE          = (1<<0)
 RUBY_MEMORY_VIEW_FORMAT            = (1<<1)

--- a/manual/doc/spec/memory_view.md
+++ b/manual/doc/spec/memory_view.md
@@ -55,7 +55,7 @@ numo-narray の `Numo::NArray` や rmagick の `Magick::Image` といった、 c
 
 `format` は以下の [d:pack_template] を並べた文字列です。
 
-```
+```text
 c, C, s, s!, S, S!, n, v, i, i!, I, I!, l, l!, L, L!,
 N, V, f, e, g, q, q!, Q, Q!, d, E, G, j, J, x
 ```


### PR DESCRIPTION
## 概要

#3435 のフォローアップです。メモリビュー文書のコードブロック 2 箇所に言語指定を追加します。

- `manual/capi/memory_view.md`: `RUBY_MEMORY_VIEW_*` フラグ定数の一覧(C の定義)に `c`
- `manual/doc/spec/memory_view.md`: pack テンプレート文字の一覧(コードではない列挙)に `text`

どちらも既存の使用実績がある指定です(`c` は manual/capi の複数ファイル、`text` は
manual/api の複数ファイルで使用)。lint(check_blank_lines /
check_indent_in_samplecode / check_single_space_indent)はパスしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
