### PR TITLE
Dir#chdir を追加

### DIFF
--- a/manual/api/_builtin/Dir.md
+++ b/manual/api/_builtin/Dir.md
@@ -126,7 +126,7 @@ p Dir.chdir("~/.ssh")        # => Errno::ENOENT
 ```
 
 #%since 3.3
-- **SEE** [m:Dir.fchdir]
+- **SEE** [m:Dir.fchdir], [m:Dir#chdir]
 #%end
 
 #%since 3.3
@@ -458,6 +458,32 @@ p Dir.mktmpdir { |dir| Dir.empty?(dir) } # => true
 - **param** `path_name` -- 確認したいディレクトリ名。
 
 ## Instance Methods
+
+#%since 3.3
+### def chdir    -> 0
+### def chdir { ... }    -> object
+
+カレントディレクトリを self が指すディレクトリに変更します。
+
+ブロックを指定しない場合、カレントディレクトリの変更に成功すれば 0 を返します。
+
+ブロックを指定した場合、カレントディレクトリの変更はブロックの実行中に限られます。
+ブロックの実行結果を返します。
+
+- **raise** `IOError` -- 既に自身が close している場合に発生します。
+- **raise** `Errno::EXXX` -- 失敗した場合に発生します。
+
+```ruby title="例"
+Dir.chdir("/var/spool/mail")
+d = Dir.new("/usr")
+d.chdir do
+  p Dir.pwd # => "/usr"
+end
+p Dir.pwd   # => "/var/spool/mail"
+```
+
+- **SEE** [m:Dir.chdir], [m:Dir.fchdir]
+#%end
 
 ### def close    -> nil
 


### PR DESCRIPTION
## 概要

Ruby 3.3([Feature #19347](https://bugs.ruby-lang.org/issues/19347))で追加されたインスタンスメソッド版の `Dir#chdir` を追加します。同じチケット由来の `Dir.fchdir` / `Dir.for_fd` は #3309 で収録済みでしたが、`Dir#chdir` だけ未収録でした(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出)。

## 内容

- `## Instance Methods` の先頭に `#%since 3.3` ゲート付きで追加(`Dir.fchdir` の既存記載のスタイルに合わせています)
- 3.4.8 実機で確認した挙動をそのまま記載:
  - ブロックなし → カレントディレクトリを変更して 0 を返す
  - ブロックあり → 変更はブロック実行中のみで、ブロックの評価結果を返す(ブロックには引数が渡されない=シグネチャは `{ ... }` 形)
  - close 済みの Dir に対しては `IOError`(closed directory)
- `Dir.chdir` の既存 SEE(`#%since 3.3` ゲート内)に `Dir#chdir` への相互リンクを追加

## 検証

- ミニ Markdown ツリーで 3.0 / 3.3 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 3.0 ではエントリなし(クラス側 SEE もゲート内なのでリンク切れなし)、3.3 / 4.1 でエントリ生成・compileerror 0・SEE 解決を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
