### PR TITLE
psych のサンプルコードを現行の API に合わせる

### DIFF
--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -147,7 +147,9 @@ p Psych.load("---\n foo: bar", symbolize_names: true)  # => {:foo=>"bar"}
 ```
 
 ### def Psych.safe_load(yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false, freeze: false) -> object
+#%until 3.1
 ### def Psych.safe_load(yaml, legacy_permitted_classes=[], legacy_permitted_symbols=[], legacy_aliases=false, legacy_filename=nil) -> object
+#%end
 
 安全に YAML フォーマットの文書を読み込み Ruby のオブジェクトを生成して返します。
 
@@ -223,6 +225,7 @@ p yaml["aaa"]["bbb"].frozen?          # = true
 p yaml["aaa"]["bbb"].first.frozen?    # = true
 ```
 
+#%until 3.1
 また legacy_permitted_classes などのオプション引数は非推奨な引数となっています。
 [m:$-w] が true の時にオプション引数を渡すと警告が出力されます。
 
@@ -234,6 +237,7 @@ require 'date'
 Psych.safe_load("", [Date])
 ```
 
+#%end
 - **param** `io` -- YAMLフォーマットの文書の読み込み先のIOオブジェクト。
 - **param** `permitted_classes` -- 追加で読み込みを許可するクラスの配列。
 - **param** `permitted_symbols` -- 引数 permitted_classesに [c:Symbol] を含む場合に読み込みを許可する [c:Symbol] の配列。
@@ -246,7 +250,10 @@ Psych.safe_load("", [Date])
 - **param** `freeze` -- true を指定すると再帰的に freeze されたオブジェクトを返します。
               デフォルトは false です。
 
+### def Psych.parse(yaml, filename: nil) -> Psych::Nodes::Document
+#%until 3.1
 ### def Psych.parse(yaml, filename = nil) -> Psych::Nodes::Document
+#%end
 
 YAML ドキュメントをパースし、YAML の AST を返します。
 
@@ -267,7 +274,7 @@ require 'psych'
 p Psych.parse("---\n - a\n - b") # => #<Psych::Nodes::Document:...>
 
 begin
-  Psych.parse("--- `", "file.txt")
+  Psych.parse("--- `", filename: "file.txt")
 rescue Psych::SyntaxError => ex
   p ex.file    # => 'file.txt'
   p ex.message # => "(file.txt): found character that cannot start any token while scanning for the next token at line 1 column 5"

--- a/manual/api/psych/Psych__ScalarScanner.md
+++ b/manual/api/psych/Psych__ScalarScanner.md
@@ -13,9 +13,11 @@ YAML の scalar 型を読み込んで Ruby の built-in 型に変換するクラ
 
 ## Class Methods
 
-### def Psych::ScalarScanner.new
+### def Psych::ScalarScanner.new(class_loader) -> Psych::ScalarScanner
 
 新たな ScalarScanner オブジェクトを生成します。
+
+- **param** `class_loader` -- YAML のタグから Ruby のクラスを解決するための Psych::ClassLoader オブジェクト
 
 ## Instance Methods
 
@@ -26,7 +28,7 @@ YAML の scalar である文字列を Ruby のオブジェクトに変換した�
 ```ruby
 require 'psych'
 
-scanner = Psych::ScalarScanner.new
+scanner = Psych::ScalarScanner.new(Psych::ClassLoader.new)
 p scanner.tokenize("yes") # => true
 p scanner.tokenize("year") # => "year"
 p scanner.tokenize("12") # =>  12

--- a/manual/api/psych/Psych__Visitors.md
+++ b/manual/api/psych/Psych__Visitors.md
@@ -18,11 +18,11 @@ Ruby オブジェクトから YAML の AST を構築するためのクラスで�
 ```ruby
 require 'psych'
 
-builder = Psych::Visitors::YAMLTree.new
+builder = Psych::Visitors::YAMLTree.create
 builder << { :foo => 'bar' }
 builder << ["baz", "bazbaz"]
 p builder.tree # => #<Psych::Nodes::Stream ... > A stream containing two documents
-puts tree.to_yaml
+puts builder.tree.to_yaml
 # =>
 # ---
 # :foo: bar
