### PR TITLE
json の GeneratorMethods の名前空間を実在する JSON::Ext 配下に改名する

### DIFF
--- a/manual/api/json/Array.md
+++ b/manual/api/json/Array.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::Array
+  - JSON::Ext::Generator::GeneratorMethods::Array
 ---
 # reopen Array
 

--- a/manual/api/json/FalseClass.md
+++ b/manual/api/json/FalseClass.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::FalseClass
+  - JSON::Ext::Generator::GeneratorMethods::FalseClass
 ---
 # reopen FalseClass
 

--- a/manual/api/json/Float.md
+++ b/manual/api/json/Float.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::Float
+  - JSON::Ext::Generator::GeneratorMethods::Float
 ---
 # reopen Float
 

--- a/manual/api/json/Hash.md
+++ b/manual/api/json/Hash.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::Hash
+  - JSON::Ext::Generator::GeneratorMethods::Hash
 ---
 # reopen Hash
 

--- a/manual/api/json/Integer.md
+++ b/manual/api/json/Integer.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::Integer
+  - JSON::Ext::Generator::GeneratorMethods::Integer
 ---
 # reopen Integer
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Array.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Array.md
@@ -1,18 +1,14 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::NilClass
 ---
-# module JSON::Generator::GeneratorMethods::NilClass
+# module JSON::Ext::Generator::GeneratorMethods::Array
 
-[c:NilClass] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:Array] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
 
 自身から生成した JSON 形式の文字列を返します。
-
-"null" という文字列を返します。
 
 - **param** `state_or_hash` -- 生成する JSON 形式の文字列をカスタマイズするために [c:JSON::State] のインスタンスか、
                      [m:JSON::State.new] の引数と同じ [c:Hash] を指定します。
@@ -20,6 +16,6 @@ alias:
 ```ruby title="例"
 require "json"
 
-p nil.to_json # => "null"
+p [1, 2, 3].to_json # => "[1,2,3]"
 ```
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__FalseClass.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__FalseClass.md
@@ -1,9 +1,7 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::FalseClass
 ---
-# module JSON::Generator::GeneratorMethods::FalseClass
+# module JSON::Ext::Generator::GeneratorMethods::FalseClass
 
 [c:FalseClass] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Float.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Float.md
@@ -1,11 +1,9 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::Integer
 ---
-# module JSON::Generator::GeneratorMethods::Integer
+# module JSON::Ext::Generator::GeneratorMethods::Float
 
-[c:Integer] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:Float] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
@@ -18,6 +16,6 @@ alias:
 ```ruby title="例"
 require "json"
 
-p 10.to_json # => "10"
+p (1.0).to_json # => "1.0"
 ```
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Hash.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Hash.md
@@ -1,18 +1,14 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::TrueClass
 ---
-# module JSON::Generator::GeneratorMethods::TrueClass
+# module JSON::Ext::Generator::GeneratorMethods::Hash
 
-[c:TrueClass] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:Hash] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
 
 自身から生成した JSON 形式の文字列を返します。
-
-"true" という文字列を返します。
 
 - **param** `state_or_hash` -- 生成する JSON 形式の文字列をカスタマイズするために [c:JSON::State] のインスタンスか、
                      [m:JSON::State.new] の引数と同じ [c:Hash] を指定します。
@@ -20,5 +16,7 @@ alias:
 ```ruby title="例"
 require "json"
 
-p true.to_json # => "true"
+person = { "name" => "tanaka", "age" => 19 }
+person.to_json # => "{\"name\":\"tanaka\",\"age\":19}"
 ```
+

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Integer.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Integer.md
@@ -1,11 +1,9 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::Float
 ---
-# module JSON::Generator::GeneratorMethods::Float
+# module JSON::Ext::Generator::GeneratorMethods::Integer
 
-[c:Float] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:Integer] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
@@ -18,6 +16,6 @@ alias:
 ```ruby title="例"
 require "json"
 
-p (1.0).to_json # => "1.0"
+p 10.to_json # => "10"
 ```
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__NilClass.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__NilClass.md
@@ -1,16 +1,16 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::Hash
 ---
-# module JSON::Generator::GeneratorMethods::Hash
+# module JSON::Ext::Generator::GeneratorMethods::NilClass
 
-[c:Hash] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:NilClass] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
 
 自身から生成した JSON 形式の文字列を返します。
+
+"null" という文字列を返します。
 
 - **param** `state_or_hash` -- 生成する JSON 形式の文字列をカスタマイズするために [c:JSON::State] のインスタンスか、
                      [m:JSON::State.new] の引数と同じ [c:Hash] を指定します。
@@ -18,7 +18,6 @@ alias:
 ```ruby title="例"
 require "json"
 
-person = { "name" => "tanaka", "age" => 19 }
-person.to_json # => "{\"name\":\"tanaka\",\"age\":19}"
+p nil.to_json # => "null"
 ```
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Object.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__Object.md
@@ -1,9 +1,7 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::Object
 ---
