### PR TITLE
Kernel.#eval に評価される文字列のエンコーディングの扱いを追記

### DIFF
--- a/manual/api/_builtin/functions.md
+++ b/manual/api/_builtin/functions.md
@@ -2421,6 +2421,15 @@ eval 実行後にも引き継がれます。
 fname と lineno が与えられた場合には、ファイル
 fname の行番号 lineno から文字列 expr が書かれているかのようにコンパイルされます。スタックトレースの表示などを差し替えることができます。
 
+expr は、文字列 expr 自身のエンコーディングをスクリプトエンコーディング([ref:d:spec/m17n#script_encoding])として評価されます。ただし expr の先頭にマジックコメント([ref:d:spec/m17n#magic_comment])がある場合は、そこで指定されたエンコーディングが優先されます。
+
+```ruby
+# ソースファイルが UTF-8 の場合
+p eval("__ENCODING__")                        # => #<Encoding:UTF-8>
+p eval("__ENCODING__".encode("EUC-JP"))       # => #<Encoding:EUC-JP>
+p eval("# encoding: us-ascii\n__ENCODING__")  # => #<Encoding:US-ASCII>
+```
+
 bind によらずに特定のオブジェクトのコンテキストで expr を評価したい場合、
 [m:Module#module_eval], [m:BasicObject#instance_eval] が使えます。
 


### PR DESCRIPTION
#3537 での指摘([コメント](https://github.com/rurema/doctree/issues/3537#issuecomment-5488352494)で scivola さんが挙げた「`Kernel.#eval` にマジックコメントの扱いについて書かれていない」件)への対応です。

## 変更内容

`Kernel.#eval` の説明に、評価される文字列のエンコーディングの扱いを 1 段落+実行例で追記します:

- expr は文字列自身のエンコーディングをスクリプトエンコーディングとして評価される
- expr の先頭にマジックコメントがあればそちらが優先される
- スクリプトエンコーディング・マジックコメントの説明(`doc/spec/m17n`)への参照リンク付き

## 検証

- 挙動は 3.3.12・3.4.8・4.0.6 で実測(同一の挙動。例の出力はファイルから抽出して実行し一致を確認)。UTF-8 で書かれたコードが ASCII-8BIT の String として `eval` される場合にマジックコメントで救済される(issue で挙がった Thor の事例)ことも同機構で再現しています
- lint 4 種: pass
- 4.1 の DB 生成+ `bitclust checklink`(capi 込み): リンク切れ 0 件
- 生成 HTML で追記段落と参照リンク 2 箇所の描画を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
