### PR TITLE
演算子式の優先順位表に rescue 修飾子・defined?・if などの修飾子を追加する

### DIFF
--- a/manual/doc/spec/operator.md
+++ b/manual/doc/spec/operator.md
@@ -33,9 +33,12 @@
        ||
        ..  ...
        ?:(条件演算子)
+       rescue(修飾子)
        =(+=, -= ... )
+       defined?
        not
-低い   and or
+       and or
+低い   if unless while until(修飾子)
 ```
 
 左の「高い」「低い」は演算子の優先順位です。
@@ -44,6 +47,19 @@
 ```ruby
 p a && b || c # => (a && b) || c
 p a || b && c # =>  a || (b && c)
+```
+
+表中の rescue(修飾子)、defined?、if unless while until(修飾子)は言語に組み込みのキーワードで、再定義できません。
+それぞれについては [ref:d:spec/control#rescue_modifier]、[ref:d:spec/def#defined]、
+[ref:d:spec/control#if_modifier]、[ref:d:spec/control#unless_modifier]、
+[ref:d:spec/control#while_modifier]、[ref:d:spec/control#until_modifier] を参照してください。
+
+ブロックの「{ }」と「do ... end」の間では、「{ }」の方が強く結び付きます。
+以下の例では「{ }」は近い方の map に、「do ... end」は遠い方の p に結び付いています。
+
+```ruby
+p [1, 2].map { |x| x * 2 }      # => [2, 4]
+p [1, 2].map do |x| x * 2 end   # => #<Enumerator: [1, 2]:map>
 ```
 
 ほとんどの演算子は特別な形式のメソッド呼び出しですが、一部のものは言語に組み込みで、再定義できません。


### PR DESCRIPTION
Fixes #3513

## 背景

「演算子式」の優先順位表に、ruby/ruby の `doc/syntax/precedence.rdoc` にある `rescue`(修飾子)・`defined?`・`if unless while until`(修飾子)が漏れていました。挿入位置と方針は #3513 のコメントで実測結果とともに提案し、合意済みです。

## 変更内容

- 優先順位表に 3 行を追加(実測で確認した並び: `?:` > `rescue` 修飾子 > `=` > `defined?` > `not` > `and or` > `if` 等の修飾子。「低い」ラベルは新しい最下行へ移動)
- 追加した項目が言語組み込みのキーワードで再定義できないことと、各説明ページ(`spec/control` の各修飾子・`spec/def` の `defined?`)への参照を表の下に追記
- ブロック `{ }` は合意どおり表の行にはせず、「`do ... end` より強く結び付く」という相対関係のみを実行例つきの注記として追加(rdoc の「列挙した全演算より低い」は実挙動と不一致のため)

## 検証

- lint 4 種: pass
- 4.1 の DB 生成+ `bitclust checklink`(capi 込み): リンク切れ 0 件(参照 6 箇所のアンカー実在は grep でも確認)
- 生成 HTML で表の 3 行・参照リンク 6 箇所・注記のコードブロックの描画を確認
- 注記の実行例の出力は 3.4.8 で実測(優先順位の並び自体の検証スクリプトは issue のコメント参照= 3.3/3.4/4.0 で同一結果)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