-# module JSON::Generator::GeneratorMethods::Object
+# module JSON::Ext::Generator::GeneratorMethods::Object
 
 [c:Object] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__String.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__String.md
@@ -1,9 +1,7 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::String
 ---
-# module JSON::Generator::GeneratorMethods::String
+# module JSON::Ext::Generator::GeneratorMethods::String
 
 [c:String] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
@@ -33,9 +31,9 @@ puts "𤘩宮城".to_json(ascii_only: true) # => "\ud851\ude29\u5bae\u57ce"
 
 ### def to_json_raw -> String
 
-自身に対して [m:JSON::Generator::GeneratorMethods::String#to_json_raw_object] を呼び出して [m:JSON::Generator::GeneratorMethods::Hash#to_json] した結果を返します。
+自身に対して [m:JSON::Ext::Generator::GeneratorMethods::String#to_json_raw_object] を呼び出して [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] した結果を返します。
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::String#to_json_raw_object], [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::String#to_json_raw_object], [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]
 
 ### def to_json_raw_object -> Hash
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__String__Extend.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__String__Extend.md
@@ -1,14 +1,13 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::String::Extend
+until: "4.0"
 ---
-# module JSON::Generator::GeneratorMethods::String::Extend
+# module JSON::Ext::Generator::GeneratorMethods::String::Extend
 
 [c:String] に JSON で使用する特異メソッドを追加するためのモジュールです。
 
 ## Class Methods
-### def JSON::Generator::GeneratorMethods::String::Extend.json_create(hash) -> String
+### def JSON::Ext::Generator::GeneratorMethods::String::Extend.json_create(hash) -> String
 
 JSON のオブジェクトから Ruby の文字列を生成して返します。
 

--- a/manual/api/json/JSON__Ext__Generator__GeneratorMethods__TrueClass.md
+++ b/manual/api/json/JSON__Ext__Generator__GeneratorMethods__TrueClass.md
@@ -1,16 +1,16 @@
 ---
 library: json
-alias:
-  - JSON::Ext::Generator::GeneratorMethods::Array
 ---
-# module JSON::Generator::GeneratorMethods::Array
+# module JSON::Ext::Generator::GeneratorMethods::TrueClass
 
-[c:Array] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
+[c:TrueClass] に JSON で使用するインスタンスメソッドを追加するためのモジュールです。
 
 ## Public Instance Methods
 ### def to_json(state_or_hash = nil) -> String
 
 自身から生成した JSON 形式の文字列を返します。
+
+"true" という文字列を返します。
 
 - **param** `state_or_hash` -- 生成する JSON 形式の文字列をカスタマイズするために [c:JSON::State] のインスタンスか、
                      [m:JSON::State.new] の引数と同じ [c:Hash] を指定します。
@@ -18,6 +18,5 @@ alias:
 ```ruby title="例"
 require "json"
 
-p [1, 2, 3].to_json # => "[1,2,3]"
+p true.to_json # => "true"
 ```
-

--- a/manual/api/json/NilClass.md
+++ b/manual/api/json/NilClass.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::NilClass
+  - JSON::Ext::Generator::GeneratorMethods::NilClass
 ---
 # reopen NilClass
 

--- a/manual/api/json/Object.md
+++ b/manual/api/json/Object.md
@@ -1,7 +1,7 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::Object
+  - JSON::Ext::Generator::GeneratorMethods::Object
 ---
 # reopen Object
 

--- a/manual/api/json/String.md
+++ b/manual/api/json/String.md
@@ -1,9 +1,11 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::String
+  - JSON::Ext::Generator::GeneratorMethods::String
 extend:
-  - JSON::Generator::GeneratorMethods::String::Extend
+#%until 4.0
+  - JSON::Ext::Generator::GeneratorMethods::String::Extend
+#%end
 ---
 # reopen String
 

--- a/manual/api/json/TrueClass.md
+++ b/manual/api/json/TrueClass.md
@@ -1,6 +1,6 @@
 ---
 library: json
 include:
-  - JSON::Generator::GeneratorMethods::TrueClass
+  - JSON::Ext::Generator::GeneratorMethods::TrueClass
 ---
 # reopen TrueClass

--- a/manual/api/json/add/bigdecimal.md
+++ b/manual/api/json/add/bigdecimal.md
@@ -26,9 +26,9 @@ JSON のオブジェクトから [c:BigDecimal] のオブジェクトを生成�
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]
             に渡されます。
 
 ```ruby title="例"
@@ -36,4 +36,4 @@ require 'json/add/bigdecimal'
 p BigDecimal('0.123456789123456789').to_json # => "{\"json_class\":\"BigDecimal\",\"b\":\"36:0.123456789123456789e0\"}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/complex.md
+++ b/manual/api/json/add/complex.md
@@ -23,9 +23,9 @@ JSON のオブジェクトから [c:Complex] のオブジェクトを生成し�
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]
             に渡されます。
 
 ```ruby title="例"
@@ -33,4 +33,4 @@ require 'json/add/complex'
 p (2+3i).to_json # => "{\"json_class\":\"Complex\",\"r\":2,\"i\":3}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/date.md
+++ b/manual/api/json/add/date.md
@@ -20,9 +20,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -31,4 +31,4 @@ p Date.today.to_json
 # => "{\"json_class\":\"Date\",\"y\":2018,\"m\":12,\"d\":11,\"sg\":2299161.0}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/date_time.md
+++ b/manual/api/json/add/date_time.md
@@ -20,9 +20,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -31,4 +31,4 @@ p DateTime.now.to_json
 # => "{\"json_class\":\"DateTime\",\"y\":2018,\"m\":12,\"d\":10,\"H\":1,\"M\":28,\"S\":57,\"of\":\"3/8\",\"sg\":2299161.0}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/exception.md
+++ b/manual/api/json/add/exception.md
@@ -18,9 +18,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -36,4 +36,4 @@ rescue => e
 end
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/ostruct.md
+++ b/manual/api/json/add/ostruct.md
@@ -25,8 +25,8 @@ JSON のオブジェクトから [c:OpenStruct] のオブジェクトを生成�
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/range.md
+++ b/manual/api/json/add/range.md
@@ -18,9 +18,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -28,4 +28,4 @@ require "json/add/core"
 p (1..5).to_json # => "{\"json_class\":\"Range\",\"a\":[1,5,false]}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/rational.md
+++ b/manual/api/json/add/rational.md
@@ -23,9 +23,9 @@ JSON のオブジェクトから [c:Rational] のオブジェクトを生成し�
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]
             に渡されます。
 
 ```ruby title="例"
@@ -33,4 +33,4 @@ require 'json/add/rational'
 p (1/3r).to_json # => "{\"json_class\":\"Rational\",\"n\":1,\"d\":3}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/regexp.md
+++ b/manual/api/json/add/regexp.md
@@ -18,9 +18,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]
             に渡されます。
 
 ```ruby title="例"

