### PR TITLE
Ruby 側で削除されたメソッドを版ゲートする(openssl・net-smtp・net-imap・strscan)

### DIFF
--- a/manual/api/net/imap.md
+++ b/manual/api/net/imap.md
@@ -298,6 +298,7 @@ p Net::IMAP.format_datetime(Time.new(2011, 6, 20, 13, 20, 1))
 
 - **param** `time` -- 変換する時刻オブジェクト
 
+#%until 3.1
 ### def Net::IMAP.max_flag_count -> Integer
 
 サーバからのレスポンスに含まれる flag の上限を返します。
@@ -319,6 +320,7 @@ p Net::IMAP.format_datetime(Time.new(2011, 6, 20, 13, 20, 1))
 - **param** `count` -- 設定する最大値の整数
 - **SEE** [m:Net::IMAP.max_flag_count]
 
+#%end
 ### def Net::IMAP.default_port -> Integer
 ### def Net::IMAP.default_imap_port -> Integer
 
@@ -1006,13 +1008,17 @@ THREADコマンドを送り、メールボックスを検索した結果をス�
 - **param** `charset` -- 検索条件の解釈に用いるCHARSET名(文字列)
 - **SEE** [c:Net::IMAP::ThreadMember], [m:Net::IMAP#thread]
 
+#%until 3.4
 ### def client_thread -> Thread
 
 このメソッドは obsolete です。使わないでください。
+#%end
 
+#%until 3.3
 ### def client_thread=(th)
 
 このメソッドは obsolete です。使わないでください。
+#%end
 
 ### def idle {|resp| ...} -> Net::IMAP::TaggedResponse
 
@@ -2065,5 +2071,7 @@ true を返します。
 
 サーバからのレスポンスに含まれるフラグが多すぎるときに発生する例外です。
 
+#%until 3.1
 この上限は [m:Net::IMAP.max_flag_count=] で設定します。
+#%end
 

--- a/manual/api/net/smtp/Net__SMTP.md
+++ b/manual/api/net/smtp/Net__SMTP.md
@@ -397,8 +397,13 @@ ready は obsolete です。
 - **param** `secret` -- 認証で使うパスワード
 - **param** `authtype` -- 認証の種類(:plain, :login, :cram_md5 のいずれか)
 
+#%until 3.3
 - **SEE** [m:Net::SMTP.start], [m:Net::SMTP#start], [m:Net::SMTP#auth_plain], [m:Net::SMTP#auth_login], [m:Net::SMTP#auth_cram_md5]
+#%else
+- **SEE** [m:Net::SMTP.start], [m:Net::SMTP#start]
+#%end
 
+#%until 3.3
 ### def auth_plain(user, secret) -> ()
 
 PLAIN 認証を行います。
@@ -432,6 +437,7 @@ CRAM-MD5 認証を行います。
 - **param** `user` -- 認証で使うアカウント名
 - **param** `secret` -- 認証で使うパスワード
 
+#%end
 ### def rset -> Net::SMTP::Response
 
 RSET コマンドを送ります。
@@ -520,7 +526,9 @@ QUIT が送られるため利用する必要はないはずです。
 #%# --- OMASK
 #%# --- CRAM_BUFSIZE
 
+#%until 3.3
 ### const Revision -> String
 
 ファイルのリビジョンです。使わないでください。
+#%end
 

--- a/manual/api/openssl/OpenSSL__Config.md
+++ b/manual/api/openssl/OpenSSL__Config.md
@@ -50,6 +50,7 @@ filename を省略した場合は空のオブジェクトが生成されます�
 - **param** `section` -- セクションを表す文字列。"" を渡すことでグローバルな設定情報を読むことができます。
 - **param** `name` -- キーを表す文字列
 
+#%until 3.1
 ### def value(name) -> String | nil
 ### def value(section, name) -> String | nil
 
@@ -108,6 +109,7 @@ section は obsolete です。[] を使ってください。
 
 オブジェクトに含まれる設定情報を OpenSSL の設定ファイルの形式で出力します。
 
+#%end
 ### def each {|section, key, value| ... } -> self
 
 オブジェクトに含まれる全ての設定情報を順にブロックに渡し呼び出します。

--- a/manual/api/strscan.md
+++ b/manual/api/strscan.md
@@ -260,7 +260,9 @@ p s.pre_match        # => "test "
 ```
 
 ### def eos? -> bool
+#%until 4.0
 ### def empty? -> bool
+#%end
 
 スキャンポインタが文字列の末尾を指しているなら true を、末尾以外を指しているなら false を返します。
 
@@ -275,8 +277,10 @@ s.scan(/\w+/)
 p s.eos?      # => true
 ```
 
+#%until 4.0
 [m:StringScanner#empty?] は将来のバージョンで削除される予定です。
 代わりに [m:StringScanner#eos?] を使ってください。
+#%end
 
 ### def exist?(regexp) -> Integer | nil
 #%#Ruby 1.8.6 以降は以下の記述に沿った仕様に変わります。
@@ -320,14 +324,18 @@ p s.getch                         # => nil
 ```
 
 ### def get_byte -> String | nil
+#%until 4.0
 ### def getbyte -> String | nil
+#%end
 
 1 バイトスキャンして文字列で返します。
 スキャンポインタをその後ろに進めます。
 スキャンポインタが文字列の末尾を指すなら nil を返します。
 
+#%until 4.0
 [m:StringScanner#getbyte] は将来のバージョンで削除される予定です。
 代わりに [m:StringScanner#get_byte] を使ってください。
+#%end
 
 ```ruby title="例"
 require 'strscan'
@@ -465,7 +473,9 @@ p s.matched_size # => nil
 ```
 
 ### def peek(bytes) -> String
+#%until 4.0
 ### def peep(bytes) -> String
+#%end
 
 スキャンポインタから長さ bytes バイト分だけ文字列を返します。
 
@@ -477,8 +487,10 @@ p s.peek(4) # => "test"
 
 また、このメソッドを実行してもスキャンポインタは移動しません。
 
+#%until 4.0
 [m:StringScanner#peep] は将来のバージョンでは削除される予定です。
 代わりに [m:StringScanner#peek] を使ってください。
+#%end
 
 - **param** `bytes` -- 0 以上の整数を指定します。
              ただし、スキャン対象の文字列の長さを超える分は無視されます。
@@ -686,13 +698,17 @@ p s.rest?       # => false
 ```
 
 ### def rest_size -> Integer
+#%until 4.0
 ### def restsize -> Integer
+#%end
 
 文字列の残りの長さを返します。
 stringscanner.rest.size と同じです。
 
+#%until 4.0
 [m:StringScanner#restsize] は将来のバージョンで削除される予定です。
 代わりに[m:StringScanner#rest_size] を使ってください。
+#%end
 
 ```ruby title="例"
 require 'strscan'
@@ -918,7 +934,9 @@ p s.scan(/\w+/)    # => "0123"
 ```
 
 ### def terminate -> self
+#%until 4.0
 ### def clear -> self
+#%end
 
 スキャンポインタを文字列末尾後まで進め、マッチ記録を捨てます。
 
@@ -940,8 +958,10 @@ p s[0]        # => nil
 p s.pos       # => 11
 ```
 
+#%until 4.0
 [m:StringScanner#clear] は将来のバージョンで削除される予定です。
 代わりに [m:StringScanner#terminate] を使ってください。
+#%end
 
 ### def unscan -> self
 


### PR DESCRIPTION
Ruby 本体・付属 gem 側で削除されたメソッド・定数 17 件を `#%until` で版ゲートします。境界はすべて **Ruby x.y.0 時点のソースツリー/ピン版 gem のソース**で確定させました(最新 teeny やローカル gem での実測は teeny ドリフトの罠があるため)。

## 変更内容

### openssl — `#%until 3.1`

`OpenSSL::Config` の `#value`・`#add_value`・`#[]=`・`#section`。Ruby 3.1 で config.rb が削除され C 実装に置き換わった際に、これらの obsolete メソッドは移植されませんでした(v3_0_7 に config.rb あり・v3_1_0 でファイル消滅を確認)。

### net/smtp — `#%until 3.3`

`Net::SMTP#auth_plain`・`#auth_login`・`#auth_cram_md5`・`Net::SMTP::Revision`。Ruby 3.3.0 のピン net-smtp 0.4.0 で authenticator 方式に置き換えられ削除されました。`#authenticate` の SEE も版分岐します。

### net/imap — 境界が段階的

- `Net::IMAP.max_flag_count`・`.max_flag_count=`: `#%until 3.1`(bundled 化最初のピン 0.2.2 で既に消滅)。`Net::IMAP::FlagCountError` の説明中の参照 1 文もゲート
- `Net::IMAP#client_thread=`: `#%until 3.3`(ピン 0.4.9 で setter だけ先に消滅)
- `Net::IMAP#client_thread`: `#%until 3.4`(0.4.9 では非推奨警告付きで残存・0.5 系で消滅)

### strscan — `#%until 4.0`

`StringScanner#clear`・`#empty?`・`#getbyte`・`#peep`・`#restsize`(いずれも現行名 terminate・eos?・get_byte・peek・rest_size の旧別名)。**v3_4_0〜v3_4_10 の全 teeny で健在**で、strscan 3.1.6(Ruby 4.0.0 同梱)で削除されました。各エントリは別名見出し行のみをゲートし、「将来のバージョンで削除される予定です」という注記 5 箇所も 4.0 未満にゲートします。

## 検証

- lint 4 種: pass
- 3.0・3.1・3.3・3.4・4.0・4.1 の 6 版で DB 生成+`bitclust checklink`(capi 込み): リンク切れ 0 件
- 境界ごとにメソッド単位の lookup で「境界前= あり/境界後= なし」を確認(例: `StringScanner#peep` は 3.4 あり・4.0 なし、`peek` は 4.0 もあり)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
