### PR TITLE
ZeroDivisionError を詳細かつ正確に

### DIFF
--- a/manual/api/_builtin/ZeroDivisionError.md
+++ b/manual/api/_builtin/ZeroDivisionError.md
@@ -3,4 +3,30 @@ library: _builtin
 ---
 # class ZeroDivisionError < StandardError
 
-整数に対して整数の 0 で除算を行ったときに発生します。
+ゼロによる除算ができない場合にやろうとすると発生します。
+
+```ruby title="ZeroDivisionError が発生する例"
+# Integer や Rational の数値を Integer や Rational のゼロで割ろうとした
+3 / 0  # ~> ZeroDivisionError
+3r / 0 # ~> ZeroDivisionError
+3 / 0r # ~> ZeroDivisionError
+
+# ゼロを除数とした整商や剰余を求めようとした
+3.0.div(0.0)     # ~> ZeroDivisionError
+3.0.divmod(0.0)  # ~> ZeroDivisionError
+3.0 % 0.0        # ~> ZeroDivisionError
+3.remainder(0.0) # ~> ZeroDivisionError
+
+# ゼロを素因数分解しようとした
+require "prime"
+
+0.prime_division # ~> ZeroDivisionError
+```
+
+```ruby title="ゼロで割ることができる例"
+# 浮動小数点演算ではゼロで割ることができる
+p 1 / 0.0 # => Infinity
+p 1.0 / 0 # => Infinity
+p 1.fdiv(0) # => Infinity
+p 0.0 / 0 # => NaN
+```


### PR DESCRIPTION
ZeroDivisionError の説明が不十分かつ若干不正確[^a]なので，これを改善します。

[^a]: 「整数に対して整数の 0 で除算」でも `fdiv` なら発生しない