### PR TITLE
サンプルコードに不足している require を追加し、実行結果の注釈を修正

### DIFF
--- a/manual/api/date/Date.md
+++ b/manual/api/date/Date.md
@@ -611,6 +611,7 @@ ISO 8601 書式の文字列を返します (拡大表記はつかいません)�
 [m:Date#strftime] に `'%Y-%m-%d'` を指定した場合と同様、時刻を含まない日付のみの文字列になります。
 
 ```ruby title="例"
+require 'date'
 p Date.new(2001, 2, 3).iso8601 # => "2001-02-03"
 ```
 
@@ -759,6 +760,7 @@ p Date.new(2008,2,29).prev_year(4)  # => #<Date: 2004-02-29 ...>
 (時刻は 00:00:00 固定です)。
 
 ```ruby title="例"
+require 'date'
 p Date.new(2001, 2, 3).rfc3339 # => "2001-02-03T00:00:00+00:00"
 ```
 
@@ -881,6 +883,7 @@ XML Schema (date) による書式の文字列を返します。
 - **param** `array_of_names_or_nil` -- パターンマッチに使用する名前の配列を指定します。nil の場合は全てをパターンマッチに使用します。
 
 ```ruby title="例"
+require 'date'
 d = Date.new(2022, 10, 5)
 
 if d in wday: 3, day: ..7 # deconstruct_keys が使われます

--- a/manual/api/date/DateTime.md
+++ b/manual/api/date/DateTime.md
@@ -323,6 +323,7 @@ self を返します。
 - **param** `array_of_names_or_nil` -- パターンマッチに使用する名前の配列を指定します。nil の場合は全てをパターンマッチに使用します。
 
 ```ruby title="例"
+require 'date'
 dt = DateTime.new(2022, 10, 5, 13, 30)
 
 if dt in wday: 1..5, hour: 10..18 # deconstruct_keys が使われます

--- a/manual/api/irb/inspector.md
+++ b/manual/api/irb/inspector.md
@@ -59,6 +59,7 @@ irb(main):001:0> :abc # => abcabc
 - **param** `inspector` -- [c:IRB::Inspector] オブジェクトを指定します。
 
 ```ruby
+require "irb/inspector"
 p IRB::Inspector.keys_with_inspector(IRB::Inspector::INSPECTORS[true])
 # => [true, :p, "p", :inspect, "inspect"]
 ```

--- a/manual/api/irb/inspector.md
+++ b/manual/api/irb/inspector.md
@@ -61,7 +61,7 @@ irb(main):001:0> :abc # => abcabc
 ```ruby
 require "irb/inspector"
 p IRB::Inspector.keys_with_inspector(IRB::Inspector::INSPECTORS[true])
-# => [true, :p, "p", :inspect, "inspect"]
+# => [true, :pp, "pp", :pretty_inspect, "pretty_inspect"]
 ```
 
 # object IRB::Inspector::INSPECTORS

--- a/manual/api/openssl/OpenSSL__BN.md
+++ b/manual/api/openssl/OpenSSL__BN.md
@@ -199,6 +199,8 @@ odd が真なら、生成される整数は奇数のみとなります。
 自身を other ビット左シフトした値を返します。
 
 ```ruby
+require 'openssl'
+
 bn = 1.to_bn
 pp bn << 1    # => #<OpenSSL::BN 2>
 pp bn         # => #<OpenSSL::BN 1>

--- a/manual/api/ostruct.md
+++ b/manual/api/ostruct.md
@@ -49,6 +49,7 @@ OpenStruct は Ruby のメソッド探索を利用して、プロパティに必
 これは、Ruby バージョン間の非互換性の原因にもなります：
 
 ```ruby
+require 'ostruct'
 o = OpenStruct.new
 p o.then          # => Ruby < 2.6 では nil、Ruby >= 2.6 では Enumerator
 ```
@@ -56,6 +57,7 @@ p o.then          # => Ruby < 2.6 では nil、Ruby >= 2.6 では Enumerator
 以下の方法では、組み込みライブラリのメソッドが上書きされる可能性があり、バグやセキュリティ上の問題が発生する可能性があります：
 
 ```ruby
+require 'ostruct'
 o = OpenStruct.new
 p o.methods       # => [:to_h, :marshal_load, :marshal_dump, :each_pair, ...]
 o.methods = [:foo, :bar]
@@ -65,6 +67,7 @@ p o.methods       # => [:foo, :bar]
 衝突を避けるために [c:OpenStruct] は ! で終わるメソッドは protected と private でのみ使用し、public な組み込みライブラリの ! で終わるメソッドはエイリアスを定義しています：
 
 ```ruby
+require 'ostruct'
 o = OpenStruct.new(make: 'Bentley', class: :luxury)
 p o.class         # => :luxury
 p o.class!        # => OpenStruct

--- a/manual/api/ostruct.md
+++ b/manual/api/ostruct.md
@@ -59,7 +59,7 @@ p o.then          # => Ruby < 2.6 では nil、Ruby >= 2.6 では Enumerator
 ```ruby
 require 'ostruct'
 o = OpenStruct.new
-p o.methods       # => [:to_h, :marshal_load, :marshal_dump, :each_pair, ...]
+p o.methods       # => [:to_h, :marshal_dump, :each_pair, ...] (内容と順序は Ruby のバージョンによって異なります)
 o.methods = [:foo, :bar]
 p o.methods       # => [:foo, :bar]
 ```

--- a/manual/api/rdoc/RDoc__KNOWN_CLASSES.md
+++ b/manual/api/rdoc/RDoc__KNOWN_CLASSES.md
@@ -11,6 +11,8 @@ library:
 Ruby の組み込みクラスの内部的な変数名がキー、クラス名が値のハッシュです。
 
 ```ruby
+require 'rdoc/known_classes'
+
 p RDoc::KNOWN_CLASSES["rb_cObject"] # => "Object"
 ```
 


### PR DESCRIPTION
`manual/api/` のサンプルコード 10 個が、必要なライブラリを読み込んでおらず、単体で実行すると `NameError` や `NoMethodError` になります。`docs/SampleCodeGuideline.md` が「実行に必要な require や変数の宣言を省略していること」を守れていない例として挙げているものに当たるため、不足している require を補いました。

#3485（psych）・#3487（objspace）と同じ形の修正で、`require` を足すだけで通るサンプルはこれで打ち止めです。

## 変更内容

| ファイル | 個数 | 足した require | 実行時のエラー |
| --- | --- | --- | --- |
| `api/date/Date.md` | 3 | `require 'date'` | `uninitialized constant Date` |
| `api/ostruct.md` | 3 | `require 'ostruct'` | `uninitialized constant OpenStruct` |
| `api/date/DateTime.md` | 1 | `require 'date'` | `uninitialized constant DateTime` |
| `api/irb/inspector.md` | 1 | `require "irb/inspector"` | `uninitialized constant IRB` |
| `api/openssl/OpenSSL__BN.md` | 1 | `require 'openssl'` | `undefined method 'to_bn' for an instance of Integer` |
| `api/rdoc/RDoc__KNOWN_CLASSES.md` | 1 | `require 'rdoc/known_classes'` | `uninitialized constant RDoc` |

require の書き方（クォートの種類と、直後に空行を置くかどうか）は、同じファイル内の既存のサンプルに合わせています。前例が無い `irb/inspector.md` と `RDoc__KNOWN_CLASSES.md` は、同じディレクトリの他のページに合わせました（どちらもページに対応するサブライブラリを直接 require する形です）。

## 確認

- 10 ブロックすべてを 3.0.7 / 3.2.11 / 3.3.12 / 3.4.9 / 4.0.6 で実行し、**require 無しでは落ち、足すと通る**ことを確認しました
- `Date#deconstruct_keys` と `DateTime#deconstruct_keys` の 2 ブロックは `#%since 3.2` の内側なので、3.2 以降の 4 版で確認しています（3.0 / 3.1 では生成されません）
- `rake check_filename_case_conflicts` / `check_indent_in_samplecode` / `check_single_space_indent` / `check_blank_lines` 通過
- `rake generate:3.4` → `check_links:3.4` で 0 broken link
- `rake statichtml:3.4` → `check_format` 通過。各ページの描画も確認しました

## 追記: 実行結果の注釈の修正 2 件

レビューでの合意（[コメント](https://github.com/rurema/doctree/pull/3488#issuecomment-5302456160)）に基づき、require を足して初めて実行できるようになったことで見つかった注釈の誤りを 2 件直しました。

| ファイル | 修正前 | 修正後 |
| --- | --- | --- |
| `api/irb/inspector.md:64` | `# => [true, :p, "p", :inspect, "inspect"]` | `# => [true, :pp, "pp", :pretty_inspect, "pretty_inspect"]` |
| `api/ostruct.md:62` | `# => [:to_h, :marshal_load, :marshal_dump, :each_pair, ...]` | `# => [:to_h, :marshal_dump, :each_pair, ...] (内容と順序は Ruby のバージョンによって異なります)` |

- `irb/inspector.md` は、`true` が pp のグループへ移った irb 1.3.1（Ruby 3.0.1 同梱）以降の値です。旧い値が正しいのは 3.0.0 だけで、3.0 のマニュアルはひとつしか生成されないため、`#%since` での出し分けはせず単純に置き換えました
- `ostruct.md` は `marshal_load` が 5 版とも private で `o.methods` に現れないため、値そのものが成り立っていませんでした。順序と内容は版によって変わるので、`manual/api/objspace.md:444,457` の `# => 234 (実行するたびに変わります)` と同じ形の断り書きを添えています
- どちらも 3.0.7 / 3.2.11 / 3.3.12 / 3.4.9 / 4.0.6 の全 5 版で実測し、新しい値が全版で一致することを確認しました
