### PR TITLE
Complex の基本的な修正

### DIFF
--- a/manual/api/_builtin/Complex.md
+++ b/manual/api/_builtin/Complex.md
@@ -3,41 +3,108 @@ library: _builtin
 ---
 # class Complex < Numeric
 
-複素数を扱うクラスです。
+複素数を表すクラスです。
 
-[c:Complex] オブジェクトを作成するには、[m:Kernel?.Complex]、
-[m:Complex.rect]、[m:Complex.polar]、[m:Numeric#to_c]、
-[m:String#to_c] のいずれかを使用します。
+実部・虚部を、実数を表す数値オブジェクトとして保持します。
 
-```ruby title="Complex オブジェクトの作り方"
-p Complex(1)         # => (1+0i)
-p Complex(2, 3)      # => (2+3i)
-p Complex.polar(2, 3)  # => (-1.9799849932008908+0.2822400161197344i)
-p Complex(0.3)       # => (0.3+0i)
-p Complex('0.3-0.5i')  # => (0.3-0.5i)
-p Complex('2/3+3/4i')  # => ((2/3)+(3/4)*i)
-p Complex('1@2')     # => (-0.4161468365471424+0.9092974268256817i)
-p 3.to_c             # => (3+0i)
-p 0.3.to_c           # => (0.3+0i)
-p '0.3-0.5i'.to_c    # => (0.3-0.5i)
-p '2/3+3/4i'.to_c    # => ((2/3)+(3/4)*i)
-p '1@2'.to_c         # => (-0.4161468365471424+0.9092974268256817i)
+[c:Complex] オブジェクトは以下の方法で生成できます。
+
+- 虚数リテラルで記述する
+- [m:Kernel?.Complex]、[m:Complex.rect]、[m:Complex.polar] を使う
+- 他の数値クラスのオブジェクトから [m:Numeric#to_c] で変換する
+- 文字列表現から [m:String#to_c] で変換する
+
+```ruby title="リテラルによる生成"
+p 1i # => (0+1i)
+# 虚部は Integer オブジェクトで保持される
+
+p 1.0i # => (0+1.0i)
+# 虚部は Float オブジェクトで保持される
+
+p 1ri   # => (0+(1/1)*i)
+p 0.5ri # => (0+(1/2)*i)
+# 虚部は Rational オブジェクトで保持される
+
+p 1+2i # => (1+2i)
+# `1+2i` という形式のリテラルがあるわけではなく、
+# Integer のリテラル `1` と虚数リテラル `2i` と
+# 減算演算子 `-` からなる演算子式
 ```
 
-[c:Complex] オブジェクトは有理数の形式も実数の形式も扱う事ができます。
+```ruby title="Complex メソッドによる生成"
+# 実部のみ与える
+p Complex(1)          # => (1+0i)
+p Complex(0.3)        # => (0.3+0i)
+
+# 実部と虚部を与える
+p Complex(2, 3)       # => (2+3i)
+
+# 文字列表現を与える（実部・虚部に浮動小数点リテラル形式を使う）
+p Complex("0.3-0.5i") # => (0.3-0.5i)
+
+# 文字列表現を与える（実部・虚部に有理数リテラル形式を使う）
+p Complex("2/3+3/4i") # => ((2/3)+(3/4)*i)
+
+# 文字列表現を与える（絶対値と偏角による極形式）
+p Complex("2@3.141592653589793") # => (-2+0.0i)
+```
+
+```ruby title="Complex.rect メソッドによる生成"
+# 実部と虚部を与える
+p Complex.rect(2, 3) # => (2+3i)
+# `Complex(2, 3)` と変わらない
+```
+
+```ruby title="Complex.polar メソッドによる生成"
+# 絶対値と偏角を与える
+p Complex.polar(0.5, Math::PI / 2) # => (0.0+0.5i)
+```
+
+```ruby title="他の数値クラスオブジェクトからの変換による生成"
+p 3.to_c    # => (3+0i)
+p 0.3.to_c  # => (0.3+0i)
+p 0.5r.to_c # => ((1/2)+0i)
+```
+
+```ruby title="文字列表現からの変換による生成
+p "0.3-0.5i".to_c    # => (0.3-0.5i)
+p "2/3+3/4i".to_c    # => ((2/3)+(3/4)*i)
+p "2@3.141592653589793".to_c # => (-2+0.0i)
+```
+
+複素数演算において、オペランドの実部・虚部のクラスは演算結果の実部・虚部のクラスに影響します。
 
 ```ruby title="例"
-p Complex(1, 1) / 2  # => ((1/2)+(1/2)*i)
-p Complex(1, 1) / 2.0  # => (0.5+0.5i)
+a = 3.0 + 3i
+# 実部が Float、虚部が Integer
+
+p a / 2 # => (1.5+(3/2)*i)
+# 実部は Float、虚部は Rational になる
+```
+
+実部・虚部ともに `Integer` もしくは `Rational` であるような `Complex` オブジェクト、および `Integer` オブジェクト、`Rational` オブジェクトの間の加減乗除算は丸め誤差なく行われます。
+
+```ruby title="虚部が Rational と Float の場合の誤差の比較"
+p ([1ri / 10] * 10).sum
+# => (0+(1/1)*i)
+# 演算誤差無し
+
+# 参考：
+p ([1.0i / 10] * 10).sum
+# => (0+0.9999999999999999i)
+# `1.0i / 10` の時点で誤差が生じている
+# それを 10 個足し合わせることで、`to_s` でも分かる誤差になっている
 ```
 
 ## Instance Methods
 
 ### def *(other) -> Complex
 
-積を計算します。
+`self` に `other` を掛けた値（＝積）を返します。
 
-- **param** `other` -- 自身に掛ける数
+`Complex` オブジェクトを左項とする算術演算子 `*` はこのメソッドの呼び出しになります。
+
+- **param** `other` -- `self` に対する乗数
 
 ```ruby title="例"
 p Complex(1, 2) * 2            # => (2+4i)
@@ -47,19 +114,23 @@ p Complex(1, 2) * Rational(1, 2) # => ((1/2)+(1/1)*i)
 
 ### def **(other) -> Complex
 
-冪(べき)乗を計算します。
+`self` の `other` 乗を返します。
 
-- **param** `other` -- 自身を other 乗する数
+`Complex` オブジェクトを左項とする算術演算子 `**` はこのメソッドの呼び出しになります。
+
+- **param** `other` -- `self` に対する冪指数（べきしすう）
 
 ```ruby title="例"
-p Complex('i') ** 2           # => (-1+0i)
+p 1i ** 2 # => (-1+0i)
 ```
 
 ### def +(other) -> Complex
 
-和を計算します。
+`self` に `other` を足した値（＝和）を返します。
 
-- **param** `other` -- 自身に足す数
+`Complex` オブジェクトを左項とする算術演算子 `+` はこのメソッドの呼び出しになります。
+
+- **param** `other` -- `self` に加算する数値
 
 ```ruby title="例"
 p Complex(1, 2) + Complex(2, 3) # => (3+5i)
@@ -67,9 +138,11 @@ p Complex(1, 2) + Complex(2, 3) # => (3+5i)
 
 ### def -(other) -> Complex
 
-差を計算します。
+`self` から `other` を引いた値（＝差）を返します。
 
-- **param** `other` -- 自身から引く数
+`Complex` オブジェクトを左項とする算術演算子 `-` はこのメソッドの呼び出しになります。
+
+- **param** `other` -- `self` から減算する数値
 
 ```ruby title="例"
 p Complex(1, 2) - Complex(2, 3) # => (-1-1i)
@@ -77,48 +150,59 @@ p Complex(1, 2) - Complex(2, 3) # => (-1-1i)
 
 ### def -@ -> Complex
 
-自身の符号を反転させたものを返します。
+`0` から `self` を引いた値を返します。
+
+`Complex` オブジェクトに対する単項演算子 `-` はこのメソッドの呼び出しになります。
 
 ```ruby title="例"
-p -Complex(1)   # => (-1+0i)
+p -Complex(1)     # => (-1+0i)
 p -Complex(-1, 1) # => (1-1i)
 ```
 
 ### def /(other)   -> Complex
 ### def quo(other) -> Complex
 
-商を計算します。
+`self` を `other` で割った値（＝商）を返します。
 
-- **param** `other` -- 自身を割る数
+- **param** `other` -- `self` に対する除数
 
 ```ruby title="例"
-p Complex(10.0) / 3  # => (3.3333333333333335+(0/1)*i)
-p Complex(10)   / 3  # => ((10/3)+(0/1)*i)
+p Complex(1.0) / 2 # => (0.5+0i)
+# 実部が Float、虚部が Integer
+
+p Complex(1) / 2.0 # => (0.5+0.0i)
+# 実部・虚部ともに Float
+
+p Complex(3, 4) / 2 # => ((3/2)+2i)
+# 実部が Rational、虚部が Integer
 ```
 
 - **SEE** [m:Numeric#quo]
 
 ### def ==(other) -> bool
 
-数値として等しいか判定します。
+`self` が数値として `other` と等しければ `true` を、そうでなければ `false` を返します。
 
-- **param** `other` -- 自身と比較する数値
+`other` が数値でないときは `false` を返します。
+
+`Complex` オブジェクトを左項とする比較演算子 `==` はこのメソッドの呼び出しになります。
+
+- **param** `other` -- 比較対象
 
 ```ruby title="例"
 p Complex(2, 1) == Complex(1) # => false
 p Complex(1, 0) == Complex(1) # => true
-p Complex(1, 0) == 1        # => true
+p Complex(1, 0) == 1          # => true
+p Complex(1, 0) == 1.0        # => true
 ```
 
 ### def <=>(other) -> -1 | 0 | 1 | nil
 
-self の虚部がゼロで other が実数の場合、
-self の実部の <=> メソッドで other と比較した結果を返します。
-other が Complex で虚部がゼロの場合も同様です。
+`self` と `other` が共に実数（＝虚部がゼロの数）のとき `self.real <=> other.real` の結果を返します。
 
-その他の場合は nil を返します。
+そうでないときは `nil` を返します。
 
-- **param** `other` -- 自身と比較する数値
+- **param** `other` -- 比較対象
 
 ```ruby title="例"
 p Complex(2, 3)  <=> Complex(2, 3) # => nil
@@ -149,7 +233,7 @@ p Complex(2)     <=> 3           # => -1
 ### def abs       -> Numeric
 ### def magnitude -> Numeric
 
-自身の絶対値を返します。
+`self` の絶対値（absolute value）を返します。
 
 以下の計算の結果を [c:Float] オブジェクトで返します。
 
@@ -167,7 +251,7 @@ p Complex('1/2', '1/2').abs # => 0.7071067811865476
 
 ### def abs2 -> Numeric
 
-自身の絶対値の 2 乗を返します。
+`self` の絶対値の 2 乗を返します。
 
 以下の計算の結果を返します。
 
@@ -187,7 +271,7 @@ p Complex('1/2', '1/2').abs2 # => (1/2)
 ### def angle -> Float
 ### def phase -> Float
 
-自身の偏角を[-π,π]の範囲で返します。
+`self` の偏角を [-π,π] の範囲で返します。
 
 ```ruby title="例"
 p Complex.polar(3, Math::PI/2).arg # => 1.5707963267948966
@@ -207,11 +291,13 @@ p Complex(-0.0, 0).arg          # =>  3.141592653589793
 p Complex(-0.0, -0.0).arg       # => -3.141592653589793
 ```
 
+メソッド名の `arg` は argument（偏角）に由来しますが、「引数」の argument と紛らわしいためか、`argument` というエイリアスは用意されていません。
+
 - **SEE** [m:Numeric#arg]
 
 ### def finite? -> bool
 
-実部と虚部の両方が有限値の場合に true を、そうでない場合に false を返します。
+実部と虚部の両方が有限値の場合に `true` を、そうでない場合に `false` を返します。
 
 ```ruby title="例"
 p (1 + 1i).finite?               # => true
@@ -222,7 +308,7 @@ p (Float::INFINITY + 1i).finite? # => false
 
 ### def infinite? -> nil | 1
 
-実部と虚部のどちらも無限大ではない場合に nil を、そうでない場合に 1 を返します。
+実部と虚部のどちらも正または負の無限大ではない場合に `nil` を、そうでない場合に `1` を返します。
 
 ```ruby title="例"
 p (1+1i).infinite?                 # => nil
@@ -233,7 +319,7 @@ p (Float::INFINITY + 1i).infinite? # => 1
 
 ### def coerce(other) -> [Complex, Complex]
 
-other を [c:Complex] に変換して [変換後の other, self] の配列を返します。
+`other` を [c:Complex] に変換して `[変換後の other, self]` の配列を返します。
 
 - **raise** `TypeError` -- 変換できないオブジェクトを指定した場合に発生します。
 
@@ -244,7 +330,7 @@ p Complex(1).coerce(2) # => [(2+0i), (1+0i)]
 ### def conjugate -> Complex
 ### def conj      -> Complex
 
-自身の共役複素数を返します。
+`self` の共役複素数を返します。
 
 ```ruby title="例"
 p Complex(1, 2).conj # => (1-2i)
@@ -252,7 +338,7 @@ p Complex(1, 2).conj # => (1-2i)
 
 ### def denominator -> Integer
 
-分母を返します。
+`self` の分母（denominator）を返します。
 
 以下のように、実部と虚部の分母の最小公倍数を整数で返します。
 
@@ -271,7 +357,7 @@ p Complex(3).denominator          # => 1
 
 ### def fdiv(other) -> Complex
 
-self を other で割った商を返します。
+`self` を `other` で割った商を返します。
 実部と虚部が共に [c:Float] の値になります。
 
 - **param** `other` -- 自身を割る数
@@ -291,7 +377,7 @@ p Complex(11, 22).quo(3)  # => ((11/3)+(22/3)*i)
 ### def imag      -> Numeric
 ### def imaginary -> Numeric
 
-自身の虚部を返します。
+`self` の虚部を返します。
 
 ```ruby title="例"
 p Complex(3, 2).imag # => 2
@@ -301,7 +387,7 @@ p Complex(3, 2).imag # => 2
 
 ### def inspect -> String
 
-自身を人間が読みやすい形の文字列表現にして返します。
+`self` を人間が読みやすい形の文字列表現にして返します。
 
 ```ruby title="例"
 p Complex(2).inspect                     # => "(2+0i)"
@@ -313,7 +399,7 @@ p Complex(Float::NAN, Float::NAN).inspect  # => "(NaN+NaN*i)"
 
 ### def numerator -> Complex
 
-分子を返します。
+`self` の分子（numerator）を返します。
 
 ```ruby title="例"
 p Complex('1/2+2/3i').numerator # => (3+4i)
@@ -324,7 +410,7 @@ p Complex(3).numerator        # => (3+0i)
 
 ### def polar -> [Numeric, Numeric]
 
-自身の絶対値と偏角を配列にして返します。
+`self` の絶対値と偏角を配列にして返します。
 
 ```ruby title="例"
 p Complex.polar(1, 2).polar # => [1, 2]
@@ -334,7 +420,7 @@ p Complex.polar(1, 2).polar # => [1, 2]
 
 ### def real -> Numeric
 
-自身の実部を返します。
+`self` の実部を返します。
 
 ```ruby title="例"
 p Complex(3, 2).real # => 3
@@ -342,7 +428,7 @@ p Complex(3, 2).real # => 3
 
 ### def real? -> false
 
-常に false を返します。
+常に `false` を返します。
 
 ```ruby title="例"
 p (2+3i).real? # => false
@@ -354,7 +440,9 @@ p (2+0i).real? # => false
 ### def rect        -> [Numeric, Numeric]
 ### def rectangular -> [Numeric, Numeric]
 
-実部と虚部を配列にして返します。
+`self` の実部と虚部を配列にして返します。
+
+メソッド名は、これが複素数の直交形式（rectangular form）の成分を得るものであることから。
 
 ```ruby title="例"
 p Complex(3).rect  # => [3, 0]
@@ -366,49 +454,99 @@ p Complex(3, 2).rect # => [3, 2]
 
 ### def to_f -> Float
 
-自身を [c:Float] に変換します。
+`self` の虚部が [c:Integer] か [c:Rational] のゼロであれば実部を [c:Float] に変換して返します。
 
-- **raise** `RangeError` -- 虚部が実数か、0 ではない場合に発生します。
+- **raise** `RangeError` -- 虚部がゼロでなかったり [c:Float] のゼロである場合に発生します。
 
 ```ruby title="例"
-p Complex(3).to_f  # => 3.0
-p Complex(3.5).to_f  # => 3.5
-Complex(3, 2).to_f # ~> RangeError
+p (1 + 0i).to_f  # => 1.0
+p (1 + 0ri).to_f # => 1.0
+```
+
+```ruby title="変換できない例"
+# 虚部がゼロでない
+(1 + 2i).to_f # ~> RangeError
+
+# 虚部がゼロだが Float の 0.0 である
+(1 + 0.0i).to_f # ~> RangeError
 ```
 
 ### def to_i -> Integer
 
-自身を整数に変換します。
+`self` の虚部が [c:Integer] か [c:Rational] のゼロであれば実部を [c:Integer] に変換して返します。
 
-- **raise** `RangeError` -- 虚部が実数か、0 ではない場合に発生します。
+- **raise** `RangeError` -- 虚部がゼロでなかったり [c:Float] のゼロである場合に発生します。
 
 ```ruby title="例"
-p Complex(3).to_i  # => 3
-p Complex(3.5).to_i  # => 3
-Complex(3, 2).to_i # ~> RangeError
+p (1.9 + 0i).to_i  # => 1
+p (1.9 + 0ri).to_i # => 1
+```
+
+```ruby title="変換できない例"
+# 虚部がゼロでない
+(1 + 2i).to_i # ~> RangeError
+
+# 虚部がゼロだが Float の 0.0 である
+(1 + 0.0i).to_i # ~> RangeError
 ```
 
 ### def to_r             -> Rational
-### def rationalize      -> Rational
-### def rationalize(eps) -> Rational
 
-自身を [c:Rational] に変換します。
+#%since 3.4
+`self` の虚部がゼロであれば実部を [c:Rational] に変換して返します。
 
-- **param** `eps` -- 許容する誤差。常に無視されます。
+- **raise** `RangeError` -- 虚部がゼロでない場合に発生します。
+#%else
+`self` の虚部が [c:Integer] か [c:Rational] のゼロであれば実部を [c:Rational] に変換して返します。
 
-- **raise** `RangeError` -- 虚部が実数か、0 ではない場合に発生します。
+- **raise** `RangeError` -- 虚部がゼロでなかったり [c:Float] のゼロである場合に発生します。
+#%end
 
 ```ruby title="例"
-p Complex(3).to_r  # => (3/1)
-Complex(3, 2).to_r # ~> RangeError
+p (0.75 + 0i).to_r   # => (3/4)
+p (0.75 + 0ri).to_r  # => (3/4)
+#%since 3.4
+p (0.75 + 0.0i).to_r # => (3/4)
+#%end
 ```
 
-#%# rationalize メソッドの引数 eps は常に無視されるため、to_r メソッド
-#%# と同じエントリとしました(sho-h)。
+```ruby title="変換できない例"
+# 虚部がゼロでない
+(1 + 2i).to_r # ~> RangeError
+#%until 3.4
+
+# 虚部がゼロだが Float の 0.0 である
+(1 + 0.0i).to_r # ~> RangeError
+#%end
+```
+
+### def rationalize -> Rational
+### def rationalize(eps) -> Rational
+
+`self` の虚部が [c:Integer] か [c:Rational] のゼロであれば実部を [c:Rational] に変換して返します。許容誤差 `eps` を与えることもできます。
+
+- **param** `eps` -- 許容する誤差。
+
+- **raise** `RangeError` -- 虚部がゼロでなかったり [c:Float] のゼロである場合に発生します。
+
+```ruby title="例"
+p Complex(0.1).rationalize            # => (1/10)
+p Complex(Math::PI).rationalize(0.01) # => (22/7)
+```
+
+```ruby title="変換できない例"
+# 虚部がゼロでない
+(1 + 2i).rationalize # ~> RangeError
+
+# 虚部がゼロだが Float の 0.0 である
+(1 + 0.0i).rationalize # ~> RangeError
+```
+
+- **SEE** [m:Float#rationalize], [m:Integer#rationalize], [m:Rational#rationalize]
 
 ### def to_s -> String
 
-自身を "実部 + 虚部i" 形式の文字列にして返します。
+`self` を "実部 + 虚部i" 形式の文字列にして返します。
 
 ```ruby title="例"
 p Complex(2).to_s                     # => "2+0i"
@@ -421,7 +559,7 @@ p Complex(Float::NAN, Float::NAN).to_s  # => "NaN+NaN*i"
 ### def to_c -> self
 {: since="1.9.1"}
 
-self を返します。
+`self` を返します。
 
 ```ruby title="例"
 p Complex(2).to_c    # => (2+0i)
@@ -430,14 +568,16 @@ p Complex(-8, 6).to_c  # => (-8+6i)
 
 ## Class Methods
 
-### def Complex.rect(r, i = 0)        -> Complex
-### def Complex.rectangular(r, i = 0) -> Complex
+### def Complex.rect(re, im = 0)        -> Complex
+### def Complex.rectangular(real, imag = 0) -> Complex
 
-実部が r、虚部が i である [c:Complex] クラスのオブジェクトを生成します。
+実部が `real`、虚部が `imag` である [c:Complex] クラスのオブジェクトを生成します。
 
-- **param** `r` -- 生成する複素数の実部。
+複素数の直交形式（rectangular form）に基づくためこの名があります。
 
-- **param** `i` -- 生成する複素数の虚部。省略した場合は 0 です。
+- **param** `real` -- 生成する複素数の実部。
+
+- **param** `imag` -- 生成する複素数の虚部。省略した場合は `0` です。
 
 ```ruby title="例"
 p Complex.rect(1)         # => (1+0i)
@@ -449,7 +589,9 @@ p Complex.rectangular(1, 2) # => (1+2i)
 
 ### def Complex.polar(r, theta = 0) -> Complex
 
-絶対値が r、偏角が theta である [c:Complex] クラスのオブジェクトを生成します。
+絶対値が `r`、偏角が `theta` である [c:Complex] クラスのオブジェクトを生成します。
+
+複素数の極形式（polar form）に基づくために基づくためこの名があります。
 
 - **param** `r` -- 生成する複素数の絶対値。
 
@@ -466,11 +608,11 @@ p Complex.polar(2.0, Math::PI)  # => (-2.0+2.4492127076447545e-16i)
 ### def marshal_dump -> Array
 
 [m:Marshal?.load] のためのメソッドです。
-Complex::compatible#marshal_load で復元可能な配列を返します。
+`Complex::compatible#marshal_load` で復元可能な配列を返します。
 
 2.0 以降では [m:Marshal?.load] で 1.8 系の [c:Complex] オブジェクトを保存した文字列も復元できます。
 
-[注意] Complex::compatible は通常の方法では参照する事ができません。
+[注意] `Complex::compatible` は通常の方法では参照できません。
 
 #%# https://bugs.ruby-lang.org/issues/6625 を参照。
 
@@ -478,4 +620,4 @@ Complex::compatible#marshal_load で復元可能な配列を返します。
 
 ### const I -> Complex
 
-虚数単位です。(0+1i) を返します。
+虚数単位です。`(0+1i)` を返します。

--- a/manual/api/_builtin/Complex.md
+++ b/manual/api/_builtin/Complex.md
@@ -66,7 +66,7 @@ p 0.3.to_c  # => (0.3+0i)
 p 0.5r.to_c # => ((1/2)+0i)
 ```
 
-```ruby title="文字列表現からの変換による生成
+```ruby title="文字列表現からの変換による生成"
 p "0.3-0.5i".to_c    # => (0.3-0.5i)
 p "2/3+3/4i".to_c    # => ((2/3)+(3/4)*i)
 p "2@3.141592653589793".to_c # => (-2+0.0i)
@@ -164,6 +164,8 @@ p -Complex(-1, 1) # => (1-1i)
 
 `self` を `other` で割った値（＝商）を返します。
 
+`Complex` オブジェクトを左項とする算術演算子 `/` はこのメソッドの呼び出しになります。
+
 - **param** `other` -- `self` に対する除数
 
 ```ruby title="例"
@@ -201,6 +203,8 @@ p Complex(1, 0) == 1.0        # => true
 `self` と `other` が共に実数（＝虚部がゼロの数）のとき `self.real <=> other.real` の結果を返します。
 
 そうでないときは `nil` を返します。
+
+`Complex` オブジェクトを左項とする二項演算子 `<=>` はこのメソッドの呼び出しになります。
 
 - **param** `other` -- 比較対象
 
@@ -360,7 +364,7 @@ p Complex(3).denominator          # => 1
 `self` を `other` で割った商を返します。
 実部と虚部が共に [c:Float] の値になります。
 
-- **param** `other` -- 自身を割る数
+- **param** `other` -- `self` に対する除数
 
 ```ruby title="例"
 p Complex(11, 22).fdiv(3) # => (3.6666666666666665+7.333333333333333i)
@@ -413,7 +417,7 @@ p Complex(3).numerator        # => (3+0i)
 `self` の絶対値と偏角を配列にして返します。
 
 ```ruby title="例"
-p Complex.polar(1, 2).polar # => [1, 2]
+p Complex.polar(1, 2).polar # => [1.0, 2.0]
 ```
 
 - **SEE** [m:Numeric#polar]
@@ -568,7 +572,7 @@ p Complex(-8, 6).to_c  # => (-8+6i)
 
 ## Class Methods
 
-### def Complex.rect(re, im = 0)        -> Complex
+### def Complex.rect(real, imag = 0)        -> Complex
 ### def Complex.rectangular(real, imag = 0) -> Complex
 
 実部が `real`、虚部が `imag` である [c:Complex] クラスのオブジェクトを生成します。
@@ -591,7 +595,7 @@ p Complex.rectangular(1, 2) # => (1+2i)
 
 絶対値が `r`、偏角が `theta` である [c:Complex] クラスのオブジェクトを生成します。
 
-複素数の極形式（polar form）に基づくために基づくためこの名があります。
+複素数の極形式（polar form）に基づくためこの名があります。
 
 - **param** `r` -- 生成する複素数の絶対値。
 
@@ -600,7 +604,7 @@ p Complex.rectangular(1, 2) # => (1+2i)
 ```ruby title="例"
 p Complex.polar(2.0)          # => (2.0+0.0i)
 p Complex.polar(2.0, 0)       # => (2.0+0.0i)
-p Complex.polar(2.0, Math::PI)  # => (-2.0+2.4492127076447545e-16i)
+p Complex.polar(2.0, Math::PI)  # => (-2.0+0.0i)
 ```
 
 ## Private Instance Methods


### PR DESCRIPTION
[Complex](https://docs.ruby-lang.org/ja/4.0/class/Complex.html) に基本的な修正を施します。

主な修正点は次のとおりです。

# 要約

* 「複素数を扱うクラス」→「複素数を表すクラス」
* 実部・虚部を，実数を表す数値オブジェクトで保持することを追記
  * 内部的に他のオブジェクトへの参照を持っていることは Complex を理解するうえで重要
* 実部・虚部のクラスが演算を通じてどうなるかを追記
* 実部・虚部のクラスが丸め誤差の有無に影響することを追記
* 生成方法
  * リテラルを追加
    * 「虚数リテラル」という用語を使用
  * サンプルコードで詳しく

# `-@`

* 「自身の符号を反転させたものを」→「`0` から `self` を引いた値を」
  * 複素数なので符号は無い
  * 実装は実部・虚部の符号反転だが，ユーザーは知らなくてよいこと

# 算術系・比較系メソッド

* 書き方を Integer に合わせる

## `/`, `quo`

* サンプルコード
  * 無限小数が出る例を避けた
  * 実部・虚部のクラスに関わる例を追加

## `==`

* サンプルコード
  * `Complex(1, 0) == 1.0` を追加

## `<=>`

* 実部に対する `<=>` という形で説明を簡素化

# 変換系メソッド

* `to_r` と `rationalize` を分離
  * 以下のコメントがあったが Ruby 2.7.8 でも eps は無視されないことを確認
    ```
    #%# rationalize メソッドの引数 eps は常に無視されるため、to_r メソッド
    #%# と同じエントリとしました(sho-h)。
    ```
* `to_f`, `to_i`, `rationalize` が RangeError となる条件
  * 原文は「虚部が実数か、0 ではない場合」
    * 意味が取りにくい（「実数」は Float を意図したと思われる）
  * 虚部が非ゼロで発生するばかりか Float の `0.0` もダメ
    * rdoc にも明記されている
    * 説明に明記しサンプルコードにも反映
* `to_r` が RangeError となる条件
  * おおむね `to_i` などと同じ
  * しかし，なぜか Ruby 3.4 からは Float の `0.0` を認めている
    * rdoc の説明は Ruby 3.4 以降は間違い
    * 意図的な仕様変更なのかよく分からない
    * Ruby 3.4 のリリースノートに見当たらず
    * 実装は確かに変更されているよう
    * バージョン分岐で対応

## `rationalize`

* サンプルコード
  * 半端な数のものに（`Complex(3)` → `Complex(0.1)`
  * `eps` をt買う
* 引数 `eps` について
  * 説明文で触れる
    * 詳しい説明は避けた（よく分からないので）
      * Float などの `rationalize` を見てもらう前提
  * `- **param**` の「常に無視されます。」を削除
    * 無視されないので
    * 「無視される」としたコメントも削除
  * rdoc は `rationalize(epsilon = nil) → rational` となっているが間違い。
    * `nil` を与えると NoMethodError が発生
    * よって，メソッドシグニチャーは現行のもので合ってる
* `Float#rationalize`, `Integer#rationalize`, `Rational#rationalize` への参照

# `arg`

* 「arg」の由来を書く

# `inifnite?`

* 「どちらも無限大ではない」→「どちらも正または負の無限大ではない」

# `rect`

* メソッド名の由来として「複素数の直交形式（rectangular form）」という用語を記述

# `Complex.rect`

* 引数名を `r`, `i` から `real`, `imag` へ
  * `i` が虚数単位とやや紛らわしいため
  * rdoc（および C の実装）は `real`, `imag` を採用
  * 実部・虚部を得るメソッドの名 `real`, `imag`（および `imaginary`）とも整合
* メソッド名の由来として「複素数の直交形式（rectangular form）」という用語を記述

# `Complex.polar`

* メソッド名の由来として「複素数の極形式（polar form）」という用語を記述

# 用語に英語を付加

* いくつかの用語に英語を付加（メソッド名の由来が分かりやすいよう）
  * 「絶対値」→「絶対値（absolute value）」
  * 「分母」→「分母（denominator）」
  * 「分子」→「分子（numerator）」

# `- **return**` の削除

* 説明文そのまんまの `- **return**` は省く

# サンプルコード全般

* リテラルで書いたほうが見た目が簡素になるものをリテラル化
  * 今回の修正ではごく一部にとどまる（優先度低く中断）

# 表記

* 「自身」→「`self`」
* コードスパン化
* 和文中の丸括弧を全角に
* 「変換します。」→「変換して返します。」
* 「参照する事ができません。」→「参照できません。」