### PR TITLE
uri: 実 Ruby に存在するのに記載が無かった公開メソッド 11 件のドキュメントを追加する

### DIFF
--- a/manual/api/uri/Generic.md
+++ b/manual/api/uri/Generic.md
@@ -525,6 +525,57 @@ HTTP_PROXY(環境変数が大文字小文字を区別しない場合は http_pro
 
 - **SEE** [c:ENV]
 
+#%since 4.0
+### def authority -> [String, String, String, Integer] | nil
+
+`self` の authority 情報を [user, password, host, port] という 4 要素の配列で返します。
+
+user・password・host・port のいずれか一つでも設定されていれば配列を返します。設定されていない要素は nil になります。user・password・host・port のいずれも設定されていない場合は nil を返します。
+
+```ruby title="例"
+require 'uri'
+u = URI.parse('foo://myuser:mypass@www.example.com:8080/bar')
+p u.authority # => ["myuser", "mypass", "www.example.com", 8080]
+
+p URI::Generic.build(scheme: 'foo').authority # => nil
+```
+
+- **SEE** [m:URI::Generic#userinfo], [m:URI::Generic#host], [m:URI::Generic#port]
+
+#%end
+
+#%since 3.2
+### def decoded_user -> String | nil
+
+`self` の user を URI デコードした文字列で返します。設定されていない場合は nil を返します。
+
+```ruby title="例"
+require 'uri'
+u = URI.parse('http://my%20user:my%20pass@www.example.com/')
+p u.user         # => "my%20user"
+p u.decoded_user # => "my user"
+```
+
+- **SEE** [m:URI::Generic#user], [m:URI.decode_uri_component]
+
+#%end
+
+#%since 3.2
+### def decoded_password -> String | nil
+
+`self` の password を URI デコードした文字列で返します。設定されていない場合は nil を返します。
+
+```ruby title="例"
+require 'uri'
+u = URI.parse('http://my%20user:my%20pass@www.example.com/')
+p u.password         # => "my%20pass"
+p u.decoded_password # => "my pass"
+```
+
+- **SEE** [m:URI::Generic#password], [m:URI.decode_uri_component]
+
+#%end
+
 ## Constants
 
 ### const COMPONENT -> [Symbol]

--- a/manual/api/uri/HTTP.md
+++ b/manual/api/uri/HTTP.md
@@ -71,6 +71,48 @@ u = URI.parse("http://example.com/search?q=xxx")
 p u.request_uri                                  # => "/search?q=xxx"
 ```
 
+#%since 3.1
+### def authority -> String
+
+[RFC:3986] の Section 3.2 で定義されている authority を文字列で返します。
+
+port が [m:URI::Generic.default_port] と同じ場合は host だけを返します。そうでない場合は "host:port" という形式の文字列を返します。
+
+```ruby title="例"
+require 'uri'
+p URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').authority
+# => "www.example.com"
+p URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').authority
+# => "www.example.com:8000"
+p URI::HTTP.build(host: 'www.example.com', port: 80, path: '/foo/bar').authority
+# => "www.example.com"
+```
+
+- **SEE** [m:URI::HTTP#origin], [m:URI::Generic.default_port]
+
+#%end
+
+#%since 3.1
+### def origin -> String
+
+[RFC:6454] で定義されている origin を文字列で返します。
+
+"scheme://authority" という形式の文字列になります。
+
+```ruby title="例"
+require 'uri'
+p URI::HTTP.build(host: 'www.example.com', path: '/foo/bar').origin
+# => "http://www.example.com"
+p URI::HTTP.build(host: 'www.example.com', port: 8000, path: '/foo/bar').origin
+# => "http://www.example.com:8000"
+p URI::HTTPS.build(host: 'www.example.com', path: '/foo/bar').origin
+# => "https://www.example.com"
+```
+
+- **SEE** [m:URI::HTTP#authority]
+
+#%end
+
 # class URI::HTTPS < URI::HTTP
 
 HTTPS URI を表すクラスです。

--- a/manual/api/uri/URI.md
+++ b/manual/api/uri/URI.md
@@ -262,6 +262,130 @@ p URI.encode_www_form_component('Ruby リファレンスマニュアル')
 - **param** `enc` -- 指定された場合、パーセントエンコーディングする前に、strをこのエンコーディングに変換
 - **SEE** [m:URI.decode_www_form_component], [m:URI.encode_www_form]
 
+### def URI.for(scheme, *arguments, default: URI::Generic) -> URI::Generic
+
+scheme と arguments から新しい URI オブジェクトを生成して返します。
+
+scheme を大文字にしたものが [m:URI.scheme_list] に登録されていれば、そのクラスのインスタンスを生成します。登録されていない場合は default で指定したクラスを使います。arguments はそのクラスの `new` にそのまま渡されます。
+
+- **param** `scheme` -- 生成する URI の scheme を文字列で指定します。
+- **param** `arguments` -- 構成要素を、生成に使うクラスの `new` に渡す引数と同じ形式で指定します。
+- **param** `default` -- scheme に対応するクラスが登録されていない場合に使うクラスを指定します。省略した場合は `URI::Generic` です。
+
+```ruby title="例"
+require 'uri'
+values = ["john.doe", "www.example.com", "123", nil, "/forum/questions/", nil, "tag=networking&order=newest", "top"]
+p URI.for('https', *values)
+# => #<URI::HTTPS https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top>
+p URI.for('foo', *values, default: URI::HTTP)
+# => #<URI::HTTP foo://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top>
+```
+
+- **SEE** [m:URI.scheme_list], [c:URI::Generic]
+#%since 3.1
+- **SEE** [m:URI.register_scheme]
+
+#%end
+
+#%since 3.1
+### def URI.register_scheme(scheme, klass) -> Class
+
+klass を、scheme という文字列で表される URI のスキームに対応するクラスとして登録します。
+
+以後、この scheme を使って [m:URI.parse] や [m:URI.for] を呼び出すと、klass のインスタンスが生成されるようになります。scheme を大文字にした文字列は、Ruby の定数名として有効なものでなければなりません。
+
+- **param** `scheme` -- 登録するスキーム名を文字列で指定します。
+- **param** `klass` -- scheme に対応させるクラスを指定します。
+- **return** -- 引数 klass をそのまま返します。
+- **raise** `ArgumentError` -- scheme を大文字にした文字列が、定数名として使えない場合に発生します。
+
+```ruby title="例"
+require 'uri'
+p URI.register_scheme('MS_SEARCH', URI::Generic) # => URI::Generic
+p URI.scheme_list['MS_SEARCH']                   # => URI::Generic
+```
+
+- **SEE** [m:URI.scheme_list]
+
+#%end
+
+### def URI.scheme_list -> {String => Class}
+
+定義されているスキームとクラスの対応をハッシュで返します。
+
+キーはスキーム名を表す大文字の文字列、値は対応する [c:URI::Generic] のサブクラスです。
+
+```ruby title="例"
+require 'uri'
+p URI.scheme_list
+# => {"HTTPS" => URI::HTTPS, "LDAP" => URI::LDAP, "FILE" => URI::File, "FTP" => URI::FTP, "LDAPS" => URI::LDAPS, "MAILTO" => URI::MailTo, "WS" => URI::WS, "WSS" => URI::WSS, "HTTP" => URI::HTTP}
+```
+
+#%since 3.1
+- **SEE** [m:URI.register_scheme]
+
+#%end
+
+#%since 3.4
+### def URI.parser=(parser = URI::RFC3986_PARSER)
+
+`self` が使うデフォルトのパーサを設定します。
+
+このメソッドを呼び出すと、[m:URI.parse] や [m:URI.split] などが使うパーサ(`URI::RFC3986_Parser` または `URI::RFC2396_Parser` のインスタンス)が切り替わります。同時に `URI::PARSER`・`URI::Parser` や、パーサが提供する正規表現に対応する定数群も、指定したパーサのものに更新されます。
+
+- **param** `parser` -- 設定するパーサを、`URI::RFC3986_Parser` または `URI::RFC2396_Parser` のインスタンスで指定します。省略した場合は `URI::RFC3986_PARSER` を設定します。
+
+```ruby title="例"
+require 'uri'
+URI.parser = URI::RFC2396_PARSER
+p URI::PARSER.class      # => URI::RFC2396_Parser
+URI.parser = URI::RFC3986_PARSER
+p URI::PARSER.class      # => URI::RFC3986_Parser
+```
+
+#%end
+
+#%since 3.2
+### def URI.decode_uri_component(str, enc=Encoding::UTF_8) -> String
+
+URL エンコードされた文字列 str をデコードした文字列を返します。
+
+[m:URI.decode_www_form_component] と同様の変換を行いますが、"+" という文字はデコードせずそのまま残す点が異なります。
+
+enc で指定したエンコーディングの文字列が URL エンコードされたものとみなし、返り値にそのエンコーディングを付加します。
+
+- **param** `str` -- デコード対象の文字列です。
+- **param** `enc` -- 変換先のエンコーディングです。
+- **raise** `ArgumentError` -- str の %-エンコーディングの書式が不正である場合に発生します。
+
+```ruby title="例"
+require 'uri'
+p URI.decode_uri_component('a+b%20c') # => "a+b c"
+```
+
+- **SEE** [m:URI.encode_uri_component], [m:URI.decode_www_form_component]
+
+#%end
+
+#%since 3.2
+### def URI.encode_uri_component(str, enc=nil) -> String
+
+文字列 str を URL エンコードした文字列を返します。
+
+[m:URI.encode_www_form_component] と同様の変換を行いますが、空白文字 " " を "+" ではなく "%20" に変換する点が異なります。
+
+- **param** `str` -- エンコードする文字列です。
+- **param** `enc` -- 指定された場合、パーセントエンコーディングする前に、str をこのエンコーディングに変換します。
+
+```ruby title="例"
+require 'uri'
+p URI.encode_uri_component('Ruby is fun+test') # => "Ruby%20is%20fun%2Btest"
+```
+
+- **SEE** [m:URI.decode_uri_component], [m:URI.encode_www_form_component]
+
+#%end
+
 ## Constants
 
 ### const UNSAFE -> Regexp


### PR DESCRIPTION
uri ライブラリで、実 Ruby には存在するのに記載が無かった公開メソッド 11 件のドキュメントを追加します(refs #3548 の不足側・第 8 弾)。原典は uri gem v1.1.1(Ruby 4.0 同梱)の rdoc です。初出版が 3.0 より後のものは `#%since` で囲みました。

## 追加したエントリ(11 メソッド・3 ファイル)

- `URI`: `for`、`scheme_list`、`register_scheme`(3.1)、`parser=`(3.4)、`decode_uri_component`/`encode_uri_component`(3.2)
- `URI::Generic`: `authority`(4.0)、`decoded_user`/`decoded_password`(3.2)
- `URI::HTTP`: `authority`/`origin`(3.1)

## 対象外にしたもの(26 件)

- protected の `URI::Generic#set_*`/`#component_ary`、`URI::FTP`/`URI::LDAP`/`URI::MailTo` の `set_*`(20 件)
- `URI::HTTP#buffer_open`/`URI::FTP#buffer_open`(open-uri が定義)、`URI.const_missing`/`URI.get_encoding`/`URI::Generic.use_proxy?`(原典で `:nodoc:`)、`URI::HTTP#check_host`(内部の検査用)

## 検証

- 使用例はローカルの Ruby(uri 1.1.1)で実行して出力を確認
- 全見出しを Ruby 4.0.0 と master で確認、lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
