### PR TITLE
RubyVM::AbstractSyntaxTree の未収録 API を追加

### DIFF
--- a/manual/api/_builtin/RubyVM__AbstractSyntaxTree.md
+++ b/manual/api/_builtin/RubyVM__AbstractSyntaxTree.md
@@ -21,9 +21,32 @@ parser gem (<https://github.com/whitequark/parser>)や
 
 ## Singleton Methods
 
+#%since 3.2
+### def RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(backtrace_location) -> Integer
+
+引数の [c:Thread::Backtrace::Location] が指すコードの位置に対応するノードの ID を返します。
+
+ID は [m:RubyVM::AbstractSyntaxTree::Node#node_id] と同じ体系の整数で、具体的な値は Ruby のバージョンやパーサによって異なります。
+
+- **param** `backtrace_location` -- [c:Thread::Backtrace::Location] を指定します。
+
+- **raise** `TypeError` -- backtrace_location が [c:Thread::Backtrace::Location] でない場合に発生します。
+
+```ruby title="例"
+loc = caller_locations(0, 1).first
+p RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc) # => 3
+```
+
+- **SEE** [m:RubyVM::AbstractSyntaxTree::Node#node_id]
+#%end
+
 ### def RubyVM::AbstractSyntaxTree.of(proc) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
 ### def RubyVM::AbstractSyntaxTree.of(proc, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+#%else
+#%since 3.1
+### def RubyVM::AbstractSyntaxTree.of(proc, keep_script_lines: false) -> RubyVM::AbstractSyntaxTree::Node
+#%end
 #%end
 
 引数 proc に渡したProcやメソッドオブジェクトの抽象構文木を返します。
@@ -31,11 +54,20 @@ parser gem (<https://github.com/whitequark/parser>)や
 このメソッドはProcやメソッドが定義されたファイルを読み込む必要があるため、
 irbのようなファイルを介さない対話的環境では動作しません。
 
+#%since 3.4
+また、Ruby 3.4 以降でデフォルトになったパーサ(Prism)でコンパイルされたコードに対しては使えません。使う場合は `--parser=parse.y` を付けて Ruby を起動してください。
+#%end
+
 - **param** `proc` -- Procもしくはメソッドオブジェクトを指定します。
+#%since 3.1
+- **param** `keep_script_lines` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#script_lines] でノードと関連づけられたソースコードのテキストを取得できます。
+#%end
 #%since 3.2
-- **param** `keep_script_lines` -- true を指定すると、 Node#script_lines でノードと関連づけられたソースコードのテキストを取得できます。
-- **param** `keep_tokens` -- true を指定すると、 Node#token が利用できます。
+- **param** `keep_tokens` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#tokens] が利用できます。
 - **param** `error_tolerant` -- true を指定すると、構文エラーが発生した際にエラー箇所を type が :ERROR であるようなノードに置き換えてツリーを生成します。
+#%end
+#%since 3.4
+- **raise** `RuntimeError` -- Prism でコンパイルされたコードを指定した場合に発生します。
 #%end
 
 ```ruby
@@ -73,14 +105,20 @@ pp RubyVM::AbstractSyntaxTree.of(method(:hello))
 ### def RubyVM::AbstractSyntaxTree.parse(string) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
 ### def RubyVM::AbstractSyntaxTree.parse(string, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+#%else
+#%since 3.1
+### def RubyVM::AbstractSyntaxTree.parse(string, keep_script_lines: false) -> RubyVM::AbstractSyntaxTree::Node
+#%end
 #%end
 
 文字列を抽象構文木にパースし、その木の根ノードを返します。
 
 - **param** `string` -- パースする対象の Ruby のコードを文字列で指定します。
+#%since 3.1
+- **param** `keep_script_lines` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#script_lines] でノードと関連づけられたソースコードのテキストを取得できます。
+#%end
 #%since 3.2
-- **param** `keep_script_lines` -- true を指定すると、 Node#script_lines でノードと関連づけられたソースコードのテキストを取得できます。
-- **param** `keep_tokens` -- true を指定すると、 Node#token が利用できます。
+- **param** `keep_tokens` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#tokens] が利用できます。
 - **param** `error_tolerant` -- true を指定すると、構文エラーが発生した際にエラー箇所を type が :ERROR であるようなノードに置き換えてツリーを生成します。
 #%end
 - **raise** `SyntaxError` -- string が Ruby のコードとして正しくない場合に発生します。
@@ -105,14 +143,20 @@ pp RubyVM::AbstractSyntaxTree.parse("x = 1; p(x; y=2", error_tolerant: true)
 ### def RubyVM::AbstractSyntaxTree.parse_file(pathname) -> RubyVM::AbstractSyntaxTree::Node
 #%since 3.2
 ### def RubyVM::AbstractSyntaxTree.parse_file(pathname, keep_script_lines: false, error_tolerant: false, keep_tokens: false) -> RubyVM::AbstractSyntaxTree::Node
+#%else
+#%since 3.1
+### def RubyVM::AbstractSyntaxTree.parse_file(pathname, keep_script_lines: false) -> RubyVM::AbstractSyntaxTree::Node
+#%end
 #%end
 
 pathname のファイルを読み込み、その内容を抽象構文木にパースし、その木の根ノードを返します。
 
 - **param** `pathname` -- パースする対象のファイルパスを指定します
+#%since 3.1
+- **param** `keep_script_lines` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#script_lines] でノードと関連づけられたソースコードのテキストを取得できます。
+#%end
 #%since 3.2
-- **param** `keep_script_lines` -- true を指定すると、 Node#script_lines でノードと関連づけられたソースコードのテキストを取得できます。
-- **param** `keep_tokens` -- true を指定すると、 Node#token が利用できます。
+- **param** `keep_tokens` -- true を指定すると、[m:RubyVM::AbstractSyntaxTree::Node#tokens] が利用できます。
 - **param** `error_tolerant` -- true を指定すると、構文エラーが発生した際にエラー箇所を type が :ERROR であるようなノードに置き換えてツリーを生成します。
 #%end
 - **raise** `SyntaxError` -- pathname から取得された文字列が Ruby のコードとして正しくない場合に発生します。

--- a/manual/api/_builtin/RubyVM__AbstractSyntaxTree__Location.md
+++ b/manual/api/_builtin/RubyVM__AbstractSyntaxTree__Location.md
@@ -1,0 +1,57 @@
+---
+library: _builtin
+since: "3.4"
+---
+# class RubyVM::AbstractSyntaxTree::Location < Object
+
+抽象構文木のノード([c:RubyVM::AbstractSyntaxTree::Node])に関連づけられた位置情報を表すクラスです。
+
+[m:RubyVM::AbstractSyntaxTree::Node#locations] で取得できます。
+
+[c:RubyVM::AbstractSyntaxTree] と同様に MRI の実装の詳細を表す実験的な API であり、予告なしに変更される可能性があります。
+
+## Instance Methods
+
+### def first_column -> Integer
+
+ソースコード中で、この位置情報が指す範囲が始まる列番号を返します。
+
+列番号は0-originで、バイト単位で表されます。
+
+```ruby
+loc = RubyVM::AbstractSyntaxTree.parse('1 + 2').locations.first
+p loc.first_column # => 0
+```
+
+### def first_lineno -> Integer
+
+ソースコード中で、この位置情報が指す範囲が始まる行番号を返します。
+
+行番号は1-originです。
+
+```ruby
+loc = RubyVM::AbstractSyntaxTree.parse('1 + 2').locations.first
+p loc.first_lineno # => 1
+```
+
+### def last_column -> Integer
+
+ソースコード中で、この位置情報が指す範囲が終わる列番号を返します。
+
+列番号は0-originで、バイト単位で表されます。
+
+```ruby
+loc = RubyVM::AbstractSyntaxTree.parse('1 + 2').locations.first
+p loc.last_column # => 5
+```
+
+### def last_lineno -> Integer
+
+ソースコード中で、この位置情報が指す範囲が終わる行番号を返します。
+
+行番号は1-originです。
+
+```ruby
+loc = RubyVM::AbstractSyntaxTree.parse('1 + 2').locations.first
+p loc.last_lineno # => 1
+```

--- a/manual/api/_builtin/RubyVM__AbstractSyntaxTree__Node.md
+++ b/manual/api/_builtin/RubyVM__AbstractSyntaxTree__Node.md
@@ -10,6 +10,22 @@ since: "2.6.0"
 
 ## Instance Methods
 
+#%since 3.2
+### def all_tokens -> Array | nil
+
+self を含むスクリプト全体のトークンの配列を返します。
+各トークンの形式は [m:RubyVM::AbstractSyntaxTree::Node#tokens] と同じです。
+
+keep_tokens を有効にしてパースした場合にだけ利用でき、そうでない場合は nil を返します。
+
+```ruby
+root = RubyVM::AbstractSyntaxTree.parse("x = 1", keep_tokens: true)
+p root.all_tokens.size # => 5
+```
+
+- **SEE** [m:RubyVM::AbstractSyntaxTree::Node#tokens]
+#%end
+
 ### def children -> Array
 
 self の子ノードを配列で返します。
@@ -77,6 +93,95 @@ p node.last_column # => 5
 node = RubyVM::AbstractSyntaxTree.parse('1 + 1')
 p node.last_lineno # => 1
 ```
+
+#%since 3.4
+### def locations -> Array
+
+self に関連づけられた位置情報([c:RubyVM::AbstractSyntaxTree::Location])の配列を返します。
+
+最初の要素は self 全体の位置です。ノードの種類によっては、キーワードなど部分ごとの位置情報が続きます(対応する位置が無い要素は nil になります)。
+
+```ruby
+node = RubyVM::AbstractSyntaxTree.parse("return 1 unless x").children[2]
+p node.type # => :UNLESS
+p node.locations
+# => [#<RubyVM::AbstractSyntaxTree::Location:@1:0-1:17>,
+#     #<RubyVM::AbstractSyntaxTree::Location:@1:9-1:15>, nil, nil]
+```
+
+- **SEE** [c:RubyVM::AbstractSyntaxTree::Location]
+#%end
+
+#%since 3.1
+### def node_id -> Integer
+
+self に割り当てられた ID を返します。
+
+ID は抽象構文木の中でノードを識別するための整数です。具体的な値は Ruby のバージョンやパーサによって異なります。
+
+```ruby
+node = RubyVM::AbstractSyntaxTree.parse("x = 1 + 2\ny = 3\n")
+p node.node_id # => 9
+```
+
+#%since 3.2
+- **SEE** [m:RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location]
+#%end
+#%end
+
+#%since 3.1
+### def script_lines -> Array | nil
+
+スクリプト全体の各行を要素とする文字列の配列を返します。
+
+keep_script_lines を有効にしてパースした場合にだけ利用でき、そうでない場合は nil を返します。
+
+```ruby
+root = RubyVM::AbstractSyntaxTree.parse("x = 1 + 2\ny = 3\n", keep_script_lines: true)
+p root.script_lines # => ["x = 1 + 2\n", "y = 3\n"]
+```
+
+- **SEE** [m:RubyVM::AbstractSyntaxTree::Node#source], [m:RubyVM::AbstractSyntaxTree.parse]
+#%end
+
+#%since 3.1
+### def source -> String | nil
+
+self に対応する部分のソースコードを文字列で返します。
+
+keep_script_lines を有効にしてパースした場合にだけ利用でき、そうでない場合は nil を返します。
+
+```ruby
+root = RubyVM::AbstractSyntaxTree.parse("x = 1 + 2\ny = 3\n", keep_script_lines: true)
+p root.source                         # => "x = 1 + 2\ny = 3"
+p root.children[2].children[0].source # => "x = 1 + 2"
+```
+
+- **SEE** [m:RubyVM::AbstractSyntaxTree::Node#script_lines]
+#%end
+
+#%since 3.2
+### def tokens -> Array | nil
+
+self に対応する部分のトークンの配列を返します。
+
+各トークンは `[id, type, ソース文字列, 位置情報]` の 4 要素の配列です。
+位置情報は `[first_lineno, first_column, last_lineno, last_column]` の配列です。
+
+keep_tokens を有効にしてパースした場合にだけ利用でき、そうでない場合は nil を返します。
+
+```ruby
+root = RubyVM::AbstractSyntaxTree.parse("x = 1", keep_tokens: true)
+pp root.tokens
+# => [[0, :tIDENTIFIER, "x", [1, 0, 1, 1]],
+#     [1, :tSP, " ", [1, 1, 1, 2]],
+#     [2, :"=", "=", [1, 2, 1, 3]],
+#     [3, :tSP, " ", [1, 3, 1, 4]],
+#     [4, :tINTEGER, "1", [1, 4, 1, 5]]]
+```
+
+- **SEE** [m:RubyVM::AbstractSyntaxTree::Node#all_tokens], [m:RubyVM::AbstractSyntaxTree.parse]
+#%end
 
 ### def type -> Symbol
 


### PR DESCRIPTION
## 概要

`tools/method-versions` の逆方向突き合わせ(#3466 の `undocumented.tsv`)で検出された `RubyVM::AbstractSyntaxTree` 系の未収録 API をまとめて追加します。RubyVM 配下ですが、既に `RubyVM::AbstractSyntaxTree` と `Node` の基本メソッドは収録済みなので、その続きという位置づけです。

- `Node#node_id` / `Node#script_lines` / `Node#source`(3.1)
- `Node#tokens` / `Node#all_tokens` / `RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location`(3.2)
- `Node#locations` と `RubyVM::AbstractSyntaxTree::Location` クラス(3.4、[Feature #20624](https://bugs.ruby-lang.org/issues/20624)。新規ファイル)

## 既存記載の修正(実測に基づく)

1. **`parse` / `parse_file` / `of` の `keep_script_lines:` は 3.2 でなく 3.1 から**です(3.1.7 実機で 3 メソッドとも受理を確認。`error_tolerant:` / `keep_tokens:` は 3.2 のままで正しい)。従来ひとまとめだった 3.2 ゲートを、`#%since 3.2` / `#%else` + `#%since 3.1` の入れ子に分割しました
2. param 説明の「`Node#token` が利用できます」の誤記をリンク付きの `Node#tokens` に修正(`script_lines` の言及もリンク化)
3. **`of` は 3.4 以降デフォルトの Prism でコンパイルされたコードに使えません**(`RuntimeError: cannot get AST for ISEQ compiled by prism`。`--parser=parse.y` 起動で回避できることを 3.4.8 で確認)。この注記と raise を `#%since 3.4` ゲートで追加

## 記載内容の根拠(すべて実測)

all-ruby 3.1.7 / 3.2.11 / 4.0.6 + 手元 3.4.8 で確認:

- `script_lines` / `source` / `tokens` / `all_tokens` はオプション無効時 nil(全版)
- `tokens` の各要素は `[id, type, ソース文字列, 位置情報]` で、**位置情報は 4.0 でも `[first_lineno, first_column, last_lineno, last_column]` の素の配列**(Location オブジェクトではない)
- `UNLESS` ノードの `locations` は nil 要素を含む(`[全体, keyword, nil, nil]`)— 「対応する位置が無い要素は nil」と明記
- `node_id` 系の具体値はパーサ依存(parse.y と Prism で異なる)なので、その旨を明記。例の出力(`node_id # => 9` など)は 4 版すべてで一致した入力を選んでいます
- `node_id_for_backtrace_location` の `TypeError`(引数型)も実測

## 検証

- ミニ Markdown ツリーで 3.0 / 3.1 / 3.2 / 3.4 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 存在マトリクス(3.0=なし → 3.1=node_id 系 → 3.2=tokens 系 → 3.4=locations/Location)・parse のシグネチャ出し分け(3.0=1 本/3.1=`keep_script_lines` のみ/3.2=3 キーワード)・Prism 注記の 3.4 限定・Location クラスの版ゲート、すべて期待どおり。compileerror 0
- `rake check_blank_lines check_indent_in_samplecode` 通過
- 他の open PR とファイル重複なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
