### PR TITLE
resolv: 記載が無かった Resolv::DNS::Resource#ttl のドキュメントを追加する

### DIFF
--- a/manual/api/resolv.md
+++ b/manual/api/resolv.md
@@ -1541,6 +1541,14 @@ DNSリソースを表す抽象クラスです。
 #%# この定数はユーザが使うべきではありません。
 #%#
 
+## Instance Methods
+
+### def ttl -> Integer
+
+この DNS リソースレコードの残り TTL(Time To Live)を返します。
+
+[m:Resolv::DNS#getresource] などで取得したリソースで、DNS サーバから返された TTL の値を保持しています。
+
 # class Resolv::IPv4 < Object
 
 IPv4のアドレスを表すクラスです。


### PR DESCRIPTION
resolv ライブラリで、実 Ruby には存在するのに記載が無かった `Resolv::DNS::Resource#ttl` のドキュメントを追加します(refs #3548 の不足側・第 7 弾)。原典は resolv gem v0.7.0(Ruby 4.0 同梱)の rdoc です。Ruby 3.0 から存在するので版ゲートはありません。

## 対象外にしたもの(42 件)

- 原典で `:nodoc:` または `:stopdoc:` 内の内部 API: 各 Resource クラスの `encode_rdata`/`decode_rdata`、`Resolv::DNS#lazy_initialize`/`#fetch_resource`/`#make_udp_requester`/`#make_tcp_requester`/`#extract_resources`、`Resolv::DNS.allocate_request_id`/`.free_request_id`/`.bind_random_port`/`.random`、`Resolv::DNS::Name#[]`/`#length`、`Resolv::DNS::Resource.get_class`、`Resolv::DNS::Resource::Generic.create`/`.type_class_equal?`、`Resolv::Hosts#lazy_initialize`
- `Resolv::DNS::Resource::Generic#data`: 原典には rdoc がありますが、既存ページが「ユーザが使うべきではない」として意図的にコメントアウトしているため、そのままにしました

## 検証

- lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
