### PR TITLE
Module#ruby2_keywords と Proc#ruby2_keywords の本文を翻訳

### DIFF
--- a/manual/api/_builtin/Module.md
+++ b/manual/api/_builtin/Module.md
@@ -1975,26 +1975,15 @@ end
 
 ### def ruby2_keywords(method_name, ...)    -> nil
 
-For the given method names, marks the method as passing keywords through
-a normal argument splat.  This should only be called on methods that
-accept an argument splat (\`*args\`) but not explicit keywords or a
-keyword splat.  It marks the method such that if the method is called
-with keyword arguments, the final hash argument is marked with a special
-flag such that if it is the final element of a normal argument splat to
-another method call, and that method call does not include explicit
-keywords or a keyword splat, the final element is interpreted as
-keywords. In other words, keywords will be passed through the method to
-other methods.
+引数で指定した名前のメソッドに、通常の引数スプラット(`*args`)を通してキーワード引数を透過させるためのフラグを設定します。引数スプラットは受け取るものの、明示的なキーワード引数やキーワードスプラット(`**kwargs`)は受け取らないメソッドに対してだけ使ってください。
 
-This should only be used for methods that delegate keywords to another
-method, and only for backwards compatibility with Ruby versions before
-2.7.
+フラグを設定したメソッドがキーワード引数付きで呼び出されると、末尾の Hash 引数に特別なフラグが設定されます。その Hash が別のメソッド呼び出しの引数スプラットの末尾要素として渡され、かつその呼び出しが明示的なキーワード引数やキーワードスプラットを含まない場合、末尾要素はキーワード引数として解釈されます。つまり、キーワード引数がこのメソッドを経由してほかのメソッドへ渡されるようになります。
 
-This method will probably be removed at some point, as it exists only
-for backwards compatibility. As it does not exist in Ruby versions
-before 2.7, check that the module responds to this method before calling
-it. Also, be aware that if this method is removed, the behavior of the
-method will change so that it does not pass through keywords.
+キーワード引数をほかのメソッドに委譲するメソッドに対して、Ruby 2.7 より前のバージョンとの後方互換性のためだけに使ってください。
+
+このメソッドは後方互換性のためだけに存在するので、いずれ削除される可能性があります。Ruby 2.7 より前のバージョンには存在しないため、例のように呼び出す前にこのメソッドに応答するかを確認してください。また、このメソッドが削除されたときには、フラグを設定していたメソッドはキーワード引数を透過しない挙動に変わることに注意してください。
+
+- **param** `method_name` -- メソッド名を [c:String] か [c:Symbol] で指定します。複数指定できます。
 
 ```ruby title="例"
 module Mod
@@ -2004,6 +1993,8 @@ module Mod
   ruby2_keywords(:foo) if respond_to?(:ruby2_keywords, true)
 end
 ```
+
+- **SEE** [m:main.ruby2_keywords], [m:Proc#ruby2_keywords], [m:Hash.ruby2_keywords_hash]
 
 ### def using(module) -> self
 

--- a/manual/api/_builtin/Proc.md
+++ b/manual/api/_builtin/Proc.md
@@ -442,25 +442,13 @@ p prc.parameters(lambda: false) # => [[:opt, :x], [:opt, :y], [:rest, :other]]
 
 ### def ruby2_keywords -> proc
 
-Marks the proc as passing keywords through a normal argument splat. This
-should only be called on procs that accept an argument splat (\`*args\`)
-but not explicit keywords or a keyword splat.  It marks the proc such
-that if the proc is called with keyword arguments, the final hash
-argument is marked with a special flag such that if it is the final
-element of a normal argument splat to another method call, and that
-method call does not include explicit keywords or a keyword splat, the
-final element is interpreted as keywords.  In other words, keywords will
-be passed through the proc to other methods.
+self に、通常の引数スプラット(`*args`)を通してキーワード引数を透過させるためのフラグを設定し、self を返します。引数スプラットは受け取るものの、明示的なキーワード引数やキーワードスプラット(`**kwargs`)は受け取らない Proc に対してだけ使ってください。
 
-This should only be used for procs that delegate keywords to another
-method, and only for backwards compatibility with Ruby versions before
-2.7.
+フラグを設定した Proc がキーワード引数付きで呼び出されると、末尾の Hash 引数に特別なフラグが設定されます。その Hash が別のメソッド呼び出しの引数スプラットの末尾要素として渡され、かつその呼び出しが明示的なキーワード引数やキーワードスプラットを含まない場合、末尾要素はキーワード引数として解釈されます。つまり、キーワード引数がこの Proc を経由してほかのメソッドへ渡されるようになります。
 
-This method will probably be removed at some point, as it exists only
-for backwards compatibility. As it does not exist in Ruby versions
-before 2.7, check that the proc responds to this method before calling
-it. Also, be aware that if this method is removed, the behavior of the
-proc will change so that it does not pass through keywords.
+キーワード引数をほかのメソッドに委譲する Proc に対して、Ruby 2.7 より前のバージョンとの後方互換性のためだけに使ってください。
+
+このメソッドは後方互換性のためだけに存在するので、いずれ削除される可能性があります。Ruby 2.7 より前のバージョンには存在しないため、例のように呼び出す前に [m:Object#respond_to?] で確認してください。また、このメソッドが削除されたときには、フラグを設定していた Proc はキーワード引数を透過しない挙動に変わることに注意してください。
 
 ```ruby
 module Mod
@@ -470,3 +458,5 @@ module Mod
   foo.ruby2_keywords if foo.respond_to?(:ruby2_keywords)
 end
 ```
+
+- **SEE** [m:Module#ruby2_keywords], [m:Hash.ruby2_keywords_hash]


### PR DESCRIPTION
## 概要

`Module#ruby2_keywords` の本文が rdoc の英文のまま残っていたので日本語に翻訳します(#3476 の `main.ruby2_keywords` 追加の際に発見)。確認したところ `Proc#ruby2_keywords` も同一内容の英文だったため、2 エントリまとめて対応しています。

## 内容

- 訳の正確さは実測で担保しています: キーワード引数がスプラット越しに透過すること、`Proc#ruby2_keywords` が **self を返す**こと(`equal?` で確認。冒頭文に明記)、`Module#ruby2_keywords` が private で例の `respond_to?(:ruby2_keywords, true)` が正しいこと
- 用語は既存エントリに合わせています(`Hash.ruby2_keywords_hash` の「ruby2_keywords フラグ」、`main.ruby2_keywords` の「透過」など)
- あわせて `Module` 側に **param** 行(String か Symbol・複数指定可)を追加し、両エントリに SEE(`main.ruby2_keywords` / `Module#ruby2_keywords` / `Proc#ruby2_keywords` / `Hash.ruby2_keywords_hash` の相互リンク)を追加しました。例は原文のまま変更していません

## 検証

- ミニ Markdown ツリーで 3.0 / 4.1 の `init` + `update --markdowntree` + `lookup --html`: 両エントリとも compileerror 0・SEE 解決を確認
- `rake check_blank_lines check_indent_in_samplecode` 通過
- #3477(RubyVM::AbstractSyntaxTree 系)とファイル重複なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
