### PR TITLE
zlib: 実 Ruby に存在するのに記載が無かった公開メソッド 9 件のドキュメントを追加する

### DIFF
--- a/manual/api/zlib/GzipReader.md
+++ b/manual/api/zlib/GzipReader.md
@@ -113,6 +113,37 @@ Zlib::GzipReader.open('hoge.gz'){|gz|
 }
 ```
 
+### def Zlib::GzipReader.zcat(io, options = {}) -> String
+### def Zlib::GzipReader.zcat(io, options = {}) {|string| ... } -> nil
+
+io に含まれているすべての gzip ストリームを展開します。io の末尾まで、複数の gzip ストリームが連続して格納されている場合も扱います。gzip ストリームの後ろに gzip 形式以外のデータがあってはいけません。
+
+ブロックが与えられた場合は、展開したストリームごとにブロックを呼び出し、`nil` を返します。ブロックが与えられなかった場合は、すべてのストリームを展開した結果を連結した文字列を返します。
+
+- **param** `io` -- 読み込み元の IO オブジェクトを指定します。
+- **param** `options` -- [m:Zlib::GzipReader.new] に渡すオプションをハッシュで指定します。
+
+```ruby
+require 'zlib'
+
+File.open('multi.gz', 'wb') { |f|
+  f.write(Zlib.gzip('hoge'))
+  f.write(Zlib.gzip('fuga'))
+}
+
+File.open('multi.gz') { |f|
+  p Zlib::GzipReader.zcat(f) # => "hogefuga"
+}
+
+File.open('multi.gz') { |f|
+  Zlib::GzipReader.zcat(f) { |chunk| p chunk }
+}
+# => "hoge"
+# => "fuga"
+```
+
+- **SEE** [m:Zlib::GzipReader.new]
+
 ## Instance Methods
 
 ### def eof -> bool
@@ -777,4 +808,199 @@ gz.close
 
 gzip フォーマットの解析のために読み込んだ余剰のデータを返します。
 gzip ファイルが最後まで解析されていない場合は nil を返します。
+
+### def getbyte -> Integer | nil
+
+IO クラスの同名メソッド[m:IO#getbyte]と同じです。
+
+但し、gzip ファイル中にエラーがあった場合 [c:Zlib::Error] 例外や
+[c:Zlib::GzipFile::Error] 例外が発生します。
+
+gzip ファイルのフッターの処理に注意して下さい。
+gzip ファイルのフッターには圧縮前データのチェックサムが記録されています。GzipReader オブジェクトは、次の時に展開したデータとフッターの照合を行い、エラーがあった場合は
+[c:Zlib::GzipFile::NoFooter], [c:Zlib::GzipFile::CRCError],
+[c:Zlib::GzipFile::LengthError] 例外を発生させます。
+
+  - EOF (圧縮データの最後) を越えて読み込み要求を受けた時。
+    すなわち [m:Zlib::GzipReader#read],
+    [m:Zlib::GzipReader#gets] メソッド等が nil を返す時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipFile#close] メソッドが
+    呼び出された時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipReader#unused] メソッドが
+    呼び出された時。
+
+- **raise** `Zlib::Error` -- [c:Zlib::Error] を参照
+- **raise** `Zlib::GzipFile::Error` -- [c:Zlib::GzipFile::Error]を参照
+- **raise** `Zlib::GzipFile::NoFooter` -- [c:Zlib::GzipFile::NoFooter]を参照
+- **raise** `Zlib::GzipFile::CRCError` -- [c:Zlib::GzipFile::CRCError]を参照
+- **raise** `Zlib::GzipFile::LengthError` -- [c:Zlib::GzipFile::LengthError]を参照
+
+```ruby
+require 'zlib'
+
+Zlib::GzipWriter.open('hoge.gz') { |gz| gz.print 'hoge' }
+
+Zlib::GzipReader.open('hoge.gz') { |gz|
+  while b = gz.getbyte
+    puts b
+  end
+}
+# => 104
+# => 111
+# => 103
+# => 101
+```
+
+- **SEE** [m:IO#getbyte]
+
+### def readbyte -> Integer
+
+IO クラスの同名メソッド[m:IO#readbyte]と同じです。
+
+但し、gzip ファイル中にエラーがあった場合 [c:Zlib::Error] 例外や
+[c:Zlib::GzipFile::Error] 例外が発生します。
+
+gzip ファイルのフッターの処理に注意して下さい。
+gzip ファイルのフッターには圧縮前データのチェックサムが記録されています。GzipReader オブジェクトは、次の時に展開したデータとフッターの照合を行い、エラーがあった場合は
+[c:Zlib::GzipFile::NoFooter], [c:Zlib::GzipFile::CRCError],
+[c:Zlib::GzipFile::LengthError] 例外を発生させます。
+
+  - EOF (圧縮データの最後) を越えて読み込み要求を受けた時。
+    すなわち [m:Zlib::GzipReader#read],
+    [m:Zlib::GzipReader#gets] メソッド等が nil を返す時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipFile#close] メソッドが
+    呼び出された時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipReader#unused] メソッドが
+    呼び出された時。
+
+- **raise** `EOFError` -- EOF に到達したとき発生します。
+- **raise** `Zlib::Error` -- [c:Zlib::Error] を参照
+- **raise** `Zlib::GzipFile::Error` -- [c:Zlib::GzipFile::Error]を参照
+- **raise** `Zlib::GzipFile::NoFooter` -- [c:Zlib::GzipFile::NoFooter]を参照
+- **raise** `Zlib::GzipFile::CRCError` -- [c:Zlib::GzipFile::CRCError]を参照
+- **raise** `Zlib::GzipFile::LengthError` -- [c:Zlib::GzipFile::LengthError]を参照
+
+```ruby
+require 'zlib'
+
+Zlib::GzipWriter.open('hoge.gz') { |gz| gz.print 'hoge' }
+
+Zlib::GzipReader.open('hoge.gz') { |gz|
+  begin
+    puts gz.readbyte
+  rescue EOFError => err
+    puts err
+    break
+  end while true
+}
+# => 104
+# => 111
+# => 103
+# => 101
+# => end of file reached
+```
+
+- **SEE** [m:IO#readbyte]
+
+### def each_char{|c| ... } -> nil
+### def each_char -> Enumerator
+
+IO クラスの同名メソッド[m:IO#each_char]と同じです。
+
+但し、gzip ファイル中にエラーがあった場合 [c:Zlib::Error] 例外や
+[c:Zlib::GzipFile::Error] 例外が発生します。
+
+gzip ファイルのフッターの処理に注意して下さい。
+gzip ファイルのフッターには圧縮前データのチェックサムが記録されています。GzipReader オブジェクトは、次の時に展開したデータとフッターの照合を行い、エラーがあった場合は
+[c:Zlib::GzipFile::NoFooter], [c:Zlib::GzipFile::CRCError],
+[c:Zlib::GzipFile::LengthError] 例外を発生させます。
+
+  - EOF (圧縮データの最後) を越えて読み込み要求を受けた時。
+    すなわち [m:Zlib::GzipReader#read],
+    [m:Zlib::GzipReader#gets] メソッド等が nil を返す時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipFile#close] メソッドが
+    呼び出された時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipReader#unused] メソッドが
+    呼び出された時。
+
+- **raise** `Zlib::Error` -- [c:Zlib::Error] を参照
+- **raise** `Zlib::GzipFile::Error` -- [c:Zlib::GzipFile::Error]を参照
+- **raise** `Zlib::GzipFile::NoFooter` -- [c:Zlib::GzipFile::NoFooter]を参照
+- **raise** `Zlib::GzipFile::CRCError` -- [c:Zlib::GzipFile::CRCError]を参照
+- **raise** `Zlib::GzipFile::LengthError` -- [c:Zlib::GzipFile::LengthError]を参照
+
+```ruby
+require 'zlib'
+
+Zlib::GzipWriter.open('hoge.gz') { |gz| gz.print 'hoge' }
+
+Zlib::GzipReader.open('hoge.gz') { |gz|
+  gz.each_char { |c| print c, ' ' }
+}
+# => h o g e 
+```
+
+- **SEE** [m:IO#each_char]
+
+### def ungetbyte(char) -> nil
+
+IO クラスの同名メソッド[m:IO#ungetbyte]と同じです。
+
+但し、gzip ファイル中にエラーがあった場合 [c:Zlib::Error] 例外や
+[c:Zlib::GzipFile::Error] 例外が発生します。
+
+gzip ファイルのフッターの処理に注意して下さい。
+gzip ファイルのフッターには圧縮前データのチェックサムが記録されています。GzipReader オブジェクトは、次の時に展開したデータとフッターの照合を行い、エラーがあった場合は
+[c:Zlib::GzipFile::NoFooter], [c:Zlib::GzipFile::CRCError],
+[c:Zlib::GzipFile::LengthError] 例外を発生させます。
+
+  - EOF (圧縮データの最後) を越えて読み込み要求を受けた時。
+    すなわち [m:Zlib::GzipReader#read],
+    [m:Zlib::GzipReader#gets] メソッド等が nil を返す時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipFile#close] メソッドが
+    呼び出された時。
+  - EOF まで読み込んだ後、[m:Zlib::GzipReader#unused] メソッドが
+    呼び出された時。
+
+- **param** `char` -- 読み戻したい 1 バイトを、バイト値(整数)または 1 文字の文字列で指定します。
+
+- **raise** `Zlib::Error` -- [c:Zlib::Error] を参照
+- **raise** `Zlib::GzipFile::Error` -- [c:Zlib::GzipFile::Error]を参照
+- **raise** `Zlib::GzipFile::NoFooter` -- [c:Zlib::GzipFile::NoFooter]を参照
+- **raise** `Zlib::GzipFile::CRCError` -- [c:Zlib::GzipFile::CRCError]を参照
+- **raise** `Zlib::GzipFile::LengthError` -- [c:Zlib::GzipFile::LengthError]を参照
+
+```ruby
+require 'zlib'
+
+Zlib::GzipWriter.open('hoge.gz') { |gz| gz.print 'hoge' }
+
+Zlib::GzipReader.open('hoge.gz') { |gz|
+  b1 = gz.getbyte
+  b2 = gz.getbyte
+  printf "%d -> %d\n", b1, b2
+  gz.ungetbyte(b2)
+  p gz.getbyte
+}
+# => 104 -> 111
+# => 111
+```
+
+- **SEE** [m:IO#ungetbyte]
+
+### def external_encoding -> Encoding
+
+`self` が読み込むデータの外部エンコーディングを返します。[m:Zlib::GzipReader.new] や [m:Zlib::GzipReader.open] の `:external_encoding` オプションや `:encoding` オプションで指定した値を返します。省略した場合はデフォルトの外部エンコーディング([m:Encoding.default_external])を返します。
+
+```ruby
+require 'zlib'
+
+Zlib::GzipWriter.open('hoge.gz') { |gz| gz.print 'hoge' }
+
+Zlib::GzipReader.open('hoge.gz', external_encoding: 'EUC-JP') { |gz|
+  p gz.external_encoding # => #<Encoding:EUC-JP>
+}
+```
+
+- **SEE** [m:IO#external_encoding]
 

--- a/manual/api/zlib/Inflate.md
+++ b/manual/api/zlib/Inflate.md
@@ -159,3 +159,29 @@ true を返し、残りのデータは入力バッファ内に保持されます
 
 What is this?
 
+### def add_dictionary(string) -> self
+
+今後必要になるかもしれない辞書 string を、あらかじめ展開ストリームに登録します。
+
+複数の辞書を登録することができます。展開ストリームは、実際に要求される辞書に応じて、登録済みの辞書の中から適切なものを自動的に選択します。[m:Zlib::Inflate#set_dictionary] と違い、[c:Zlib::NeedDict] 例外を捕捉してから辞書をセットし直す必要がありません。
+
+- **param** `string` -- 展開ストリームにあらかじめ登録しておく辞書を文字列で指定します。
+
+```ruby
+require 'zlib'
+
+dict = 'hoge_fuga_ugougo'
+str = 'hogehogefugafuga' * 3
+
+dez = Zlib::Deflate.new
+dez.set_dictionary(dict)
+compressed = dez.deflate(str)
+compressed << dez.finish
+
+inz = Zlib::Inflate.new
+inz.add_dictionary(dict)
+p inz.inflate(compressed) == str # => true
+```
+
+- **SEE** [m:Zlib::Inflate#set_dictionary]
+

--- a/manual/api/zlib/Zlib.md
+++ b/manual/api/zlib/Zlib.md
@@ -80,6 +80,33 @@ CRC チェックサムの計算に用いるテーブルを配列で返します�
 
 - **SEE** [m:Zlib::Inflate.inflate]
 
+### module_function def gzip(string, level: nil, strategy: nil) -> String
+
+string を gzip 形式に圧縮した文字列を返します。
+
+- **param** `string` -- 圧縮する文字列を指定します。
+- **param** `level` -- 圧縮の水準を整数で指定します。有効な値は [m:Zlib::NO_COMPRESSION], [m:Zlib::BEST_SPEED], [m:Zlib::BEST_COMPRESSION], [m:Zlib::DEFAULT_COMPRESSION] (デフォルト) 及び 0 から 9 の整数です。
+- **param** `strategy` -- 圧縮方法を整数で指定します。有効な値は [m:Zlib::FILTERED], [m:Zlib::HUFFMAN_ONLY], [m:Zlib::DEFAULT_STRATEGY] (デフォルト) 等です。[m:Zlib::Deflate.new] を参照してください。
+
+```ruby
+require 'zlib'
+
+compressed = Zlib.gzip('hoge fuga')
+p Zlib.gunzip(compressed) # => "hoge fuga"
+```
+
+- **SEE** [m:Zlib?.gunzip]
+
+### module_function def gunzip(string) -> String
+
+gzip 形式で圧縮された文字列 string を展開した文字列を返します。[m:Zlib?.gzip] で圧縮したデータを元に戻すために使います。
+
+- **param** `string` -- 展開する、gzip 形式で圧縮された文字列を指定します。
+
+- **raise** `Zlib::GzipFile::Error` -- gzip 形式でないデータを渡した場合などに発生します。
+
+- **SEE** [m:Zlib?.gzip]
+
 ## Constants
 
 ### const VERSION -> String


### PR DESCRIPTION
zlib ライブラリで、実 Ruby には存在するのに記載が無かった公開メソッド 9 件のドキュメントを追加します(refs #3548 の不足側・第 12 弾)。原典は zlib gem v3.2.2(Ruby 4.0 同梱)の `zlib.c` の rdoc です。すべて 3.0 から存在するので版分岐はありません。

## 追加したエントリ(9 メソッド・3 ファイル)

- `Zlib.gzip` / `Zlib.gunzip`(module function)
- `Zlib::GzipReader.zcat`(複数の gzip ストリームをまとめて展開)
- `Zlib::GzipReader#getbyte` / `#readbyte` / `#each_char` / `#ungetbyte`: IO 互換メソッド。既存の `getc`/`readchar`/`each_byte`/`ungetc` の項目と同じ構成で、フッター検査の注意と例外を記載しています
- `Zlib::GzipReader#external_encoding`
- `Zlib::Inflate#add_dictionary`

## 検証

- 全見出しを Ruby 4.0.0 で確認、実行例は 3.4.8 で実行(`getbyte` 系のフッター検査は CRC を壊した gzip データで例外を実測)
- lint 4 種 OK、3.0〜4.1 の 7 版で DB 生成+checklink 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
