### PR TITLE
StringScanner::Error の superclass を StandardError にする

### DIFF
--- a/manual/api/strscan.md
+++ b/manual/api/strscan.md
@@ -1031,7 +1031,7 @@ p StringScanner::Version.frozen? # => true
 [c:StringScanner] クラスの詳しいバージョンを文字列で返します。
 この文字列は [m:Object#freeze] されています。
 
-# class StringScanner::Error
+# class StringScanner::Error < StandardError
 
 スキャン中に発生したエラーをあらわす例外です。
 


### PR DESCRIPTION
fix #3441

`# class StringScanner::Error` に superclass の記載がなく、ページでは Object を継承しているかのように表示されていました。実際は strscan.c で `rb_eStandardError` の下に定義されているため(全対象バージョン共通)、`< StandardError` を追記します。

## 検証

- mini md ツリーで 3.0 / 4.1 の DB を生成し、`StringScanner::Error` の superclass が StandardError で登録されることを確認
- superclass 未記載で名前が Error/Exception 系の H1 クラス宣言を manual/api 全体で走査し、他に同種の箇所がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
