### PR TITLE
bundled gem の rbs・typeprof・repl_type_completor のスタブページを追加する

### DIFF
--- a/manual/api/rbs.md
+++ b/manual/api/rbs.md
@@ -1,0 +1,13 @@
+---
+type: library
+category: Development
+---
+Ruby プログラムの型を記述する言語 RBS を扱うためのライブラリです。型定義の構文解析などの API と、`rbs` コマンドを提供します。
+
+このライブラリはbundled gem(gemファイルのみを同梱)です。詳しい内容は下記のページを参照してください。
+
+- rubygems.org: <https://rubygems.org/gems/rbs>
+- プロジェクトページ: <https://github.com/ruby/rbs>
+- リファレンス: <https://www.rubydoc.info/gems/rbs>
+
+- **SEE** [ref:d:glossary#bundled-gem]

--- a/manual/api/repl_type_completor.md
+++ b/manual/api/repl_type_completor.md
@@ -1,0 +1,14 @@
+---
+type: library
+since: "3.4"
+category: Development
+---
+型解析に基づいて REPL の入力補完を行うライブラリです。irb の `--type-completor` オプションを指定したときの補完エンジンとして利用され、通常このライブラリを直接 require することはありません。
+
+このライブラリはbundled gem(gemファイルのみを同梱)です。詳しい内容は下記のページを参照してください。
+
+- rubygems.org: <https://rubygems.org/gems/repl_type_completor>
+- プロジェクトページ: <https://github.com/ruby/repl_type_completor>
+- リファレンス: <https://www.rubydoc.info/gems/repl_type_completor>
+
+- **SEE** [lib:irb], [ref:d:glossary#bundled-gem]

--- a/manual/api/typeprof.md
+++ b/manual/api/typeprof.md
@@ -1,0 +1,13 @@
+---
+type: library
+category: Development
+---
+Ruby コードを型注釈なしで解析し、メソッドの型シグネチャなどを RBS の形式で推定する型解析ツールです。`typeprof` コマンドを提供します。
+
+このライブラリはbundled gem(gemファイルのみを同梱)です。詳しい内容は下記のページを参照してください。
+
+- rubygems.org: <https://rubygems.org/gems/typeprof>
+- プロジェクトページ: <https://github.com/ruby/typeprof>
+- リファレンス: <https://www.rubydoc.info/gems/typeprof>
+
+- **SEE** [lib:rbs], [ref:d:glossary#bundled-gem]


### PR DESCRIPTION
bundled gem のうちリファレンスに項目がなかった rbs・typeprof・repl_type_completor のスタブページを追加します。

## 背景

標準添付ライブラリをライブラリ単位で棚卸ししたところ(2026-08-28。ruby/ruby の `doc/standard_library.*`・`gems/bundled_gems` と突き合わせ)、bundled gems のうちこの 3 つだけ項目がありませんでした。power_assert や minitest と同じスタブ形式(概要 1 文+公式ページへのリンク+用語集への SEE)でページを追加し、ライブラリ一覧が bundled gems を網羅するようにします。

## 変更内容

- `manual/api/rbs.md`・`manual/api/typeprof.md`・`manual/api/repl_type_completor.md` を追加
- repl_type_completor は Ruby 3.4 で bundled gem に追加されたため `since: "3.4"` を付与。irb の `--type-completor` オプションから利用されるライブラリで、通常直接 require しない旨を明記(なお ruby 本体の `doc/standard_library.md` はこの gem を記載していませんが、`gems/bundled_gems` には 3.4 から載っています)

## 検証

- lint 4 種(filename case / indent / single space / blank lines): pass
- 3.3・3.4・4.1 の DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- ライブラリ一覧への収載: rbs・typeprof は 3.3 に収載/repl_type_completor は 3.3 に載らず 3.4・4.1 に収載(since ゲートの動作確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