--- a/manual/api/json/add/struct.md
+++ b/manual/api/json/add/struct.md
@@ -18,9 +18,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -29,4 +29,4 @@ Person = Struct.new(:name, :age)
 p Person.new("tanaka", 29).to_json # => "{\"json_class\":\"Person\",\"v\":[\"tanaka\",29]}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/symbol.md
+++ b/manual/api/json/add/symbol.md
@@ -23,8 +23,8 @@ JSON のオブジェクトから [c:Symbol] のオブジェクトを生成して
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]

--- a/manual/api/json/add/time.md
+++ b/manual/api/json/add/time.md
@@ -18,9 +18,9 @@ JSON のオブジェクトから Ruby のオブジェクトを生成して返し
 
 自身を JSON 形式の文字列に変換して返します。
 
-内部的にはハッシュにデータをセットしてから [m:JSON::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
+内部的にはハッシュにデータをセットしてから [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] を呼び出しています。
 
-- **param** `args` -- 引数はそのまま [m:JSON::Generator::GeneratorMethods::Hash#to_json] に渡されます。
+- **param** `args` -- 引数はそのまま [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json] に渡されます。
 
 ```ruby title="例"
 require "json/add/core"
@@ -28,4 +28,4 @@ require "json/add/core"
 p Time.now.to_json # => "{\"json_class\":\"Time\",\"s\":1544968675,\"n\":676167000}"
 ```
 
-- **SEE** [m:JSON::Generator::GeneratorMethods::Hash#to_json]
+- **SEE** [m:JSON::Ext::Generator::GeneratorMethods::Hash#to_json]


### PR DESCRIPTION
json の to_json を提供するモジュール群の名前空間を、実在する `JSON::Ext::Generator::GeneratorMethods::*` に改名します。

## 背景

標準添付ライブラリの全メソッドエントリ実測(2026-08-28)より。これらのモジュールは `JSON::Generator::GeneratorMethods::*` として文書化されていましたが、この名前空間は Ruby 3.0 以降のどの版にも存在しません(pure ruby 実装の削除に伴うもの)。実在する `JSON::Ext::Generator::GeneratorMethods::*` は 3.0(all-ruby)と 4.0 で確認済みです。

## 変更内容

- モジュールページ 10 件の見出しと参照を改名し、ファイル名もクラスパスに合わせて `JSON__Ext__Generator__GeneratorMethods__*.md` へ改名
- 各ページに元々あった `JSON::Ext::...` の alias 宣言は、正式名になったため削除
- reopen ページ(json/Array.md など)の `include:`/`extend:` 宣言と、`json/add/*` の参照(計 31 ファイル)もあわせて更新
- `String::Extend` だけは Ruby 4.0 で削除されています(v3_4_0 の generator.c には定義があり、v4.0.0 で消滅)。ページに `until: "4.0"` を付け、`json/String.md` の `extend:` 宣言も同様にゲートします

## 検証

- lint 4 種: pass
- 3.4・4.0 の DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- 新名称のクラスが解決され、旧名称が消えること・`String::Extend` が 3.4 に載り 4.0 で消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
