### PR TITLE
ReFe.md の文がコードブロックに取り込まれていたのを直す

### DIFF
--- a/manual/doc/ReFe.md
+++ b/manual/doc/ReFe.md
@@ -23,41 +23,33 @@ $ bitclust setup
 
 最新 Ruby リファレンスマニュアル用に ReFe のデータを構築するには以下の手順で行います。(詳細は ReFe の README を参照してください)
 
-(1) <http://i.loveruby.net/ja/prog/refe.html> から ReFe の基本セット
+(1) <http://i.loveruby.net/ja/prog/refe.html> から ReFe の基本セットを取って来てインストールします。
 
-```text
-を取って来てインストールします。
-
-    tar xvzf refe-x.x.x.tar.gz
-    cd refe-x.x.x
-    ruby setup.rb config
-    ruby setup.rb setup
-    (必要に応じて root になってください)
-    ruby setup.rb install
+```console
+tar xvzf refe-x.x.x.tar.gz
+cd refe-x.x.x
+ruby setup.rb config
+ruby setup.rb setup
+(必要に応じて root になってください)
+ruby setup.rb install
 ```
 
-(2) <https://web.archive.org/web/20110706181204/http://www.ruby-lang.org/ja/man/man-rd-ja.tar.gz>
+(2) <https://web.archive.org/web/20110706181204/http://www.ruby-lang.org/ja/man/man-rd-ja.tar.gz> にあるのが最新のリファレンスマニュアルの tarball です。これを取得します。
 
-```text
-にあるのが最新のリファレンスマニュアルの tarball です。
-これを取得します。
+(3) 取得した man-rd-ja.tar.gz を展開し、ReFeデータベースを構築します。/usr/local/share/refe は適宜環境に応じて変更してください(変更した場合は refe を実行するのに環境変数 REFE_DATA_DIR を設定する必要があります)
+
+```console
+gzip -dc man-rd-ja.tar.gz | tar xvf -
+cd man-rd-ja
+(必要に応じて root になってください)
+mkrefe_rubyrefm -d /usr/local/share/refe *.rd
 ```
-
-(3) 取得した man-rd-ja.tar.gz を展開し、ReFeデータベースを構築します。
-
-```text
-/usr/local/share/refe は適宜環境に応じて変更してください(変更した場合は
-refe を実行するのに環境変数 REFE_DATA_DIR を設定する必要があります)
-
-    gzip -dc man-rd-ja.tar.gz | tar xvf -
-    cd man-rd-ja
-    (必要に応じて root になってください)
-    mkrefe_rubyrefm -d /usr/local/share/refe *.rd
 
 /usr/local/share/refe 下に以下のディレクトリとファイルができます。
 
-    class_document/        method_document/
-    class_document_comp    method_document_comp
+```text
+class_document/        method_document/
+class_document_comp    method_document_comp
 ```
 
 (4) 後は使うだけです。
@@ -76,12 +68,7 @@ IO#puts
 
 ### ReFe の Emacs インタフェースのインストール方法
 
-(1) refe.el を取って来て
-
-```text
-/usr/local/share/emacs/site-lisp などの Emacs Lisp ライブラリの置き場所
-に置きます。
-```
+(1) refe.el を取って来て /usr/local/share/emacs/site-lisp などの Emacs Lisp ライブラリの置き場所に置きます。
 
 (2) .emacs に以下を書いておきます。
 


### PR DESCRIPTION
`manual/doc/ReFe.md` で、地の文がコードブロックに取り込まれて文が途中で切れている箇所を直します。

RD からの変換で、番号付き項目の継続行（4 スペースインデント）が、その後ろの verbatim ブロックごと ```text に取り込まれたのが原因のようです。

```
(1) <http://i.loveruby.net/ja/prog/refe.html> から ReFe の基本セット

```text
を取って来てインストールします。

    tar xvzf refe-x.x.x.tar.gz
```

`refm/doc/ReFe.rd` では、この地の文と verbatim はインデントの深さで区別されていました（継続行が 4、verbatim が 8）。

## 変更内容

- 地の文をコードブロックから段落に戻す（4 箇所）
- 残ったコマンド列は `console` / `text` のブロックにし、RD の verbatim インデントの名残だった 4 スペースを除く

対象は (1)・(2)・(3) と、Emacs インタフェースの節の (1) です。

## 確認したこと

生成した HTML で 4 箇所とも文がつながることを確認しました。

```
(1) http://i.loveruby.net/ja/prog/refe.html から ReFe の基本セットを取って来てインストールします。
(2) <a class="external" href="https://web.archive.org/…/man-rd-ja.tar.gz">…</a> にあるのが最新のリファレンスマニュアルの tarball です。これを取得します。
(3) 取得した man-rd-ja.tar.gz を展開し、ReFeデータベースを構築します。/usr/local/share/refe は適宜環境に応じて変更してください(…)
(1) refe.el を取って来て /usr/local/share/emacs/site-lisp などの Emacs Lisp ライブラリの置き場所に置きます。
```

(2) の URL はコードブロックの外に出たことで自動リンクになりました。

`rake check_filename_case_conflicts check_indent_in_samplecode check_single_space_indent check_blank_lines` / `rake generate:3.4 check_links:3.4`（0 broken link）/ `rake statichtml:3.4 check_format` はすべて通っています。

なお、このページは内容自体が古く（`man-rd-ja.tar.gz` は Wayback Machine 経由、`setup.rb` 時代の手順）、書き直す判断もあり得ると思います。ここでは変換由来の崩れだけを直しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
