### PR TITLE
メソッドエントリの誤りを実測に基づいて修正する

### DIFF
--- a/manual/api/bigdecimal/BigDecimal.md
+++ b/manual/api/bigdecimal/BigDecimal.md
@@ -314,6 +314,25 @@ while (v + 1.0 > 1.0) {
 
 - **SEE** [m:BigDecimal#_dump], [m:Marshal?.dump], [m:Marshal?.load]
 
+### def BigDecimal.save_exception_mode { ... } -> object
+
+例外処理に関する [m:BigDecimal.mode] の設定を保存してブロックを評価します。ブロック中で変更した設定はブロックの評価後に復元されます。
+
+ブロックの評価結果を返します。
+
+### def BigDecimal.save_rounding_mode { ... } -> object
+
+丸め処理に関する [m:BigDecimal.mode] の設定を保存してブロックを評価します。
+ブロック中で変更した設定はブロックの評価後に復元されます。
+
+ブロックの評価結果を返します。
+
+### def BigDecimal.save_limit { ... } -> object
+
+現在の [m:BigDecimal.limit] の設定を保存してブロックを評価します。ブロック中で変更した設定はブロックの評価後に復元されます。
+
+ブロックの評価結果を返します。
+
 ## Instance Methods
 
 ### def +(other) -> BigDecimal
@@ -873,25 +892,6 @@ other に [c:Rational] オブジェクトを指定した場合は self の有効
 self のハッシュ値を返します。
 
 符号、小数部、指数部が同じ場合に同じハッシュ値を返します。
-
-### def save_exception_mode { ... } -> object
-
-例外処理に関する [m:BigDecimal.mode] の設定を保存してブロックを評価します。ブロック中で変更した設定はブロックの評価後に復元されます。
-
-ブロックの評価結果を返します。
-
-### def save_rounding_mode { ... } -> object
-
-丸め処理に関する [m:BigDecimal.mode] の設定を保存してブロックを評価します。
-ブロック中で変更した設定はブロックの評価後に復元されます。
-
-ブロックの評価結果を返します。
-
-### def save_limit { ... } -> object
-
-現在の [m:BigDecimal.limit] の設定を保存してブロックを評価します。ブロック中で変更した設定はブロックの評価後に復元されます。
-
-ブロックの評価結果を返します。
 
 ### def clone -> self
 

--- a/manual/api/cgi/cookie.md
+++ b/manual/api/cgi/cookie.md
@@ -182,12 +182,12 @@ cookies = CGI::Cookie.parse("raw_cookie_string")
 
 - **param** `val` -- 真を指定すると自身はセキュアクッキーになります。
 
-### def httopnly -> bool
+### def httponly -> bool
 
 自身がhttpオンリークッキーである場合は、真を返します。
 そうでない場合は、偽を返します。
 
-### def httopnly=(val)
+### def httponly=(val)
 
 httpオンリークッキーであるかどうかを変更します。
 

--- a/manual/api/json/JSON.md
+++ b/manual/api/json/JSON.md
@@ -427,11 +427,6 @@ puts JSON.pretty_generate(hash, space: "\t")
 
 ## Constants
 
-### const VARIANT_BINARY -> bool
-
-拡張ライブラリ版を使用している場合に真を返します。
-そうでない場合は偽を返します。
-
 ### const JSON::VERSION -> String
 
 このライブラリのバージョンを表す文字列です。

--- a/manual/api/strscan.md
+++ b/manual/api/strscan.md
@@ -998,16 +998,6 @@ rescue => err
 end
 ```
 
-#%# bc-rdoc: detected missing name: matchedsize
-### def matchedsize -> Integer | nil
-
-[m:StringScanner#matched_size] と同じです。
-
-このメソッドは は将来のバージョンで削除される予定です。
-代わりに [m:StringScanner#matched_size] を使ってください。
-
-- **SEE** [m:StringScanner#matched_size]
-
 ## Constants
 
 ### const Version -> String


### PR DESCRIPTION
標準添付ライブラリの全メソッドエントリ実測(2026-08-28・3.0〜4.0 の 6 版)で見つかった、バージョンに依存しない文書の誤りを修正します。

## 変更内容

- **cgi/cookie.md**: `httopnly`・`httopnly=` は `httponly`・`httponly=` の誤字でした(`CGI::Cookie` の実メソッド名で確認)
- **bigdecimal/BigDecimal.md**: `save_exception_mode`・`save_rounding_mode`・`save_limit` は特異メソッド(`BigDecimal.mode` などと同じ)ですが、Instance Methods 節に裸の def で書かれていました。Class Methods 節へ移し `BigDecimal.` プレフィックスを付けます
- **json/JSON.md**: `JSON::VARIANT_BINARY` は json 2.x(Ruby 3.0 同梱)で削除済みのため項目を削除します
- **strscan.md**: `StringScanner#matchedsize` は Ruby 3.0 時点で既に存在しない(`matched_size` の項目は残っています)ため項目を削除します

## 検証

- lint 4 種: pass
- 4.1 の DB 生成+`bitclust checklink`: リンク切れ 0 件
- 描画確認: `CGI::Cookie` ページに httponly が現れ httopnly が消えること・`BigDecimal.save_exception_mode` が特異メソッドとして載ること・matchedsize / VARIANT_BINARY が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
