### PR TITLE
error_highlight のページを追加し did_you_mean の gem 種別の記述を更新する

### DIFF
--- a/manual/api/did_you_mean.md
+++ b/manual/api/did_you_mean.md
@@ -21,10 +21,10 @@ category: Development
 デフォルトで有効になっており、無効にするにはコマンドラインオプションで
 --disable=did_you_mean を指定します。
 
-このライブラリはbundled gem(gemファイルのみを同梱)です。詳しい内容は下記のページを参照してください。
+このライブラリはdefault gemです。詳しい内容は下記のページを参照してください。
 
 - rubygems.org: <https://rubygems.org/gems/did_you_mean>
 - プロジェクトページ: <https://github.com/ruby/did_you_mean>
 - リファレンス: <https://www.rubydoc.info/gems/did_you_mean/>
 
-- **SEE** [ref:d:glossary#bundled-gem]
+- **SEE** [ref:d:glossary#default-gem]

--- a/manual/api/error_highlight.md
+++ b/manual/api/error_highlight.md
@@ -1,0 +1,38 @@
+---
+type: library
+since: "3.1"
+category: Development
+---
+[c:NameError] などの実行時エラーが起きたときに、エラーメッセージにエラーの該当箇所のコード抜粋と下線を追加して表示するライブラリです。
+
+```ruby
+json = {}
+json[:article][:title]
+#%version 3.4...
+# ~> undefined method '[]' for nil (NoMethodError)
+#%end
+#%version 3.3...3.4
+# ~> undefined method `[]' for nil (NoMethodError)
+#%end
+#%version ...3.3
+# ~> undefined method `[]' for nil:NilClass (NoMethodError)
+#%end
+#
+#    json[:article][:title]
+#                  ^^^^^^^^
+```
+
+デフォルトで有効になっており、無効にするにはコマンドラインオプションで
+--disable-error_highlight を指定します。
+
+プログラムからは、エラーの該当箇所の位置情報を取得する `ErrorHighlight.spot` や、
+表示のカスタマイズのための `ErrorHighlight.formatter` / `ErrorHighlight.formatter=`
+が利用できます。
+
+このライブラリはdefault gemです。詳しい内容は下記のページを参照してください。
+
+- rubygems.org: <https://rubygems.org/gems/error_highlight>
+- プロジェクトページ: <https://github.com/ruby/error_highlight>
+- リファレンス: <https://www.rubydoc.info/gems/error_highlight>
+
+- **SEE** [lib:did_you_mean], [ref:d:glossary#default-gem]


### PR DESCRIPTION
Ruby 3.1 で追加された default gem の error_highlight のページを追加し、あわせて did_you_mean のページの gem 種別の記述を更新します。

## 背景

標準添付ライブラリのライブラリ単位の棚卸し(2026-08-28)で、error_highlight(Ruby 3.1 で追加された default gem)が未収載であることが分かりました。did_you_mean と同様の「自動で有効になるエラー支援機能」なので、同じ構成の短いページ(概要+実行例+無効化方法+公式ページへのリンク)を `since: "3.1"` で追加します。

## 変更内容

### error_highlight.md の追加

実行例のエラーメッセージは各版の実挙動に合わせて版分岐しています(3.1.7・3.2.11 は all-ruby、3.3.12・3.4.8・4.0.6 は手元のバイナリで実測):

- 3.1/3.2: ``undefined method `[]' for nil:NilClass``
- 3.3: ``undefined method `[]' for nil``
- 3.4 以降: `undefined method '[]' for nil`(引用符の変更)
- 3.0.7 では該当箇所の表示自体がないことも確認(`since: "3.1"` の裏取り)

### did_you_mean.md の gem 種別の更新

did_you_mean は Ruby 2.7 で bundled gem から default gem になりましたが(2.6 までの `gems/bundled_gems` には記載があり、2.7 からは `lib/did_you_mean.rb` としてツリーに同梱)、ページは bundled gem 時代の記述のままでした。default gem である旨に更新し、用語集への SEE も `glossary#default-gem` に変更します。

## 検証

- lint 4 種: pass
- 3.0・3.1・4.1 の DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- ライブラリ一覧: 3.0 に error_highlight が載らず、3.1・4.1 に収載(since ゲートの動作確認)
- 描画確認: 3.1 と 4.1 で実行例のエラーメッセージが版どおりに切り替わり、`#%` ディレクティブの露出なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
