### PR TITLE
Encoding に不足している定数を追加する

### DIFF
--- a/manual/api/_builtin/Encoding.md
+++ b/manual/api/_builtin/Encoding.md
@@ -432,11 +432,22 @@ ISO-2022-JP に加え、ESC ( I でいわゆる半角カナを許し、Windows �
 ### const EUC_CN -> Encoding
 ### const EUCCN -> Encoding
 ### const EucCN -> Encoding
+### const GB2312 -> Encoding
+{: since=""}
 
-ENC-CN エンコーディングです。
+EUC-CN エンコーディングです。
 
 中国で用いられる簡体字中国語 EUCのエンコーディングです。
 GB2312 と呼ばれることも多いです。
+
+### const EUC_JIS_2004 -> Encoding
+{: since=""}
+### const EUC_JISX0213 -> Encoding
+{: since=""}
+
+EUC-JIS-2004 エンコーディングです。
+
+日本語 EUC 亜種で、JIS X 0213:2004 の文字集合を取り扱えます。
 
 ### const EUC_KR -> Encoding
 ### const EUCKR -> Encoding
@@ -1170,6 +1181,18 @@ Emacs-Mule エンコーディングです。
 Emacsの多言語化(Mule)で使われているステートレスのエンコーディングです。
 
 - **SEE** <http://web.archive.org/web/20100714080650/http://www.m17n.org/mule/pricai96/mule.en.html>
+
+#%since 4.0
+### const UNICODE_VERSION -> String
+
+Ruby の Unicode 対応(大文字・小文字の変換や正規表現の Unicode プロパティなど)が基づいている Unicode のバージョンです。
+
+Ruby のバージョンによって値は変わります。
+
+```ruby
+p Encoding::UNICODE_VERSION # => "17.0.0"
+```
+#%end
 
 # class EncodingError < StandardError
 

--- a/manual/api/_builtin/Encoding.md
+++ b/manual/api/_builtin/Encoding.md
@@ -1192,6 +1192,7 @@ Ruby のバージョンによって値は変わります。
 ```ruby
 p Encoding::UNICODE_VERSION # => "17.0.0"
 ```
+
 #%end
 
 # class EncodingError < StandardError


### PR DESCRIPTION
Closes #3494

報告された定数の抜けを、全対象バージョン(3.0.7 / 3.1.7 / 3.2.9 / 3.3.12 / 3.4.8 / 4.0.6、一部 2.7.8 も)での実測に基づいて追加します。

## 追加内容

- **GB2312**: 実測すると既存の `Encoding::EUC_CN` と**同一エンコーディング**でした(`Encoding::GB2312.names` → `["GB2312", "EUC-CN", "eucCN"]`)。新規エントリではなく既存の EUC_CN エントリへの別名追加にしています。ついでに説明文の「ENC-CN」を「EUC-CN」に修正しました(タイポ)
- **EUC_JIS_2004 / EUC_JISX0213**: 新規エントリ。両定数とも EUC-JIS-2004(JIS X 0213:2004 対応の日本語 EUC 亜種)を指します
- **UNICODE_VERSION**: Ruby 4.0 で追加された **String** 定数(4.0.6 で `"17.0.0"`・3.4.8 以前には無いことを実測)。`#%since 4.0` でゲートし、値がバージョンで変わる旨も書いています
- 上記の古くからある定数(GB2312・EUC_JIS_2004 系)には `{: since=""}` を付けてバッジを非表示にしています(凍結版の文書に無いため、自動算出だと「Ruby 3.0 から」と誤表示されるのを防ぐ)

## CP720 / IBM720 について

issue に挙がっていた CP720 / IBM720 は**既に収録済み**でした(`### const IBM720` / `### const CP720` のエントリが CP437 の後にあります)ので、この PR では触っていません。

## 検証

ミニ md ツリーで 3.4 / 4.0 の DB を構築し、EUC_CN グループが 4 つの別名で描画されること・`EUC_JIS_2004` の両名エントリ・`UNICODE_VERSION` が 4.0 のみに現れる(3.4 では不在)ことを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
