### PR TITLE
Ractor#[] と Ractor#[]= を追加

### DIFF
--- a/manual/api/_builtin/Ractor.md
+++ b/manual/api/_builtin/Ractor.md
@@ -154,6 +154,52 @@ p l.lambda?            # => true
 
 ## Instance Methods
 
+### def [](sym) -> object | nil
+
+カレント Ractor(このメソッドを呼び出した Ractor)の Ractor-local storage の sym に対応するデータを取り出します。
+sym に対応するデータがなければ nil を返します。
+
+#%since 4.0
+self がカレント Ractor でない場合は例外が発生します。
+#%else
+self がカレント Ractor でなくても例外にはならず、常にカレント Ractor の Ractor-local storage を参照します(self は使われません)。
+#%end
+
+- **param** `sym` -- Ractor-local storage のキーを指定します。
+#%since 4.0
+- **raise** `RuntimeError` -- self がカレント Ractor でない場合に発生します。
+#%end
+
+```ruby title="例"
+Ractor.current[:user] = "me"
+p Ractor.current[:user] # => "me"
+p Ractor.current[:none] # => nil
+```
+
+#%since 3.4
+- **SEE** [m:Ractor.\[\]], [m:Ractor.store_if_absent]
+#%end
+
+### def []=(sym, val)
+
+カレント Ractor(このメソッドを呼び出した Ractor)の Ractor-local storage の sym に val を格納します。
+
+#%since 4.0
+self がカレント Ractor でない場合は例外が発生します。
+#%else
+self がカレント Ractor でなくても例外にはならず、常にカレント Ractor の Ractor-local storage に格納します(self は使われません)。
+#%end
+
+- **param** `sym` -- Ractor-local storage のキーを指定します。
+- **param** `val` -- 格納するデータを指定します。
+#%since 4.0
+- **raise** `RuntimeError` -- self がカレント Ractor でない場合に発生します。
+#%end
+
+#%since 3.4
+- **SEE** [m:Ractor.\[\]=], [m:Ractor.store_if_absent]
+#%end
+
 #%since 4.0
 ### def close -> bool
 


### PR DESCRIPTION
## 概要

Ruby 3.0 の Ractor 導入時から存在する Ractor-local storage のインスタンスメソッド版 `Ractor#[]` / `Ractor#[]=` を追加します(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出。クラスメソッド版 `Ractor.[]` / `Ractor.[]=`(3.4)は #3280 系で収録済みですが、インスタンス版は未収録でした)。

## 内容

all-ruby 3.0.7 / 4.0.6 + 手元 3.4.8 の実測で確認した版差をそのまま記載しています:

- **3.x**: レシーバは無視され、常にカレント Ractor(このメソッドを呼び出した Ractor)の storage を操作します。他の Ractor をレシーバにしても例外にならず、カレントの値を読み書きします(実測: main から `r[:k]` すると main 側の値が返り、`r[:k] = v` も main 側に書く)
- **4.0 以降**: self がカレント Ractor でない場合は `RuntimeError`("Cannot get/set ractor local storage for non-current ractor")

この差は `#%since 4.0` / `#%else` の本文分岐+raise の 4.0 ゲートで表現しています。例は全版で同じ挙動になる `Ractor.current` レシーバのみ使用。

- SEE のクラスメソッド版へのリンクは `#%since 3.4` ゲート内に配置(3.0〜3.3 のページからのリンク切れ回避)
- ブラケット名の参照は `[m:Ractor.\[\]]` のエスケープ形を使用(bitclust の `convert_bare_refs` が `\[` `\]` を復元する実装で、描画でラベル「Ractor.[]」と href(`method/Ractor/s/=5b=5d`)の解決を確認済み。manual 内では初出の書き方です)

## 検証

- ミニ Markdown ツリーで 3.0 / 3.4 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 3.0=#%else 本文・raise なし・SEE なし/3.4=#%else 本文+SEE あり/4.1=4.0 側本文+`RuntimeError`+SEE、いずれも compileerror 0
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
