### PR TITLE
Integer#hash と Symbol#hash の個別エントリを追加する

### DIFF
--- a/manual/api/_builtin/Integer.md
+++ b/manual/api/_builtin/Integer.md
@@ -903,6 +903,18 @@ p 1 >= Complex(0, 0)  # ~> NoMethodError
 p 1 >= "0" # ~> ArgumentError: comparison of Integer with String failed
 ```
 
+### def hash -> Integer
+
+self のハッシュ値を返します。
+
+eql? で等しい整数は、常にハッシュ値も等しくなります。
+
+[c:Integer] のインスタンスは、[c:Hash] のキーとして使われるとき Ruby 内部の
+組み込みのハッシュ関数でハッシュ値が計算されます。そのため、この hash メソッドを
+再定義しても Hash のキーとしての振る舞いは変わりません。
+
+- **SEE** [m:Object#hash]
+
 ### def ~        -> Integer
 
 `self` をビット論理反転した整数を返します。

--- a/manual/api/_builtin/Symbol.md
+++ b/manual/api/_builtin/Symbol.md
@@ -208,6 +208,18 @@ p :aaa == :aaa  # => true
 p :aaa == :xxx  # => false
 ```
 
+### def hash -> Integer
+
+self のハッシュ値を返します。
+
+eql? で等しいシンボルは、常にハッシュ値も等しくなります。
+
+[c:Symbol] のインスタンスは、[c:Hash] のキーとして使われるとき Ruby 内部の
+組み込みのハッシュ関数でハッシュ値が計算されます。そのため、この hash メソッドを
+再定義しても Hash のキーとしての振る舞いは変わりません。
+
+- **SEE** [m:Object#hash]
+
 ### def start_with?(*prefixes)   -> bool
 
 self の先頭が prefixes のいずれかであるとき true を返します。


### PR DESCRIPTION
#3194 の選択肢 3(特別なケースにだけ個別エントリ+注記を足す)の実装です。[issue コメントに書いたエントリ案](https://github.com/rurema/doctree/issues/3194#issuecomment-5077345802)の形をベースにしています。

## 変更内容

- Integer.md と Symbol.md に `hash` の個別エントリを追加(各 +12 行)
- 記述は issue コメントの案のとおり、組み込みのハッシュ関数が使われるため再定義しても `Hash` のキーとしての振る舞いが変わらない旨を注記し、`Object#hash` の該当記述へ SEE で誘導
- コメント案からの調整 2 点: 書き出しを執筆ルールに合わせて「self のハッシュ値を返します」に(String.md と同じ)・String.md にならって「eql? で等しい〜は、常にハッシュ値も等しくなります」の一文を追加
- 配置は Integer= 比較演算子群の直後(`>=` と `~` の間)・Symbol= `==` の直後
- バッジ用の `{: since=}` は付けていません(どちらも全対象バージョンに存在するため)

なお、これは「再定義されたメソッドのみ記載する」現行方針の例外です。組み込みハッシュ関数という特別扱いを説明するために例外的に置く、という位置づけになります(String#hash は再定義実体があるので従来から通常エントリ)。選択肢 2(継承メソッド節への導線追加= bitclust 側)の要否は引き続き issue で判断する想定なので、この PR では issue をクローズしません。

## 検証

- owner 実測(Ruby 3.4.8): `Integer#hash`・`Symbol#hash` とも owner は Kernel(= 再定義していない)。String/Float は各クラスで再定義、という issue コメントの前提と一致
- 再定義テスト実測: `Integer#hash`/`Symbol#hash` を再定義しても `Hash` のキー検索は正常動作し、再定義メソッドは呼ばれない(呼び出しカウンタ 0。直接 `.hash` を呼んだ場合は再定義が使われる)
- 3.4 DB を実ビルドし、両エントリの収載(instance_method・public)と HTML 描画・リンク 3 種([`Integer`]/[`Hash`]/`Object#hash`)の解決を確認
- lint 4 種(filename case・samplecode indent・single-space indent・blank lines)pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
