### PR TITLE
4.0 以降の DB 構築時に RBS 型シグネチャを取り込む

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 021d7c71bd3204c571f0023b7637025305cd4731
+  revision: 239c4ab89e60c70615524f0bc2ffc095a63e5af6
   specs:
     bitclust-core (1.6.1)
       drb
@@ -8,6 +8,7 @@ GIT
       nkf
       progressbar (>= 1.9.0, < 2.0)
       rack
+      rbs (>= 3.10)
       rouge
       webrick
     bitclust-dev (1.6.1)
@@ -20,16 +21,23 @@ GEM
   specs:
     drb (2.2.3)
     json (2.21.2)
+    logger (1.7.0)
     nkf (0.3.0)
+    prism (1.9.0)
     progressbar (1.13.0)
-    rack (3.2.6)
+    rack (3.2.7)
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
     rake (13.2.1)
-    rouge (5.0.0)
+    rbs (4.1.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rouge (5.1.0)
       strscan (~> 3.1)
     strscan (3.1.8)
+    tsort (0.2.0)
     webrick (1.9.2)
 
 PLATFORMS

--- a/Rakefile
+++ b/Rakefile
@@ -80,6 +80,30 @@ def check_bitclust_version!
   MESSAGE
 end
 
+# RBS 型シグネチャ（rurema/bitclust#321）を取り込む対象バージョン →
+# ruby/rbs のタグ（その版に同梱される rbs の系列）。表に無いバージョンには
+# 取り込まない（シグネチャ表示は 4.0 以降のみ）。4.1 は rbs 4.0 系を
+# 追随中なので、4.1 リリース時に同梱される rbs の確定タグへ更新する
+RBS_TAGS = {
+  "4.0" => "v3.10.0",
+  "4.1" => "v4.0.3",
+}
+RBS_CHECKOUT_BASE = ENV.fetch("RBS_CHECKOUT_BASE", "/tmp")
+RBS_CHECKOUT_MUTEX = Mutex.new
+
+def rbs_checkout(tag)
+  dir = File.join(RBS_CHECKOUT_BASE, "rbs-#{tag}")
+  # rake generate は multitask（スレッド並列）なので clone は排他する
+  RBS_CHECKOUT_MUTEX.synchronize do
+    unless File.directory?(dir)
+      succeeded = system("git", "clone", "--depth=1", "--branch=#{tag}",
+                         "https://github.com/ruby/rbs.git", dir)
+      raise "Failed to checkout ruby/rbs #{tag}" unless succeeded
+    end
+  end
+  dir
+end
+
 # ソースは manual/ の Markdown ツリー（manual/doc は manual/api から自動で取り込まれる）。
 # 旧 refm/ は移行ウィンドウ中の凍結ソース。旧経路でビルドしたい場合は
 # BITCLUST_SOURCE=refm を指定する。
@@ -106,6 +130,11 @@ def generate_database(version)
     succeeded = system("bundle", "exec", "bitclust", "--database=#{db}", "--capi",
                        "update", "--markdowntree=manual/capi")
     raise "Failed to update BitClust C API database" unless succeeded
+  end
+  if (tag = RBS_TAGS[version])
+    succeeded = system("bundle", "exec", "bitclust", "rbssig",
+                       "--sig-root=#{rbs_checkout(tag)}", db)
+    raise "Failed to fill RBS signatures" unless succeeded
   end
 end
 


### PR DESCRIPTION
rurema/bitclust#321(RBS 型シグネチャ表示)の doctree 側の組み込みです。

## 変更内容

- `Rakefile`: `generate_database` の最終ステップとして `bitclust rbssig --sig-root=<ruby/rbs チェックアウト> /tmp/db-X.Y` を実行します。対象バージョン → rbs タグ(その版に同梱される rbs の系列)の対応表 `RBS_TAGS` で管理し(4.0 = v3.10.0。4.1 は rbs 4.0 系を追随中のため当面 v4.0.3)、表に無いバージョン(3.x)には何もしません。ruby/rbs のチェックアウトは `RBS_CHECKOUT_BASE`(既定 `/tmp`)にタグごとにキャッシュし、`rake generate` が multitask(スレッド並列)なので clone は Mutex で排他します
- `Gemfile.lock`: bitclust の revision を rurema/bitclust#321 のマージコミット(239c4ab8)へ更新(bitclust-core に `rbs >= 3.10` の依存が増えるため `bundle update bitclust-core bitclust-dev refe2` で再生成)。rbs は最新の 4.1.3 で解決されます — 4.0 用(ruby/rbs v3.10.0)と 4.1 用(同 v4.0.3)の両 sig ツリーを 1 つの bundle で読むため、パーサは新しい系列の方が安全です(古いパーサは新しい sig の構文で失敗しえます)。rbs 4.1.3 で bitclust のテストと両タグの実データ取り込みが通ること、生成内容が rbs 3.10.3 とバイト一致することを確認済みです。rack/rouge のマイナーバンプは再解決の巻き添えです

## 検証

- `rake generate:4.0`(manual/ フルツリー)を実走し、新ステップ経由で 1881 メソッドエントリにシグネチャが付与されることを確認済みです:
  ```
  db-4.0 (version 4.0): entries_updated=1881 sigs_matched=1881 methods_missed=6135
  ```
  missed の大半は stdlib のメソッドで、core 以外のシグネチャ取り込みは今後の拡張です(対応が無いメソッドは何も表示されません)
- 表示例・HTML 構造・4.0 ゲートの仕組みは rurema/bitclust#321 を参照してください

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
