### PR TITLE
組み込みクラスの記載が無かった公開メソッド 11 件のドキュメントを追加する

### DIFF
--- a/manual/api/_builtin/GC.md
+++ b/manual/api/_builtin/GC.md
@@ -520,6 +520,32 @@ SEGV が起きるでしょう。
 
 - **SEE** [m:GC.compact]
 
+### def GC.verify_internal_consistency -> nil
+
+GC 内部の一貫性を検証します。
+
+デバッグ用のメソッドです。世代別 GC (RGenGC) をサポートしている場合は世代間の一貫性もあわせて検証します。内部に矛盾が見つかった場合はプロセスが異常終了します。
+
+本メソッドは CRuby 以外では動作しません。
+
+```ruby title="例"
+p GC.verify_internal_consistency # => nil
+```
+
+#%since 3.1
+#%until 3.3
+### def GC.using_rvargc? -> bool
+
+実験的機能である Variable Width Allocation (可変長のオブジェクト割り当て) が有効かどうかを返します。
+
+有効な場合は true を、そうでない場合は false を返します。この値はビルド時の設定に依存します。
+
+- **SEE** [m:GC.stat]
+
+#%end
+
+#%end
+
 ## Instance Methods
 
 ### def garbage_collect(full_mark: true, immediate_mark: true, immediate_sweep: true) -> nil

