### PR TITLE
socket: 実 Ruby に存在するのに記載が無かった公開メソッド 8 件のドキュメントを追加する

### DIFF
--- a/manual/api/socket/Socket.md
+++ b/manual/api/socket/Socket.md
@@ -720,6 +720,38 @@ pp Socket.getifaddrs
 #    #<Socket::Ifaddr lo0 UP,LOOPBACK,RUNNING,MULTICAST 127.0.0.1 netmask=255.?.?.? (5 bytes for 16 bytes sockaddr_in)>]
 ```
 
+#%since 3.4
+### def Socket.tcp_fast_fallback -> bool
+### def Socket.tcp_fast_fallback=(enable)
+
+Happy Eyeballs Version 2([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305))を [m:TCPSocket.new] と [m:Socket.tcp] で既定で有効にするかどうかを取得・設定します。
+
+`true` にすると、[m:TCPSocket.new] と [m:Socket.tcp] の両方で Happy Eyeballs Version 2 が有効になります(Windows では [m:TCPSocket.new] はこのアルゴリズムに対応していません)。`false` にすると Ruby 3.3 以前の動作に戻ります。
+
+明示的に設定しなければ既定値は `true` です。
+
+#%since 4.0
+ただし、環境変数 `RUBY_TCP_NO_FAST_FALLBACK=1` が設定されている場合、既定値は `false` になります。
+
+#%end
+メソッド呼び出しごとに制御したい場合は、各メソッドのキーワード引数 `fast_fallback` を使ってください。
+
+- **param** `enable` -- `true` なら Happy Eyeballs Version 2 を有効に、`false` なら無効にします。
+
+```ruby
+require 'socket'
+
+p Socket.tcp_fast_fallback   # => true
+
+Socket.tcp_fast_fallback = false
+p Socket.tcp_fast_fallback   # => false
+```
+
+- **SEE** [m:Socket.tcp]
+- **SEE** [m:TCPSocket.new]
+
+#%end
+
 ## Instance Methods
 
 ### def accept -> Array

--- a/manual/api/socket/Socket__Option.md
+++ b/manual/api/socket/Socket__Option.md
@@ -68,6 +68,50 @@ SOL_SOCKET/SO_LINGER 用の Socket::Option オブジェクトを新たに生成�
 - **param** `onoff` -- 0/1もしくは真偽値
 - **param** `secs` -- 整数値
 
+### def Socket::Option.byte(family, level, optname, integer) -> Socket::Option
+
+1 バイトの整数をデータとして持つ `Socket::Option` オブジェクトを新たに生成し返します。
+
+family, level, optname には Socket::SOL_SOCKET のような整数の他、文字列("SOL_SOCKET", "SOCKET")、シンボル(:SOL_SOCKET, :SOCKET)を指定できます。
+
+- **param** `family` -- ソケットファミリー
+- **param** `level` -- ソケットオプションレベル
+- **param** `optname` -- オプションの名前
+- **param** `integer` -- データ(1 バイトの整数)
+
+```ruby
+require 'socket'
+
+p Socket::Option.byte(:INET, :SOCKET, :KEEPALIVE, 1)
+# => #<Socket::Option: INET SOCKET KEEPALIVE "\x01">
+```
+
+### def Socket::Option.ipv4_multicast_loop(integer) -> Socket::Option
+
+IPPROTO_IP/IP_MULTICAST_LOOP 用の `Socket::Option` オブジェクトを新たに生成し返します。
+
+- **param** `integer` -- データ(整数)
+
+```ruby
+require 'socket'
+
+p Socket::Option.ipv4_multicast_loop(1)
+# => #<Socket::Option: INET IP MULTICAST_LOOP 1>
+```
+
+### def Socket::Option.ipv4_multicast_ttl(integer) -> Socket::Option
+
+IPPROTO_IP/IP_MULTICAST_TTL 用の `Socket::Option` オブジェクトを新たに生成し返します。
+
+- **param** `integer` -- データ(整数)
+
+```ruby
+require 'socket'
+
+p Socket::Option.ipv4_multicast_ttl(10)
+# => #<Socket::Option: INET IP MULTICAST_TTL 10>
+```
+
 ## Instance Methods
 ### def family -> Integer
 
@@ -119,3 +163,25 @@ to_s は過去との互換性のために存在します。
 data に対し [m:String#unpack] を呼び出し、その結果を返します。
 
 このメソッドは過去との互換性のために存在します。
+
+### def byte -> Integer
+
+オプションのデータ(内容)を 1 バイトの整数に変換して返します。
+
+- **raise** `TypeError` -- dataのバイト数が不適切である(sizeof(char)と異なる)場合に発生します
+- **SEE** [m:Socket::Option#data]
+
+### def ipv4_multicast_loop -> Integer
+
+オプションが IPPROTO_IP/IP_MULTICAST_LOOP である場合に、オプションのデータ(内容)を整数に変換して返します。
+
+- **raise** `TypeError` -- family が AF_INET でない、または level/optname が IPPROTO_IP/IP_MULTICAST_LOOP でない場合に発生します
+- **SEE** [m:Socket::Option#data]
+
+### def ipv4_multicast_ttl -> Integer
+
+オプションが IPPROTO_IP/IP_MULTICAST_TTL である場合に、オプションのデータ(内容)を整数に変換して返します。
+
+- **raise** `TypeError` -- family が AF_INET でない、または level/optname が IPPROTO_IP/IP_MULTICAST_TTL でない場合に発生します
+- **SEE** [m:Socket::Option#data]
+


### PR DESCRIPTION
socket ライブラリで、実 Ruby には存在するのに記載が無かった公開メソッド 8 件のドキュメントを追加します(refs #3548 の不足側・第 11 弾)。原典は Ruby 4.0.0 の ext/socket(`option.c`・`socket.c`)の rdoc です。

## 追加したエントリ(8 メソッド・2 ファイル)

- `Socket.tcp_fast_fallback` / `tcp_fast_fallback=`(3.4)。`TCPSocket.new` と `Socket.tcp` の Happy Eyeballs Version 2 を全体で有効/無効にする設定です。環境変数 `RUBY_TCP_NO_FAST_FALLBACK` の記述は 4.0 の rdoc で追加されたので `#%since 4.0` で囲みました
- `Socket::Option.byte` / `.ipv4_multicast_loop` / `.ipv4_multicast_ttl` と同名のインスタンスメソッド 3 件(3.0 から)。既存の `int`/`bool`/`linger` の項目と同じ構成です。`byte` の実行例は rdoc の例と違い Linux での実際の `inspect` 出力(`"\x01"`)に合わせています

## 対象外にしたもの

- `Socket.tcp_with_fast_fallback`: 4.0 で `private_class_method` になった内部実装(`:stopdoc:` 配下)
- `Addrinfo#connect_internal`: protected

## 検証

- 全見出しを Ruby 3.4.0 と 4.0.0 で確認、実行例は 3.4.8 で実行
- lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件。入れ子の `#%since 4.0` は前処理出力で 3.4 に出ず 4.0 に出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