@@ -32,7 +32,8 @@ puts tree.to_yaml
 ```
 
 ## Class Methods
-### def Psych::Visitors::YAMLTree.new(options = {}, emitter = Psych::TreeBuilder.new, ss = Psych::ScalarScanner.new) -> Psych::Visitors::YAMLTree
+### def Psych::Visitors::YAMLTree.create(options = {}, emitter = nil) -> Psych::Visitors::YAMLTree
+### def Psych::Visitors::YAMLTree.new(emitter, ss, options) -> Psych::Visitors::YAMLTree
 
 YAMLTree オブジェクトを生成します。
 
@@ -44,10 +45,12 @@ emitter には AST の構築に使われる [c:Psych::TreeBuilder] オブジェ�
 ss は Ruby の [c:String] が YAML document 上で quote が必要かどうかを判定するための [c:Psych::ScalarScanner] オブジェクトを渡します。
 
 emitter, ss は通常デフォルトのものから変える必要はないでしょう。
+create では emitter を省略すると [c:Psych::TreeBuilder] が、ss には [c:Psych::ScalarScanner] が用意されます。
+new は 3 つの引数がすべて必須です。
 
 - **param** `options` -- オプション
 - **param** `emitter` -- AST の構築に使う [c:Psych::TreeBuilder] オブジェクト
-- **param** `ss` -- 文字列に quite が必要かどうかを判定するための [c:Psych::ScalarScanner] オブジェクト
+- **param** `ss` -- 文字列に quote が必要かどうかを判定するための [c:Psych::ScalarScanner] オブジェクト
 
 ## Instance Methods
 ### def started -> bool

--- a/manual/api/psych/core_ext.md
+++ b/manual/api/psych/core_ext.md
@@ -27,13 +27,13 @@ class Foo
 end
   
 # Dumps Ruby object normally  
-p Psych.dump(Foo.new(3)) 
+puts Psych.dump(Foo.new(3))
 # =>
 # --- !ruby/object:Foo
 # x: 3
   
 # Registers tag with class Foo
-Foo.yaml_as("tag:example.com,2013:foo")
+Foo.yaml_tag("tag:example.com,2013:foo")
 # ... and dumps the object of Foo class
 Psych.dump(Foo.new(3), STDOUT)
 # =>
@@ -41,8 +41,12 @@ Psych.dump(Foo.new(3), STDOUT)
 # x: 3 
   
 # Loads the object from the tagged YAML node
+#%since 3.1
+p Psych.load(<<EOS, permitted_classes: [Foo])
+#%else
 p Psych.load(<<EOS)
---- !<tag:example.com,2012:foo>
+#%end
+--- !<tag:example.com,2013:foo>
 x: 8
 EOS
 # => #<Foo:0x0000000130f48 @x=8>


### PR DESCRIPTION
[#3485](https://github.com/rurema/doctree/pull/3485) で `require` を足しても動かなかったブロックのうち、記述そのものが現行の psych と合っていない 5 件を直します。

| 箇所 | 原稿 | 実測 |
| --- | --- | --- |
| `psych.md` `Psych.safe_load` | 位置引数のシグネチャと「オプション引数を使用した例」 | 3.0 のみ動作。3.1 以降は `ArgumentError` |
| `psych.md` `Psych.parse` | `def Psych.parse(yaml, filename = nil)` と `Psych.parse("--- `", "file.txt")` | 同上。キーワード引数の形は 3.0 でも動く |
| `psych/Psych__ScalarScanner.md` | `def Psych::ScalarScanner.new`（引数なし） | 全版で `class_loader` が必須 |
| `psych/Psych__Visitors.md` | `YAMLTree.new(options = {}, emitter = ..., ss = ...)` | 全版で `new(emitter, ss, options)` の 3 つが必須。省略できるのは `create` |
| `psych/core_ext.md` | `Foo.yaml_as(...)` | 全版に存在しない（syck 時代の名前）。見出しは `Object.yaml_tag` |

- `safe_load` と `parse` の位置引数は **psych 4.0（Ruby 3.1 同梱）で削除**されました。同じファイルの `Psych.load` が既に `#%until 3.1` で出し分けているので、それに揃えています。`parse` の例はキーワード引数の形が 3.0 でも通るため、出し分けずに `filename:` へ直しました。
- `ScalarScanner.new` はシグネチャに `class_loader` を足し、例では `Psych::ClassLoader.new` を渡すようにしました。`YAMLTree` は `create` を見出しに追加し、例も `create` と `builder.tree.to_yaml` に直しています（`puts tree.to_yaml` は `tree` が未定義でした）。
- `core_ext.md` は `yaml_as` を `yaml_tag` に直したうえで、**登録したタグ（2013）と読み込むタグ（2012）が食い違っていた**のを揃え、`p` を `puts` に変えて注釈どおりの出力にしました。`Psych.load` は psych 4.0 から安全側が既定になり `Psych::DisallowedClass` になるため、3.1 以降は `permitted_classes:` を渡しています。ついでに `Psych__Visitors.md` の「quite」を「quote」に直しました。

実測は 3.0.7 / 3.1.7 / 3.2.11 / 3.3.12 / 3.4.9 / 4.0.6 で行い、**同梱の psych を見るために `ruby --disable-gems` を使いました**（gem で更新された psych が入っていると 3.2 でも 5.4.0 が読まれてしまうため）。それぞれの同梱版は 3.3.2 / 4.0.4 / 5.0.1 / 5.1.2 / 5.2.2 / 5.3.1 です。3.1 は手元に無いので `docker run --rm ruby:3.1-slim` で測りました。

直したあと全 6 版でブロックを再実行し、対象の 5 件がすべて通ることを確認しています。同じファイルに残る `Psych.safe_load(yaml, ...)` と `parser.parse(yaml_document)` は**変数が未定義の説明用の断片**なのでそのままにしました。

`rake generate` / `rake check_links`（全 CI 版で 0 broken link）/ `rake check_format` / `rake check_blank_lines` / `rake check_single_space_indent` / `rake check_indent_in_samplecode` を確認し、3.0 / 3.1 / 4.0 の描画で出し分けが意図どおりになっていることも見ています。
