### PR TITLE
Integer#hash と Symbol#hash に {: since=""} を付ける

### DIFF
--- a/manual/api/_builtin/Integer.md
+++ b/manual/api/_builtin/Integer.md
@@ -904,6 +904,7 @@ p 1 >= "0" # ~> ArgumentError: comparison of Integer with String failed
 ```
 
 ### def hash -> Integer
+{: since=""}
 
 self のハッシュ値を返します。
 

--- a/manual/api/_builtin/Symbol.md
+++ b/manual/api/_builtin/Symbol.md
@@ -209,6 +209,7 @@ p :aaa == :xxx  # => false
 ```
 
 ### def hash -> Integer
+{: since=""}
 
 self のハッシュ値を返します。
 


### PR DESCRIPTION
#3544 で追加した `Integer#hash` と `Symbol#hash` のエントリが、本番では「Ruby 3.0 から」のバッジ付きで表示されていました(バッジ算出が記録の残る最古の版を初出と誤算出するため)。どちらも最古の版より前から存在するメソッドなので、`{: since=""}` を付けて初出不明を明示し、バッジを出さないようにします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
