### PR TITLE
psych のサンプルコードに不足している require を追加

### DIFF
--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -124,6 +124,8 @@ filename はパース中に発生した例外のメッセージに用います�
 - **SEE** [m:Psych.parse]
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.load("--- a")         # => 'a'
 p Psych.load("---\n - a\n - b") # => ['a', 'b']
 
@@ -138,6 +140,8 @@ end
 キーワード引数 symbolize_names に true を指定した場合はハッシュのキーを [c:Symbol] に変換して返します。
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.load("---\n foo: bar")                       # => {"foo"=>"bar"}
 p Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 ```
@@ -162,6 +166,9 @@ p Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 任意のクラスを許可するにはキーワード引数 permitted_classes を指定すると、そのクラスが追加されます。例えば Date クラスを許可するには以下のように書いてください:
 
 ```ruby title="permitted_classes: に Date を渡した例"
+require 'psych'
+require 'date'
+
 Psych.safe_load(yaml, permitted_classes: [Date])
 ```
 
@@ -170,6 +177,8 @@ Psych.safe_load(yaml, permitted_classes: [Date])
 エイリアスはキーワード引数 aliases を指定することで明示的に許可できます。
 
 ```ruby title="aliases: true の例"
+require 'psych'
+
 x = []
 x << x
 yaml = Psych.dump x
@@ -188,6 +197,8 @@ filename はパース中に発生した例外のメッセージに用います�
 キーワード引数 symbolize_names に true を指定した場合はハッシュのキーを [c:Symbol] に変換して返します。
 
 ```ruby title="symbolize_names: true の例"
+require 'psych'
+
 p Psych.safe_load("---\n foo: bar")                       # => {"foo"=>"bar"}
 p Psych.safe_load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 ```
@@ -216,6 +227,9 @@ p yaml["aaa"]["bbb"].first.frozen?    # = true
 [m:$-w] が true の時にオプション引数を渡すと警告が出力されます。
 
 ```ruby title="オプション引数を使用した例"
+require 'psych'
+require 'date'
+
 # warning: Passing permitted_classes with the 2nd argument of Psych.safe_load is deprecated. Use keyword argument like Psych.safe_load(yaml, permitted_classes: ...) instead.
 Psych.safe_load("", [Date])
 ```
@@ -248,6 +262,8 @@ AST については [c:Psych::Nodes] を参照してください。
 - **SEE** [m:Psych.load]
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Document:...>
 
 begin
@@ -283,6 +299,8 @@ yaml が 複数の YAML ドキュメントを含む場合を取り扱うこと�
 - **SEE** [c:Psych::Nodes]
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.parse_stream("---\n - a\n - b") # => #<Psych::Nodes::Stream:0x00>
 ```
 
@@ -303,6 +321,9 @@ options で出力に関するオプションを以下の指定できます。
 - **param** `options` -- 出力オプション
 
 ```ruby title="例"
+require 'psych'
+require 'stringio'
+
 # Dump an array, get back a YAML string
 p Psych.dump(['a', 'b'])  # => "---\n- a\n- b\n"
 
@@ -323,6 +344,8 @@ Psych.dump(['a', ['b']], StringIO.new, :indentation => 3)
 - **param** `objects` -- 変換対象のオブジェクト列
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.dump_stream("foo\n  ", {}) # => "--- ! \"foo\\n  \"\n--- {}\n"
 ```
 
@@ -341,12 +364,16 @@ Ruby のオブジェクトに変換します。
 ブロックなしの場合はオブジェクトの配列を返します。
 
 ```ruby title="例"
+require 'psych'
+
 p Psych.load_stream("--- foo\n...\n--- bar\n...") # => ['foo', 'bar']
 ```
 
 ブロックありの場合は各オブジェクト引数としてそのブロックを呼び出します。
 
 ```ruby title="例"
+require 'psych'
+
 list = []
 Psych.load_stream("--- foo\n...\n--- bar\n...") do |ruby|
   list << ruby

--- a/manual/api/psych/Psych__Handler.md
+++ b/manual/api/psych/Psych__Handler.md
@@ -311,6 +311,8 @@ YAML ドキュメントを再構築するようなハンドラです。
 以下の例では STDIN から YAML ドキュメントを入力し、再構築した YAML ドキュメントを STDERR に出力します。
 
 ```ruby
+require 'psych'
+
 parser = Psych::Parser.new(Psych::Emitter.new($stderr))
 parser.parse($stdin)
 ```

