### PR TITLE
Ractor#close_incoming と Ractor#close_outgoing を追加

### DIFF
--- a/manual/api/_builtin/Ractor.md
+++ b/manual/api/_builtin/Ractor.md
@@ -163,6 +163,40 @@ self がこのメソッドを呼び出した Ractor ではない場合、Ractor:
 
 #%end
 
+#%until 4.0
+### def close_incoming -> bool
+
+self の incoming port を閉じます。すでに閉じられていた場合は true を、そうでなければ false を返します。
+
+閉じると、self への [m:Ractor#send] と self 内での [m:Ractor.receive] は
+[c:Ractor::ClosedError] を発生させるようになります(受信待ちでブロックしていた場合も同様です)。
+
+Ractor の実行が終了すると、incoming port と outgoing port は自動的に閉じられます。
+
+```ruby title="例"
+r = Ractor.new { Ractor.receive }
+p r.close_incoming # => false
+r.send(1)          # ~> Ractor::ClosedError
+```
+
+- **SEE** [m:Ractor#close_outgoing], [m:Ractor#send], [m:Ractor.receive]
+
+### def close_outgoing -> bool
+
+self の outgoing port を閉じます。すでに閉じられていた場合は true を、そうでなければ false を返します。
+
+閉じると、self への [m:Ractor#take] と self 内での [m:Ractor.yield] は
+[c:Ractor::ClosedError] を発生させるようになります(送信待ち・受信待ちでブロックしていた場合も同様です)。
+
+```ruby title="例"
+r = Ractor.new { Ractor.receive }
+p r.close_outgoing # => false
+r.take             # ~> Ractor::ClosedError
+```
+
+- **SEE** [m:Ractor#close_incoming], [m:Ractor#take], [m:Ractor.yield]
+#%end
+
 #%since 4.0
 ### def default_port -> Ractor::Port
 


### PR DESCRIPTION
## 概要

Ruby 3.0〜3.4 に存在し、4.0 のポート再設計で削除された `Ractor#close_incoming` / `Ractor#close_outgoing` を追加します(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出)。`#%until 4.0` でゲートしているため 4.0 以降のページには現れません。

## 内容

all-ruby 3.0.7 + 手元 3.4.8 の実測で確認した内容をそのまま記載しています(両版で挙動同一):

- 返り値は「すでに閉じられていたか」(未クローズの生存 Ractor への初回呼び出しは false、2 回目は true)
- incoming port を閉じると、self への `Ractor#send` と self 内での `Ractor.receive` が `Ractor::ClosedError` になる(受信待ちでブロックしていた場合も例外)
- outgoing port を閉じると、self への `Ractor#take` と self 内での `Ractor.yield` が同様に `Ractor::ClosedError` になる
- Ractor の実行終了時に両ポートは自動的に閉じられる(終了済み Ractor への呼び出しは両方 true を返すことを実測)
- 4.0.6 では `close` のみが存在し、この 2 メソッドは削除済み(matrix.tsv とも一致)

`[c:Ractor::ClosedError]` は `api/ractor/ClosedError.md`(since 3.0)として収録済みなのでゲート内からのリンクは全対象版で解決します。SEE の `Ractor#take` / `Ractor.yield` も同じ `#%until 4.0` 側にのみ存在するエントリです。

## 検証

- ミニ Markdown ツリーで 3.0 / 3.4 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 3.0/3.4 でエントリ生成・compileerror 0・SEE と `Ractor::ClosedError` のリンク解決、4.1 では「no such method」(ゲートで消えている)を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過
- 同じ Ractor.md を触る `Ractor#[] / #[]=` の PR とは挿入位置が別で、両ブランチを順にマージする sim で衝突なし・両エントリ併存を確認済み(マージ順は自由)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
