### PR TITLE
箇条書きを `*` から `-` へ

### DIFF
--- a/manual/api/_builtin/RubyVM__YJIT.md
+++ b/manual/api/_builtin/RubyVM__YJIT.md
@@ -18,12 +18,12 @@ Ruby 3.2 で「実験的」の位置づけが外れ、Ruby 3.3 では実行時�
 
 有効化するには以下のいずれかの方法を使います。
 
-* コマンドラインオプション `--yjit`
-* 環境変数 `RUBY_YJIT_ENABLE`
+- コマンドラインオプション `--yjit`
+- 環境変数 `RUBY_YJIT_ENABLE`
 #%since 3.3
-* (Ruby 3.3 以降) [m:RubyVM::YJIT.enable] による実行時の有効化
+- (Ruby 3.3 以降) [m:RubyVM::YJIT.enable] による実行時の有効化
 #%else
-* (Ruby 3.3 以降) `RubyVM::YJIT.enable` による実行時の有効化
+- (Ruby 3.3 以降) `RubyVM::YJIT.enable` による実行時の有効化
 #%end
 
 このモジュールは、YJIT が対応していないプラットフォームでは定義されないことがあります。

--- a/manual/api/_builtin/Thread.md
+++ b/manual/api/_builtin/Thread.md
@@ -119,7 +119,7 @@ p Thread.current # => #<Thread:0x4022e6fc run>
 ```ruby
 th = Thread.new do
 end
-    
+
 p Thread.kill(th)     # => #<Thread:0x40221bc8 dead>
 ```
 
@@ -129,10 +129,10 @@ p Thread.kill(th)     # => #<Thread:0x40221bc8 dead>
 
 ```ruby
 Thread.new do
-  sleep 
+  sleep
 end
 sleep 0.1
-  
+
 p Thread.list   # => [#<Thread:0x40377a54 sleep>, #<Thread:0x4022e6fc run>]
 ```
 
@@ -215,7 +215,7 @@ Thread.new do
   }
   exit
 end
- 
+
 loop do
   Thread.pass
   p :main
@@ -1111,11 +1111,11 @@ self に対応するネイティブスレッドの ID を返します。
 
 ID は OS に依存します(pthread_self(3) が返す POSIX スレッド ID とは異なります)。
 
-  * Linux では gettid(2) が返す TID です。
-  * macOS では pthread_threadid_np(3) が返すシステム全体で一意な整数の ID です。
-  * FreeBSD では pthread_getthreadid_np(3) が返すスレッド固有の整数の ID です。
-  * Windows では GetThreadId() が返すスレッド識別子です。
-  * その他のプラットフォームでは [c:NotImplementedError] が発生します。
+- Linux では gettid(2) が返す TID です。
+- macOS では pthread_threadid_np(3) が返すシステム全体で一意な整数の ID です。
+- FreeBSD では pthread_getthreadid_np(3) が返すスレッド固有の整数の ID です。
+- Windows では GetThreadId() が返すスレッド識別子です。
+- その他のプラットフォームでは [c:NotImplementedError] が発生します。
 
 スレッドがまだネイティブスレッドと結びついていない場合や、すでに切り離された場合は nil を返します。
 

--- a/manual/api/_builtin/lambda_proc.md
+++ b/manual/api/_builtin/lambda_proc.md
@@ -2,10 +2,10 @@
 
 Proc オブジェクトを生成する手段には、主に以下の四つがあります。
 
-* [m:Proc.new]
-* [m:Kernel?.proc]
-* [m:Kernel?.lambda]
-* `->(){ }` (`->` を使った lambda の短縮記法)
+- [m:Proc.new]
+- [m:Kernel?.proc]
+- [m:Kernel?.lambda]
+- `->(){ }` (`->` を使った lambda の短縮記法)
 
 このうち [m:Proc.new] と [m:Kernel?.proc] は同じ性質の Proc オブジェクトを生成し、
 [m:Kernel?.lambda] と `->(){ }` も互いに同じ性質の Proc オブジェクトを生成しますが、前二者と後二者では、生成される Proc オブジェクトの引数の扱いや return・break の挙動などが異なります(詳細は後述)。生成された Proc オブジェクトが後二者

--- a/manual/api/openssl/ASN1__ObjectId.md
+++ b/manual/api/openssl/ASN1__ObjectId.md
@@ -5,7 +5,7 @@ library: openssl
 
 ASN.1 のオブジェクト識別子を表すクラス。
 
-* ITU-T X.660 <https://www.itu.int/rec/T-REC-X.660/en>
+- ITU-T X.660 <https://www.itu.int/rec/T-REC-X.660/en>
 
 ## Class Methods
 
@@ -41,7 +41,7 @@ OpenSSLの内部テーブルに登録します。
 require "openssl"
 OpenSSL::ASN1::ObjectId.register(
   "2.5.29.9", "subjectDirAttrs", "X509v3 Subject Directory Attributes")
