### PR TITLE
ReFe.md を現在の refe2 に合わせて全面更新

### DIFF
--- a/manual/doc/ReFe.md
+++ b/manual/doc/ReFe.md
@@ -20,12 +20,14 @@ $ bitclust setup
 
 `bitclust setup` はリファレンスマニュアルのソース
 ([rurema/doctree](https://github.com/rurema/doctree)) を
-`~/.bitclust/rubydoc` に取得し、`~/.bitclust/db-3.4.0` のような
-ディレクトリにバージョンごとのデータベースを構築します。
+`~/.bitclust/rubydoc` に取得し、`~/.bitclust` 配下に
+バージョンごとのデータベースを構築します。
 対象バージョンは `--versions` オプションで変更できます。
+バージョンはリファレンスマニュアルの版と同じく `3.4` のように
+teeny を省いた形式で指定します。
 
 ```console
-$ bitclust setup --versions=3.4.0,4.0.0
+$ bitclust setup --versions=3.4,4.0
 ```
 
 マニュアルの更新を取り込むときは、もう一度 `bitclust setup` を実行します。

--- a/manual/doc/ReFe.md
+++ b/manual/doc/ReFe.md
@@ -1,79 +1,77 @@
 # ReFe
 
-ReFeについては
-<http://i.loveruby.net/ja/prog/refe.html>
-をご覧ください。
+ReFe は Ruby リファレンスマニュアルをコマンドラインから検索するツールです。
+gem 名は refe2、コマンド名は `refe` で、現在は BitClust の一部として
+[rurema/bitclust](https://github.com/rurema/bitclust) で開発されています。
 
-### Gems版
+### インストール
 
-Gemsをお使いの方は、以下のコマンドを実行する事でインストールできます。
-([ruby-list:41478])
+gem でインストールします。
 
 ```console
 $ gem install refe2
 ```
-  
-以下のコマンドでデータベースを構築します。
+
+次に、検索用データベースを構築します。
 
 ```console
 $ bitclust setup
 ```
 
-### Ruby リファレンスマニュアルの検索ツール ReFe のデータ構築について
-
-最新 Ruby リファレンスマニュアル用に ReFe のデータを構築するには以下の手順で行います。(詳細は ReFe の README を参照してください)
-
-(1) <http://i.loveruby.net/ja/prog/refe.html> から ReFe の基本セットを取って来てインストールします。
-
-```console
-tar xvzf refe-x.x.x.tar.gz
-cd refe-x.x.x
-ruby setup.rb config
-ruby setup.rb setup
-(必要に応じて root になってください)
-ruby setup.rb install
-```
-
-(2) <https://web.archive.org/web/20110706181204/http://www.ruby-lang.org/ja/man/man-rd-ja.tar.gz> にあるのが最新のリファレンスマニュアルの tarball です。これを取得します。
-
-(3) 取得した man-rd-ja.tar.gz を展開し、ReFeデータベースを構築します。/usr/local/share/refe は適宜環境に応じて変更してください(変更した場合は refe を実行するのに環境変数 REFE_DATA_DIR を設定する必要があります)
+`bitclust setup` はリファレンスマニュアルのソース
+([rurema/doctree](https://github.com/rurema/doctree)) を
+`~/.bitclust/rubydoc` に取得し、`~/.bitclust/db-3.4.0` のような
+ディレクトリにバージョンごとのデータベースを構築します。
+対象バージョンは `--versions` オプションで変更できます。
 
 ```console
-gzip -dc man-rd-ja.tar.gz | tar xvf -
-cd man-rd-ja
-(必要に応じて root になってください)
-mkrefe_rubyrefm -d /usr/local/share/refe *.rd
+$ bitclust setup --versions=3.4.0,4.0.0
 ```
 
-/usr/local/share/refe 下に以下のディレクトリとファイルができます。
+マニュアルの更新を取り込むときは、もう一度 `bitclust setup` を実行します。
 
-```text
-class_document/        method_document/
-class_document_comp    method_document_comp
-```
+### 使い方
 
-(4) 後は使うだけです。
+メソッド名やクラス名を指定すると、マッチしたエントリを表示します。
 
 ```console
-refe IO puts
-IO#puts
---- puts([obj[, ...]])
+$ refe Array#clear
+Array#clear
+### def clear    -> self
 
-    各 obj を self に出力した後、改行します。
-    引数の扱いは puts と同じです(詳細はこちらを参照し
-    てください)。
-
-    nil を返します。
+配列の要素をすべて削除して空にします。
+(以下略)
 ```
 
-### ReFe の Emacs インタフェースのインストール方法
+クラス名とメソッド名を空白で区切って `refe Array clear` のように
+指定することもできます。名前は前方一致で検索され、大文字小文字の
+違いは無視されるので、うろ覚えでも引けます。
 
-(1) refe.el を取って来て /usr/local/share/emacs/site-lisp などの Emacs Lisp ライブラリの置き場所に置きます。
+マッチしたエントリが複数あるときは名前の一覧が表示されます。
 
-(2) .emacs に以下を書いておきます。
-
-```common_lisp
-(require 'refe)
+```console
+$ refe map
+Array#map Enumerable#map Enumerator::Lazy#map IO::Buffer.map
+Matrix#map Vector#map
 ```
 
-(3) 引きたいメソッド名の位置に合わせて M-x refe を実行します。
+主なオプション:
+
+- `-a`, `--all` -- マッチした全エントリの説明を表示します
+- `-l`, `--line` -- 1 エントリを 1 行で表示します
+- `--class` -- クラス名・モジュール名だけを検索します
+- `-d PATH`, `--database=PATH` -- データベースの場所を指定します
+
+既定以外の場所のデータベースを常用する場合は、環境変数 `REFE2_DATADIR`
+でも指定できます。
+
+詳細は BitClust の
+[doc/usage.md](https://github.com/rurema/bitclust/blob/master/doc/usage.md)
+を参照してください。
+
+### 初代 ReFe について
+
+初代の ReFe(1.x 系)は青木峰郎さん作の別実装のツールで、Ruby 1.8 時代の
+リファレンスマニュアルを検索するものでした。現在の refe2 はこれを置き換えた
+BitClust ベースの別実装です。初代 ReFe については
+<http://i.loveruby.net/ja/prog/refe.html> を参照してください。


### PR DESCRIPTION
## 概要

#3456(ReFe.md の整形修正)の際に、ページの内容自体が現在の refe2 と乖離していることが分かったので、全面的に更新します。

## 現状の問題

- 冒頭が初代 ReFe(1.x・青木峰郎さん作の別実装)のページへの誘導のみで、現在の refe2 の説明がない
- 「データ構築について」節は、初代 ReFe の tar からのインストール+旧 RD マニュアル(web.archive.org 上の man-rd-ja.tar.gz)+`mkrefe_rubyrefm` という手順で、現在は成立しない(`mkrefe_rubyrefm` は bitclust には存在しない初代 ReFe の付属ツール)
- 記載の環境変数 `REFE_DATA_DIR` は現行コードに存在しない(現行は `REFE2_DATADIR`)
- Emacs インタフェース(refe.el)の節も初代 ReFe のもので、refe2 に Emacs インタフェースはなく、入手経路も現存が確認できない
- `[ruby-list:41478]` は 2005 年の初代 ReFe Gems 版のアナウンスで、現行 refe2 の参照としては不適切

## 変更内容

- 現行の refe2(gem 名 refe2・コマンド名 `refe`・[rurema/bitclust](https://github.com/rurema/bitclust) 同梱)の説明に全面更新
- `bitclust setup` の動作(doctree を `~/.bitclust/rubydoc` に取得し、既定で 3.3.0/3.4.0/4.0.0 の DB を構築・`--versions` で変更可)を setup_command.rb の実装で確認して記載
- 使い方(前方一致・大文字小文字無視・複数マッチ時の一覧表示・`-a`/`-l`/`--class`/`-d`・`REFE2_DATADIR`)を実測で確認して記載。詳細は bitclust の [doc/usage.md](https://github.com/rurema/bitclust/blob/master/doc/usage.md) へ誘導
- 初代 ReFe は「初代 ReFe について」節として歴史的経緯を残す

## 検証

- Ruby 4.0 の DB を manual/api から構築し、使用例(`refe Array#clear`・`refe map` など)は実出力を採取して記載
- 新しいページを DB に取り込み MDCompiler で描画確認(見出しは doc ページの慣例に合わせ `###`。既存ページと同じ h1 描画になることを確認)
- `rake check_blank_lines check_indent_in_samplecode` 通過

なお、このページへの manual/ 内からのリンクは index.md のコメントアウト行のみで、生きた参照はありません(検索とダイレクト URL で到達するページです)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
