### PR TITLE
Prism::Node の Ruby 3.4 で追加されたメソッドを版ゲートする

### DIFF
--- a/manual/api/prism/Node.md
+++ b/manual/api/prism/Node.md
@@ -32,11 +32,11 @@ p call.compact_child_nodes.size # => 2
 
 ## Class Methods
 
+#%since 3.4
 ### def Prism::Node.type -> Symbol
 
 [m:Prism::Node#type] のクラスメソッド版です。インスタンスを作らずにノードクラス自体からノードの種類を表すシンボルを得られます。
 
-#%since 3.4
 ### def Prism::Node.fields -> [Prism::Reflection::Field]
 
 このノードクラスが持つフィールド(子ノードや属性)を表す
@@ -48,10 +48,12 @@ p call.compact_child_nodes.size # => 2
 
 ## Instance Methods
 
+#%since 3.4
 ### def type -> Symbol
 
 ノードの種類を表すシンボル(例 `:program_node`、`:call_node`)を返します。case 式や配列との比較でノードの種類を判定するときに使えます。
 
+#%end
 ### def location -> Prism::Location
 
 ノードのソースコード上の位置を表す [c:Prism::Location] を返します。
@@ -61,6 +63,7 @@ p call.compact_child_nodes.size # => 2
 ノードの位置に対応するソースコードの文字列を返します。
 [`location.slice`](m:Prism::Location#slice) と同じです。
 
+#%since 3.4
 ### def accept(visitor) -> object
 
 Visitor パターンの受け入れメソッドです。ノードの種類に応じた
@@ -83,6 +86,7 @@ Visitor パターンの受け入れメソッドです。ノードの種類に応
 コメントの関連付け先になりうる子ノードや位置情報の配列を返します。
 [m:Prism::ParseResult#attach_comments!] が内部で使用します。
 
+#%end
 ### def copy(**params) -> Prism::Node
 
 自身と同じクラスの新しいノードを、指定したフィールドだけを差し替えて複製します。渡せるキーワードはノードクラスごとのフィールド名で、指定しなかったフィールドは自身の値を引き継ぎます。
@@ -96,10 +100,12 @@ p copied.class        # => Prism::CallNode
 p copied.equal?(call) # => false
 ```
 
+#%since 3.4
 ### def deconstruct -> [Prism::Node | nil]
 
 [m:Prism::Node#child_nodes] のエイリアスです。パターンマッチの配列パターン(`case node; in [a, b]`)で使われます。
 
+#%end
 ### def deconstruct_keys(keys) -> Hash
 
 パターンマッチのハッシュパターン(`case node; in {value:}`)で使われます。ノードの各フィールドをキーに持つハッシュを返します。


### PR DESCRIPTION
`Prism::Node` の Ruby 3.4 で追加されたメソッド 7 件を `#%since 3.4` で版ゲートします(同ページの `Prism::Node.fields` と同じ方式。バッジは版別 DB の収録有無から自動算出されます)。

## 背景

標準添付ライブラリの全メソッドエントリ実測(2026-08-28)より。Ruby 3.3 同梱の prism 0.19.0(3.3.0 と 3.3.12 で同一バージョンであることを確認)には存在せず、3.4 以降に存在するメソッドです:

- `Prism::Node.type` / `Prism::Node#type`
- `Prism::Node#accept`
- `Prism::Node#child_nodes` / `Prism::Node#compact_child_nodes`
- `Prism::Node#comment_targets`
- `Prism::Node#deconstruct`

`Prism::Node.type` は既存の `Prism::Node.fields` のゲートを広げて含めています。同ページの他のメソッド(slice・location など)は 3.3 にも存在することを実測で確認しています。

## 検証

- lint 4 種: pass
- 3.3・3.4 の DB 生成+`bitclust checklink`: リンク切れ 0 件
- 3.3 の `Prism::Node` のメソッド一覧から 7 件が消え(instance_methods= copy, deconstruct_keys, inspect, location, newline?, pretty_print, slice, to_dot のみ)、3.4 には現れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