-p OpenSSL::ASN1::ObjectId.new("2.5.29.9").long_name 
+p OpenSSL::ASN1::ObjectId.new("2.5.29.9").long_name
 # => "X509v3 Subject Directory Attributes"
 ```
 

--- a/manual/doc/news/1_9_0.md
+++ b/manual/doc/news/1_9_0.md
@@ -892,5 +892,4 @@ ruby version 1.9.0 は開発版です。
 
 ## 参考
 
-* [Changes in Ruby 1.9](https://web.archive.org/web/20071227043008/http://eigenclass.org/hiki.rb?Changes+in+Ruby+1.9)
-
+- [Changes in Ruby 1.9](https://web.archive.org/web/20071227043008/http://eigenclass.org/hiki.rb?Changes+in+Ruby+1.9)

--- a/manual/doc/news/3_2_0.md
+++ b/manual/doc/news/3_2_0.md
@@ -335,68 +335,68 @@
 
 ## 標準添付ライブラリの更新(機能追加とバグ修正を除く)
 
-  - Bundler
-    - Bundler は性能改善のために利用する依存解決ライブラリを Molinillo(<https://github.com/CocoaPods/Molinillo>) から PubGrub(<https://github.com/jhawthorn/pub_grub>) に変更しました。
-    - gem を Rust で書くための雛形作成コマンドとして bundle gem --ext=rust をサポートしました。 <https://github.com/rubygems/rubygems/pull/6149>
-    - git clone をより速く実行できるように改善しました。 <https://github.com/rubygems/rubygems/pull/4475>
+- Bundler
+  - Bundler は性能改善のために利用する依存解決ライブラリを Molinillo(<https://github.com/CocoaPods/Molinillo>) から PubGrub(<https://github.com/jhawthorn/pub_grub>) に変更しました。
+  - gem を Rust で書くための雛形作成コマンドとして bundle gem --ext=rust をサポートしました。 <https://github.com/rubygems/rubygems/pull/6149>
+  - git clone をより速く実行できるように改善しました。 <https://github.com/rubygems/rubygems/pull/4475>
 
-  - RubyGems
-    - cargo builder を mswin 環境でサポートしました。 <https://github.com/rubygems/rubygems/pull/6167>
+- RubyGems
+  - cargo builder を mswin 環境でサポートしました。 <https://github.com/rubygems/rubygems/pull/6167>
 
-  - CGI
-    - CGI.escapeURIComponent と CGI.unescapeURIComponent が追加されました。 [feature:18822]
+- CGI
+  - CGI.escapeURIComponent と CGI.unescapeURIComponent が追加されました。 [feature:18822]
 
-  - Coverage
-    - Coverage.setup が eval: true を受け付けるようになりました。これにより、evalと関連するメソッドでコードカバレッジを生成することができるようになりました。 [feature:19008]
-    - Coverage.supported?(mode) は、どのようなカバレッジモードがサポートされているかを検出することができます。 [feature:19026]
+- Coverage
+  - Coverage.setup が eval: true を受け付けるようになりました。これにより、evalと関連するメソッドでコードカバレッジを生成することができるようになりました。 [feature:19008]
+  - Coverage.supported?(mode) は、どのようなカバレッジモードがサポートされているかを検出することができます。 [feature:19026]
 
-  - Date
-    - Date#deconstruct_keys と DateTime#deconstruct_keys が追加されました。 [feature:19071]
+- Date
+  - Date#deconstruct_keys と DateTime#deconstruct_keys が追加されました。 [feature:19071]
 
-  - ERB
-    - ERB::Util.html_escape が CGI.escapeHTML よりも高速化されました。
-      - エスケープが必要な文字列がない場合、String オブジェクトを確保しません。
-      - 引数が String の場合、#to_s を呼ばずにスキップします。
-      - ERB::Escape.html_escape が ERB::Util.html_escape のエイリアスになりました。そのため、 Rails にモンキーパッチする必要がなくなります。
-    - ERB::Util.url_encode が CGI.escapeURIComponent を用いて高速化されました。
-    - erbコマンドから -S オプションが削除されました。
+- ERB
+  - ERB::Util.html_escape が CGI.escapeHTML よりも高速化されました。
+    - エスケープが必要な文字列がない場合、String オブジェクトを確保しません。
+    - 引数が String の場合、#to_s を呼ばずにスキップします。
+    - ERB::Escape.html_escape が ERB::Util.html_escape のエイリアスになりました。そのため、 Rails にモンキーパッチする必要がなくなります。
+  - ERB::Util.url_encode が CGI.escapeURIComponent を用いて高速化されました。
+  - erbコマンドから -S オプションが削除されました。
 
-  - FileUtils
-    - FileUtils.ln_sr メソッドが追加され、 FileUtils.ln_s に relative: オプションが追加されました。 [feature:18925]
+- FileUtils
+  - FileUtils.ln_sr メソッドが追加され、 FileUtils.ln_s に relative: オプションが追加されました。 [feature:18925]
 
-  - IRB
-    - debug.gem と統合したコマンドが複数追加されました: debug, break, catch, next, delete, step, continue, finish, backtrace, info
-      - これらは Gemfile に gem "debug" と記述しなくても動かすことができます。
-      - 詳細は What's new in Ruby 3.2's IRB?(<https://st0012.dev/whats-new-in-ruby-3-2-irb>) を参照してください。
-    - Pry のようなコマンドや機能が複数追加されました。
-      - edit と show_cmds (Pry の help コマンド相当) が追加されました。
-      - ls コマンドに出力をフィルタするための -g または -G オプションが追加されました。
-      - show_source のエイリアスとして $ が追加されました、また引数をクオートする必要がなくなりました。
-      - whereami のエイリアスとして @ が追加されました。
+- IRB
+  - debug.gem と統合したコマンドが複数追加されました: debug, break, catch, next, delete, step, continue, finish, backtrace, info
+    - これらは Gemfile に gem "debug" と記述しなくても動かすことができます。
+    - 詳細は What's new in Ruby 3.2's IRB?(<https://st0012.dev/whats-new-in-ruby-3-2-irb>) を参照してください。
+  - Pry のようなコマンドや機能が複数追加されました。
+    - edit と show_cmds (Pry の help コマンド相当) が追加されました。
+    - ls コマンドに出力をフィルタするための -g または -G オプションが追加されました。
+    - show_source のエイリアスとして $ が追加されました、また引数をクオートする必要がなくなりました。
+    - whereami のエイリアスとして @ が追加されました。
 
-  - Net::Protocol
-    - Net::BufferedIO が性能改善されました。 <https://github.com/ruby/net-protocol/pull/14>
+- Net::Protocol
+  - Net::BufferedIO が性能改善されました。 <https://github.com/ruby/net-protocol/pull/14>
 
-  - Pathname
-    - Pathname#lutime が追加されました。 <https://github.com/ruby/pathname/pull/20>
+- Pathname
+  - Pathname#lutime が追加されました。 <https://github.com/ruby/pathname/pull/20>
 
-  - Socket
-    - サポートされたプラットフォームに以下の定数が追加されました。
-      - SO_INCOMING_CPU
-      - SO_INCOMING_NAPI_ID
-      - SO_RTABLE
-      - SO_SETFIB
-      - SO_USER_COOKIE
-      - TCP_KEEPALIVE
-      - TCP_CONNECTION_INFO
+- Socket
+  - サポートされたプラットフォームに以下の定数が追加されました。
+    - SO_INCOMING_CPU
+    - SO_INCOMING_NAPI_ID
+    - SO_RTABLE
+    - SO_SETFIB
+    - SO_USER_COOKIE
+    - TCP_KEEPALIVE
+    - TCP_CONNECTION_INFO
 
-  - SyntaxSuggest
-    - syntax_suggest の機能であった dead_end がRubyに統合されました。 [feature:18159]
+- SyntaxSuggest
+  - syntax_suggest の機能であった dead_end がRubyに統合されました。 [feature:18159]
 
-  - UNIXSocket
-    - Windows の UNIXSocket のサポートが追加されました。匿名ソケットをエミュレートします。 File.socket? と File::Stat#socket? のサポートを可能な限り追加されました。 [feature:19135]
+- UNIXSocket
+  - Windows の UNIXSocket のサポートが追加されました。匿名ソケットをエミュレートします。 File.socket? と File::Stat#socket? のサポートを可能な限り追加されました。 [feature:19135]
 
-* 以下の default gems のバージョンがアップデートされました。
+- 以下の default gems のバージョンがアップデートされました。
   - RubyGems 3.4.1
   - abbrev 0.1.1
   - benchmark 0.2.1
@@ -462,7 +462,7 @@
   - yaml 0.2.1
   - zlib 3.0.0
 
-* 以下の bundled gems のバージョンがアップデートされました。
+- 以下の bundled gems のバージョンがアップデートされました。
   - minitest 5.16.3
   - power_assert 2.0.3
   - test-unit 3.5.7


### PR DESCRIPTION
箇条書きが `*` で書かれているために**箇条書きとして表示されていない**ものがいくつかありました。
これを `-` に訂正します。

manual/doc/news/3_2_0.md は，修正箇所と繋がっている（一体であるはずの）`-` による箇条書きのインデントを修正箇所に揃えました。

古いニュース記事（Ruby 1.9 よりも前）は直していません。

修正ファイルにあった，コードブロック内の余計な行末スペースは削除しました。削除して問題ないことは目視で判断しました。