### PR TITLE
rake の DSL メソッドの記述を Kernel から Rake::DSL へ移す

### DIFF
--- a/manual/api/rake/Rake__DSL.md
+++ b/manual/api/rake/Rake__DSL.md
@@ -3,7 +3,13 @@ library: rake
 include:
   - RakeFileUtils
 ---
-# reopen Kernel
+# module Rake::DSL
+
+Rakefile の中で使うタスク定義などの DSL メソッドを定義するモジュールです。
+
+`require "rake"` すると main オブジェクトがこのモジュールで
+extend されるため、Rakefile のトップレベルでは task や desc などを
+直接呼び出せます。
 
 ## Private Instance Methods
 
@@ -45,7 +51,7 @@ end
 
 ファイルを作成するタスクを定義します。
 
-主に [m:Kernel#directory] を定義するために使用します。
+主に [m:Rake::DSL#directory] を定義するために使用します。
 
 ### def directory(dir) -> ()
 

--- a/manual/api/rake/Rake__DefaultLoader.md
+++ b/manual/api/rake/Rake__DefaultLoader.md
@@ -3,7 +3,7 @@ library: rake
 ---
 # class Rake::DefaultLoader
 
-[m:Kernel#import] で使用するデフォルトのローダーです。
+[m:Rake::DSL#import] で使用するデフォルトのローダーです。
 
 ## Public Instance Methods
 

--- a/manual/api/rake/Rake__Task.md
+++ b/manual/api/rake/Rake__Task.md
@@ -8,7 +8,7 @@ library: rake
 タスクは一つ以上の関連するアクションと事前タスクを持ちます。
 タスクを実行すると、まず始めに全ての事前タスクを一度だけ実行してから自身のアクションを実行します。
 
-タスクは通常 [m:Kernel#task], [m:Kernel#file] という便利なメソッドを使用して定義します。
+タスクは通常 [m:Rake::DSL#task], [m:Rake::DSL#file] という便利なメソッドを使用して定義します。
 
 ## Public Instance Methods
 


### PR DESCRIPTION
rake の DSL メソッド(task・desc など 9 件)の記述を Kernel から `Rake::DSL` へ移します。

## 背景

標準添付ライブラリの全メソッドエントリ実測(2026-08-28)より。`task`・`file`・`file_create`・`directory`・`multitask`・`namespace`・`rule`・`desc`・`import` は Kernel の reopen として文書化されていましたが、rake 0.9(2011)以降の実体は `Rake::DSL` の private インスタンスメソッドで、Kernel には存在しません(3.0〜4.0 の全版で実測)。

## 変更内容

- `rake/Kernel.md` の見出しを `# module Rake::DSL` に変更し、ファイル名もクラスパスに合わせて `Rake__DSL.md` へ改名
- Rakefile 中でトップレベルに書ける仕組み(`require "rake"` で main オブジェクトが `Rake::DSL` で extend される。実測で確認)を冒頭に追記
- 参照元 3 箇所(`Rake::Task`・`Rake::DefaultLoader`・ページ内)の `Kernel#` 参照を `Rake::DSL#` に更新

## 検証

- lint 4 種: pass
- 4.1 の DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- `Rake::DSL` ページに 9 メソッドが載ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