--- a/manual/api/_builtin/Random__Formatter.md
+++ b/manual/api/_builtin/Random__Formatter.md
@@ -56,3 +56,33 @@ p prng.alphanumeric(10, chars: [*"!".."/"]) # => ",.,++%/''."
 ```
 
 - **SEE** [m:SecureRandom.alphanumeric]
+
+### def random_number -> Float
+### def random_number(max) -> Integer | Float
+### def random_number(range) -> Integer | Float
+
+生の乱数から整形した乱数を生成して返します。[m:Random#rand] とほぼ同じ働きをします。
+
+[c:Random] のインスタンスメソッド、および [c:Random] と [c:SecureRandom] の特異メソッドとして使用できます。
+
+- **param** `max` -- 生成する数値の上限を整数または浮動小数点数で指定します。
+         正の整数を指定した場合は 0 以上 max 未満の整数を、
+         正の浮動小数点数を指定した場合は 0.0 以上 max 未満の浮動小数点数を返します。
+         省略するか、nil、0、負の数を指定した場合は 0.0 以上 1.0 未満の浮動小数点数を返します。
+- **param** `range` -- 生成する数値の範囲を [c:Range] で指定します。
+         範囲の両端が整数であれば範囲内の整数を、そうでなければ範囲内の浮動小数点数を返します。
+         始端が終端より大きいなど空の範囲を指定した場合は 0.0 以上 1.0 未満の浮動小数点数を返します。
+- **raise** `ArgumentError` -- 数値にも範囲にも変換できないオブジェクトを指定した場合に発生します。
+
+[m:Random#rand] とは異なり、負の数や空の範囲を指定してもエラーにはならず、
+0.0 以上 1.0 未満の浮動小数点数にフォールバックします。
+
+```ruby title="例"
+prng = Random.new
+p prng.random_number       # => 0.3881631795458004
+p prng.random_number(100)  # => 54
+p prng.random_number(1..6) # => 3
+```
+
+- **SEE** [m:Random#rand]
+

--- a/manual/api/_builtin/RubyVM.md
+++ b/manual/api/_builtin/RubyVM.md
@@ -59,6 +59,28 @@ p RubyVM.stat(:next_shape_id)
 
 含まれる統計名と値は処理系の実装の詳細であり、バージョンによって変わります。この値に依存すべきではありません。
 
+#%since 3.1
+### def RubyVM.keep_script_lines -> bool
+### def RubyVM.keep_script_lines=(bool)
+
+読み込んだスクリプトのソースコードの行を記録するかどうかを取得、設定します。
+
+有効にすると、以降にロードされたスクリプトのソースコードの行が記録され、
+[m:RubyVM::InstructionSequence#script_lines] などから参照できるようになります。
+
+このメソッドは Ruby 内部での利用、デバッグ、研究のための API です。それ以外の目的で使うべきではありません。将来のバージョンとの互換性も保証されません。
+
+- **param** `bool` -- 記録を有効にするかどうかを true か false で指定します。
+
+```ruby title="例"
+p RubyVM.keep_script_lines # => false
+RubyVM.keep_script_lines = true
+p RubyVM.keep_script_lines # => true
+RubyVM.keep_script_lines = false
+```
+
+#%end
+
 ## Constants
 
 ### const OPTS -> [String]

--- a/manual/api/_builtin/RubyVM__InstructionSequence.md
+++ b/manual/api/_builtin/RubyVM__InstructionSequence.md
@@ -284,6 +284,77 @@ p RubyVM::InstructionSequence.load_from_binary_extra_data(binary) # => extra_dat
 
 - **SEE** [m:RubyVM::InstructionSequence#to_binary]
 
+#%since 3.3
+### def RubyVM::InstructionSequence.compile_prism(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
+
+引数 source で指定した Ruby のソースコードを構文解析器 Prism でパースしてコンパイルし、
+[c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
+
+[m:RubyVM::InstructionSequence.compile] とは異なり、常に Prism でパースします。
+
+- **param** `source` -- Ruby のソースコードを表す文字列、または開いた File オブジェクトを指定します。
+- **param** `file` -- ファイル名を文字列で指定します。
+- **param** `path` -- 引数 file の絶対パスファイル名を文字列で指定します。
+- **param** `line` -- 引数 source の 1 行目の行番号を指定します。
+- **param** `options` -- コンパイル時のオプションを true、false、[c:Hash] オブジェクトのいずれかで指定します。詳細は
+               [m:RubyVM::InstructionSequence.compile_option=] を参照してください。
+
+```ruby title="例"
+iseq = RubyVM::InstructionSequence.compile_prism("a = 1 + 2")
+p iseq.eval # => 3
+```
+
+- **SEE** [m:RubyVM::InstructionSequence.compile]
+
+### def RubyVM::InstructionSequence.compile_file_prism(file, options = nil) -> RubyVM::InstructionSequence
+
+引数 file で指定した Ruby のソースコードを構文解析器 Prism でパースしてコンパイルし、
+[c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
+
+[m:RubyVM::InstructionSequence.compile_file] とは異なり、常に Prism でパースします。
+
+- **param** `file` -- ファイル名を文字列で指定します。
+- **param** `options` -- コンパイル時のオプションを true、false、[c:Hash] オブジェクトのいずれかで指定します。詳細は
+               [m:RubyVM::InstructionSequence.compile_option=] を参照してください。
+
+```ruby title="例"
+# /tmp/hello.rb
+puts "Hello, world!"
+
+iseq = RubyVM::InstructionSequence.compile_file_prism("/tmp/hello.rb")
+iseq.eval
+# => Hello, world!
+```
+
+- **SEE** [m:RubyVM::InstructionSequence.compile_file]
+
+#%end
+
+#%since 3.4
+### def RubyVM::InstructionSequence.compile_parsey(source, file = nil, path = nil, line = 1, options = nil) -> RubyVM::InstructionSequence
+
+引数 source で指定した Ruby のソースコードを、旧来のパーサ(parse.y)でパースしてコンパイルし、
+[c:RubyVM::InstructionSequence] オブジェクトを作成して返します。
+
+Ruby 3.4 以降、[m:RubyVM::InstructionSequence.compile] は既定でパーサ Prism を使いますが、
+本メソッドは常に parse.y でパースします。
+
+- **param** `source` -- Ruby のソースコードを表す文字列、または開いた File オブジェクトを指定します。
+- **param** `file` -- ファイル名を文字列で指定します。
+- **param** `path` -- 引数 file の絶対パスファイル名を文字列で指定します。
+- **param** `line` -- 引数 source の 1 行目の行番号を指定します。
+- **param** `options` -- コンパイル時のオプションを true、false、[c:Hash] オブジェクトのいずれかで指定します。詳細は
+               [m:RubyVM::InstructionSequence.compile_option=] を参照してください。
+
+```ruby title="例"
+iseq = RubyVM::InstructionSequence.compile_parsey("a = 1 + 2")
+p iseq.eval # => 3
+```
+
+- **SEE** [m:RubyVM::InstructionSequence.compile]
+
+#%end
+
 ## Instance Methods
 
 ### def inspect -> String
@@ -646,3 +717,60 @@ iseq.to_binary("extra_data")
 
 - **SEE** [m:RubyVM::InstructionSequence.load_from_binary]
 - **SEE** [m:RubyVM::InstructionSequence.load_from_binary_extra_data]
+
+### def each_child {|child_iseq| ... } -> self
+
+`self` が直接含む(ネストした)命令シーケンスを、それぞれ引数としてブロックに渡して繰り返します。
+
+繰り返す順序は実装やバージョンによって異なるため、順序に依存すべきではありません。
+
+```ruby title="例"
+def foo
+  bar = -> { 1 }
+  bar.call
+end
+
+iseq = RubyVM::InstructionSequence.of(method(:foo))
+children = []
+iseq.each_child {|child| children << child.label }
+p children # => ["block in foo"]
+```
+
+### def trace_points -> [[Integer, Symbol]]
+
+`self` が表す命令シーケンス内のトレースポイント(イベントが発生しうる位置)の一覧を返します。
+
+配列の要素は `[行番号, イベントを表す Symbol]` という 2 要素の配列です。
+イベントを表す Symbol は `:class`、`:call`、`:b_call`、`:line`、`:end`、`:return`、`:b_return` のいずれかです。
+
+```ruby title="例"
+iseq = RubyVM::InstructionSequence.compile(<<~RUBY)
+  def hello
+    puts "hi"
+  end
+RUBY
+p iseq.trace_points # => [[1, :line]]
+```
+
+#%since 3.1
+### def script_lines -> [String] | nil
+
+`self` が表す命令シーケンスに対応するソースコードの行を配列で返します。記録されていない場合は nil を返します。
+
+配列に含まれる行は `self` の命令シーケンスの範囲に限られず、ソースファイル全体の行です。
+
+記録するには、コンパイルする前に [m:RubyVM.keep_script_lines] を true に設定しておく必要があります。
+
+このメソッドは Ruby 内部での利用、デバッグ、研究のための API です。それ以外の目的で使うべきではありません。将来のバージョンとの互換性も保証されません。
+
+```ruby title="例"
+RubyVM.keep_script_lines = true
+iseq = RubyVM::InstructionSequence.compile("num = 1 + 2\nputs num")
+p iseq.script_lines # => ["num = 1 + 2\n", "puts num"]
+RubyVM.keep_script_lines = false
+```
+
+- **SEE** [m:RubyVM.keep_script_lines]
+
+#%end
+


### PR DESCRIPTION
#3548 のメソッド過不足チェックで組み込みの不足として挙がった、リリース済み版(3.0〜4.0)の公開メソッド 16 件のうち、原典(`gc.c`・`gc.rb`・`random.c`・`vm.c`・`iseq.c`)の rdoc に説明があるものを追加しました。手順は #3553〜#3565 と同じです(原典を元に執筆 → all-ruby docker の各 x.y.0 と ruby:master で見出しの存在を機械確認 → lint・3.0〜4.1 の DB 生成・checklink)。

## 追加したメソッド(11 件)

- `GC.verify_internal_consistency`・`GC.using_rvargc?`(3.1〜3.2 のみ= `#%since 3.1`+`#%until 3.3`)
- `Random::Formatter#random_number`(負数・0・空の範囲を渡すと `Random#rand` と違って例外にならず 0.0 以上 1.0 未満の Float になることを 3.0〜4.0 の各版で実測して記載)
- `RubyVM.keep_script_lines`/`keep_script_lines=`(3.1)
- `RubyVM::InstructionSequence#each_child`・`#trace_points`・`#script_lines`(3.1)・`.compile_prism`/`.compile_file_prism`(3.3)・`.compile_parsey`(3.4)

## 対象外にしたもの

- `Class.allocate`: 3.1 で `Module.allocate` を塞ぐ内部修正により特異メソッドとして見えるようになっただけで、内容は記載済みの `Class#allocate` と同じ
- `GC.verify_transient_heap_internal_consistency`(3.0〜3.2): どの版にも rdoc が無い
- `Process::Tms.inspect`: Struct 一般の仕組みで、Tms 固有のものではない
- `RubyVM::YJIT.simulate_oom!`: 3.2 以降 `:nodoc:`
- `Set#flatten_merge`: protected

4.1(master)で新規に増えた 42 件と未文書クラス(`RubyVM::ZJIT`・`Thread::Monitor` など)は 4.1 リリースに向けて別途扱います。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
