### PR TITLE
io/console: 実 Ruby に存在するのに記載が無かった IO のメソッド 24 件のドキュメントを追加する

### DIFF
--- a/manual/api/io/console.md
+++ b/manual/api/io/console.md
@@ -129,17 +129,42 @@ cooked モードを有効にします。端末のモードを後で元に戻す�
 
 - **SEE** [m:IO#cooked]
 
+#%until 4.1
 ### def console_mode -> IO::ConsoleMode
+#%else
+### def console_mode -> IO::Console::Mode
+#%end
 ### def console_mode=(mode)
 
 現在の端末の入出力モードを取得し、または設定します。
 
-`console_mode` は現在のモードを表す `IO::ConsoleMode` のインスタンスを返します。
+#%until 4.1
+`console_mode` は現在のモードを表す [c:IO::ConsoleMode] のインスタンスを返します。
+#%else
+`console_mode` は現在のモードを表す [c:IO::Console::Mode] のインスタンスを返します。
+#%end
 `console_mode=` は mode に指定したモードを端末に設定します。[m:IO#raw] などでモードを
 変更する前に `console_mode` で現在の状態を取得しておき、後で `console_mode=` に渡して
 元に戻す、という使い方ができます。
 
-- **param** `mode` -- 設定するモードを表す `IO::ConsoleMode` のインスタンスです。
+```ruby
+require "io/console"
+mode = STDIN.console_mode
+begin
+  STDIN.console_mode = mode.raw
+  # raw モードでの処理
+ensure
+  STDIN.console_mode = mode
+end
+```
+
+- **param** `mode` -- 設定するモードを表す、`console_mode` が返すのと同じクラスのオブジェクトです。
+- **raise** `TypeError` -- mode がモードを表すオブジェクトでない場合に発生します。
+#%until 4.1
+- **SEE** [c:IO::ConsoleMode]
+#%else
+- **SEE** [c:IO::Console::Mode]
+#%end
 
 ### def beep -> self
 
@@ -375,3 +400,147 @@ p IO.console # => #<File:/dev/tty>
 プロセスが端末から切り離された状態で実行すると nil を返します。
 
 戻り値はプラットフォームや環境に依存します。
+
+#%until 4.1
+# class IO::ConsoleMode < Object
+#%else
+# class IO::Console::Mode < Object
+
+alias IO::ConsoleMode
+#%end
+
+端末の入出力モードを表すクラスです。
+
+現在のモードは [m:IO#console_mode] で取得します。`new` でインスタンスを作ることは
+できません。取得したモードは `dup` でコピーできます。
+
+このクラスのメソッドは `self` が保持するモードの値を変更するだけで、端末には
+反映されません。変更したモードを端末に反映するには [m:IO#console_mode=] に渡してください。
+
+#%since 4.1
+Ruby 4.1 で `IO::ConsoleMode` から `IO::Console::Mode` に改名されました。
+旧名の `IO::ConsoleMode` は非推奨の別名として残っていますが、参照すると非推奨の警告が出ます。
+#%end
+
+```ruby
+require "io/console"
+mode = STDIN.console_mode
+noecho = mode.dup
+noecho.echo = false
+STDIN.console_mode = noecho  # エコーバックを無効にする
+begin
+  password = STDIN.gets
+ensure
+  STDIN.console_mode = mode  # 元に戻す
+end
+```
+
+- **SEE** [m:IO#console_mode], [m:IO#console_mode=]
+
+## Instance Methods
+
+### def echo=(flag)
+
+文字入力時のエコーバックを有効にするかどうかを `self` に設定します。
+
+- **param** `flag` -- 真を指定した場合はエコーバックを有効に、偽を指定した場合は無効にします。
+- **SEE** [m:IO#echo=]
+
+#%since 4.1
+### def echo? -> bool
+### def echo -> bool
+
+`self` で文字入力時のエコーバックが有効かどうかを返します。
+
+- **SEE** [m:IO#echo?]
+
+#%end
+#%until 4.1
+### def raw(min: 1, time: 0, intr: false) -> IO::ConsoleMode
+#%else
+### def raw(min: 1, time: 0, intr: false) -> IO::Console::Mode
+#%end
+
+`self` を raw モードに変更したコピーを返します。`self` は変更しません。
+
+キーワード引数の意味は [m:IO#raw] と同じです。
+
+- **param** `min` -- 入力操作 (read) 時に受信したい最小のバイト数を指定します。
+- **param** `time` -- タイムアウトするまでの秒数を指定します。
+- **param** `intr` -- true を指定した場合は、割り込み (interrupt) 、中止 (quit) 、停止 (suspend) の各シグナルを生成する制御文字が有効になります。
+- **raise** `ArgumentError` -- intr に true または false 以外の値を指定した場合に発生します。
+- **SEE** [m:IO#raw]
+
+### def raw!(min: 1, time: 0, intr: false) -> self
+
+`self` を raw モードに変更します。
+
+キーワード引数の意味は [m:IO#raw] と同じです。
+
+- **param** `min` -- 入力操作 (read) 時に受信したい最小のバイト数を指定します。
+- **param** `time` -- タイムアウトするまでの秒数を指定します。
+- **param** `intr` -- true を指定した場合は、割り込み (interrupt) 、中止 (quit) 、停止 (suspend) の各シグナルを生成する制御文字が有効になります。
+- **raise** `ArgumentError` -- intr に true または false 以外の値を指定した場合に発生します。
+- **SEE** [m:IO#raw!]
+
+#%since 4.1
+### def min -> Integer | nil
+
+入力操作 (read) 時に受信したい最小のバイト数(termios の VMIN)を返します。
+
+termios を利用できない環境(Windows)では nil を返します。
+
+- **SEE** [m:IO#raw]
+
+### def min=(min)
+
+入力操作 (read) 時に受信したい最小のバイト数(termios の VMIN)を設定します。
+
+- **param** `min` -- 最小のバイト数を整数で指定します。nil を指定した場合は 1 になります。0 から 255 の範囲外の値を指定した場合は 255 になります。
+
+termios を利用できない環境(Windows)では何もしません。
+
+### def time -> Rational | nil
+
+入力操作 (read) がタイムアウトするまでの秒数(termios の VTIME)を [c:Rational] で返します。
+値は 0.1 秒単位です。
+
+termios を利用できない環境(Windows)では nil を返します。
+
+- **SEE** [m:IO#raw]
+
+### def time=(time)
+
+入力操作 (read) がタイムアウトするまでの秒数(termios の VTIME)を設定します。
+
+- **param** `time` -- 秒数を数値で指定します。0.1 秒単位に切り捨てられ、25.5 秒を超える値は 25.5 秒になります。nil を指定した場合は 0 になります。
+
+termios を利用できない環境(Windows)では何もしません。
+
+### def virtual_terminal_processing? -> bool
+### def virtual_terminal_processing=(enabled)
+
+出力時に仮想端末シーケンス(エスケープシーケンス)を処理するかどうかを返し、または設定します。
+
+このメソッドは Windows でのみ使用できます。
+
+- **param** `enabled` -- 真を指定した場合は処理を有効に、偽を指定した場合は無効にします。
+
+### def wrap_at_eol_output? -> bool
+### def wrap_at_eol_output=(enabled)
+
+出力が行末に達したときに次の行へ折り返すかどうかを返し、または設定します。
+
+このメソッドは Windows でのみ使用できます。
+
+- **param** `enabled` -- 真を指定した場合は折り返しを有効に、偽を指定した場合は無効にします。
+
+#%end
+#%until 4.1
+## Constants
+
+### const VERSION -> String
+
+io/console ライブラリのバージョンを表す文字列です。
+
+#%end

--- a/manual/api/io/console.md
+++ b/manual/api/io/console.md
@@ -129,6 +129,238 @@ cooked モードを有効にします。端末のモードを後で元に戻す�
 
 - **SEE** [m:IO#cooked]
 
+### def console_mode -> IO::ConsoleMode
+### def console_mode=(mode)
+
+現在の端末の入出力モードを取得し、または設定します。
+
+`console_mode` は現在のモードを表す `IO::ConsoleMode` のインスタンスを返します。
+`console_mode=` は mode に指定したモードを端末に設定します。[m:IO#raw] などでモードを
+変更する前に `console_mode` で現在の状態を取得しておき、後で `console_mode=` に渡して
+元に戻す、という使い方ができます。
+
+- **param** `mode` -- 設定するモードを表す `IO::ConsoleMode` のインスタンスです。
+
+### def beep -> self
+
+端末を鳴らします。
+
+### def goto(line, column) -> self
+
+カーソル位置を line 行目、column 列目に移動します。
+
+- **param** `line` -- 移動先の行を 0 から始まる整数で指定します。
+- **param** `column` -- 移動先の列を 0 から始まる整数で指定します。
+
+- **SEE** [m:IO#cursor]
+
+### def goto_column(column) -> self
+
+カーソルを同じ行のまま column 列目に移動します。
+
+- **param** `column` -- 移動先の列を 0 から始まる整数で指定します。
+
+- **SEE** [m:IO#goto]
+
+### def cursor -> [Integer, Integer] | nil
+### def cursor=(pos)
+
+現在のカーソル位置を取得し、または移動します。
+
+`cursor` は現在のカーソル位置を、行と列からなる要素数 2 の配列で返します。行・列とも
+0 から始まる整数です。端末が対応していないなど、位置を取得できない場合は nil を返します。
+
+`cursor=` はカーソル位置を pos で移動します。`io.cursor = [line, column]` は
+`io.goto(line, column)` と同じです。
+
+- **param** `pos` -- 移動先の位置を表す、行と列からなる要素数 2 の配列です。
+- **raise** `ArgumentError` -- pos が要素数 2 の配列に変換できない場合に発生します。
+
+- **SEE** [m:IO#goto]
+
+### def cursor_up(n) -> self
+
+カーソルを n 行上に移動します。
+
+- **param** `n` -- 移動する行数を整数で指定します。
+
+- **SEE** [m:IO#cursor_down]
+
+### def cursor_down(n) -> self
+
+カーソルを n 行下に移動します。
+
+- **param** `n` -- 移動する行数を整数で指定します。
+
+- **SEE** [m:IO#cursor_up]
+
+### def cursor_left(n) -> self
+
+カーソルを n 列左に移動します。
+
+- **param** `n` -- 移動する列数を整数で指定します。
+
+- **SEE** [m:IO#cursor_right]
+
+### def cursor_right(n) -> self
+
+カーソルを n 列右に移動します。
+
+- **param** `n` -- 移動する列数を整数で指定します。
+
+- **SEE** [m:IO#cursor_left]
+
+#%since 4.1
+### def hide_cursor -> self
+
+カーソルを非表示にします。
+
+- **SEE** [m:IO#show_cursor]
+
+#%end
+
+#%since 4.1
+### def show_cursor -> self
+
+カーソルを表示します。
+
+- **SEE** [m:IO#hide_cursor]
+
+#%end
+
+### def erase_line(mode) -> self
+
+カーソル位置を基準にして、行の一部または全体を消去します。
+
+- **param** `mode` -- 消去する範囲を表す 0 から 2 の整数です。0 はカーソルから行末まで、
+           1 は行頭からカーソルまで(カーソル位置を含む)、2 は行全体を消去します。
+           nil を指定した場合は 0 として扱われます。
+- **raise** `ArgumentError` -- mode が 0 から 2 の範囲外の整数の場合に発生します。
+
+- **SEE** [m:IO#erase_screen]
+
+### def erase_screen(mode) -> self
+
+カーソル位置を基準にして、画面の一部または全体を消去します。
+
+- **param** `mode` -- 消去する範囲を表す 0 から 3 の整数です。0 はカーソルから画面末尾まで、
+           1 は画面先頭からカーソルまで(カーソル位置を含む)、2 は画面全体、
+           3 は画面の外にスクロールした部分も含めた全体を消去します。
+           nil を指定した場合は 0 として扱われます。
+- **raise** `ArgumentError` -- mode が 0 から 3 の範囲外の整数の場合に発生します。
+
+- **SEE** [m:IO#erase_line], [m:IO#clear_screen]
+
+### def clear_screen -> self
+
+画面全体を消去し、カーソルを左上に移動します。
+
+[m:IO#erase_screen] に 2 を指定して呼び出した後、 [m:IO#goto] で先頭(0 行目、0 列目)に
+移動するのと同じです。
+
+- **SEE** [m:IO#erase_screen], [m:IO#goto]
+
+### def scroll_forward(n) -> self
+
+画面全体を n 行分、上方向にスクロールします。新しく現れた行は空白になります。
+
+- **param** `n` -- スクロールする行数を整数で指定します。
+
+- **SEE** [m:IO#scroll_backward]
+
+### def scroll_backward(n) -> self
+
+画面全体を n 行分、下方向にスクロールします。新しく現れた行は空白になります。
+
+- **param** `n` -- スクロールする行数を整数で指定します。
+
+- **SEE** [m:IO#scroll_forward]
+
+### def pressed?(key) -> bool
+
+key で指定したキーが押されているかどうかを返します。
+
+このメソッドは Windows でのみ使用できます。
+
+- **param** `key` -- 調べたいキーを表す仮想キーコード(整数)か、その名前を
+           "VK_" 接頭辞を除いた文字列またはシンボルで指定します。
+- **raise** `ArgumentError` -- key が文字列またはシンボルで、対応する仮想キーコードが
+           見つからない場合に発生します。
+- **raise** `NotImplementedError` -- Windows 以外の環境で発生します。
+
+### def check_winsize_changed { ... } -> self
+
+コンソールの入力イベントキューに溜まっているイベントを読み進め、ウィンドウサイズが
+変更されたイベントが見つかるたびにブロックを評価します。ウィンドウサイズの変更以外の
+イベントは読み捨てます。ブロックには常に nil が渡されます。
+
+このメソッドは Windows でのみ使用できます。
+
+- **raise** `NotImplementedError` -- Windows 以外の環境で発生します。
+
+#%since 4.1
+### def console_input_events(max_events = 1, timeout: nil) -> [{Symbol => object}]
+
+コンソールの入力イベントを、発生順を保ったまま最大 max_events 件読み込んで返します。
+
+少なくとも 1 件のイベントを読み込めるまでブロックします。 timeout を指定した場合、
+その秒数が経過してもイベントを読み込めなかったときは空の配列を返します。
+
+戻り値の配列の各要素は、1 件のイベントの情報を持つハッシュです。 `:type` キーの値に
+よって、残りのキーの構成が変わります。
+
+- `:key` -- `:key_down`、`:repeat_count`、`:virtual_key_code`、`:virtual_scan_code`、
+  `:unicode_char`、`:control_key_state` を持ちます。
+- `:mouse` -- `:position` ([行, 列])、`:button_state`、`:control_key_state`、
+  `:event_flags` を持ちます。
+- `:window_buffer_size` -- `:size` ([行, 列]) を持ちます。
+- `:menu` -- `:command_id` を持ちます。
+- `:focus` -- `:set_focus` を持ちます。
+
+このメソッドは Windows でのみ使用できます。
+
+- **param** `max_events` -- 読み込むイベントの最大件数です。省略した場合は 1 です。
+- **param** `timeout` -- タイムアウトするまでの秒数です。省略した場合はタイムアウトしません。
+- **raise** `ArgumentError` -- max_events に 0 を指定した場合に発生します。
+- **raise** `NotImplementedError` -- Windows 以外の環境で発生します。
+
+#%end
+
+#%since 4.1
+### def input_pending? -> bool
+
+`self` から、ブロックせずに読み込めるデータがあるかどうかを返します。
+
+#%end
+
+### def getpass(prompt = nil) -> String
+
+エコーバックなしで 1 行読み込んで返します。
+
+prompt を指定した場合、読み込む前にそれを出力します。 `self` が標準入力の場合、
+prompt は標準エラー出力に出力します。読み込んだ文字列の末尾の改行は
+[m:String#chomp!] と同じ規則で取り除かれます。
+
+```ruby invalid
+require "io/console"
+STDIN.getpass("Enter password: ")
+```
+
+- **param** `prompt` -- 入力を促すために出力する文字列です。省略した場合は何も出力しません。
+- **return** -- 読み込んだ文字列を返します。
+
+- **SEE** [m:String#chomp!]
+
+#%since 3.4
+### def ttyname -> String | nil
+
+`self` が端末に接続されている場合、その端末名を返します。端末に接続されていない
+場合は nil を返します。
+
+- **return** -- 端末名の文字列、または nil を返します。
+
+#%end
+
 ## Singleton Methods
 
 ### def IO.console -> File | nil


### PR DESCRIPTION
io/console ライブラリで、実 Ruby には存在するのに記載が無かった `IO` のメソッド 24 件のドキュメントを追加します(refs #3548 の不足側・第 2 弾)。原典は io-console gem v0.8.2(Ruby 4.0 同梱)の `console.c` の rdoc と、4.1 分は master です。初出版が 3.0 より後のものは `#%since` で囲みました(`ttyname` 3.4、`hide_cursor`/`show_cursor`/`input_pending?`/`console_input_events` 4.1)。

## 追加したエントリ(24 メソッド・見出し 24 行・1 ファイル)

- 端末制御: `console_mode`/`console_mode=`、`beep`、`goto`、`goto_column`、`cursor`/`cursor=`、`cursor_up`/`cursor_down`/`cursor_left`/`cursor_right`、`hide_cursor`/`show_cursor`、`erase_line`、`erase_screen`、`clear_screen`、`scroll_forward`/`scroll_backward`
- 入力: `getpass`、`input_pending?`、`pressed?`、`check_winsize_changed`、`console_input_events`(後ろ 3 つは Windows 専用。他の環境では `NotImplementedError`)
- `ttyname`

## 補足

- `erase_screen` の `mode` 3(スクロールアウトした部分を含む全消去)は原典の rdoc には無く実装にだけあるので、実装に合わせて記載しています
- `ttyname` の原典 rdoc は実装と逆の説明になっているため、実装(端末なら名前・そうでなければ nil)に合わせました
- `check_winsize_changed` は master で非推奨になっていますが、4.1 未リリースのため注記は入れていません

## 検証

- 全見出しを Ruby 4.0.0 と master で確認(Windows 専用の 3 件は Linux では NotImplemented スタブとして定義されていることを確認)
- lint 4 種 OK、3.0/3.3/3.4/4.0/4.1 の DB 生成+checklink 0 件、`#%since` の境界を lookup で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
