### PR TITLE
Ruby 3.3 で削除された irb/ext/save-history と rubygems/indexer に版ゲートを付ける

### DIFF
--- a/manual/api/irb/ext/save-history.md
+++ b/manual/api/irb/ext/save-history.md
@@ -1,6 +1,6 @@
 ---
 type: library
-until: "3.4"
+until: "3.3"
 ---
 [c:IRB::Context] にヒストリの読み込み、保存の機能を提供するサブライブラリです。
 

--- a/manual/api/irb/extend-command.md
+++ b/manual/api/irb/extend-command.md
@@ -14,7 +14,9 @@ require:
 #%end
   - irb/ext/tracer
   - irb/ext/use-loader
+#%until 3.3
   - irb/ext/save-history
+#%end
 ---
 #%# irb/cmd/fork.rb はどこからも require されないため省略しました。
 

--- a/manual/api/rubygems/indexer.md
+++ b/manual/api/rubygems/indexer.md
@@ -1,5 +1,6 @@
 ---
 type: library
+until: "3.3"
 include:
   - Gem::UserInteraction
 require:


### PR DESCRIPTION
Ruby 3.3 で削除された `irb/ext/save-history` と `rubygems/indexer` に版ゲートを付けます。

## 背景

標準添付ライブラリの require 実測(2026-08-28)より。どちらも Ruby 3.3.0 のソースツリー(v3_3_0)にファイルが存在しないことを確認しています。

- `irb/ext/save-history`: irb 1.11(Ruby 3.3.0 同梱)で削除されました。ページの `until` を `"3.4"` から `"3.3"` に修正し、`irb/extend-command` の front matter の require リストも同様にゲートします。代替の `irb/history` ページは `since: "3.3"` で収録済みです
- `rubygems/indexer`: RubyGems 3.5(Ruby 3.3.0 同梱)で削除されました。`until: "3.3"` を追加します

なお同時に調べた `irb/cmd/*`(chws・help・load・pushws・subirb)と `irb/extend-command` 本体は **Ruby 3.3.0 にはまだ存在する**(3.3 系の teeny リリースに同梱される新しい irb では削除済み)ため、`until: "3.4"` のままとしています。

## 検証

- lint 4 種: pass
- 3.2・3.3 の DB 生成+`bitclust checklink`: リンク切れ 0 件
- ライブラリ一覧: 両ライブラリとも 3.2 に収載・3.3 で消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
