### PR TITLE
date: 記載が無かった Date#day_fraction と Date#infinite? のドキュメントを追加する

### DIFF
--- a/manual/api/date/Date.md
+++ b/manual/api/date/Date.md
@@ -910,3 +910,19 @@ end
 - **SEE** [ref:d:spec/pattern_matching#matching_non_primitive_objects]
 #%end
 
+### def day_fraction -> Integer | Rational
+
+1 日のうちで経過した時刻を分数で返します。真夜中を `0`、正午を `Rational(1, 2)` として計算します。
+
+`self` が時刻の情報を持たない場合(`Date` のインスタンスなど)は、整数の `0` を返します。
+
+```ruby title="例"
+require 'date'
+p Date.new(2001, 2, 3).day_fraction         # => 0
+p DateTime.new(2001, 2, 3, 12).day_fraction # => (1/2)
+```
+
+### def infinite? -> false
+
+常に `false` を返します。
+


### PR DESCRIPTION
date ライブラリで、実 Ruby には存在するのに記載が無かった `Date#day_fraction` と `Date#infinite?` のドキュメントを追加します(refs #3548 の不足側・第 6 弾)。原典は date gem v3.5.1(Ruby 4.0 同梱)の `date_core.c` の rdoc です。どちらも Ruby 3.0 から存在するので版ゲートはありません。

## 対象外にしたもの

- `Date#as_json` / `DateTime#as_json`: json/add/date が定義するメソッドで、`json/add/date.md` 側の未記載として json の回で扱います(json 3.0 では json/add 自体が削除されるため 4.1 の until も要ります)

## 検証

- 見出しを Ruby 4.0.0 と master で確認、使用例はローカルの Ruby 3.4.8 で実行
- lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
