### PR TITLE
Array#deconstruct と Hash#deconstruct_keys を追加

### DIFF
--- a/manual/api/_builtin/Array.md
+++ b/manual/api/_builtin/Array.md
@@ -728,6 +728,22 @@ p ary.count{|x|x%2==0}  # => 3
 
 - **SEE** [m:Enumerable#count]
 
+### def deconstruct -> self
+{: since="2.7.0"}
+
+self を返します。
+
+このメソッドは以下のようにパターンマッチ(配列パターン)で利用されます。
+
+```ruby title="例"
+case [1, [2, 3]]
+in [a, [b, c]] # 裏側で #deconstruct を呼ぶ
+  p [a, b, c] # => [1, 2, 3]
+end
+```
+
+- **SEE** [m:Hash#deconstruct_keys], [ref:d:spec/pattern_matching#matching_non_primitive_objects]
+
 ### def delete(val)           -> object | nil
 ### def delete(val) { ... }   -> object
 

--- a/manual/api/_builtin/Hash.md
+++ b/manual/api/_builtin/Hash.md
@@ -1057,6 +1057,27 @@ p g.dig(:foo, 1)             # => 11
 
 - **SEE** [m:Array#dig], [m:Struct#dig], [m:OpenStruct#dig]
 
+### def deconstruct_keys(keys) -> self
+{: since="2.7.0"}
+
+self を返します。引数 keys は無視されます(キーによる絞り込みは行いません)。
+
+このメソッドは以下のようにパターンマッチ(ハッシュパターン)で利用されます。
+
+```ruby title="例"
+h = {name: "Alice", age: 29}
+
+case h
+in {name: String => name} # 裏側で #deconstruct_keys を呼ぶ
+  puts "Hello, #{name}"
+end
+# "Hello, Alice" が表示される
+```
+
+- **param** `keys` -- パターンに現れるキーの配列が渡されます(全体をマッチさせるパターンでは nil)。このメソッドは引数を使用しません。
+
+- **SEE** [m:Array#deconstruct], [ref:d:spec/pattern_matching#matching_non_primitive_objects]
+
 ### def rehash -> self
 
 キーのハッシュ値を再計算します。


### PR DESCRIPTION
## 概要

Ruby 2.7 のパターンマッチ導入時に追加されたまま未収録だった `Array#deconstruct` と `Hash#deconstruct_keys` を追加します。`Data` / `MatchData` / `Struct` / `CSV::Row` などの同名メソッドは収録済みで、組み込みクラスではこの 2 つだけが欠けていました(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出)。

## 内容

- どちらも本体は「self を返す」だけなので、説明はその旨+パターンマッチでの利用例(`Data#deconstruct` の既存記載のスタイルに合わせています)
- `Hash#deconstruct_keys` は引数 keys を完全に無視して self を返します(`Data`/`Struct` のようなキーによる絞り込みなし)。3.4.8 実機で `equal?` により同一オブジェクトであること、配列以外(文字列など)を渡してもエラーにならないことを確認済み
- 凍結 DB(〜2.7.0)にエントリが無く自動計算ではバッジが 3.0 になるため、明示 `{: since="2.7.0"}` を付与
- `Hash#deconstruct_keys` の例は返り値の `p` 表示を載せず、パターンマッチ経由にしています(Hash の inspect 表示が 3.4 で変わった版差を例に持ち込まないため)
- SEE は相互リンク+パターンマッチ仕様ページ(`spec/pattern_matching` の非プリミティブ節。ゲートなしの doc ページなので全対象版でリンク可)

## 検証

- ミニ Markdown ツリーで 3.0 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 両版でエントリ生成・`since Ruby 2.7.0` バッジ表示・compileerror 0・SEE(相互+`ref:d` アンカー)解決を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
