### PR TITLE
コードサンプルの require 'set' を 3.2 未満だけに表示する

### DIFF
--- a/manual/api/_builtin/Enumerable.md
+++ b/manual/api/_builtin/Enumerable.md
@@ -24,8 +24,10 @@ Enumerableモジュールはインクルードされています。ただし、�
 - **param** `pattern` -- ブロックの代わりに各要素に対して pattern === item を評価します。
 
 ```ruby title="例"
+#%until 3.2
 require 'set'
 
+#%end
 # すべて正の数か？
 p Set[5,  6, 7].all? {|v| v > 0 }      # => true
 p Set[5, -1, 7].all? {|v| v > 0 }      # => false
@@ -56,7 +58,9 @@ p({foo: 0, bar: 1}.all?(Hash))         # => false
 - **param** `pattern` -- ブロックの代わりに各要素に対して pattern === item を評価します。
 
 ```ruby title="例"
+#%until 3.2
 require 'set'
+#%end
 p Set[1, 2, 3].any? {|v| v > 3 }         # => false
 p Set[1, 2, 3].any? {|v| v > 1 }         # => true
 p Set[].any? {|v| v > 0 }                # => false
@@ -937,7 +941,9 @@ p [].minmax_by{} # => [nil, nil]
 - **param** `pattern` -- ブロックの代わりに各要素に対して pattern === item を評価します。
 
 ```ruby title="例"
+#%until 3.2
 require 'set'
+#%end
 p Set['ant', 'bear', 'cat'].none? {|word| word.length == 5}  # => true
 p Set['ant', 'bear', 'cat'].none? {|word| word.length >= 4}  # => false
 p Set['ant', 'bear', 'cat'].none?(/d/)                     # => true
@@ -962,7 +968,9 @@ p Set[nil, false, true].none?                              # => false
 - **param** `pattern` -- ブロックの代わりに各要素に対して pattern === item を評価します。
 
 ```ruby title="例"
+#%until 3.2
 require 'set'
+#%end
 p Set['ant', 'bear', 'cat'].one? {|word| word.length == 4}  # => true
 p Set['ant', 'bear', 'cat'].one? {|word| word.length > 4} # => false
 p Set['ant', 'bear', 'cat'].one?(/t/)                     # => false

--- a/manual/doc/symref.md
+++ b/manual/doc/symref.md
@@ -173,7 +173,9 @@ Ruby スクリプトで使われる記号の一覧です。
   定義されることもあります。
 
   ```ruby
+#%until 3.2
   require 'set'
+#%end
 #%since 4.0
   p Set[1, 2] | Set[2, 3] # => Set[1, 2, 3]
 #%else


### PR DESCRIPTION
fix #3437

Ruby 3.2 から Set は `require "set"` なしで使えるようになったため(NEWS の `[feature:16989]`)、コードサンプルの `require 'set'` を `#%until 3.2` でゲートし、3.0/3.1 のページにだけ表示するようにします。

対象は全バージョン共通で描画される 5 箇所です。

- `_builtin/Enumerable.md` の all? / any? / none? / one? の例(4 箇所)
- `doc/symref.md` の Set の例(1 箇所)

以下は現状のままにします。

- `set.md`・`set/Set.md`・`set/Enumerable.md` 内の 37 箇所: front matter `until: "3.2"` の 3.0/3.1 専用ページで、そこでは require が必要
- `doc/news/3_2_0.md` の 1 箇所: NEWS 翻訳の記録そのもの

## 検証

- mini md ツリーで 3.1 / 3.4 の DB を生成し、all?/any?/none?/one? の描画が 3.1 = require あり/3.4 = require なし(ゲート化で先頭空行も残らない)になることを確認
- symref.md は Preprocessor 直接実行で 3.1(require あり+旧 inspect 表記)/3.4(require なし+旧 inspect 表記)/4.1(require なし+新 inspect 表記)を確認
- `rake check_blank_lines check_indent_in_samplecode` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
