### PR TITLE
GC.latest_compact_info を追加

### DIFF
--- a/manual/api/_builtin/GC.md
+++ b/manual/api/_builtin/GC.md
@@ -484,7 +484,22 @@ p GC.measure_total_time # => false
 
 詳細は[feature:15626]を参照してください。
 
-- **SEE** [m:GC.verify_compaction_references]
+- **SEE** [m:GC.verify_compaction_references], [m:GC.latest_compact_info]
+
+### def GC.latest_compact_info -> Hash
+
+最後に実行されたヒープコンパクション([m:GC.compact] など)の統計情報を返します。
+
+返り値の [c:Hash] のキーは以下のとおりで、値はいずれもオブジェクトの型ごとの件数を表す [c:Hash] です(コンパクションがまだ実行されていない場合は空の [c:Hash])。
+
+- `:considered` -- 移動の対象として検討されたオブジェクト数
+- `:moved` -- 実際に移動されたオブジェクト数
+#%since 3.2
+- `:moved_up` -- 移動先のアドレスが元より高かったオブジェクト数
+- `:moved_down` -- 移動先のアドレスが元より低かったオブジェクト数
+#%end
+
+- **SEE** [m:GC.compact], [m:GC.auto_compact]
 
 ### def GC.verify_compaction_references(toward: nil, double_heap: nil) -> Hash
 


### PR DESCRIPTION
## 概要

Ruby 3.0 で追加されたまま未収録だった `GC.latest_compact_info` を追加します(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出。`GC.compact` / `GC.auto_compact` / `GC.verify_compaction_references` は収録済みでした)。

## 内容

- `GC.compact` エントリの直後に追加し、`GC.compact` の SEE にも相互リンクを足しました
- 返り値のキー構成は実測どおりに記載:
  - 3.0 / 3.1: `:considered`(移動の対象として検討された数)と `:moved`(実際に移動された数)の 2 キー
  - 3.2 以降: `:moved_up` / `:moved_down`(移動先アドレスの方向別)が加わる → `#%since 3.2` で分岐
  - all-ruby 3.0.7 / 3.1.7 / 3.2.11 / 4.0.6 + 手元 3.4.8 でキー集合を確認
- 値はいずれもオブジェクトの型ごとの件数を表す Hash で、コンパクション未実行時は空の Hash になることも実測して明記
- 例は付けていません(件数が実行ごとに変わり、Hash の inspect 表示も 3.4 で変わるため版分岐が本文より大きくなる。隣接する `GC.compact` / `GC.verify_compaction_references` も例なしの構成です)

## 検証

- ミニ Markdown ツリーで 3.0 / 3.2 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 3.0=2 キー・3.2/4.1=4 キーで描画・compileerror 0・SEE 解決を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
