### PR TITLE
Regexp.new の option/code 引数の記述を実測に合わせて修正

### DIFF
--- a/manual/api/_builtin/Regexp.md
+++ b/manual/api/_builtin/Regexp.md
@@ -48,7 +48,8 @@ p Regexp.new('abc').frozen?
 - **param** `option` -- [m:Regexp::IGNORECASE], [m:Regexp::MULTILINE],
               [m:Regexp::EXTENDED]
               の論理和を指定します。
-              [c:Integer] 以外であれば真偽値の指定とみなされ、真なら [m:Regexp::IGNORECASE] の指定と同じになります。
+              [c:String] であれば `"i"`（IGNORECASE）、`"m"`（MULTILINE）、`"x"`（EXTENDED）を並べたオプション文字列として解釈します。それ以外の文字を含む文字列を与えると [c:ArgumentError] が発生します。
+              [c:Integer] でも [c:String] でもなければ真偽値の指定とみなされ、真なら [m:Regexp::IGNORECASE] の指定と同じになります。
 #%else
 ### def Regexp.compile(string, option = nil, code = nil) -> Regexp
 ### def Regexp.new(string, option = nil, code = nil) -> Regexp
@@ -62,10 +63,16 @@ p Regexp.new('abc').frozen?
 - **param** `option` -- [m:Regexp::IGNORECASE], [m:Regexp::MULTILINE],
               [m:Regexp::EXTENDED]
               の論理和を指定します。
+#%since 3.2
+              [c:String] であれば `"i"`（IGNORECASE）、`"m"`（MULTILINE）、`"x"`（EXTENDED）を並べたオプション文字列として解釈します。それ以外の文字を含む文字列を与えると [c:ArgumentError] が発生します。
+              [c:Integer] でも [c:String] でもなければ真偽値の指定とみなされ、真なら [m:Regexp::IGNORECASE] の指定と同じになります。
+#%else
               [c:Integer] 以外であれば真偽値の指定とみなされ、真なら [m:Regexp::IGNORECASE] の指定と同じになります。
+#%end
 
-- **param** `code` -- `"n"`, `"N"` を与えると、返り値のエンコーディングは ASCII-8BIT になります。
-            それ以外の指定は警告を出力します。
+- **param** `code` -- `"n"` または `"N"` を与えると、パターンを ASCII-8BIT（バイナリ）のパターンとして扱います。
+            パターンが ASCII 文字だけの場合、返り値のエンコーディングは US-ASCII になります。
+            それ以外の指定は無視されます。
 #%end
 
 - **raise**  `RegexpError` -- 正規表現のコンパイルに失敗した場合発生します。


### PR DESCRIPTION
#3490 のレビュー中に見つかった、#3490 より前からある `Regexp.new` / `Regexp.compile` の記述の不一致 3 件の修正です(#3490 での scivola さんの依頼を受けたものです)。**このブランチは #3490 の上に作ってあり、#3490 マージ後は差分がこのコミットだけになります。**

3.0.7 / 3.1.7 / 3.2.11 / 3.3.12 / 3.4.8 / 4.0.1 / 4.0.6 の実測に基づきます。

## 修正内容

1. **`option` 引数: Ruby 3.2 からの文字列指定を追記**([Feature #18788](https://bugs.ruby-lang.org/issues/18788))
   - `"i"`（IGNORECASE）・`"m"`（MULTILINE）・`"x"`（EXTENDED）の並びとして解釈され、それ以外の文字を含むと `ArgumentError` になります(`Regexp.new("a", "im").options` → `5`・`Regexp.new("a", "z")` → `ArgumentError` を実測)
   - 3.3 以上の分岐には無条件で、3.3 未満の分岐には `#%since 3.2` ゲート付きで追記しました(3.0/3.1 では文字列も従来どおり真偽値扱いで IGNORECASE になることを実測確認)
2. **`code` 引数: 「それ以外の指定は警告を出力します」→「無視されます」**
   - `"u"` や `"e"` を与えても警告は出ません(`$VERBOSE = true` でも。3.0.7〜3.2.11 で実測)
3. **`code` 引数: ASCII-8BIT になる条件を正確に**
   - ASCII-8BIT になるのはパターンが非 ASCII バイトを含む場合のみで、ASCII 文字だけのパターンでは `encoding` は US-ASCII を返します(実測)

## 検証

ミニ md ツリーで 3.0 / 3.1 / 3.2 / 3.3 / 4.0 の 5 版の DB を構築し、`Regexp.new` の描画を確認しました。

- 3.0 / 3.1: 3 引数シグネチャ・文字列オプションの記述なし(従来の真偽値の文のみ)
- 3.2: 3 引数シグネチャ+文字列オプションの記述あり(`#%since`/`#%else` のネストが意図どおり解決)
- 3.3 / 4.0: 2 引数シグネチャ+文字列オプションの記述あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)
