### PR TITLE
サンプルコードの # ==> を # => に統一

### DIFF
--- a/manual/api/bigdecimal/BigDecimal.md
+++ b/manual/api/bigdecimal/BigDecimal.md
@@ -289,7 +289,7 @@ Ruby の [c:Float] クラスが保持できる有効数字の数を返します�
 
 ```ruby
 require 'bigdecimal'
-p BigDecimal::double_fig  # ==> 16 (depends on the CPU etc.)
+p BigDecimal::double_fig  # => 16 (depends on the CPU etc.)
 ```
 
 double_figは以下の C プログラムの結果と同じです。

--- a/manual/api/matrix/Matrix.md
+++ b/manual/api/matrix/Matrix.md
@@ -1051,7 +1051,7 @@ p Matrix[[1+2i, 1i, 0], [1, 2, 3]].real
 行列を実部と虚部に分解したものを返します。
 
 ```ruby title="例"
-m.rect == [m.real, m.imag]  # ==> true for all matrices m
+m.rect == [m.real, m.imag]  # => true for all matrices m
 ```
 
 - **SEE** [m:Matrix#imaginary], [m:Matrix#real]


### PR DESCRIPTION
#3460 と同型の `# ==>` の残り 2 箇所を `# =>` に統一します(注釈テキストはそのまま)。

- `manual/api/bigdecimal/BigDecimal.md` — `BigDecimal::double_fig` の例
- `manual/api/matrix/Matrix.md` — `Matrix#rect` の例

これで manual 内の `# ==>` は無くなります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
