### PR TITLE
Random.seed を追加

### DIFF
--- a/manual/api/_builtin/Random.md
+++ b/manual/api/_builtin/Random.md
@@ -96,6 +96,22 @@ p rand(10.0)       # => 6                   (rand(10) と同じ)
 #%else
 - **SEE** [m:Kernel?.rand], [m:Random::DEFAULT]
 #%end
+
+### def Random.seed -> Integer
+
+デフォルトの擬似乱数生成器([m:Kernel?.rand] や [m:Random.rand] が使うもの)の現在の種を返します。
+
+[m:Kernel?.srand] や [m:Random.srand] で新しい種を設定するまで、同じ値を返します。
+
+```ruby title="例"
+srand(42)
+p Random.seed  # => 42
+Random.srand(7)
+p Random.seed  # => 7
+```
+
+- **SEE** [m:Random#seed], [m:Random.srand], [m:Kernel?.srand]
+
 ### def Random.bytes(size) -> String
 
 ランダムなバイナリー文字列を返します。結果の文字列のサイズを指定できます。


### PR DESCRIPTION
## 概要

Ruby 3.0 で追加されたまま未収録だった `Random.seed` を追加します(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出。`Random#seed`(インスタンス版)や `Random.new_seed` / `Random.srand` は収録済みでした)。

## 内容

- デフォルトの擬似乱数生成器(`Kernel.#rand` などが使うもの)の現在の種を返すメソッドとして、`Random.srand` エントリの直後に追加
- `srand(42)` 後に 42、`Random.srand(7)` 後に 7 を返し、読み出しだけでは変化しないことを all-ruby 3.0.7 / 4.0.6 + 手元 3.4.8 で確認し、その実測値を例にしています
- SEE は `Random#seed` / `Random.srand` / `Kernel.#srand`(既存エントリと同じ `[m:Kernel?.srand]` 表記)

## 検証

- ミニ Markdown ツリーで 3.0 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 両版でエントリ生成・compileerror 0・SEE 解決を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
