### PR TITLE
doc/spec/m17n.md: リテラルエンコーディングの例の注釈を実際の出力に合わせる

### DIFF
--- a/manual/doc/spec/m17n.md
+++ b/manual/doc/spec/m17n.md
@@ -221,7 +221,11 @@ locale がスクリプトエンコーディングになります。
 # coding: us-ascii
 p __ENCODING__        #=> #<Encoding:US-ASCII>
 p "abc".encoding      #=> #<Encoding:US-ASCII>
+#%since 3.4
+p "\x80".encoding     #=> #<Encoding:BINARY (ASCII-8BIT)>
+#%else
 p "\x80".encoding     #=> #<Encoding:ASCII-8BIT>
+#%end
  
 
 # coding: euc-jp
@@ -229,6 +233,6 @@ p __ENCODING__        #=> #<Encoding:EUC-JP>
 p "abc".encoding      #=> #<Encoding:EUC-JP>
 p "\x80".encoding     #=> #<Encoding:EUC-JP>
 p "\u3042".encoding   #=> #<Encoding:UTF-8>  (Unicode エスケープがあるので UTF-8 になる)
-p "\x80\u3042".encoding #=> エラー: UTF-8 mixed within US-ASCII source
+p "\x80\u3042".encoding #=> エラー: UTF-8 mixed within EUC-JP source
 ```
 


### PR DESCRIPTION
`doc/spec/m17n.md` の「リテラルのエンコーディング」の例で、注釈が実際の出力と食い違っていた 2 点を直します(#3545 の作業中に見つけたものです。#3545 とは独立にマージできます)。

- US-ASCII の例の `"\x80".encoding` は Ruby 3.4 以降 `#<Encoding:BINARY (ASCII-8BIT)>` と表示されるので、`Integer#chr` や prism の例と同じく `#%since 3.4` で版分岐しました。
- EUC-JP の例の最終行のエラーメッセージは、実際には `UTF-8 mixed within EUC-JP source` です(2022 年の 3addb2027 で「エラー」に文言を補った際の誤りでした)。

3.3.12・3.4.8・4.0.6 で実測し、プリプロセッサ出力(3.0/3.3/3.4/4.0/4.1)が版ごとに意図した行になることを確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
