### PR TITLE
main.ruby2_keywords を追加

### DIFF
--- a/manual/api/_builtin/main.md
+++ b/manual/api/_builtin/main.md
@@ -145,3 +145,28 @@ p "ABC".downcase # => "ABC"
 
 - **SEE** [m:Module#refine], [m:Module#using]
 
+### def main.ruby2_keywords(method_name, ...) -> nil
+{: since="2.7.0"}
+
+トップレベルで定義したメソッドに、可変長引数(`*args`)で受けたキーワード引数を別のメソッド呼び出しへそのまま渡すためのフラグを設定します。
+
+Ruby 2.7 より前との後方互換性のために用意されているメソッドです。
+詳細は [m:Module#ruby2_keywords] を参照してください。
+
+- **param** `method_name` -- メソッド名を [c:String] か [c:Symbol] で指定します。複数指定できます。
+
+```ruby title="例"
+def target(a, k: 0)
+  [a, k]
+end
+
+def pass(*args)
+  target(*args)
+end
+ruby2_keywords :pass
+
+p pass(1, k: 2) # => [1, 2]
+```
+
+- **SEE** [m:Module#ruby2_keywords], [m:Proc#ruby2_keywords], [m:Hash.ruby2_keywords_hash]
+


### PR DESCRIPTION
## 概要

Ruby 2.7 で追加されたまま未収録だったトップレベル版の `main.ruby2_keywords` を追加します(`tools/method-versions` の逆方向突き合わせ=別 PR の `undocumented.tsv` で検出。`Module#ruby2_keywords` / `Proc#ruby2_keywords` / `Hash.ruby2_keywords_hash` は収録済みで、main オブジェクトの private 特異メソッドとして定義されるトップレベル版だけが欠けていました)。

## 内容

- main.md の既存エントリ(`main.using` / `main.define_method`)と同じ構成で末尾に追加。本文は簡潔にして詳細は `Module#ruby2_keywords` 参照
- 実測(all-ruby 3.0.7 / 4.0.6 + 手元 3.4.8・全版同一挙動): 返り値 nil・`*args` 越しのキーワード引数の透過(例の `pass(1, k: 2) # => [1, 2]` は実測値)・メソッド名の複数指定可
- 凍結 DB(〜2.7.0)にエントリが無く自動計算ではバッジが 3.0 になるため、明示 `{: since="2.7.0"}` を付与(`Array#deconstruct` の PR と同じ理由)

## 検証

- ミニ Markdown ツリーで 3.0 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 両版でエントリ生成・`since Ruby 2.7.0` バッジ表示・compileerror 0 を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
