### PR TITLE
pp の「出力のカスタマイズ」のサンプルに require を追加し出力例を現行に合わせる

### DIFF
--- a/manual/api/pp.md
+++ b/manual/api/pp.md
@@ -79,9 +79,15 @@ ne_width=6>], @singleline_width=6>, @sharing_detection=false>
 [c:PP] は [c:PrettyPrint] のサブクラスですので、上で PrettyPrint のメソッドとされているものは
 PP のメソッドでもあります。
 
+pp ライブラリは読み込み時に組み込みクラスの pretty_print メソッドを定義するため、
+[m:Kernel?.pp] の初回呼び出しによる自動 require に頼ると、先に書いた再定義が上書きされてしまいます。
+カスタマイズする場合はあらかじめ pp を require してください。
+
 以下は Hash の pretty printing のカスタマイズの例です。
 
 ```ruby
+require 'pp'
+
 class Hash
   def pretty_print(q)
     q.group(2, "<hash>") do
@@ -119,10 +125,10 @@ pp h
 
 # =>
 # <hash>
-#   :d => "dddddddddd...",
 #   :a => "aaaaa",
 #   :b => "bbbbbbbbbb",
-#   :c => "cccccccccc..."
+#   :c => "cccccccccc...",
+#   :d => "dddddddddd..."
 # </hash>
 ```
 


### PR DESCRIPTION
Fixes #3536

## 背景

「出力のカスタマイズ」のサンプルは `require "pp"` なしではカスタマイズが効きません。組み込みの `Kernel.#pp` は初回呼び出し時に pp を自動 require しますが、その読み込みで pp ライブラリ自身が `Hash#pretty_print` を定義し直すため、サンプル先頭で定義したカスタマイズがちょうど初回の `pp` 呼び出し時に上書きされます(`Hash.instance_method(:pretty_print).source_location` が `pp` 呼び出しの前後でサンプルの定義→ pp.rb 内の定義に変わることを 3.3.12・3.4.8・4.0.1・4.0.6 で確認)。

また出力例の要素順(`:d` が先頭)は Hash が挿入順を保持しなかった Ruby 1.8 時代のもので、現行 Ruby では `:a` → `:b` → `:c` → `:d` の挿入順になります。

## 変更内容

- サンプル先頭に `require 'pp'` を追加
- 出力例を実際の実行結果(上記 4 バージョンで同一)に更新
- 自動 require に頼ると再定義が上書きされる旨の説明を 1 段落追加

## 検証

- 修正後のサンプルをファイルから抽出して 3.3.12・3.4.8・4.0.1・4.0.6 で実行し、出力例と完全一致することを確認
- lint 4 種 pass・4.1 の DB 生成+ `bitclust checklink`(capi 込み)リンク切れ 0 件

なお同ページ冒頭の「どちらが読みやすいでしょうか?」節の PP オブジェクトのダンプ例も現行の PrettyPrint の内部構造とは一致しない古いものですが(1.8 時代の 32bit 環境のダンプ)、例示目的の節なので本 PR では触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