--- a/manual/api/psych/Psych__Nodes.md
+++ b/manual/api/psych/Psych__Nodes.md
@@ -17,6 +17,8 @@ Ruby のオブジェクトに変換できます。
 以下の例ではスカラを1つ持つリストの AST を構築しています。
 
 ```ruby
+require 'psych'
+
 # Create our nodes
 stream = Psych::Nodes::Stream.new
 doc    = Psych::Nodes::Document.new

--- a/manual/api/psych/Psych__Nodes__Document.md
+++ b/manual/api/psych/Psych__Nodes__Document.md
@@ -35,6 +35,8 @@ implicit にはドキュメントが implicit に始まっているかどうか�
 tag directive を1つ持ち、 implicit にドキュメントが開始している Document オブジェクトを生成しています。
 
 ```ruby
+require 'psych'
+
 Psych::Nodes::Document.new(
   [1,1],
   [["!", "tag:tenderlovemaking.com,2009:"]],

--- a/manual/api/psych/Psych__Nodes__Mapping.md
+++ b/manual/api/psych/Psych__Nodes__Mapping.md
@@ -16,6 +16,8 @@ Psych::Nodes::Mapping は 0 個以上の子ノードを持つことができま�
 子ノードは mapping のキーと値が交互に並んでいます。
 
 ```ruby
+require 'psych'
+
 ast = Psych.parse(<<EOS)
 %YAML 1.1
 ---

--- a/manual/api/psych/Psych__Nodes__Node.md
+++ b/manual/api/psych/Psych__Nodes__Node.md
@@ -22,6 +22,8 @@ YAML AST のノードを表す抽象クラスです。
 タグが付加されていない場合は nil を返します。
 
 ```ruby
+require 'psych'
+
 ast = Psych.parse(<<EOS)
 ---
 - !!str a

--- a/manual/api/psych/Psych__Parser.md
+++ b/manual/api/psych/Psych__Parser.md
@@ -15,6 +15,8 @@ YAML のパーサ。
 以下の例では YAML ドキュメント に含まれているスカラー値を表示します。
 
 ```ruby
+require 'psych'
+
 # Handler for detecting scalar values
 class ScalarHandler < Psych::Handler
   def scalar value, anchor, tag, plain, quoted, style
@@ -30,6 +32,8 @@ parser.parse(yaml_document)
 STDIN からの入力をパース→YAMLフォーマットで STDERR に出力という流れになっています。
 
 ```ruby
+require 'psych'
+
 parser = Psych::Parser.new(Psych::Emitter.new($stderr))
 parser.parse($stdin)
 ```

--- a/manual/api/psych/Psych__ScalarScanner.md
+++ b/manual/api/psych/Psych__ScalarScanner.md
@@ -24,6 +24,8 @@ YAML の scalar 型を読み込んで Ruby の built-in 型に変換するクラ
 YAML の scalar である文字列を Ruby のオブジェクトに変換したものを返します。
 
 ```ruby
+require 'psych'
+
 scanner = Psych::ScalarScanner.new
 p scanner.tokenize("yes") # => true
 p scanner.tokenize("year") # => "year"

--- a/manual/api/psych/Psych__Stream.md
+++ b/manual/api/psych/Psych__Stream.md
@@ -9,6 +9,8 @@ IO に出力する機能を持つクラスです。
 start で変換を開始し、push で変換する Ruby オブジェクトを渡し、最後に finish を呼ぶことで変換を完了します。
 
 ```ruby
+require 'psych'
+
 stream = Psych::Stream.new($stdout)
 stream.start
 stream.push({:foo => 'bar'})
@@ -20,6 +22,8 @@ YAML document は(バッファリングされずに)直接 $stdout に出力さ�
 finish を確実に呼び出すためには [m:Psych::Stream#start] メソッドをブロック付きで呼び出すとよいでしょう。
 
 ```ruby
+require 'psych'
+
 stream = Psych::Stream.new($stdout)
 stream.start do |em|
   em.push(:foo => 'bar')

--- a/manual/api/psych/Psych__TreeBuilder.md
+++ b/manual/api/psych/Psych__TreeBuilder.md
@@ -12,6 +12,8 @@ YAML AST を構築するためのクラスです。
 ### Example
 
 ```ruby
+require 'psych'
+
 parser = Psych::Parser.new Psych::TreeBuilder.new
 parser.parse('--- foo')
 parser.handler.root # => #<Psych::Nodes::Stream:0x00000001400000 ... >

--- a/manual/api/psych/Psych__Visitors.md
+++ b/manual/api/psych/Psych__Visitors.md
@@ -16,6 +16,8 @@ Ruby オブジェクトから YAML の AST を構築するためのクラスで�
 ### 例
 
 ```ruby
+require 'psych'
+
 builder = Psych::Visitors::YAMLTree.new
 builder << { :foo => 'bar' }
 builder << ["baz", "bazbaz"]


### PR DESCRIPTION
`manual/api/psych.md` と `manual/api/psych/` のサンプルコードは、大半が `require` を持たないため単体では実行できず、貼り付けると `uninitialized constant Psych` になります。`docs/SampleCodeGuideline.md` が「実行に必要な require や変数の宣言を省略していること」を守れていない例として挙げているものに当たるため、不足している require を補いました。

ruby ブロック 28 個のうち、単体で実行できないものが **25 個から 8 個** に減ります。

## 変更内容

| 追加した require | 箇所 | 理由 |
| --- | ---: | --- |
| `require 'psych'` | 24 ブロック | `Psych` が未定義 |
| `require 'stringio'` | `psych.md` の `Psych.dump` の例 | 3.4 以降は psych だけでは `StringIO` が未定義 |
| `require 'date'` | `psych.md` の `permitted_classes` の例 2 つ | 3.0 では psych だけでは `Date` が未定義 |

`require 'psych'` は既に書かれている `manual/api/psych.md:17` と `manual/api/psych/core_ext.md:19` に合わせた表記です。

### `require 'stringio'` について

`Psych.dump(['a', 'b'], StringIO.new)` の行は、直前の `Psych.dump(['a', 'b'])` が psych の内部で `require "stringio"` を走らせるため、ブロック全体を実行するぶんには 3.4 / 4.0 でも動いてしまいます。ただしその行だけを取り出すと落ちるので、明示的に require するようにしました。

| Ruby | psych | `require 'psych'` 後の `StringIO` | 同 `Date` |
| --- | --- | --- | --- |
| 3.0 | 3.3.2 | 定義済み | 未定義 |
| 3.2 | 5.0.1 | 定義済み | 未定義 |
| 3.3 | 5.1.2 | 定義済み | 未定義 |
| 3.4 | 5.4.0 | 未定義 | 定義済み |
| 4.0 | 5.3.1 | 未定義 | 定義済み |

psych が `date` を eager require するのは 5.2.1 以降なので、`Date` が未定義になるのは 3.3 以前です。

## 残っている実行できないブロック

require を足しても動かないものが 8 個残ります。原因が require ではなく記述そのものなので、この PR には含めていません。別途対応するつもりです。

| 箇所 | 症状 |
| --- | --- |
| `psych.md` の `aliases: true` の例 | `# ~>` で例外を示している意図的なもの。**問題なし** |
| `psych.md` の `permitted_classes: に Date を渡した例` | 変数 `yaml` が未定義 |
| `psych/Psych__Parser.md` の最初の例 | 変数 `yaml_document` が未定義 |
| `psych.md` の `オプション引数を使用した例` | `safe_load` の位置引数は psych 4.0（Ruby 3.1）で削除済み |
| `psych.md` の `Psych.parse` の例 | 同上。`Psych.parse(yaml, filename)` はキーワード引数のみ |
| `psych/Psych__ScalarScanner.md` | `ScalarScanner.new` は class_loader が必須（3.0〜4.0 の全てで `ArgumentError`） |
| `psych/Psych__Visitors.md` | `YAMLTree.new` は 3 引数必須。引数なしで作るなら `YAMLTree.create` |
| `psych/core_ext.md` | 見出しは `Object.yaml_tag` だが例は `Foo.yaml_as` を呼んでいる。`yaml_as` は 3.0〜4.0 のどれにも存在しない |

## 確認

- 実行環境は ruby 4.0.6。3.0.7 / 3.2.11 / 3.3.12 / 3.4.9 でも各ブロックを実行して確認しました
- `rake check_filename_case_conflicts` / `check_indent_in_samplecode` / `check_single_space_indent` / `check_blank_lines` 通過
- `rake generate:3.4` → `check_links:3.4` で 0 broken link
- `rake statichtml:3.4` → `check_format` 通過。`class/Psych.html` の描画も確認しました
