### PR TITLE
psych: 実 Ruby に存在するのに記載が無かった公開メソッド 29 件のドキュメントを追加する

### DIFF
--- a/manual/api/psych.md
+++ b/manual/api/psych.md
@@ -423,6 +423,143 @@ Ruby のオブジェクトに変換します。
 #%# --- domain_types
 #%# --- domain_types=(val)
 
+### def Psych.safe_load_file(filename) -> object
+
+filename で指定したファイルの内容を安全に YAML ドキュメントとして読み込み、Ruby のオブジェクトに変換します。
+
+オプションは [m:Psych.safe_load] と同じものが指定できます。ファイルが空の場合は fallback オプションで指定した値(デフォルトは nil)を返します。
+
+- **param** `filename` -- 読み込むファイルの名前
+- **raise** `Psych::SyntaxError` -- YAML ドキュメントに文法エラーが発見されたときに発生します
+- **SEE** [m:Psych.safe_load], [m:Psych.load_file]
+
+#%since 4.0
+### def Psych.safe_load_stream(yaml, filename: nil, permitted_classes: [], aliases: false) -> [object]
+### def Psych.safe_load_stream(yaml, filename: nil, permitted_classes: [], aliases: false){|obj| ... } -> nil
+
+複数の YAML ドキュメントを含むデータを、[m:Psych.safe_load] と同様に安全に Ruby のオブジェクトに変換します。
+
+ブロックなしの場合は変換したオブジェクトの配列を返します。
+
+ブロックありの場合は変換した各オブジェクトを引数としてそのブロックを呼び出し、nil を返します。
+
+permitted_classes、aliases の意味は [m:Psych.safe_load] と同じです。
+
+- **param** `yaml` -- YAML ドキュメント(文字列 or IO オブジェクト)
+- **param** `filename` -- [c:Psych::SyntaxError] 発生時にファイル名として表示する文字列
+- **param** `permitted_classes` -- 追加で読み込みを許可するクラスの配列
+- **param** `aliases` -- エイリアスの読み込みを許可するかどうか
+- **raise** `Psych::DisallowedClass` -- yaml に permitted_classes で許可されていないクラスが含まれていたときに発生します
+- **raise** `Psych::BadAlias` -- yaml がエイリアスを含み、かつ aliases が false のときに発生します
+- **SEE** [m:Psych.safe_load], [m:Psych.load_stream]
+
+```ruby title="例"
+require 'psych'
+
+p Psych.safe_load_stream("--- foo\n...\n--- bar\n...") # => ['foo', 'bar']
+
+list = []
+Psych.safe_load_stream("--- foo\n...\n--- bar\n...") do |ruby|
+  list << ruby
+end
+p list # => ['foo', 'bar']
+```
+
+#%end
+
+#%since 3.1
+### def Psych.safe_dump(o, options = {}) -> String
+### def Psych.safe_dump(o, io, options = {}) -> ()
+
+Ruby のオブジェクト o を安全に YAML ドキュメントに変換します。
+
+[m:Psych.dump] と同様の変換を行いますが、デフォルトでは以下のクラスのオブジェクトしか変換しません。
+
+- TrueClass
+- FalseClass
+- NilClass
+- Integer
+- Float
+- String
+- Array
+- Hash
+
+options のキー permitted_classes を指定すると、変換を許可するクラスを追加できます。
+
+```ruby title="permitted_classes に Date を渡した例"
+require 'psych'
+require 'date'
+
+Psych.safe_dump(Date.today, permitted_classes: [Date])
+```
+
+o が permitted_classes で許可されていないクラスのオブジェクトを含む場合は、
+Psych::DisallowedClass 例外が発生します。
+
+io に IO オブジェクトを指定した場合は、変換されたドキュメントがその IO に書き込まれます。
+指定しなかった場合は変換されたドキュメントが文字列としてメソッドの返り値となります。
+
+options でその他に指定できる項目は [m:Psych.dump] と同じです。
+
+- **param** `o` -- 変換するオブジェクト
+- **param** `io` -- 出力先
+- **param** `options` -- 出力オプション(permitted_classes を含む)
+- **raise** `Psych::DisallowedClass` -- o が permitted_classes で許可されていないクラスのオブジェクトを含むときに発生します
+- **SEE** [m:Psych.dump], [m:Psych.safe_load]
+
+#%end
+
+#%since 3.1
+### def Psych.unsafe_load(yaml, filename: nil, fallback: false, symbolize_names: false, freeze: false) -> object
+
+YAML ドキュメント yaml を Ruby のデータ構造(オブジェクト)に変換します。
+
+[m:Psych.load] と異なりクラスの制限を行わず、任意の Ruby オブジェクトに変換します。
+外部から与えられた信頼できない YAML ドキュメントの変換には使わないでください。信頼できないドキュメントには [m:Psych.safe_load] を使ってください。
+
+入力に複数のドキュメントが含まれている場合は、先頭のものを変換して返します。
+
+yaml が空の場合は fallback で指定した値(デフォルトは false)を返します。
+
+filename はパース中に発生した例外のメッセージに用います。
+
+キーワード引数 symbolize_names に true を指定した場合はハッシュのキーを [c:Symbol] に変換して返します。
+
+キーワード引数 freeze に true を指定した場合は再帰的に [m:Object#freeze] したオブジェクトを返します。
+
+- **param** `yaml` -- YAML ドキュメント(文字列 or IO オブジェクト)
+- **param** `filename` -- [c:Psych::SyntaxError] 発生時にファイル名として表示する文字列
+- **param** `fallback` -- 引数 yaml に空の YAML を指定した場合の戻り値。デフォルトは false です
+- **param** `symbolize_names` -- ハッシュのキーを [c:Symbol] に変換するかどうか
+- **param** `freeze` -- true を指定すると再帰的に freeze されたオブジェクトを返します
+- **raise** `Psych::SyntaxError` -- YAML ドキュメントに文法エラーが発見されたときに発生します
+- **raise** `TypeError` -- yaml に nil を指定したときに発生します
+- **SEE** [m:Psych.load], [m:Psych.safe_load]
+
+```ruby title="例"
+require 'psych'
+
+p Psych.unsafe_load("--- a")             # => 'a'
+p Psych.unsafe_load("---\n - a\n - b")   # => ['a', 'b']
+```
+
+#%end
+
+#%since 3.1
+### def Psych.unsafe_load_file(filename) -> object
+
+filename で指定したファイルの内容を [m:Psych.unsafe_load] を使って Ruby のオブジェクトに変換します。
+
+信頼できないファイルの変換には使わないでください。信頼できないファイルには [m:Psych.safe_load_file] を使ってください。
+
+ファイルが空の場合は fallback で指定した値(デフォルトは false)を返します。
+
+- **param** `filename` -- 読み込むファイルの名前
+- **raise** `Psych::SyntaxError` -- YAML ドキュメントに文法エラーが発見されたときに発生します
+- **SEE** [m:Psych.unsafe_load], [m:Psych.safe_load_file], [m:Psych.load_file]
+
+#%end
+
 # class Psych::Exception < RuntimeError
 
 Psych 関連のエラーを表す例外です。

--- a/manual/api/psych/Psych__Handler.md
+++ b/manual/api/psych/Psych__Handler.md
@@ -303,6 +303,20 @@ override してください。
 
 デフォルトでは false を返します。
 
+### def event_location(start_line, start_column, end_line, end_column) -> ()
+
+各イベントが呼び出される直前に、そのイベントの位置情報とともに呼び出されます。
+
+start_line、start_column にはこれから呼び出されるイベントの開始位置の行番号・列番号が、
+end_line、end_column には終了位置の行番号・列番号が渡されます。
+
+必要に応じてこのメソッドを override してください。
+
+- **param** `start_line` -- イベントの開始位置の行番号
+- **param** `start_column` -- イベントの開始位置の列番号
+- **param** `end_line` -- イベントの終了位置の行番号
+- **param** `end_column` -- イベントの終了位置の列番号
+
 # class Psych::Emitter < Psych::Handler
 
 [c:Psych::Parser] でパースし、生じたイベントから

--- a/manual/api/psych/Psych__Nodes__Alias.md
+++ b/manual/api/psych/Psych__Nodes__Alias.md
@@ -36,3 +36,11 @@ alias が指す先の anchor を変更します。
 - **SEE** [m:Psych::Nodes::Alias#anchor],
      [m:Psych::Nodes::Alias.new]
 
+### def alias? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が alias ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#alias?]
+

--- a/manual/api/psych/Psych__Nodes__Document.md
+++ b/manual/api/psych/Psych__Nodes__Document.md
@@ -110,3 +110,11 @@ tag directive の配列を設定します。
 
 ルートノードを返します。
 
+### def document? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が document ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#document?]
+

--- a/manual/api/psych/Psych__Nodes__Mapping.md
+++ b/manual/api/psych/Psych__Nodes__Mapping.md
@@ -114,6 +114,14 @@ mapping の style を設定します。
 - **SEE** [m:Psych::Nodes::Mapping#style],
      [m:Psych::Nodes::Mapping.new]
 
+### def mapping? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が mapping ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#mapping?]
+
 ## Constants
 ### const ANY -> Integer
 

--- a/manual/api/psych/Psych__Nodes__Node.md
+++ b/manual/api/psych/Psych__Nodes__Node.md
@@ -68,3 +68,91 @@ options には以下が指定できます。
 - **param** `io` -- 書き込み先の IO
 - **param** `options` -- オプション
 
+### def alias? -> bool
+
+`self` が [c:Psych::Nodes::Alias] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Alias` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Alias]
+
+### def document? -> bool
+
+`self` が [c:Psych::Nodes::Document] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Document` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Document]
+
+### def mapping? -> bool
+
+`self` が [c:Psych::Nodes::Mapping] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Mapping` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Mapping]
+
+### def scalar? -> bool
+
+`self` が [c:Psych::Nodes::Scalar] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Scalar` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Scalar]
+
+### def sequence? -> bool
+
+`self` が [c:Psych::Nodes::Sequence] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Sequence` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Sequence]
+
+### def stream? -> bool
+
+`self` が [c:Psych::Nodes::Stream] を表すノードかどうかを返します。
+
+`Psych::Nodes::Node` では常に false を返します。`Psych::Nodes::Stream` ではこのメソッドを override しており、常に true を返します。
+
+- **SEE** [c:Psych::Nodes::Stream]
+
+### def start_line -> Integer | nil
+### def start_line=(line)
+
+`self` が表す YAML ドキュメント上の要素が開始する行番号を返します。
+
+[m:Psych.parse] などでパースして得られたノードには、パース時にこの位置情報が設定されます。手動で生成したノードでは nil のままです。
+
+- **param** `line` -- 設定する開始行番号
+- **SEE** [m:Psych::Nodes::Node#start_column], [m:Psych::Nodes::Node#end_line]
+
+### def start_column -> Integer | nil
+### def start_column=(column)
+
+`self` が表す YAML ドキュメント上の要素が開始する行内の位置(列番号)を返します。
+
+[m:Psych.parse] などでパースして得られたノードには、パース時にこの位置情報が設定されます。手動で生成したノードでは nil のままです。
+
+- **param** `column` -- 設定する開始位置の列番号
+- **SEE** [m:Psych::Nodes::Node#start_line], [m:Psych::Nodes::Node#end_column]
+
+### def end_line -> Integer | nil
+### def end_line=(line)
+
+`self` が表す YAML ドキュメント上の要素が終了する行番号を返します。
+
+[m:Psych.parse] などでパースして得られたノードには、パース時にこの位置情報が設定されます。手動で生成したノードでは nil のままです。
+
+- **param** `line` -- 設定する終了行番号
+- **SEE** [m:Psych::Nodes::Node#end_column], [m:Psych::Nodes::Node#start_line]
+
+### def end_column -> Integer | nil
+### def end_column=(column)
+
+`self` が表す YAML ドキュメント上の要素が終了する行内の位置(列番号)を返します。
+
+[m:Psych.parse] などでパースして得られたノードには、パース時にこの位置情報が設定されます。手動で生成したノードでは nil のままです。
+
+- **param** `column` -- 設定する終了位置の列番号
+- **SEE** [m:Psych::Nodes::Node#end_line], [m:Psych::Nodes::Node#start_column]
+

--- a/manual/api/psych/Psych__Nodes__Scalar.md
+++ b/manual/api/psych/Psych__Nodes__Scalar.md
@@ -127,6 +127,14 @@ scalar の style を変更します。
 - **SEE** [m:Psych::Nodes::Scalar#style=],
      [m:Psych::Nodes::Scalar.new]
 
+### def scalar? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が scalar ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#scalar?]
+
 ## Constants
 ### const ANY -> Integer
 

--- a/manual/api/psych/Psych__Nodes__Sequence.md
+++ b/manual/api/psych/Psych__Nodes__Sequence.md
@@ -132,6 +132,14 @@ sequence の style を設定します。
 - **SEE** [m:Psych::Nodes::Sequence#style],
      [m:Psych::Nodes::Sequence.new]
 
+### def sequence? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が sequence ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#sequence?]
+
 ## Constants
 ### const ANY -> Integer
 

--- a/manual/api/psych/Psych__Nodes__Stream.md
+++ b/manual/api/psych/Psych__Nodes__Stream.md
@@ -41,6 +41,14 @@ stream に使われるエンコーディングを指定します。
 - **param** `enc` -- 設定するエンコーディング
 - **SEE** [m:Psych::Nodes::Stream#encoding]
 
+### def stream? -> bool
+
+常に true を返します。
+
+[c:Psych::Nodes::Node] の同名のメソッドを override しており、`self` が stream ノードであることを示します。
+
+- **SEE** [m:Psych::Nodes::Node#stream?]
+
 ## Constants
 ### const ANY -> Integer
 

--- a/manual/api/psych/Psych__ScalarScanner.md
+++ b/manual/api/psych/Psych__ScalarScanner.md
@@ -41,3 +41,13 @@ p scanner.tokenize("12") # =>  12
 文字列を Time オブジェクトに変換します。
 
 - **param** `string` -- 変換文字列
+
+### def parse_int(string) -> Integer
+
+文字列 string を整数に変換して返します。
+
+string に含まれるカンマ(`,`)とアンダースコア(`_`)を取り除いてから [m:Kernel?.Integer] で変換します。
+
+- **param** `string` -- 変換する文字列
+- **raise** `ArgumentError` -- string を整数に変換できないときに発生します
+

--- a/manual/api/psych/core_ext.md
+++ b/manual/api/psych/core_ext.md
@@ -78,3 +78,31 @@ objects を YAML document として標準出力に出力します。
 このメソッドは irb 上でのみ定義されます。
 
 - **param** `objects` -- YAML document に変換する Ruby のオブジェクト
+
+# reopen Set
+
+## Instance Methods
+
+#%since 4.0
+### def encode_with(coder) -> Psych::Coder
+
+`self` を YAML にダンプするために [m:Psych.dump] などから呼び出されます。
+
+`self` の要素をキー、true を値とするハッシュを組み立て、coder に "hash" というキーで登録します。
+
+Ruby 3.4 までは [c:Set] は Ruby で書かれた通常のオブジェクトであり、この定義がなくても Psych でダンプできていました。Ruby 4.0 から Set は C で実装されたコアクラスになったため、以前と同じ形式でダンプできるようにこのメソッドが定義されています。
+
+- **param** `coder` -- 情報を書き込む Psych::Coder オブジェクト
+- **SEE** [m:Set#each]
+#%end
+
+#%since 4.0
+### def init_with(coder) -> self
+
+[m:Psych.load] などによって YAML から `self` を復元するために呼び出されます。
+
+[m:Set#encode_with] によって coder に登録された要素を取り出し、[m:Set#replace] で `self` の内容をその要素に置き換えます。
+
+- **param** `coder` -- 要素の情報を保持する Psych::Coder オブジェクト
+- **SEE** [m:Set#replace]
+#%end


### PR DESCRIPTION
psych ライブラリで、実 Ruby には存在するのに記載が無かった公開メソッド 29 件のドキュメントを追加します(refs #3548 の不足側・第 4 弾)。原典は psych gem v5.3.1(Ruby 4.0 同梱)の rdoc です。初出版が 3.0 より後のものは `#%since` で囲みました。

## 追加したエントリ(29 メソッド・21 エントリ・11 ファイル)

- `Psych`: `safe_load_file`、`safe_load_stream`(4.0)、`safe_dump`(3.1)、`unsafe_load`/`unsafe_load_file`(3.1)
- `Psych::Nodes::Node`: `alias?`/`document?`/`mapping?`/`scalar?`/`sequence?`/`stream?` と `start_line`/`start_column`/`end_line`/`end_column`(setter 込み)。各サブクラスのページには常に true を返す override の項目を追加
- `Psych::Handler#event_location`、`Psych::ScalarScanner#parse_int`
- `Set#encode_with`/`init_with`(4.0)。`core_ext.md` に `# reopen Set` の節を新設しました(Ruby 4.0 で Set が C 実装のコアクラスになったことに伴う YAML 対応)

## 対象外にしたもの(47 件)

- 原典で `:stopdoc:` 内の `Psych.add_builtin_type`/`add_domain_type`/`add_tag`/`remove_type`/`config`/`dump_tags(=)`/`load_tags(=)`/`domain_types(=)`(既存ページでも internal と注記済み)
- 内部用: `Psych::Visitors::YAMLTree#visit_*` 30 件・`#accept`、`Visitors::Visitor#accept`/`.dispatch_cache`、`ScalarScanner#class_loader`、`TreeBuilder#event_location`(Handler の override)
- `Psych::Parser#external_encoding=`: 値を保持するだけで効果が無い(既存ページに注記済み)

## 検証

- 全見出しを Ruby 4.0.0 と master で確認、lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件、`#%since` の境界を lookup で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
