### PR TITLE
bitclust を 1.7.0 に更新し REQUIRED_BITCLUST_VERSION を引き上げる

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/rurema/bitclust.git
-  revision: 239c4ab89e60c70615524f0bc2ffc095a63e5af6
+  revision: 5f0a733b58bf5516b1f9c1b003ba56a42c5517ee
   specs:
-    bitclust-core (1.6.1)
+    bitclust-core (1.7.0)
       drb
       json
       nkf
@@ -11,10 +11,10 @@ GIT
       rbs (>= 3.10)
       rouge
       webrick
-    bitclust-dev (1.6.1)
-      bitclust-core (= 1.6.1)
-    refe2 (1.6.1)
-      bitclust-core (= 1.6.1)
+    bitclust-dev (1.7.0)
+      bitclust-core (= 1.7.0)
+    refe2 (1.7.0)
+      bitclust-core (= 1.7.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ end
 # `cannot load such file -- drb` や `invalid option: --markdowntree` のような
 # 分かりにくいエラーで失敗するので、ビルド前に検査して案内を出す
 # (https://github.com/rurema/bitclust/issues/230)
-REQUIRED_BITCLUST_VERSION = Gem::Version.new("1.5.0")
+REQUIRED_BITCLUST_VERSION = Gem::Version.new("1.7.0")
 def check_bitclust_version!
   begin
     require "bitclust/version"


### PR DESCRIPTION
リリースされた bitclust 1.7.0(rurema/bitclust#330 のマージコミット 5f0a733)に CI 用の pin を更新し、`REQUIRED_BITCLUST_VERSION` を 1.5.0 から 1.7.0 に引き上げます。

- `Gemfile.lock` は `bundle update --conservative bitclust-core bitclust-dev refe2` で再生成(revision と自 gem の版数のみの差分。rbs は検証済みの 4.1.3 のまま)
- これで `#%version V`(単一版指定・rurema/bitclust#315)など 1.7.0 の記法を manual/ で使う前提が整います(置き換えは別 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
