### PR TITLE
bundler のページを追加する

### DIFF
--- a/manual/api/bundler.md
+++ b/manual/api/bundler.md
@@ -1,0 +1,22 @@
+---
+type: library
+category: Development
+---
+アプリケーションが依存する gem を Gemfile に記述し、その解決・インストール・ロードを一貫して行うためのライブラリです。
+
+主なインターフェースは `bundle` コマンド(`bundle install`、`bundle exec` など)です。
+Ruby コードからは主に次の API を利用します。
+
+- `require "bundler/setup"`: Gemfile に従ってロードパスを設定します(`bundle exec` 相当の状態にします)
+- `Bundler.setup`: 同じロードパス設定を明示的に行います(対象のグループも指定できます)
+- `Bundler.require`: setup に加えて、Gemfile に書かれた gem をまとめて require します
+- `Bundler.with_unbundled_env { ... }`: Bundler 由来の環境変数を取り除いた環境でブロックを実行します(Bundler 管理下のプロセスから別の Ruby プロセスを起動するときに使います)
+
+このライブラリはdefault gemです。詳しい内容は下記のページを参照してください。
+
+- 公式ドキュメント: <https://bundler.io/>
+- rubygems.org: <https://rubygems.org/gems/bundler>
+- プロジェクトページ: <https://github.com/rubygems/rubygems>
+- リファレンス: <https://www.rubydoc.info/gems/bundler>
+
+- **SEE** [lib:rubygems], [ref:d:glossary#default-gem]


### PR DESCRIPTION
bundler のページを追加します。

## 背景

bundler は default gem として対象の全バージョン(3.0〜4.1)に同梱されていますが、リファレンスには refm 時代から項目がありませんでした(標準添付ライブラリの棚卸し 2026-08-28 で確認)。default gem でページがないのは bundler と error_highlight(別 PR)だけです。

## 変更内容

主なインターフェースは `bundle` コマンドで API ドキュメントの需要は薄いため、次の構成の短いページとします:

- 役割の説明(Gemfile による依存の解決・インストール・ロード)
- コードから使う代表的な API の紹介: `require "bundler/setup"`・`Bundler.setup`・`Bundler.require`・`Bundler.with_unbundled_env`(いずれも手元の bundler ソースで挙動を確認)
- 公式ドキュメント(bundler.io)ほかへの誘導

メソッド単位の項目化はしていません(必要になったら別途)。

## 検証

- lint 4 種: pass
- 3.0・4.1 の DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- 3.0・4.1 のライブラリ一覧に bundler が収載されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
