### PR TITLE
objspace のサンプルコードの実行結果を修正し、count_nodes を 4.1 で出し分ける

### DIFF
--- a/manual/api/objspace.md
+++ b/manual/api/objspace.md
@@ -74,6 +74,7 @@ end
 
 本メソッドは C Ruby 以外では動作しません。
 
+#%until 4.1
 ### module_function def count_nodes(result_hash = nil) -> Hash
 
 ノードの種類ごとの数を格納したハッシュを返します。
@@ -84,16 +85,19 @@ end
 
 本メソッドは普通の Ruby プログラマ向けのメソッドではありません。パフォーマンスやメモリ管理に興味のある C Ruby の開発者向けのものです。
 
+Ruby 2.5 以降、パーサのノードは GC の管理対象ではないため、本メソッドは常に空のハッシュを返します。Ruby 4.1 で削除されました。
+
 ```ruby title="例"
 require 'objspace'
 
 p ObjectSpace.count_nodes
-# => {:NODE_METHOD=>2027, :NODE_FBODY=>1927, :NODE_CFUNC=>1798, ...}
+# => {}
 ```
 
 戻り値のハッシュは処理系に依存します。これは将来変更になるかもしれません。
 
 本メソッドは C Ruby 以外では動作しません。
+#%end
 
 ### module_function def count_tdata_objects(result_hash = nil) -> Hash
 
@@ -289,7 +293,11 @@ class A
 end
 
 A.new.foo
+#%since 4.0
+# => "A"
+#%else
 # => "Class"
+#%end
 ```
 
 - **SEE** [m:ObjectSpace?.trace_object_allocations_start],
@@ -317,7 +325,11 @@ class A
 end
 
 A.new.foo
+#%since 4.0
+# => "A#foo"
+#%else
 # => "Class#new"
+#%end
 ```
 
 - **SEE** [m:ObjectSpace?.trace_object_allocations_start],


### PR DESCRIPTION
`manual/api/objspace.md` のサンプルコードに書かれた実行結果のうち、実測と食い違う 3 行を修正します。[#3483](https://github.com/rurema/doctree/pull/3483) の続きで、[#3487](https://github.com/rurema/doctree/pull/3487) で `require 'objspace'` を足して実際に動かせるようになったことで見つかったものです。

| 箇所 | 原稿 | 実測 |
| --- | --- | --- |
| `ObjectSpace.count_nodes` | `{:NODE_METHOD=>2027, :NODE_FBODY=>1927, ...}` | 全サポート版で `{}` |
| `ObjectSpace.allocation_class_path` | `"Class"` | 3.0〜3.4 は原稿どおり。4.0 以降は `"A"` |
| `ObjectSpace.allocation_method_id` | `"Class#new"` | 3.0〜3.4 は原稿どおり。4.0 以降は `"A#foo"` |

- `count_nodes` は Ruby 2.5 以降、パーサのノードが GC の管理対象ではなくなったため常に空のハッシュを返します。実装も `return setup_hash(argc, argv);` だけになっており、Ruby 4.1 で削除されました（ruby/ruby `e8c61f513`。コミットメッセージに「has been a no-op and returning an empty hash since Ruby 2.5」とあります）。実行結果を `{}` に直し、その旨の一文を添えた上で、メソッド全体を `#%until 4.1` で囲みました。
- `allocation_class_path` / `allocation_method_id` が変わる境界は 4.0 です。`Class#new` の最適化（[Feature #21254](https://bugs.ruby-lang.org/issues/21254)、4.0 の NEWS にも記載）で `opt_new` 命令が追加され、`Object.new` が `Class#new` のフレームを積まずに割り当てるようになったため、記録される割り当て元が呼び出し側の `A#foo` になります。`TracePoint` で見ると 3.0〜3.4 では `[:c_call, :new, Class]` が現れ、4.0 以降では現れません。3.0〜3.4 では原稿のままが正しいので、`#%since 4.0` で出し分けています。
- 実測は 3.0.7 / 3.1.7 / 3.2.11 / 3.3.12 / 3.4.9 / 4.0.6 と 4.1.0dev（`baf5816719`）で行いました。
- `rake generate` / `rake check_links`（全 CI 版で 0 broken link）/ `rake check_format` / `rake check_blank_lines` / `rake check_single_space_indent` を確認済みです。描画も確認し、4.1 では `count_nodes` のページとライブラリ索引の項目が消え、4.0 以前では残ることを見ています。
